### PR TITLE
pkg-config is necessary to prevent warning message

### DIFF
--- a/docs/INSTALLING.md
+++ b/docs/INSTALLING.md
@@ -112,6 +112,7 @@ sudo apt-get install libgmp3-dev
 
 ```
 cd ~/pyston_deps
+sudo apt-get install pkg-config
 git clone git://github.com/vinzenz/pypa
 mkdir pypa-install
 cd pypa


### PR DESCRIPTION
We have COMMON_LDFLAGS += `pkg-config tinfo && pkg-config tinfo --libs || echo ""` in src/Makefile. pkg-config is necessary to prevent warning message
