### PR TITLE
Set pypa option for not handling future import errors

### DIFF
--- a/src/codegen/pypa-parser.cpp
+++ b/src/codegen/pypa-parser.cpp
@@ -816,6 +816,7 @@ AST_Module* pypa_parse(char const* file_path) {
     options.printerrors = false;
     options.python3allowed = false;
     options.python3only = false;
+    options.handle_future_errors = false;
     options.error_handler = pypaErrorHandler;
 
     if (pypa::parse(lexer, module, symbols, options) && module) {


### PR DESCRIPTION
Merging this requires an update of libpypa to the latest master.

In order to behave the same like the cpython backend, I had to introduce an option to suppress the '**future**' import errors. Otherwise the outputs won't be the same.
