### PR TITLE
get operator.c to compile

### DIFF
--- a/include/Python.h
+++ b/include/Python.h
@@ -16,7 +16,6 @@
 #define PYSTON_EXTINCLUDE_PYTHON_H
 
 #include <assert.h>
-#include <ctype.h> // it looks like this gets included via unicodeobject.h in CPython
 #include <errno.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -39,6 +38,7 @@
 
 #include "pydebug.h"
 
+#include "unicodeobject.h"
 #include "intobject.h"
 #include "boolobject.h"
 #include "longobject.h"

--- a/include/pyconfig.h
+++ b/include/pyconfig.h
@@ -32,5 +32,7 @@
 #define HAVE_ASINH 1
 #define HAVE_ATANH 1
 #define HAVE_EXPM1 1
+#define Py_USING_UNICODE 1
+#define Py_UNICODE_SIZE 4
 
 #endif /*Py_PYCONFIG_H*/

--- a/include/unicodeobject.h
+++ b/include/unicodeobject.h
@@ -426,8 +426,12 @@ typedef struct {
 
 PyAPI_DATA(PyTypeObject) PyUnicode_Type;
 
+// Pyston changes: these aren't direct macros any more [they potentially could be though]
+PyAPI_FUNC(bool) PyUnicode_Check(PyObject*);
+#if 0
 #define PyUnicode_Check(op) \
                  PyType_FastSubclass(Py_TYPE(op), Py_TPFLAGS_UNICODE_SUBCLASS)
+#endif
 #define PyUnicode_CheckExact(op) (Py_TYPE(op) == &PyUnicode_Type)
 
 /* Fast access macros */

--- a/src/Makefile
+++ b/src/Makefile
@@ -268,7 +268,7 @@ SRCS := $(MAIN_SRCS) $(STDLIB_SRCS)
 STDLIB_OBJS := stdlib.bc.o stdlib.stripped.bc.o
 STDLIB_RELEASE_OBJS := stdlib.release.bc.o
 
-STDMODULE_SRCS := errnomodule.c shamodule.c sha256module.c sha512module.c _math.c mathmodule.c md5.c md5module.c _sre.c $(EXTRA_STDMODULE_SRCS)
+STDMODULE_SRCS := errnomodule.c shamodule.c sha256module.c sha512module.c _math.c mathmodule.c md5.c md5module.c _sre.c operator.c $(EXTRA_STDMODULE_SRCS)
 FROM_CPYTHON_SRCS := $(addprefix ../lib_python/2.7_Modules/,$(STDMODULE_SRCS)) $(wildcard capi/*.c)
 
 # The stdlib objects have slightly longer dependency chains,

--- a/src/runtime/builtin_modules/builtins.cpp
+++ b/src/runtime/builtin_modules/builtins.cpp
@@ -419,7 +419,7 @@ extern "C" {
 BoxedClass* BaseException, *Exception, *StandardError, *AssertionError, *AttributeError, *GeneratorExit, *TypeError,
     *NameError, *KeyError, *IndexError, *IOError, *OSError, *ZeroDivisionError, *ValueError, *UnboundLocalError,
     *RuntimeError, *ImportError, *StopIteration, *Warning, *SyntaxError, *OverflowError, *DeprecationWarning,
-    *MemoryError, *LookupError, *EnvironmentError, *ArithmeticError;
+    *MemoryError, *LookupError, *EnvironmentError, *ArithmeticError, *BufferError;
 }
 
 Box* exceptionNew1(BoxedClass* cls) {
@@ -607,6 +607,7 @@ void setupBuiltins() {
     DeprecationWarning = makeBuiltinException(Warning, "DeprecationWarning");
     /*BytesWarning =*/makeBuiltinException(Warning, "BytesWarning");
     MemoryError = makeBuiltinException(StandardError, "MemoryError");
+    BufferError = makeBuiltinException(StandardError, "BufferError");
 
     repr_obj = new BoxedFunction(boxRTFunction((void*)repr, UNKNOWN, 1));
     builtins_module->giveAttr("repr", repr_obj);
@@ -700,6 +701,7 @@ void setupBuiltins() {
     builtins_module->giveAttr("object", object_cls);
     builtins_module->giveAttr("str", str_cls);
     builtins_module->giveAttr("basestring", basestring_cls);
+    builtins_module->giveAttr("unicode", unicode_cls);
     builtins_module->giveAttr("int", int_cls);
     builtins_module->giveAttr("long", long_cls);
     builtins_module->giveAttr("float", float_cls);

--- a/src/runtime/capi.cpp
+++ b/src/runtime/capi.cpp
@@ -71,7 +71,14 @@ MAKE_CHECK(Long, long_cls)
 MAKE_CHECK(List, list_cls)
 MAKE_CHECK(Tuple, tuple_cls)
 MAKE_CHECK(Dict, dict_cls)
+
+#ifdef Py_USING_UNICODE
+MAKE_CHECK(Unicode, unicode_cls)
+#endif
+
 #undef MAKE_CHECK
+
+extern "C" { int Py_Py3kWarningFlag; }
 
 extern "C" PyObject* PyDict_New() {
     return new BoxedDict();
@@ -286,6 +293,25 @@ extern "C" void PyObject_Free(void* p) {
     ASSERT(0, "I think this is good enough but I'm not sure; should test");
 }
 
+extern "C" PyObject* _PyObject_GC_Malloc(size_t) {
+    Py_FatalError("unimplemented");
+}
+extern "C" PyObject* _PyObject_GC_New(PyTypeObject*) {
+    Py_FatalError("unimplemented");
+}
+extern "C" PyVarObject* _PyObject_GC_NewVar(PyTypeObject*, Py_ssize_t) {
+    Py_FatalError("unimplemented");
+}
+extern "C" void PyObject_GC_Track(void*) {
+    Py_FatalError("unimplemented");
+}
+extern "C" void PyObject_GC_UnTrack(void*) {
+    Py_FatalError("unimplemented");
+}
+extern "C" void PyObject_GC_Del(void*) {
+    Py_FatalError("unimplemented");
+}
+
 extern "C" PyObject* PyObject_CallObject(PyObject* obj, PyObject* args) {
     RELEASE_ASSERT(args, ""); // actually it looks like this is allowed to be NULL
     RELEASE_ASSERT(args->cls == tuple_cls, "");
@@ -334,6 +360,14 @@ extern "C" PyObject* PyObject_GetIter(PyObject*) {
     Py_FatalError("unimplemented");
 }
 
+extern "C" PyObject* PyObject_GetAttr(PyObject* o, PyObject* attr_name) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyObject_GenericGetAttr(PyObject* o, PyObject* name) {
+    Py_FatalError("unimplemented");
+}
+
 extern "C" PyObject* PyObject_GetItem(PyObject* o, PyObject* key) {
     try {
         return getitem(o, key);
@@ -342,10 +376,65 @@ extern "C" PyObject* PyObject_GetItem(PyObject* o, PyObject* key) {
     }
 }
 
+extern "C" int PyObject_SetItem(PyObject* o, PyObject* key, PyObject* v) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" int PyObject_DelItem(PyObject* o, PyObject* key) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyObject_RichCompare(PyObject* o1, PyObject* o2, int opid) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" int PyObject_IsTrue(PyObject* o) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" int PyObject_Not(PyObject* o) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyObject_Call(PyObject* callable_object, PyObject* args, PyObject* kw) {
+    Py_FatalError("unimplemented");
+}
+
 extern "C" void PyObject_ClearWeakRefs(PyObject* object) {
     Py_FatalError("unimplemented");
 }
 
+extern "C" int PyObject_GetBuffer(PyObject* exporter, Py_buffer* view, int flags) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" int _PyArg_NoKeywords(const char* funcname, PyObject* kw) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" int PySequence_Check(PyObject*) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" Py_ssize_t PySequence_Size(PyObject* o) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PySequence_Concat(PyObject* o1, PyObject* o2) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PySequence_Repeat(PyObject* o, Py_ssize_t count) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PySequence_InPlaceConcat(PyObject* o1, PyObject* o2) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PySequence_InPlaceRepeat(PyObject* o, Py_ssize_t count) {
+    Py_FatalError("unimplemented");
+}
 
 extern "C" PyObject* PySequence_GetItem(PyObject* o, Py_ssize_t i) {
     try {
@@ -363,6 +452,46 @@ extern "C" PyObject* PySequence_GetSlice(PyObject* o, Py_ssize_t i1, Py_ssize_t 
     } catch (Box* b) {
         Py_FatalError("unimplemented");
     }
+}
+
+extern "C" int PySequence_SetItem(PyObject* o, Py_ssize_t i, PyObject* v) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" int PySequence_DelItem(PyObject* o, Py_ssize_t i) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" int PySequence_SetSlice(PyObject* o, Py_ssize_t i1, Py_ssize_t i2, PyObject* v) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" int PySequence_DelSlice(PyObject* o, Py_ssize_t i1, Py_ssize_t i2) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" Py_ssize_t PySequence_Count(PyObject* o, PyObject* value) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" int PySequence_Contains(PyObject* o, PyObject* value) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" Py_ssize_t PySequence_Index(PyObject* o, PyObject* value) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PySequence_List(PyObject* o) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PySequence_Tuple(PyObject* o) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PySequence_Fast(PyObject* o, const char* m) {
+    Py_FatalError("unimplemented");
 }
 
 extern "C" PyObject* PyIter_Next(PyObject*) {
@@ -453,11 +582,163 @@ extern "C" void PyMem_Free(void* ptr) {
     gc_compat_free(ptr);
 }
 
-extern "C" PyObject* PyNumber_Divide(PyObject*, PyObject*) {
+extern "C" int PyNumber_Check(PyObject*) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyNumber_Add(PyObject*, PyObject*) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyNumber_Subtract(PyObject*, PyObject*) {
     Py_FatalError("unimplemented");
 }
 
 extern "C" PyObject* PyNumber_Multiply(PyObject*, PyObject*) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyNumber_Divide(PyObject*, PyObject*) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyNumber_FloorDivide(PyObject*, PyObject*) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyNumber_TrueDivide(PyObject*, PyObject*) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyNumber_Remainder(PyObject*, PyObject*) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyNumber_Divmod(PyObject*, PyObject*) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyNumber_Power(PyObject*, PyObject*, PyObject* o3) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyNumber_Negative(PyObject* o) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyNumber_Positive(PyObject* o) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyNumber_Absolute(PyObject* o) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyNumber_Invert(PyObject* o) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyNumber_Lshift(PyObject*, PyObject*) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyNumber_Rshift(PyObject*, PyObject*) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyNumber_And(PyObject*, PyObject*) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyNumber_Xor(PyObject*, PyObject*) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyNumber_Or(PyObject*, PyObject*) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyNumber_InPlaceAdd(PyObject*, PyObject*) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyNumber_InPlaceSubtract(PyObject*, PyObject*) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyNumber_InPlaceMultiply(PyObject*, PyObject*) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyNumber_InPlaceDivide(PyObject*, PyObject*) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyNumber_InPlaceFloorDivide(PyObject*, PyObject*) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyNumber_InPlaceTrueDivide(PyObject*, PyObject*) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyNumber_InPlaceRemainder(PyObject*, PyObject*) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyNumber_InPlacePower(PyObject*, PyObject*, PyObject* o3) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyNumber_InPlaceLshift(PyObject*, PyObject*) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyNumber_InPlaceRshift(PyObject*, PyObject*) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyNumber_InPlaceAnd(PyObject*, PyObject*) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyNumber_InPlaceXor(PyObject*, PyObject*) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyNumber_InPlaceOr(PyObject*, PyObject*) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" int PyNumber_Coerce(PyObject**, PyObject**) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" int PyNumber_CoerceEx(PyObject**, PyObject**) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyNumber_Int(PyObject* o) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyNumber_Long(PyObject* o) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyNumber_Float(PyObject* o) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyNumber_Index(PyObject* o) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyNumber_ToBase(PyObject* n, int base) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" Py_ssize_t PyNumber_AsSsize_t(PyObject* o, PyObject* exc) {
     Py_FatalError("unimplemented");
 }
 

--- a/src/runtime/dict.cpp
+++ b/src/runtime/dict.cpp
@@ -256,6 +256,30 @@ extern "C" Box* dictInit(BoxedDict* self, BoxedTuple* args, BoxedDict* kwargs) {
     return None;
 }
 
+extern "C" int PyMapping_Check(PyObject* o) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" Py_ssize_t PyMapping_Size(PyObject* o) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" int PyMapping_HasKeyString(PyObject* o, char* key) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" int PyMapping_HasKey(PyObject* o, PyObject* key) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyMapping_GetItemString(PyObject* o, char* key) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" int PyMapping_SetItemString(PyObject* o, char* key, PyObject* v) {
+    Py_FatalError("unimplemented");
+}
+
 BoxedClass* dict_iterator_cls = NULL;
 extern "C" void dictIteratorGCHandler(GCVisitor* v, Box* b) {
     boxGCHandler(v, b);

--- a/src/runtime/tuple.cpp
+++ b/src/runtime/tuple.cpp
@@ -100,6 +100,10 @@ Box* tupleGetitemSlice(BoxedTuple* self, BoxedSlice* slice) {
     return _tupleSlice(self, start, stop, step);
 }
 
+extern "C" PyObject* PyTuple_GetSlice(PyObject* p, Py_ssize_t low, Py_ssize_t high) {
+    Py_FatalError("unimplemented");
+}
+
 Box* tupleGetitem(BoxedTuple* self, Box* slice) {
     assert(self->cls == tuple_cls);
 

--- a/src/runtime/types.cpp
+++ b/src/runtime/types.cpp
@@ -41,6 +41,7 @@ extern "C" void init_sha512();
 extern "C" void init_md5();
 extern "C" void init_sre();
 extern "C" void initmath();
+extern "C" void initoperator();
 
 namespace pyston {
 
@@ -290,7 +291,7 @@ extern "C" void closureGCHandler(GCVisitor* v, Box* b) {
 extern "C" {
 BoxedClass* object_cls, *type_cls, *none_cls, *bool_cls, *int_cls, *float_cls, *str_cls, *function_cls,
     *instancemethod_cls, *list_cls, *slice_cls, *module_cls, *dict_cls, *tuple_cls, *file_cls, *member_cls,
-    *closure_cls, *generator_cls, *complex_cls, *basestring_cls;
+    *closure_cls, *generator_cls, *complex_cls, *basestring_cls, *unicode_cls;
 
 
 BoxedTuple* EmptyTuple;
@@ -662,6 +663,7 @@ void setupRuntime() {
 
     // TODO we leak all the string data!
     str_cls = new BoxedClass(type_cls, basestring_cls, NULL, 0, sizeof(BoxedString), false);
+    unicode_cls = new BoxedClass(type_cls, basestring_cls, NULL, 0, sizeof(BoxedUnicode), false);
 
     // It wasn't safe to add __base__ attributes until object+type+str are set up, so do that now:
     type_cls->giveAttr("__base__", object_cls);
@@ -821,6 +823,8 @@ void setupRuntime() {
     init_md5();
     init_sre();
     initmath();
+    // TODO enable this
+    // initoperator();
 
     setupSysEnd();
 

--- a/src/runtime/types.h
+++ b/src/runtime/types.h
@@ -77,7 +77,7 @@ Box* getSysStdout();
 extern "C" {
 extern BoxedClass* object_cls, *type_cls, *bool_cls, *int_cls, *long_cls, *float_cls, *str_cls, *function_cls,
     *none_cls, *instancemethod_cls, *list_cls, *slice_cls, *module_cls, *dict_cls, *tuple_cls, *file_cls, *xrange_cls,
-    *member_cls, *method_cls, *closure_cls, *generator_cls, *complex_cls, *basestring_cls;
+    *member_cls, *method_cls, *closure_cls, *generator_cls, *complex_cls, *basestring_cls, *unicode_cls;
 }
 extern "C" { extern Box* None, *NotImplemented, *True, *False; }
 extern "C" {
@@ -230,6 +230,10 @@ public:
     BoxedString(const char* s, size_t n) __attribute__((visibility("default"))) : Box(str_cls), s(s, n) {}
     BoxedString(const std::string&& s) __attribute__((visibility("default"))) : Box(str_cls), s(std::move(s)) {}
     BoxedString(const std::string& s) __attribute__((visibility("default"))) : Box(str_cls), s(s) {}
+};
+
+class BoxedUnicode : public Box {
+    // TODO implementation
 };
 
 class BoxedInstanceMethod : public Box {

--- a/src/runtime/unicode.cpp
+++ b/src/runtime/unicode.cpp
@@ -1,0 +1,388 @@
+// Copyright (c) 2014 Dropbox, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "runtime/types.h"
+
+namespace pyston {
+
+// capi stuff
+
+extern "C" int PyUnicode_ClearFreeList() {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyUnicode_FromUnicode(const Py_UNICODE* u, Py_ssize_t size) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyUnicode_FromStringAndSize(const char* u, Py_ssize_t size) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyUnicode_FromString(const char* u) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyUnicode_FromFormat(const char* format, ...) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyUnicode_FromFormatV(const char* format, va_list vargs) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" Py_UNICODE* PyUnicode_AsUnicode(PyObject* unicode) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" Py_ssize_t PyUnicode_GetSize(PyObject* unicode) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyUnicode_FromEncodedObject(PyObject* obj, const char* encoding, const char* errors) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyUnicode_FromObject(PyObject* obj) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyUnicode_FromWideChar(const wchar_t* w, Py_ssize_t size) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" Py_ssize_t PyUnicode_AsWideChar(PyUnicodeObject* unicode, wchar_t* w, Py_ssize_t size) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyUnicode_Decode(const char* s, Py_ssize_t size, const char* encoding, const char* errors) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyUnicode_Encode(const Py_UNICODE* s, Py_ssize_t size, const char* encoding, const char* errors) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyUnicode_AsEncodedObject(PyObject* unicode, const char* encoding, const char* errors) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyUnicode_AsEncodedString(PyObject* unicode, const char* encoding, const char* errors) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyUnicode_DecodeUTF8(const char* s, Py_ssize_t size, const char* errors) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyUnicode_DecodeUTF8Stateful(const char* s, Py_ssize_t size, const char* errors,
+                                                  Py_ssize_t* consumed) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyUnicode_EncodeUTF8(const Py_UNICODE* s, Py_ssize_t size, const char* errors) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyUnicode_AsUTF8String(PyObject* unicode) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyUnicode_DecodeUTF32(const char* s, Py_ssize_t size, const char* errors, int* byteorder) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyUnicode_DecodeUTF32Stateful(const char* s, Py_ssize_t size, const char* errors, int* byteorder,
+                                                   Py_ssize_t* consumed) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyUnicode_EncodeUTF32(const Py_UNICODE* s, Py_ssize_t size, const char* errors, int byteorder) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyUnicode_AsUTF32String(PyObject* unicode) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyUnicode_DecodeUTF16(const char* s, Py_ssize_t size, const char* errors, int* byteorder) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyUnicode_DecodeUTF16Stateful(const char* s, Py_ssize_t size, const char* errors, int* byteorder,
+                                                   Py_ssize_t* consumed) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyUnicode_EncodeUTF16(const Py_UNICODE* s, Py_ssize_t size, const char* errors, int byteorder) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyUnicode_AsUTF16String(PyObject* unicode) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyUnicode_DecodeUTF7(const char* s, Py_ssize_t size, const char* errors) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyUnicode_DecodeUTF7Stateful(const char* s, Py_ssize_t size, const char* errors,
+                                                  Py_ssize_t* consumed) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyUnicode_EncodeUTF7(const Py_UNICODE* s, Py_ssize_t size, int base64SetO, int base64WhiteSpace,
+                                          const char* errors) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyUnicode_DecodeUnicodeEscape(const char* s, Py_ssize_t size, const char* errors) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyUnicode_EncodeUnicodeEscape(const Py_UNICODE* s, Py_ssize_t size) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyUnicode_AsUnicodeEscapeString(PyObject* unicode) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyUnicode_DecodeRawUnicodeEscape(const char* s, Py_ssize_t size, const char* errors) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyUnicode_EncodeRawUnicodeEscape(const Py_UNICODE* s, Py_ssize_t size) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyUnicode_AsRawUnicodeEscapeString(PyObject* unicode) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyUnicode_DecodeLatin1(const char* s, Py_ssize_t size, const char* errors) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyUnicode_EncodeLatin1(const Py_UNICODE* s, Py_ssize_t size, const char* errors) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyUnicode_AsLatin1String(PyObject* unicode) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyUnicode_DecodeASCII(const char* s, Py_ssize_t size, const char* errors) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyUnicode_EncodeASCII(const Py_UNICODE* s, Py_ssize_t size, const char* errors) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyUnicode_AsASCIIString(PyObject* unicode) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyUnicode_DecodeCharmap(const char* s, Py_ssize_t size, PyObject* mapping, const char* errors) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyUnicode_EncodeCharmap(const Py_UNICODE* s, Py_ssize_t size, PyObject* mapping,
+                                             const char* errors) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyUnicode_AsCharmapString(PyObject* unicode, PyObject* mapping) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyUnicode_TranslateCharmap(const Py_UNICODE* s, Py_ssize_t size, PyObject* table,
+                                                const char* errors) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyUnicode_DecodeMBCS(const char* s, Py_ssize_t size, const char* errors) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyUnicode_DecodeMBCSStateful(const char* s, int size, const char* errors, int* consumed) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyUnicode_EncodeMBCS(const Py_UNICODE* s, Py_ssize_t size, const char* errors) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyUnicode_AsMBCSString(PyObject* unicode) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyUnicode_Concat(PyObject* left, PyObject* right) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyUnicode_Split(PyObject* s, PyObject* sep, Py_ssize_t maxsplit) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyUnicode_Splitlines(PyObject* s, int keepend) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyUnicode_Translate(PyObject* str, PyObject* table, const char* errors) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyUnicode_Join(PyObject* separator, PyObject* seq) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" Py_ssize_t PyUnicode_Tailmatch(PyObject* str, PyObject* substr, Py_ssize_t start, Py_ssize_t end,
+                                          int direction) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" Py_ssize_t PyUnicode_Find(PyObject* str, PyObject* substr, Py_ssize_t start, Py_ssize_t end, int direction) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" Py_ssize_t PyUnicode_Count(PyObject* str, PyObject* substr, Py_ssize_t start, Py_ssize_t end) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyUnicode_Replace(PyObject* str, PyObject* substr, PyObject* replstr, Py_ssize_t maxcount) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" int PyUnicode_Compare(PyObject* left, PyObject* right) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyUnicode_RichCompare(PyObject* left, PyObject* right, int op) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* PyUnicode_Format(PyObject* format, PyObject* args) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" int PyUnicode_Contains(PyObject* container, PyObject* element) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" PyObject* _PyUnicode_AsDefaultEncodedString(PyObject*, const char*) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" void _PyUnicode_Fini() {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" void _PyUnicode_Init() {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" int _PyUnicode_IsAlpha(Py_UNICODE ch) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" int _PyUnicode_IsDecimalDigit(Py_UNICODE ch) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" int _PyUnicode_IsDigit(Py_UNICODE ch) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" int _PyUnicode_IsLinebreak(Py_UNICODE ch) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" int _PyUnicode_IsLowercase(Py_UNICODE ch) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" int _PyUnicode_IsNumeric(Py_UNICODE ch) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" int _PyUnicode_IsTitlecase(Py_UNICODE ch) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" int _PyUnicode_IsUppercase(Py_UNICODE ch) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" int _PyUnicode_IsWhitespace(Py_UNICODE ch) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" int _PyUnicode_ToDecimalDigit(Py_UNICODE ch) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" int _PyUnicode_ToDigit(Py_UNICODE ch) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" Py_UNICODE _PyUnicode_ToLowercase(Py_UNICODE ch) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" double _PyUnicode_ToNumeric(Py_UNICODE ch) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" Py_UNICODE _PyUnicode_ToTitlecase(Py_UNICODE ch) {
+    Py_FatalError("unimplemented");
+}
+
+extern "C" Py_UNICODE _PyUnicode_ToUppercase(Py_UNICODE ch) {
+    Py_FatalError("unimplemented");
+}
+
+// From CPython, unicodeobject.c
+// Used by Py_UNICODE_ISSPACE in unicodeobject.h
+/* Fast detection of the most frequent whitespace characters */
+extern "C" const unsigned char _Py_ascii_whitespace[]
+    = { 0, 0, 0, 0, 0, 0, 0, 0,
+        /*     case 0x0009: * CHARACTER TABULATION */
+        /*     case 0x000A: * LINE FEED */
+        /*     case 0x000B: * LINE TABULATION */
+        /*     case 0x000C: * FORM FEED */
+        /*     case 0x000D: * CARRIAGE RETURN */
+        0, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        /*     case 0x001C: * FILE SEPARATOR */
+        /*     case 0x001D: * GROUP SEPARATOR */
+        /*     case 0x001E: * RECORD SEPARATOR */
+        /*     case 0x001F: * UNIT SEPARATOR */
+        0, 0, 0, 0, 1, 1, 1, 1,
+        /*     case 0x0020: * SPACE */
+        1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+
+
+void setupUnicode() {
+    unicode_cls->giveAttr("__name__", boxStrConstant("unicode"));
+
+    unicode_cls->freeze();
+#include "runtime/types.h"
+}
+
+void teardownUnicode() {
+}
+}


### PR DESCRIPTION
Haven't got `import operator` to work yet, but I did get operator.c to compile.

Seems like operator.c requires unicode to be enabled, so I brought in unicodeobject.h, made `unicode_cls`, and added `Py_USING_UNICODE` to pyconfig.h (I think it's suppose to go here?)

Then I had to define a bunch more functions to get the thing to compile, but they're just unimplemented shells right now.
