### PR TITLE
Implement chained comparisons

### DIFF
--- a/test/tests/comparisons_chained.py
+++ b/test/tests/comparisons_chained.py
@@ -1,7 +1,3 @@
-# expected: fail
-# - chained comparisons
-# - "in" and "not in"
-
 def f(n):
     print "f(%d)" % n
     return n


### PR DESCRIPTION
In "remapCompare" I'm splitting up the chained comparisons into several two operand comparisons, in order to not a have to generate additional basic blocks in "evalCompare".

Type analysis just returns unknown for now.
