### PR TITLE
Fix uninitiated read of >> 3 == 3 (REPL)

### DIFF
--- a/src/jit.cpp
+++ b/src/jit.cpp
@@ -236,15 +236,18 @@ int main(int argc, char** argv) {
                     AST_Name* r = new AST_Name();
                     r->id = "repr";
                     r->ctx_type = AST_TYPE::Load;
+                    r->lineno = 0;
                     c->func = r;
                     c->starargs = NULL;
                     c->kwargs = NULL;
                     c->args.push_back(e->value);
+                    c->lineno = 0;
 
                     AST_Print* p = new AST_Print();
                     p->dest = NULL;
                     p->nl = true;
                     p->values.push_back(c);
+                    p->lineno = 0;
                     m->body[0] = p;
                 }
 


### PR DESCRIPTION
Fix the bug of
$ ~/pyston_deps/valgrind-3.10.0-install/bin/valgrind --tool=memcheck --track-origins=yes ./pyston_release 
==14909== Memcheck, a memory error detector
==14909== Copyright (C) 2002-2013, and GNU GPL'd, by Julian Seward et al.
==14909== Using Valgrind-3.10.0 and LibVEX; rerun with -h for copyright info
==14909== Command: ./pyston_release
==14909== 
Pyston v0.2 (rev 6ee8647681e9), targeting Python 2.7.6
>> 3 == 3
==14909== Conditional jump or move depends on uninitialised value(s)
==14909==    at 0x5CA990: pyston::IRGeneratorImpl::doStmt(pyston::AST_, pyston::ExcInfo) (irgenerator.cpp:2071)
==14909==    by 0x5C9B87: pyston::IRGeneratorImpl::run(pyston::CFGBlock const_) (irgenerator.cpp:2442)
==14909==    by 0x59550D: pyston::emitBBs(pyston::IRGenState_, char const_, pyston::GuardList&, pyston::GuardList const&, pyston::TypeAnalysis_, pyston::OSREntryDescriptor const_, std::unordered_set<pyston::CFGBlock*, std::hash<pyston::CFGBlock*>, std::equal_topyston::CFGBlock*, std::allocatorpyston::CFGBlock* > const&, std::unordered_set<pyston::CFGBlock*, std::hash<pyston::CFGBlock*>, std::equal_topyston::CFGBlock*, std::allocatorpyston::CFGBlock* > const&) (irgen.cpp:717)
==14909==    by 0x58FDEB: pyston::doCompile(pyston::SourceInfo_, pyston::OSREntryDescriptor const_, pyston::EffortLevel::EffortLevel, pyston::FunctionSpecialization_, std::string) (irgen.cpp:1085)
==14909==    by 0x5C5A16: pyston::compileFunction(pyston::CLFunction_, pyston::FunctionSpecialization_, pyston::EffortLevel::EffortLevel, pyston::OSREntryDescriptor const_) (hooks.cpp:194)
==14909==    by 0x5C722E: pyston::compileAndRunModule(pyston::AST_Module_, pyston::BoxedModule_) (hooks.cpp:263)
==14909==    by 0x672C88: main (jit.cpp:252)
==14909==  Uninitialised value was created by a heap allocation
==14909==    at 0x4C2B0C5: operator new(unsigned long) (vg_replace_malloc.c:324)
==14909==    by 0x672B46: main (jit.cpp:236)
==14909== 
==14909== Conditional jump or move depends on uninitialised value(s)
==14909==    at 0x5CE033: pyston::IRGeneratorImpl::evalExpr(pyston::AST_expr_, pyston::ExcInfo) (irgenerator.cpp:1062)
==14909==    by 0x5CAB7F: doAssign (irgenerator.cpp:1458)
==14909==    by 0x5CAB7F: pyston::IRGeneratorImpl::doStmt(pyston::AST_, pyston::ExcInfo) (irgenerator.cpp:2081)
==14909==    by 0x5C9B87: pyston::IRGeneratorImpl::run(pyston::CFGBlock const_) (irgenerator.cpp:2442)
==14909==    by 0x59550D: pyston::emitBBs(pyston::IRGenState_, char const_, pyston::GuardList&, pyston::GuardList const&, pyston::TypeAnalysis_, pyston::OSREntryDescriptor const_, std::unordered_set<pyston::CFGBlock_, std::hashpyston::CFGBlock*, std::equal_topyston::CFGBlock*, std::allocatorpyston::CFGBlock* > const&, std::unordered_set<pyston::CFGBlock*, std::hash<pyston::CFGBlock*>, std::equal_topyston::CFGBlock*, std::allocatorpyston::CFGBlock* > const&) (irgen.cpp:717)
==14909==    by 0x58FDEB: pyston::doCompile(pyston::SourceInfo_, pyston::OSREntryDescriptor const_, pyston::EffortLevel::EffortLevel, pyston::FunctionSpecialization_, std::string) (irgen.cpp:1085)
==14909==    by 0x5C5A16: pyston::compileFunction(pyston::CLFunction_, pyston::FunctionSpecialization_, pyston::EffortLevel::EffortLevel, pyston::OSREntryDescriptor const_) (hooks.cpp:194)
==14909==    by 0x5C722E: pyston::compileAndRunModule(pyston::AST_Module_, pyston::BoxedModule_) (hooks.cpp:263)
==14909==    by 0x672C88: main (jit.cpp:252)
==14909==  Uninitialised value was created by a heap allocation
==14909==    at 0x4C2B0C5: operator new(unsigned long) (vg_replace_malloc.c:324)
==14909==    by 0x672B46: main (jit.cpp:236)
==14909== 
True
