### PR TITLE
(more) correct semantics for import

### DIFF
--- a/src/analysis/type_analysis.cpp
+++ b/src/analysis/type_analysis.cpp
@@ -365,7 +365,11 @@ private:
             case AST_LangPrimitive::LANDINGPAD:
             case AST_LangPrimitive::GET_ITER:
             case AST_LangPrimitive::IMPORT_FROM:
+            case AST_LangPrimitive::IMPORT_STAR:
+            case AST_LangPrimitive::IMPORT_NAME:
                 return UNKNOWN;
+            case AST_LangPrimitive::NONE:
+                return NONE;
             default:
                 RELEASE_ASSERT(0, "%d", node->opcode);
         }

--- a/src/core/ast.cpp
+++ b/src/core/ast.cpp
@@ -1371,6 +1371,15 @@ bool PrintVisitor::visit_langprimitive(AST_LangPrimitive* node) {
         case AST_LangPrimitive::IMPORT_FROM:
             printf("IMPORT_FROM");
             break;
+        case AST_LangPrimitive::IMPORT_NAME:
+            printf("IMPORT_NAME");
+            break;
+        case AST_LangPrimitive::IMPORT_STAR:
+            printf("IMPORT_STAR");
+            break;
+        case AST_LangPrimitive::NONE:
+            printf("NONE");
+            break;
         default:
             RELEASE_ASSERT(0, "%d", node->opcode);
     }

--- a/src/core/ast.h
+++ b/src/core/ast.h
@@ -256,6 +256,9 @@ public:
 
     AST_Attribute() : AST_expr(AST_TYPE::Attribute) {}
 
+    AST_Attribute(AST_expr* value, AST_TYPE::AST_TYPE ctx_type, const std::string& attr)
+        : AST_expr(AST_TYPE::Attribute), value(value), ctx_type(ctx_type), attr(attr) {}
+
     static const AST_TYPE::AST_TYPE TYPE = AST_TYPE::Attribute;
 };
 
@@ -923,6 +926,9 @@ public:
         LOCALS,
         GET_ITER,
         IMPORT_FROM,
+        IMPORT_NAME,
+        IMPORT_STAR,
+        NONE,
     } opcode;
     std::vector<AST_expr*> args;
 

--- a/src/runtime/capi.cpp
+++ b/src/runtime/capi.cpp
@@ -627,7 +627,7 @@ extern "C" PyObject* PyImport_Import(PyObject* module_name) {
     RELEASE_ASSERT(module_name->cls == str_cls, "");
 
     try {
-        return import(&static_cast<BoxedString*>(module_name)->s);
+        return import(-1, None, &static_cast<BoxedString*>(module_name)->s);
     } catch (Box* e) {
         Py_FatalError("unimplemented");
     }

--- a/src/runtime/import.h
+++ b/src/runtime/import.h
@@ -19,7 +19,7 @@
 
 namespace pyston {
 
-extern "C" Box* import(const std::string* name);
+extern "C" Box* import(int level, Box* from_imports, const std::string* module_name);
 }
 
 #endif

--- a/src/runtime/objmodel.cpp
+++ b/src/runtime/objmodel.cpp
@@ -3674,7 +3674,7 @@ extern "C" Box* importFrom(Box* _m, const std::string* name) {
     raiseExcHelper(ImportError, "cannot import name %s", name->c_str());
 }
 
-extern "C" void importStar(Box* _from_module, BoxedModule* to_module) {
+extern "C" Box* importStar(Box* _from_module, BoxedModule* to_module) {
     assert(_from_module->cls == module_cls);
     BoxedModule* from_module = static_cast<BoxedModule*>(_from_module);
 
@@ -3710,7 +3710,7 @@ extern "C" void importStar(Box* _from_module, BoxedModule* to_module) {
 
             to_module->setattr(casted_attr_name->s, attr_value, NULL);
         }
-        return;
+        return None;
     }
 
     HCAttrs* module_attrs = from_module->getAttrsPtr();
@@ -3720,5 +3720,7 @@ extern "C" void importStar(Box* _from_module, BoxedModule* to_module) {
 
         to_module->setattr(p.first, module_attrs->attr_list->attrs[p.second], NULL);
     }
+
+    return None;
 }
 }

--- a/src/runtime/objmodel.h
+++ b/src/runtime/objmodel.h
@@ -76,7 +76,7 @@ extern "C" void delitem(Box* target, Box* slice);
 extern "C" Box* getclsattr(Box* obj, const char* attr);
 extern "C" Box* unaryop(Box* operand, int op_type);
 extern "C" Box* importFrom(Box* obj, const std::string* attr);
-extern "C" void importStar(Box* from_module, BoxedModule* to_module);
+extern "C" Box* importStar(Box* from_module, BoxedModule* to_module);
 extern "C" Box** unpackIntoArray(Box* obj, int64_t expected_size);
 extern "C" void assertNameDefined(bool b, const char* name, BoxedClass* exc_cls, bool local_var_msg);
 extern "C" void assertFail(BoxedModule* inModule, Box* msg);

--- a/test/tests/os_path.py
+++ b/test/tests/os_path.py
@@ -1,3 +1,24 @@
 # allow-warning: converting unicode literal to str
 
 import os.path
+
+print type(os)
+print type(os.path)
+
+import os.path as foo
+print type(foo)
+
+from os import path
+print type(path)
+
+from os import path as moo
+print type(moo)
+
+from os.path import abspath
+print type(abspath)
+
+from os.path import abspath as llama
+print type(llama)
+
+from os.path import *
+print type(commonprefix)


### PR DESCRIPTION
I added IMPORT_NAME and while I was at it, IMPORT_STAR, as language primitives. The implementation felt a bit clunky but I'm getting use to the code generator still. (One awkwardness is that IMPORT_STAR is an expression like the other LangPrimitives, but it needs to be wrapped in a Stmt.)

To illustrate here's a comparison of CPython bytecode to our IR: 

```
import a.b 

  2           0 LOAD_CONST               1 (-1)
              3 LOAD_CONST               0 (None)
              6 IMPORT_NAME              0 (a.b)
              9 STORE_FAST               0 (a) 

    #0x38213f0 = :IMPORT_NAME(-1, :NONE(), a.b)
    a = #0x38213f0
```

```
import a.b as foo 

  3          12 LOAD_CONST               1 (-1)
             15 LOAD_CONST               0 (None)
             18 IMPORT_NAME              0 (a.b)
             21 LOAD_ATTR                1 (b) 
             24 STORE_FAST               1 (foo)

    #0x3821500 = :IMPORT_NAME(-1, :NONE(), a.b)
    #0x3821500 = #0x3821500.b
    foo = #0x3821500
```

```
from a.b import *

  4          27 LOAD_CONST               1 (-1)
             30 LOAD_CONST               2 (('*',))
             33 IMPORT_NAME              0 (a.b)
             36 IMPORT_STAR                  

    #0x3821530 = :IMPORT_NAME(0, ("*",), a.b)
    :IMPORT_STAR(#0x3821530)
```

```
from a.b import c

  5          37 LOAD_CONST               1 (-1)
             40 LOAD_CONST               3 (('c',))
             43 IMPORT_NAME              0 (a.b)
             46 IMPORT_FROM              2 (c) 
             49 STORE_FAST               2 (c) 
             52 POP_TOP                      
             53 LOAD_CONST               0 (None)
             56 RETURN_VALUE                 

    #0x3821660 = :IMPORT_NAME(0, ("c",), a.b)
    #0x3821710 = :IMPORT_FROM(#0x3821660, c)
    c = #0x3821710
    return 
```
