### PR TITLE
Some small changes to simplify the generated IR.

### DIFF
--- a/src/codegen/opt/dead_allocs.cpp
+++ b/src/codegen/opt/dead_allocs.cpp
@@ -18,6 +18,7 @@
 
 #include "llvm/ADT/Statistic.h"
 #include "llvm/Analysis/AliasAnalysis.h"
+#include "llvm/Analysis/InstructionSimplify.h"
 #include "llvm/Analysis/MemoryBuiltins.h"
 #include "llvm/Analysis/Passes.h"
 #include "llvm/Analysis/PostDominators.h"
@@ -402,11 +403,12 @@ private:
 
         std::unordered_map<BasicBlock*, Value*> seen;
         Value* new_v = getLoadValFromPrevious(li->getPointerOperand(), li->getParent(), seen, chain);
-        assert(new_v);
+        if (!new_v) {
+            new_v = llvm::UndefValue::get(li->getType());
+        }
         if (VERBOSITY("opt") >= 1)
             errs() << "Remapped to: " << *new_v << '\n';
-        li->replaceAllUsesWith(new_v);
-        li->eraseFromParent();
+        llvm::replaceAndRecursivelySimplify(li, new_v);
     }
 
 public:

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -398,7 +398,19 @@ public:
 
     llvm::iterator_range<BoxIterator> pyElements();
 
-    Box(BoxedClass* cls);
+    Box(BoxedClass* cls) : cls(cls) {
+        // if (TRACK_ALLOCATIONS) {
+        // int id = Stats::getStatId("allocated_" + *getNameOfClass(c));
+        // Stats::log(id);
+        //}
+
+        // the only way cls should be NULL is if we're creating the type_cls
+        // object itself:
+        if (cls == NULL) {
+            ASSERT(type_cls == NULL, "should pass a non-null cls here");
+        } else {
+        }
+    }
 
     HCAttrs* getAttrsPtr();
 

--- a/src/gc/heap.h
+++ b/src/gc/heap.h
@@ -108,8 +108,8 @@ private:
     Block* full_heads[NUM_BUCKETS];
     LargeObj* large_head = NULL;
 
-    GCAllocation* allocSmall(size_t rounded_size, int bucket_idx);
-    GCAllocation* allocLarge(size_t bytes);
+    GCAllocation* __attribute__((__malloc__)) allocSmall(size_t rounded_size, int bucket_idx);
+    GCAllocation* __attribute__((__malloc__)) allocLarge(size_t bytes);
 
     // DS_DEFINE_MUTEX(lock);
     DS_DEFINE_SPINLOCK(lock);
@@ -134,7 +134,7 @@ public:
 
     GCAllocation* realloc(GCAllocation* alloc, size_t bytes);
 
