### PR TITLE
Remove linux-specifics from threading

### DIFF
--- a/src/core/stats.cpp
+++ b/src/core/stats.cpp
@@ -16,7 +16,7 @@
 
 #include <algorithm>
 
-#include "core/thread_utils.h"
+#include "core/threading.h"
 
 namespace pyston {
 
@@ -28,7 +28,7 @@ StatCounter::StatCounter(const std::string& name) : id(Stats::getStatId(name)) {
 
 StatPerThreadCounter::StatPerThreadCounter(const std::string& name) {
     char buf[80];
-    snprintf(buf, 80, "%s_t%d", name.c_str(), threading::gettid());
+    snprintf(buf, 80, "%s_t%lu", name.c_str(), threading::gettid());
     id = Stats::getStatId(buf);
 }
 

--- a/src/core/thread_utils.h
+++ b/src/core/thread_utils.h
@@ -24,8 +24,6 @@
 namespace pyston {
 namespace threading {
 
-pid_t gettid();
-
 template <typename T> class _LockedRegion {
 private:
     T* const mutex;

--- a/src/core/threading.h
+++ b/src/core/threading.h
@@ -27,6 +27,11 @@ namespace pyston {
 class Box;
 
 namespace threading {
+typedef uintptr_t pyston_tid_t;
+
+pyston_tid_t gettid();
+
+
 
 // returns a thread id (currently, the pthread_t id)
 intptr_t start_thread(void* (*start_func)(Box*, Box*, Box*), Box* arg1, Box* arg2, Box* arg3);
@@ -35,7 +40,7 @@ void registerMainThread();
 void finishMainThread();
 
 struct ThreadState {
-    pid_t tid; // useful mostly for debugging
+    pyston_tid_t tid; // useful mostly for debugging
     ucontext_t* ucontext;
 
     // start and end (start < end) of the threads main stack.
@@ -43,7 +48,7 @@ struct ThreadState {
     // in a generator, but those generators will be tracked separately.
     void* stack_start, *stack_end;
 
-    ThreadState(pid_t tid, ucontext_t* ucontext, void* stack_start, void* stack_end)
+    ThreadState(pyston_tid_t tid, ucontext_t* ucontext, void* stack_start, void* stack_end)
         : tid(tid), ucontext(ucontext), stack_start(stack_start), stack_end(stack_end) {}
 };
 // Gets a ThreadState per thread, not including the thread calling this function.


### PR DESCRIPTION
The `tgkill()` system call is linux-specific. The `gettid()` call is also not necessarily mapped directly to each thread of execution in pthreads. 