### PR TITLE
Astprint improvements

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -589,9 +589,13 @@ $(TOOLS_DIR)/astprint: $(TOOLS_DIR)/astprint.cpp $(BUILD_SYSTEM_DEPS) $(LLVM_DEP
 	$(ECHO) Linking $(TOOLS_DIR)/astprint
 	$(VERB) $(CXX) $< -o $@ $(LLVM_LIB_DEPS) $(ASTPRINT_OBJS) $(LDFLAGS) $(STDLIB_SRCS:.cpp=.o) $(CXXFLAGS_DBG)
 
-.PHONY: astprint
+.PHONY: astprint astcompare
 
 astprint: $(TOOLS_DIR)/astprint
+
+astcompare: astprint
+	$(ECHO) Running libpypa vs CPython AST result comparison test
+	$(TOOLS_DIR)/astprint_test.sh && echo "Success" || echo "Failure"
 
 ## END OF TOOLS
 

--- a/tools/astprint.cpp
+++ b/tools/astprint.cpp
@@ -20,8 +20,16 @@ int main(int argc, char const ** argv) {
 
     std::string fn = argv[1 + int(argc > 2)];
 
-    AST_Module* m = caching_parse(fn.c_str());
-    PrintVisitor* visitor = new PrintVisitor(4);
-    visitor->visit_module(m);
+    try {
+        AST_Module* m = caching_parse(fn.c_str());
+        PrintVisitor* visitor = new PrintVisitor(4);
+        visitor->visit_module(m);
+    } catch (Box* b) {
+        std::string msg = formatException(b);
+        printLastTraceback();
+        fprintf(stderr, "%s\n", msg.c_str());
+
+        return 1;
+    }
     return 0;
 }

--- a/tools/astprint_test.sh
+++ b/tools/astprint_test.sh
@@ -6,16 +6,24 @@ pushd `dirname $0` > /dev/null
 SCRIPTPATH=`pwd -P`
 popd > /dev/null
 
+pad=$(printf '%0.1s' " "{1..90})
 TESTSDIR=`realpath $SCRIPTPATH/../test/tests`
 
-pad=$(printf '%0.1s' " "{1..90})
-for test_script in `find $TESTSDIR -name "*.py"`;
+mkdir -p results
+for test_script in `find $TESTSDIR -name "*.py"`
 do
-    $SCRIPTPATH/astprint $test_script > $test_script.python
-    $SCRIPTPATH/astprint -x $test_script > $test_script.pypa
-    diff -q $test_script.python $test_script.pypa 2>&1 > /dev/null && result=`echo -e "[\033[0;32mSUCCESS\033[0m]"` || result=`echo -e "[\033[0;31mFAILED\033[0m]"` && TOTALRESULT=1
+    resultspath="./results/${test_script#$TESTSDIR}"
+    echo $resultspath | grep "encoding" && continue
+    echo $resultspath | grep "codec" && continue
+
+    $SCRIPTPATH/astprint $test_script 2>&1 > /dev/null || (echo $test_script "[SKIPPED]" && continue)
+
+    mkdir -p `dirname $resultspath`
+    touch $resultspath.python $resultspath.pypa
+    $SCRIPTPATH/astprint $test_script > $resultspath.python
+    grep "Warning: converting unicode literal to str" $resultspath.python 2>&1 > /dev/null && rm -f $resultspath.python && continue
+    $SCRIPTPATH/astprint -x $test_script > $resultspath.pypa
+    diff -q $resultspath.python $resultspath.pypa 2>&1 > /dev/null && result=`echo -e "[\033[0;32mSUCCESS\033[0m]"` && rm -f $resultspath.pypa $resultspath.python || result=`echo -e "[\033[0;31mFAILED\033[0m]"` && TOTALRESULT=1
     reltestscript=$(perl -MFile::Spec -e "print File::Spec->abs2rel(q($test_script),q($SCRIPTPATH))")
     echo "$reltestscript${pad:${#test_script}} " $result
 done
-
-exit $TOTAL_RESULT


### PR DESCRIPTION
This patch introduces some minor improvements to the astprint code, test script and the Makefile.

Calling now `$ make astcompare` will now start the comparison of the pyston AST result using the cpython and the pypa backend.
