### PR TITLE
basestring

### DIFF
--- a/src/runtime/builtin_modules/builtins.cpp
+++ b/src/runtime/builtin_modules/builtins.cpp
@@ -684,6 +684,7 @@ void setupBuiltins() {
     builtins_module->giveAttr("dir", new BoxedFunction(boxRTFunction((void*)dir, LIST, 1, 1, false, false), { NULL }));
     builtins_module->giveAttr("object", object_cls);
     builtins_module->giveAttr("str", str_cls);
+    builtins_module->giveAttr("basestring", basestring_cls);
     builtins_module->giveAttr("int", int_cls);
     builtins_module->giveAttr("long", long_cls);
     builtins_module->giveAttr("float", float_cls);

--- a/src/runtime/str.cpp
+++ b/src/runtime/str.cpp
@@ -353,6 +353,10 @@ extern "C" Box* strNew(BoxedClass* cls, Box* obj) {
     return str(obj);
 }
 
+extern "C" Box* basestringNew(BoxedClass* cls, Box* args, Box* kwargs) {
+    raiseExcHelper(TypeError, "The basestring type cannot be instantiated");
+}
+
 Box* _strSlice(BoxedString* self, i64 start, i64 stop, i64 step) {
     assert(self->cls == str_cls);
 
@@ -954,6 +958,13 @@ void setupStr() {
                                                    { boxStrConstant("") }));
 
     str_cls->freeze();
+
+    basestring_cls->giveAttr(
+        "__doc__", boxStrConstant("Type basestring cannot be instantiated; it is the base for str and unicode."));
+    basestring_cls->giveAttr("__new__",
+                             new BoxedFunction(boxRTFunction((void*)basestringNew, UNKNOWN, 1, 0, true, true)));
+    basestring_cls->giveAttr("__name__", boxStrConstant("basestring"));
+    basestring_cls->freeze();
 }
 
 void teardownStr() {

--- a/src/runtime/types.cpp
+++ b/src/runtime/types.cpp
@@ -300,7 +300,7 @@ extern "C" void closureGCHandler(GCVisitor* v, Box* b) {
 extern "C" {
 BoxedClass* object_cls, *type_cls, *none_cls, *bool_cls, *int_cls, *float_cls, *str_cls, *function_cls,
     *instancemethod_cls, *list_cls, *slice_cls, *module_cls, *dict_cls, *tuple_cls, *file_cls, *member_cls,
-    *closure_cls, *generator_cls, *complex_cls;
+    *closure_cls, *generator_cls, *complex_cls, *basestring_cls;
 
 
 BoxedTuple* EmptyTuple;
@@ -646,12 +646,16 @@ void setupRuntime() {
     None = new Box(none_cls);
     gc::registerPermanentRoot(None);
 
+    // You can't actually have an instance of basestring
+    basestring_cls = new BoxedClass(type_cls, object_cls, NULL, 0, sizeof(Box), false);
+
     // TODO we leak all the string data!
-    str_cls = new BoxedClass(type_cls, object_cls, NULL, 0, sizeof(BoxedString), false);
+    str_cls = new BoxedClass(type_cls, basestring_cls, NULL, 0, sizeof(BoxedString), false);
 
     // It wasn't safe to add __base__ attributes until object+type+str are set up, so do that now:
     type_cls->giveAttr("__base__", object_cls);
-    str_cls->giveAttr("__base__", object_cls);
+    basestring_cls->giveAttr("__base__", object_cls);
+    str_cls->giveAttr("__base__", basestring_cls);
     none_cls->giveAttr("__base__", object_cls);
     object_cls->giveAttr("__base__", None);
 

--- a/src/runtime/types.h
+++ b/src/runtime/types.h
@@ -77,7 +77,7 @@ Box* getSysStdout();
 extern "C" {
 extern BoxedClass* object_cls, *type_cls, *bool_cls, *int_cls, *long_cls, *float_cls, *str_cls, *function_cls,
     *none_cls, *instancemethod_cls, *list_cls, *slice_cls, *module_cls, *dict_cls, *tuple_cls, *file_cls, *xrange_cls,
-    *member_cls, *method_cls, *closure_cls, *generator_cls, *complex_cls;
+    *member_cls, *method_cls, *closure_cls, *generator_cls, *complex_cls, *basestring_cls;
 }
 extern "C" { extern Box* None, *NotImplemented, *True, *False; }
 extern "C" {

--- a/test/tests/basestring.py
+++ b/test/tests/basestring.py
@@ -1,0 +1,7 @@
+print isinstance("", basestring)
+print isinstance(3, basestring)
+
+print basestring.__doc__
+
+# should raise an exception
+t = basestring.__new__(basestring)


### PR DESCRIPTION
Add the `basestring` class. `basestring` is very simple; this is already nearly all the functionality it has. It mostly just exists as a common base for `str` and `unicode` so you can do `isinstance(foo, basestring)` and stuff.
