### PR TITLE
[use_latest_valgrind] Use valgrind-3.10.0

### DIFF
--- a/docs/INSTALLING.md
+++ b/docs/INSTALLING.md
@@ -208,11 +208,11 @@ To install:
 
 ```
 cd ~/pyston_deps
-wget http://valgrind.org/downloads/valgrind-3.9.0.tar.bz2
-tar xvf valgrind-3.9.0.tar.bz2
-mkdir valgrind-3.9.0-install
-cd valgrind-3.9.0
-./configure --prefix=$HOME/pyston_deps/valgrind-3.9.0-install
+wget http://valgrind.org/downloads/valgrind-3.10.0.tar.bz2
+tar xvf valgrind-3.10.0.tar.bz2
+mkdir valgrind-3.10.0-install
+cd valgrind-3.10.0
+./configure --prefix=$HOME/pyston_deps/valgrind-3.10.0-install
 make -j4
 make install
 sudo apt-get install libc6-dbg

--- a/src/Makefile
+++ b/src/Makefile
@@ -143,8 +143,8 @@ ifeq ($(ENABLE_VALGRIND),0)
 	COMMON_CXXFLAGS += -DNVALGRIND
 	VALGRIND := false
 else
-	COMMON_CXXFLAGS += -I$(DEPS_DIR)/valgrind-3.9.0/include
-	VALGRIND := VALGRIND_LIB=$(DEPS_DIR)/valgrind-3.9.0-install/lib/valgrind $(DEPS_DIR)/valgrind-3.9.0-install/bin/valgrind
+	COMMON_CXXFLAGS += -I$(DEPS_DIR)/valgrind-3.10.0/include
+	VALGRIND := VALGRIND_LIB=$(DEPS_DIR)/valgrind-3.10.0-install/lib/valgrind $(DEPS_DIR)/valgrind-3.10.0-install/bin/valgrind
 endif
 
 COMMON_CXXFLAGS += -DGITREV=$(shell git rev-parse HEAD | head -c 12) -DLLVMREV=$(LLVM_REVISION)
@@ -772,7 +772,7 @@ memcheck$1_%: %.py pyston$1 $$(RUN_DEPS)
 $$(call make_search,memcheck$1_%)
 memcheck_gdb$1_%: %.py pyston$1 $$(RUN_DEPS)
 	set +e; $$(VALGRIND) -v -v -v -v -v --tool=memcheck --leak-check=no --track-origins=yes --vgdb=yes --vgdb-error=0 ./pyston$1 $$(ARGS) $$< & export PID=$$$$! ; \
-	$$(GDB) --ex "set confirm off" --ex "target remote | $$(DEPS_DIR)/valgrind-3.9.0-install/bin/vgdb" --ex "continue" --ex "bt" ./pyston$1; kill -9 $$$$PID
+	$$(GDB) --ex "set confirm off" --ex "target remote | $$(DEPS_DIR)/valgrind-3.10.0-install/bin/vgdb" --ex "continue" --ex "bt" ./pyston$1; kill -9 $$$$PID
 $$(call make_search,memcheck_gdb$1_%)
 memleaks$1_%: %.py pyston$1 $$(RUN_DEPS)
 	$$(VALGRIND) --tool=memcheck --leak-check=full --leak-resolution=low --show-reachable=yes ./pyston$1 $$(ARGS) $$<


### PR DESCRIPTION
The latest release of Valgrind is 3.10.0. On the other hand, Ubuntu 14.04 use glibc 2.19 which is not supported by Valgrind is 3.9.0.
