### PR TITLE
load package/__init__.py if it exists, and set its __path__

### DIFF
--- a/test/tests/package_import.py
+++ b/test/tests/package_import.py
@@ -1,0 +1,4 @@
+import distutils
+import distutils.log
+print type(distutils)
+print type(distutils.log)


### PR DESCRIPTION
Fixes #178, but unsure about general form of patch (haven't really looked at rest of pyston code to see if it goes against convention).  Also there's a bit of redundant string allocation/manipulation going on.
