### PR TITLE
import os.path

### DIFF
--- a/src/codegen/runtime_hooks.cpp
+++ b/src/codegen/runtime_hooks.cpp
@@ -35,6 +35,7 @@
 #include "runtime/complex.h"
 #include "runtime/float.h"
 #include "runtime/generator.h"
+#include "runtime/import.h"
 #include "runtime/inline/boxing.h"
 #include "runtime/int.h"
 #include "runtime/long.h"

--- a/src/runtime/capi.cpp
+++ b/src/runtime/capi.cpp
@@ -22,6 +22,7 @@
 #include "codegen/compvars.h"
 #include "core/threading.h"
 #include "core/types.h"
+#include "runtime/import.h"
 #include "runtime/objmodel.h"
 #include "runtime/types.h"
 

--- a/src/runtime/import.cpp
+++ b/src/runtime/import.cpp
@@ -1,0 +1,107 @@
+// Copyright (c) 2014 Dropbox, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "runtime/import.h"
+
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/Path.h"
+
+#include "codegen/irgen/hooks.h"
+#include "codegen/parser.h"
+#include "runtime/capi.h"
+#include "runtime/objmodel.h"
+
+namespace pyston {
+
+BoxedModule* compileAndRunModule(const std::string& name, const std::string& fn, bool add_to_sys_modules) {
+    BoxedModule* module = createModule(name, fn, add_to_sys_modules);
+
+    AST_Module* ast = caching_parse(fn.c_str());
+    compileAndRunModule(ast, module);
+    return module;
+}
+
+#if LLVMREV < 210072
+#define LLVM_SYS_FS_EXISTS_CODE_OKAY(code) ((code) == 0)
+#else
+#define LLVM_SYS_FS_EXISTS_CODE_OKAY(code) (!(code))
+#endif
+
+extern "C" Box* import(const std::string* name) {
+    assert(name);
+
+    static StatCounter slowpath_import("slowpath_import");
+    slowpath_import.log();
+
+    Box* parent_module = NULL;
+    size_t periodIndex = name->rfind('.');
+    if (periodIndex != std::string::npos) {
+        std::string parent_name(*name, 0, periodIndex);
+        parent_module = import(&parent_name);
+    }
+
+    BoxedDict* sys_modules = getSysModulesDict();
+    Box* s = boxStringPtr(name);
+    if (sys_modules->d.find(s) != sys_modules->d.end())
+        return sys_modules->d[s];
+
+    BoxedList* path_list;
+    if (parent_module == NULL) {
+        path_list = getSysPath();
+        if (path_list == NULL || path_list->cls != list_cls) {
+            raiseExcHelper(RuntimeError, "sys.path must be a list of directory names");
+        }
+    } else {
+        path_list = static_cast<BoxedList*>(parent_module->getattr("__path__", NULL));
+        if (path_list == NULL || path_list->cls != list_cls) {
+            raiseExcHelper(ImportError, "No module named %s", name->c_str());
+        }
+    }
+
+    llvm::SmallString<128> joined_path;
+    for (int i = 0; i < path_list->size; i++) {
+        Box* _p = path_list->elts->elts[i];
+        if (_p->cls != str_cls)
+            continue;
+        BoxedString* p = static_cast<BoxedString*>(_p);
+
+        joined_path.clear();
+        llvm::sys::path::append(joined_path, p->s, *name + ".py");
+        std::string fn(joined_path.str());
+
+        if (VERBOSITY() >= 2)
+            printf("Searching for %s at %s...\n", name->c_str(), fn.c_str());
+
+        bool exists;
+        llvm::error_code code = llvm::sys::fs::exists(joined_path.str(), exists);
+        assert(LLVM_SYS_FS_EXISTS_CODE_OKAY(code));
+
+        if (!exists)
+            continue;
+
+        if (VERBOSITY() >= 1)
+            printf("Importing %s from %s\n", name->c_str(), fn.c_str());
+
+        // TODO duplication with jit.cpp:
+        BoxedModule* module = compileAndRunModule(*name, fn, true);
+        return module;
+    }
+
+    if (*name == "test") {
+        return importTestExtension();
+    }
+
+    raiseExcHelper(ImportError, "No module named %s", name->c_str());
+}
+}

--- a/src/runtime/import.h
+++ b/src/runtime/import.h
@@ -1,0 +1,25 @@
+// Copyright (c) 2014 Dropbox, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef PYSTON_RUNTIME_IMPORT_H
+#define PYSTON_RUNTIME_IMPORT_H
+
+#include "runtime/types.h"
+
+namespace pyston {
+
+extern "C" Box* import(const std::string* name);
+}
+
+#endif

--- a/src/runtime/inline/link_forcer.cpp
+++ b/src/runtime/inline/link_forcer.cpp
@@ -20,6 +20,7 @@
 #include "runtime/complex.h"
 #include "runtime/float.h"
 #include "runtime/generator.h"
+#include "runtime/import.h"
 #include "runtime/inline/boxing.h"
 #include "runtime/int.h"
 #include "runtime/list.h"

--- a/src/runtime/objmodel.h
+++ b/src/runtime/objmodel.h
@@ -75,7 +75,6 @@ extern "C" void setitem(Box* target, Box* slice, Box* value);
 extern "C" void delitem(Box* target, Box* slice);
 extern "C" Box* getclsattr(Box* obj, const char* attr);
 extern "C" Box* unaryop(Box* operand, int op_type);
-extern "C" Box* import(const std::string* name);
 extern "C" Box* importFrom(Box* obj, const std::string* attr);
 extern "C" void importStar(Box* from_module, BoxedModule* to_module);
 extern "C" void checkUnpackingLength(i64 expected, i64 given);

--- a/test/tests/os_path.py
+++ b/test/tests/os_path.py
@@ -1,0 +1,4 @@
+# allow-warning
+# gives some warnings about converting unicode -> str
+
+import os.path


### PR DESCRIPTION
I moved `import` to its own file, because I think that imports are going to end up being quite a beast. To progress, you really need to understand CPython's `import.c`, which is hard to read because it deals with all sorts of platform-specific code among all the "real logic".

I left `importFrom` and `importStart` in `objmodel.cpp` because they felt more like object manipulation and getattr'ing.

Anyway, the point of this commit was to import `os.path`. It turns out this is pretty simple. When you import `os.path`, you import and run `os` first. Then, `os` adds `os.path` to `sys.modules` (choosing the module dynamically in a platform-specific way). Finally, you try to import `os.path`, see that it is already in `sys.modules`, and use that.
