### PR TITLE
GC: Disable collection until setup runtime finished

### DIFF
--- a/src/codegen/entry.cpp
+++ b/src/codegen/entry.cpp
@@ -42,6 +42,7 @@
 #include "core/options.h"
 #include "core/types.h"
 #include "core/util.h"
+#include "gc/collector.h"
 #include "runtime/types.h"
 
 namespace pyston {
@@ -219,6 +220,8 @@ void initCodegen() {
     initGlobalFuncs(g);
 
     setupRuntime();
+
+    gc::enableAutoCollection(true);
 
     signal(SIGFPE, &handle_sigfpe);
 

--- a/src/gc/collector.cpp
+++ b/src/gc/collector.cpp
@@ -36,6 +36,7 @@ namespace gc {
 
 // unsigned numAllocs = 0;
 unsigned bytesAllocatedSinceCollection = 0;
+bool autoCollectionEnabled = false;
 
 static TraceStack roots;
 void registerStaticRootObj(void* obj) {
@@ -163,6 +164,10 @@ void runCollection() {
 
     markPhase();
     sweepPhase();
+}
+
+void enableAutoCollection(bool enable) {
+    autoCollectionEnabled = enable;
 }
 
 } // namespace gc

--- a/src/gc/collector.h
+++ b/src/gc/collector.h
@@ -91,6 +91,7 @@ public:
 // (that should be registerStaticRootPtr)
 void registerStaticRootObj(void* root_obj);
 void runCollection();
+void enableAutoCollection(bool enable);
 }
 }
 

--- a/src/gc/heap.cpp
+++ b/src/gc/heap.cpp
@@ -35,10 +35,11 @@ namespace gc {
 // extern unsigned numAllocs;
 //#define ALLOCS_PER_COLLECTION 1000
 extern unsigned bytesAllocatedSinceCollection;
+extern bool autoCollectionEnabled;
 #define ALLOCBYTES_PER_COLLECTION 2000000
 
 void _collectIfNeeded(size_t bytes) {
-    if (bytesAllocatedSinceCollection >= ALLOCBYTES_PER_COLLECTION) {
+    if (bytesAllocatedSinceCollection >= ALLOCBYTES_PER_COLLECTION && autoCollectionEnabled) {
         bytesAllocatedSinceCollection = 0;
         runCollection();
     }


### PR DESCRIPTION
Otherwise it can happen (by lowering ALLOCBYTES_PER_COLLECTION) that a collection is made which may deallocate memory of builtins because some classes will not get referenced until setupBuiltins finished.
