### PR TITLE
disable rewriting

### DIFF
--- a/src/asm_writing/icinfo.cpp
+++ b/src/asm_writing/icinfo.cpp
@@ -67,6 +67,10 @@ ICSlotRewrite::~ICSlotRewrite() {
     free(buf);
 }
 
+void ICSlotRewrite::abort() {
+    ic->failed = true;
+}
+
 void ICSlotRewrite::commit(uint64_t decision_path, CommitHook* hook) {
     bool still_valid = true;
     for (int i = 0; i < dependencies.size(); i++) {
@@ -187,7 +191,7 @@ ICInfo::ICInfo(void* start_addr, void* continue_addr, StackInfo stack_info, int 
                assembler::GenericRegister return_register, TypeRecorder* type_recorder)
     : next_slot_to_try(0), stack_info(stack_info), num_slots(num_slots), slot_size(slot_size),
       calling_conv(calling_conv), live_outs(live_outs.begin(), live_outs.end()), return_register(return_register),
-      type_recorder(type_recorder), start_addr(start_addr), continue_addr(continue_addr) {
+      type_recorder(type_recorder), failed(false), start_addr(start_addr), continue_addr(continue_addr) {
     for (int i = 0; i < num_slots; i++) {
         slots.push_back(SlotInfo(this, i));
     }
@@ -280,5 +284,9 @@ void ICInfo::clear(ICSlotInfo* icentry) {
 
     // writer->endWithSlowpath();
     llvm::sys::Memory::InvalidateInstructionCache(start, getSlotSize());
+}
+
+bool ICInfo::shouldAttempt() {
+    return !failed;
 }
 }

--- a/src/asm_writing/icinfo.h
+++ b/src/asm_writing/icinfo.h
@@ -73,6 +73,7 @@ public:
 
     void addDependenceOn(ICInvalidator&);
     void commit(uint64_t decision_path, CommitHook* hook);
+    void abort();
 
     friend class ICInfo;
 };
@@ -100,6 +101,7 @@ private:
     const std::vector<int> live_outs;
     const assembler::GenericRegister return_register;
     TypeRecorder* const type_recorder;
+    bool failed;
 
     // for ICSlotRewrite:
     ICSlotInfo* pickEntryForRewrite(uint64_t decision_path, const char* debug_name);
@@ -119,6 +121,8 @@ public:
 
     ICSlotRewrite* startRewrite(const char* debug_name);
     void clear(ICSlotInfo* entry);
+
+    bool shouldAttempt();
 
     friend class ICSlotRewrite;
 };

--- a/src/asm_writing/rewriter.cpp
+++ b/src/asm_writing/rewriter.cpp
@@ -649,6 +649,7 @@ RewriterVarUsage Rewriter::call(bool can_call_into_python, void* func_addr, std:
 void Rewriter::abort() {
     assert(!finished);
     finished = true;
+    rewrite->abort();
 
     for (auto v : args) {
         v->decUse();
@@ -1009,7 +1010,7 @@ Rewriter* Rewriter::createRewriter(void* rtn_addr, int num_args, const char* deb
 
     static StatCounter rewriter_nopatch("rewriter_nopatch");
 
-    if (!ic) {
+    if (!ic || !ic->shouldAttempt()) {
         rewriter_nopatch.log();
         return NULL;
     }


### PR DESCRIPTION
Right now, we spend _a lot_ of time trying to do rewrites that are doomed to fail. We need to detect such cases and stop trying to rewrite them.

Trying the simplest possible thing here: if the rewrite for a particular instruction fails once, don't try to rewrite it again. We might want to tweak this, but it's certainly an improvement over what we do now.

I'll let the benchmark speak for itself:

```
# master
$ time ./pyston_release -qb ../test/tests/keyword_ics.py > ~/out

real    1m48.814s
user    1m43.098s
sys 0m5.412s

# this commit
$ time ./pyston_release -qb ../test/tests/keyword_ics.py > ~/out

real    0m41.883s
user    0m37.130s
sys 0m4.648s
```

(I chose `keyword_ics.py` because it has `# expected: statfail`. It bails on function calls with keyword arguments.)
