### PR TITLE
Fix typo in IOError format string

### DIFF
--- a/src/runtime/builtin_modules/builtins.cpp
+++ b/src/runtime/builtin_modules/builtins.cpp
@@ -211,7 +211,7 @@ Box* open(Box* arg1, Box* arg2) {
 
     FILE* f = fopen(fn.c_str(), mode.c_str());
     if (!f)
-        raiseExcHelper(IOError, "[Error %d] %s: '%s'", errno, strerror(errno), fn.c_str());
+        raiseExcHelper(IOError, "[Errno %d] %s: '%s'", errno, strerror(errno), fn.c_str());
 
     return new BoxedFile(f, fn, mode);
 }


### PR DESCRIPTION
This fixes an annoying typo introduced in cfe83db.
