### PR TITLE
made __module__ a member descriptor for functions

### DIFF
--- a/src/runtime/types.h
+++ b/src/runtime/types.h
@@ -298,6 +298,9 @@ public:
     int ndefaults;
     GCdArray* defaults;
 
+    // Accessed via member descriptor
+    Box* modname; // __module__
+
     BoxedFunction(CLFunction* f);
     BoxedFunction(CLFunction* f, std::initializer_list<Box*> defaults, BoxedClosure* closure = NULL,
                   bool isGenerator = false);

--- a/test/tests/68.py
+++ b/test/tests/68.py
@@ -3,3 +3,5 @@ def f():
 
 print f.__name__
 print f.__module__
+
+print sum.__module__


### PR DESCRIPTION
make `__module__` a member descriptor for functions instead of an element in `__dict__`, and set the `__module__` to `__builtin__` for builtin functions
