### PR TITLE
small fix to test script

### DIFF
--- a/test/tests/sys_modules_test.py
+++ b/test/tests/sys_modules_test.py
@@ -9,6 +9,7 @@
 # PyPy seems to not do this, and setting sys.modules to something else
 # raises an exception when you try to import something else.
 # Jython seems to crash.
+# I've actually seen CPython segfault too, at least on 2.7.4.
 
 import sys
 

--- a/tools/tester.py
+++ b/tools/tester.py
@@ -73,7 +73,6 @@ def get_expected_output(fn):
     code = p.wait()
 
     r = code, out, err
-    assert code >= 0, "CPython exited with an unexpected exit code: %d" % (code,)
 
     cPickle.dump(r, open(cache_fn, 'w'))
     return r
@@ -150,7 +149,10 @@ def run_test(fn, check_stats, run_memcheck):
             stats[k.strip()] = int(v)
 
     expected_code, expected_out, expected_err = get_expected_output(fn)
-    if code != expected_code:
+    if expected_code < 0:
+        r += "    CPython gave unexpected exit code: %d" % expected_code
+        return r
+    elif code != expected_code:
         color = 31 # red
 
         if code == 0:


### PR DESCRIPTION
This test case is causing *CPython* to segfault for me on one of my machines (python 2.7.4 on a ubuntu vm), so I just want to modify the test script a bit so it will actually run all the tests instead of crashing when cpython crashes.