-    GCAllocation* alloc(size_t bytes) {
+    GCAllocation* __attribute__((__malloc__)) alloc(size_t bytes) {
         GCAllocation* rtn;
         // assert(bytes >= 16);
         if (bytes <= 16)

--- a/src/runtime/objmodel.cpp
+++ b/src/runtime/objmodel.cpp
@@ -494,21 +494,6 @@ HiddenClass* HiddenClass::delAttrToMakeHC(const std::string& attr) {
     return cur;
 }
 
-Box::Box(BoxedClass* cls) : cls(cls) {
-    // if (TRACK_ALLOCATIONS) {
-    // int id = Stats::getStatId("allocated_" + *getNameOfClass(c));
-    // Stats::log(id);
-    //}
-
-    // the only way cls should be NULL is if we're creating the type_cls
-    // object itself:
-    if (cls == NULL) {
-        ASSERT(type_cls == NULL, "should pass a non-null cls here");
-    } else {
-    }
-}
-
-
 HCAttrs* Box::getAttrsPtr() {
     assert(cls->instancesHaveAttrs());
 


### PR DESCRIPTION
- mark the alloc routines as no throw and no alias (=attribute(malloc), noexcept).
  This removes a lot of invokes in the IR and marks every alloc call as noalias. (While I felt somewhat frightened by the malloc attribute AFAIK the generated IR looks reasonable.)
- inline the trivial Box constructor
- fix dead allocs pass: we will now remove the useless list creation inside f2 in speculation_test.py

While this  currently does not show much speed change it at least makes the generated IR much easier to read. And theoretically should generate code faster by reducing the amount of exception handling tables and provide better optimization opportunities by having more functions marked as noalias.

For example this changes the IR of createList() from:

``` LLVM
  ; Function Attrs: uwtable
  define %"class.pyston::Box"* @createList() #0 {
  _ZN6pyston14PythonGCObjectnwEm.exit:
    %0 = tail call %"struct.pyston::gc::GCAllocation"* @_ZN6pyston2gc4Heap10allocSmallEmi(%"class.pyston::gc::Heap"* @_ZN6pyst     on2gc11global_heapE, i64 48, i32 2)
    %1 = getelementptr inbounds %"struct.pyston::gc::GCAllocation"* %0, i64 0, i32 0
    %2 = load i64* %1, align 4
    %3 = and i64 %2, -65536
    %4 = or i64 %3, 256
    store i64 %4, i64* %1, align 4
    %5 = getelementptr inbounds %"struct.pyston::gc::GCAllocation"* %0, i64 0, i32 1, i64 0
    %6 = bitcast i8* %5 to %"class.pyston::BoxedClass"**
    store %"class.pyston::BoxedClass"* null, %"class.pyston::BoxedClass"** %6, align 8, !tbaa !7
    %7 = bitcast i8* %5 to %"class.pyston::Box"*
    %8 = load %"class.pyston::BoxedClass"** @list_cls, align 8, !tbaa !10
    invoke void @_ZN6pyston3BoxC2EPNS_10BoxedClassE(%"class.pyston::Box"* %7, %"class.pyston::BoxedClass"* %8)
            to label %9 unwind label %11

  ; <label>:9                                       ; preds = %_ZN6pyston14PythonGCObjectnwEm.exit
    %10 = getelementptr inbounds %"struct.pyston::gc::GCAllocation"* %0, i64 0, i32 1, i64 8
    tail call void @llvm.memset.p0i8.i64(i8* %10, i8 0, i64 16, i32 8, i1 false)
    ret %"class.pyston::Box"* %7

  ; <label>:11                                      ; preds = %_ZN6pyston14PythonGCObjectnwEm.exit
    %12 = landingpad { i8*, i32 } personality i8* bitcast (i32 (...)* @__gxx_personality_v0 to i8*)
            cleanup
    tail call void @_ZN6pyston14PythonGCObjectdlEPv(i8* %5) #6
    unreachable
  }
```

 to:

``` LLVM
  ; Function Attrs: nounwind uwtable
  define noalias %"class.pyston::Box"* @createList() #0 {
  _ZN6pyston14PythonGCObjectnwEm.exit:
    %0 = tail call noalias %"struct.pyston::gc::GCAllocation"* @_ZN6pyston2gc4Heap10allocSmallEmi(%"class.pyston::gc::Heap"* @     _ZN6pyston2gc11global_heapE, i64 48, i32 2) #6
    %1 = getelementptr inbounds %"struct.pyston::gc::GCAllocation"* %0, i64 0, i32 0
    %2 = load i64* %1, align 4
    %3 = and i64 %2, -65536
    %4 = or i64 %3, 256
    store i64 %4, i64* %1, align 4
    %5 = getelementptr inbounds %"struct.pyston::gc::GCAllocation"* %0, i64 0, i32 1, i64 0
    %6 = bitcast i8* %5 to %"class.pyston::BoxedClass"**
    %7 = load %"class.pyston::BoxedClass"** @list_cls, align 8, !tbaa !7
    store %"class.pyston::BoxedClass"* %7, %"class.pyston::BoxedClass"** %6, align 8, !tbaa !9
    %8 = getelementptr inbounds %"struct.pyston::gc::GCAllocation"* %0, i64 0, i32 1, i64 8
    tail call void @llvm.memset.p0i8.i64(i8* %8, i8 0, i64 16, i32 8, i1 false) #6
    %9 = bitcast i8* %5 to %"class.pyston::Box"*
    ret %"class.pyston::Box"* %9
  }
```
