### PR TITLE
Fix crash: register string iterator class

### DIFF
--- a/src/runtime/str.cpp
+++ b/src/runtime/str.cpp
@@ -23,6 +23,7 @@
 #include "codegen/compvars.h"
 #include "core/common.h"
 #include "core/types.h"
+#include "gc/collector.h"
 #include "runtime/gc_runtime.h"
 #include "runtime/objmodel.h"
 #include "runtime/types.h"
@@ -565,6 +566,7 @@ Box* strCount2(BoxedString* self, Box* elt) {
 
 void setupStr() {
     str_iterator_cls = new BoxedClass(object_cls, 0, sizeof(BoxedString), false);
+    gc::registerStaticRootObj(str_iterator_cls);
     str_iterator_cls->giveAttr("__name__", boxStrConstant("striterator"));
     str_iterator_cls->giveAttr("__hasnext__",
                                new BoxedFunction(boxRTFunction((void*)BoxedStringIterator::hasnext, NULL, 1, false)));


### PR DESCRIPTION
Finally found why meteor.py is crashing all the time. Can't belief how long it took me to find this...
From now one I will always blame the gc :-D
