### PR TITLE
GC: Register None

### DIFF
--- a/src/runtime/types.cpp
+++ b/src/runtime/types.cpp
@@ -476,6 +476,7 @@ void setupRuntime() {
 
     none_cls = new BoxedClass(object_cls, 0, sizeof(Box), false);
     None = new Box(&none_flavor, none_cls);
+    gc::registerStaticRootObj(None);
 
     str_cls = new BoxedClass(object_cls, 0, sizeof(BoxedString), false);
 


### PR DESCRIPTION
Fixes one of the issues I was seeing when running "pyston_release" over our tests with ALLOCBYTES_PER_COLLECTION set to 200.
