### PR TITLE
Enable unicode type (WIP)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -278,7 +278,7 @@ STDLIB_OBJS := stdlib.bc.o stdlib.stripped.bc.o
 STDLIB_RELEASE_OBJS := stdlib.release.bc.o
 
 STDMODULE_SRCS := errnomodule.c shamodule.c sha256module.c sha512module.c _math.c mathmodule.c md5.c md5module.c _randommodule.c _sre.c operator.c binascii.c pwdmodule.c posixmodule.c $(EXTRA_STDMODULE_SRCS)
-STDOBJECT_SRCS := structseq.c capsule.c $(EXTRA_STDOBJECT_SRCS)
+STDOBJECT_SRCS := structseq.c capsule.c unicodeobject.c $(EXTRA_STDOBJECT_SRCS)
 STDPYTHON_SRCS := pyctype.c getargs.c $(EXTRA_STDPYTHON_SRCS)
 FROM_CPYTHON_SRCS := $(addprefix lib_python/2.7_Modules/,$(STDMODULE_SRCS)) $(addprefix lib_python/2.7_Objects/,$(STDOBJECT_SRCS)) $(addprefix lib_python/2.7_Python/,$(STDPYTHON_SRCS))
 

--- a/include/ucnhash.h
+++ b/include/ucnhash.h
@@ -1,0 +1,33 @@
+/* Unicode name database interface */
+
+#ifndef Py_UCNHASH_H
+#define Py_UCNHASH_H
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* revised ucnhash CAPI interface (exported through a "wrapper") */
+
+#define PyUnicodeData_CAPSULE_NAME "unicodedata.ucnhash_CAPI"
+
+typedef struct {
+
+    /* Size of this struct */
+    int size;
+
+    /* Get name for a given character code.  Returns non-zero if
+       success, zero if not.  Does not set Python exceptions. 
+       If self is NULL, data come from the default version of the database.
+       If it is not NULL, it should be a unicodedata.ucd_X_Y_Z object */
+    int (*getname)(PyObject *self, Py_UCS4 code, char* buffer, int buflen);
+
+    /* Get character code for a given name.  Same error handling
+       as for getname. */
+    int (*getcode)(PyObject *self, const char* name, int namelen, Py_UCS4* code);
+
+} _PyUnicode_Name_CAPI;
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* !Py_UCNHASH_H */

--- a/lib_python/2.7_Objects/unicodeobject.c
+++ b/lib_python/2.7_Objects/unicodeobject.c
@@ -1,0 +1,177 @@
+// Stripped-down version of CPython's Objects/unicodeobject.c,
+// containing only unicodeescape_string. To be replaced by the real
+// thing, once more unicode functionality has been exposed.
+
+#define PY_SSIZE_T_CLEAN
+#include "Python.h"
+
+#include "unicodeobject.h"
+#include "ucnhash.h"
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Pyston change: migrated from CPython's Objects/bytearray.c
+/* find and count characters and substrings */
+
+#define findchar(target, target_len, c)                         \
+  ((char *)memchr((const void *)(target), c, target_len))
+
+
+//static
+PyObject *unicodeescape_string(const Py_UNICODE *s,
+                               Py_ssize_t size,
+                               int quotes)
+{
+    PyObject *repr;
+    char *p;
+
+    static const char *hexdigit = "0123456789abcdef";
+#ifdef Py_UNICODE_WIDE
+    const Py_ssize_t expandsize = 10;
+#else
+    const Py_ssize_t expandsize = 6;
+#endif
+
+    /* XXX(nnorwitz): rather than over-allocating, it would be
+       better to choose a different scheme.  Perhaps scan the
+       first N-chars of the string and allocate based on that size.
+    */
+    /* Initial allocation is based on the longest-possible unichr
+       escape.
+
+       In wide (UTF-32) builds '\U00xxxxxx' is 10 chars per source
+       unichr, so in this case it's the longest unichr escape. In
+       narrow (UTF-16) builds this is five chars per source unichr
+       since there are two unichrs in the surrogate pair, so in narrow
+       (UTF-16) builds it's not the longest unichr escape.
+
+       In wide or narrow builds '\uxxxx' is 6 chars per source unichr,
+       so in the narrow (UTF-16) build case it's the longest unichr
+       escape.
+    */
+
+    if (size > (PY_SSIZE_T_MAX - 2 - 1) / expandsize)
+        return PyErr_NoMemory();
+
+    repr = PyString_FromStringAndSize(NULL,
+                                      2
+                                      + expandsize*size
+                                      + 1);
+    if (repr == NULL)
+        return NULL;
+
+    p = PyString_AS_STRING(repr);
+
+    if (quotes) {
+        *p++ = 'u';
+        *p++ = (findchar(s, size, '\'') &&
+                !findchar(s, size, '"')) ? '"' : '\'';
+    }
+    while (size-- > 0) {
+        Py_UNICODE ch = *s++;
+
+        /* Escape quotes and backslashes */
+        if ((quotes &&
+             ch == (Py_UNICODE) PyString_AS_STRING(repr)[1]) || ch == '\\') {
+            *p++ = '\\';
+            *p++ = (char) ch;
+            continue;
+        }
+
+#ifdef Py_UNICODE_WIDE
+        /* Map 21-bit characters to '\U00xxxxxx' */
+        else if (ch >= 0x10000) {
+            *p++ = '\\';
+            *p++ = 'U';
+            *p++ = hexdigit[(ch >> 28) & 0x0000000F];
+            *p++ = hexdigit[(ch >> 24) & 0x0000000F];
+            *p++ = hexdigit[(ch >> 20) & 0x0000000F];
+            *p++ = hexdigit[(ch >> 16) & 0x0000000F];
+            *p++ = hexdigit[(ch >> 12) & 0x0000000F];
+            *p++ = hexdigit[(ch >> 8) & 0x0000000F];
+            *p++ = hexdigit[(ch >> 4) & 0x0000000F];
+            *p++ = hexdigit[ch & 0x0000000F];
+            continue;
+        }
+#else
+        /* Map UTF-16 surrogate pairs to '\U00xxxxxx' */
+        else if (ch >= 0xD800 && ch < 0xDC00) {
+            Py_UNICODE ch2;
+            Py_UCS4 ucs;
+
+            ch2 = *s++;
+            size--;
+            if (ch2 >= 0xDC00 && ch2 <= 0xDFFF) {
+                ucs = (((ch & 0x03FF) << 10) | (ch2 & 0x03FF)) + 0x00010000;
+                *p++ = '\\';
+                *p++ = 'U';
+                *p++ = hexdigit[(ucs >> 28) & 0x0000000F];
+                *p++ = hexdigit[(ucs >> 24) & 0x0000000F];
+                *p++ = hexdigit[(ucs >> 20) & 0x0000000F];
+                *p++ = hexdigit[(ucs >> 16) & 0x0000000F];
+                *p++ = hexdigit[(ucs >> 12) & 0x0000000F];
+                *p++ = hexdigit[(ucs >> 8) & 0x0000000F];
+                *p++ = hexdigit[(ucs >> 4) & 0x0000000F];
+                *p++ = hexdigit[ucs & 0x0000000F];
+                continue;
+            }
+            /* Fall through: isolated surrogates are copied as-is */
+            s--;
+            size++;
+        }
+#endif
+
+        /* Map 16-bit characters to '\uxxxx' */
+        if (ch >= 256) {
+            *p++ = '\\';
+            *p++ = 'u';
+            *p++ = hexdigit[(ch >> 12) & 0x000F];
+            *p++ = hexdigit[(ch >> 8) & 0x000F];
+            *p++ = hexdigit[(ch >> 4) & 0x000F];
+            *p++ = hexdigit[ch & 0x000F];
+        }
+
+        /* Map special whitespace to '\t', \n', '\r' */
+        else if (ch == '\t') {
+            *p++ = '\\';
+            *p++ = 't';
+        }
+        else if (ch == '\n') {
+            *p++ = '\\';
+            *p++ = 'n';
+        }
+        else if (ch == '\r') {
+            *p++ = '\\';
+            *p++ = 'r';
+        }
+
+        /* Map non-printable US ASCII to '\xhh' */
+        else if (ch < ' ' || ch >= 0x7F) {
+            *p++ = '\\';
+            *p++ = 'x';
+            *p++ = hexdigit[(ch >> 4) & 0x000F];
+            *p++ = hexdigit[ch & 0x000F];
+        }
+
+        /* Copy everything else as-is */
+        else
+            *p++ = (char) ch;
+    }
+    if (quotes)
+        *p++ = PyString_AS_STRING(repr)[1];
+
+    *p = '\0';
+    // Pyston change: _PyString_Resize is currently not implemented.
+    /* if (_PyString_Resize(&repr, p - PyString_AS_STRING(repr))) */
+    /*     return NULL; */
+    return repr;
+}
+
+
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/codegen/ast_interpreter.cpp
+++ b/src/codegen/ast_interpreter.cpp
@@ -984,7 +984,10 @@ Value ASTInterpreter::visit_set(AST_Set* node) {
 }
 
 Value ASTInterpreter::visit_str(AST_Str* node) {
-    return boxString(node->s);
+    if (node->str_type == AST_Str::STR)
+        return boxString(node->s);
+    else
+        return boxUnicode(node->s);
 }
 
 Value ASTInterpreter::visit_name(AST_Name* node) {

--- a/src/codegen/compvars.cpp
+++ b/src/codegen/compvars.cpp
@@ -1555,7 +1555,7 @@ public:
     }
 };
 std::unordered_map<BoxedClass*, NormalObjectType*> NormalObjectType::made;
-ConcreteCompilerType* STR, *BOXED_INT, *BOXED_FLOAT, *BOXED_BOOL, *NONE;
+ConcreteCompilerType* STR, *UNICODE, *BOXED_INT, *BOXED_FLOAT, *BOXED_BOOL, *NONE;
 
 class ClosureType : public ConcreteCompilerType {
 public:

--- a/src/codegen/parse_ast.py
+++ b/src/codegen/parse_ast.py
@@ -154,7 +154,7 @@ def convert(n, f):
         elif isinstance(v, str):
             _print_str(v, f)
         elif isinstance(v, unicode):
-            _print_str(v.encode("ascii"), f)
+            _print_str(v.encode("utf-8"), f)
         elif isinstance(v, bool):
             f.write(struct.pack("B", v))
         elif isinstance(v, int):

--- a/src/codegen/parse_ast.py
+++ b/src/codegen/parse_ast.py
@@ -1,4 +1,5 @@
 import _ast
+import codecs
 import struct
 import sys
 from types import NoneType
@@ -154,7 +155,7 @@ def convert(n, f):
         elif isinstance(v, str):
             _print_str(v, f)
         elif isinstance(v, unicode):
-            _print_str(v.encode("utf-8"), f)
+            _print_str(v.encode("utf-32"), f)  # "Wide" build of Python 2.7
         elif isinstance(v, bool):
             f.write(struct.pack("B", v))
         elif isinstance(v, int):
@@ -177,7 +178,7 @@ if __name__ == "__main__":
     import time
     start = time.time()
     fn = sys.argv[1]
-    s = open(fn).read()
+    s = codecs.open(fn, 'r', 'utf-8').read()
     m = compile(s, fn, "exec", _ast.PyCF_ONLY_AST)
 
     convert(m, sys.stdout)

--- a/src/codegen/parser.cpp
+++ b/src/codegen/parser.cpp
@@ -637,8 +637,8 @@ AST_Str* read_str(BufferedReader* reader) {
         rtn->s = readString(reader);
     } else if (rtn->str_type == AST_Str::UNICODE) {
         // Don't really support unicode for now...
-        printf("Warning: converting unicode literal to str\n");
-        rtn->str_type = AST_Str::STR;
+        // printf("Warning: converting unicode literal to str\n");
+        // rtn->str_type = AST_Str::STR;
         rtn->s = readString(reader);
     } else {
         RELEASE_ASSERT(0, "%d", rtn->str_type);

--- a/src/core/ast.h
+++ b/src/core/ast.h
@@ -24,6 +24,7 @@
 #include "llvm/ADT/StringRef.h"
 
 #include "core/common.h"
+#include "core/types.h"
 
 namespace pyston {
 

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -108,7 +108,8 @@ typedef ValuedCompilerType<llvm::Value*> ConcreteCompilerType;
 ConcreteCompilerType* typeFromClass(BoxedClass*);
 
 extern ConcreteCompilerType* INT, *BOXED_INT, *LONG, *FLOAT, *BOXED_FLOAT, *VOID, *UNKNOWN, *BOOL, *STR, *NONE, *LIST,
-    *SLICE, *MODULE, *DICT, *BOOL, *BOXED_BOOL, *BOXED_TUPLE, *SET, *FROZENSET, *CLOSURE, *GENERATOR, *BOXED_COMPLEX;
+    *SLICE, *MODULE, *DICT, *BOOL, *BOXED_BOOL, *BOXED_TUPLE, *SET, *FROZENSET, *CLOSURE, *GENERATOR, *BOXED_COMPLEX,
+    *UNICODE;
 extern CompilerType* UNDEF;
 
 class CompilerVariable;

--- a/src/runtime/inline/boxing.cpp
+++ b/src/runtime/inline/boxing.cpp
@@ -47,6 +47,14 @@ Box* boxString(std::string&& s) {
     return new BoxedString(std::move(s));
 }
 
+Box* boxUnicode(const std::string& s) {
+    return new BoxedUnicode(s);
+}
+
+Box* boxUnicode(std::string&& s) {
+    return new BoxedUnicode(std::move(s));
+}
+
 extern "C" double unboxFloat(Box* b) {
     ASSERT(b->cls == float_cls, "%s", getTypeName(b)->c_str());
     BoxedFloat* f = (BoxedFloat*)b;

--- a/src/runtime/types.cpp
+++ b/src/runtime/types.cpp
@@ -841,6 +841,7 @@ void setupRuntime() {
     attrwrapper_cls = new BoxedHeapClass(type_cls, object_cls, &AttrWrapper::gcHandler, 0, sizeof(AttrWrapper), false);
 
     STR = typeFromClass(str_cls);
+    UNICODE = typeFromClass(unicode_cls);
     BOXED_INT = typeFromClass(int_cls);
     BOXED_FLOAT = typeFromClass(float_cls);
     BOXED_BOOL = typeFromClass(bool_cls);

--- a/src/runtime/types.h
+++ b/src/runtime/types.h
@@ -328,13 +328,15 @@ public:
     BoxedString(const std::string& s) __attribute__((visibility("default"))) : Box(str_cls), s(s) {}
 };
 
+typedef std::basic_string<Py_UNICODE> unicode_string;
+
 class BoxedUnicode : public Box {
 public:
-    std::string s;
+    unicode_string s;
 
-    BoxedUnicode(const char* s, size_t n) __attribute__((visibility("default"))) : Box(unicode_cls), s(s, n) {}
-    BoxedUnicode(const std::string&& s) __attribute__((visibility("default"))) : Box(unicode_cls), s(std::move(s)) {}
-    BoxedUnicode(const std::string& s) __attribute__((visibility("default"))) : Box(unicode_cls), s(s) {}
+    BoxedUnicode(const Py_UNICODE* s, size_t n) __attribute__((visibility("default"))) : Box(unicode_cls), s(s, n) {}
+    BoxedUnicode(const unicode_string&& s) __attribute__((visibility("default"))) : Box(unicode_cls), s(std::move(s)) {}
+    BoxedUnicode(const unicode_string& s) __attribute__((visibility("default"))) : Box(unicode_cls), s(s) {}
 };
 
 class BoxedInstanceMethod : public Box {

--- a/src/runtime/types.h
+++ b/src/runtime/types.h
@@ -106,6 +106,9 @@ Box* boxString(std::string&& s);
 extern "C" BoxedString* boxStrConstant(const char* chars);
 extern "C" BoxedString* boxStrConstantSize(const char* chars, size_t n);
 
+Box* boxUnicode(const std::string& s);
+Box* boxUnicode(std::string&& s);
+
 // creates an uninitialized string of length n; useful for directly constructing into the string and avoiding copies:
 BoxedString* createUninitializedString(ssize_t n);
 // Gets a writeable pointer to the contents of a string.
@@ -326,7 +329,12 @@ public:
 };
 
 class BoxedUnicode : public Box {
-    // TODO implementation
+public:
+    std::string s;
+
+    BoxedUnicode(const char* s, size_t n) __attribute__((visibility("default"))) : Box(unicode_cls), s(s, n) {}
+    BoxedUnicode(const std::string&& s) __attribute__((visibility("default"))) : Box(unicode_cls), s(std::move(s)) {}
+    BoxedUnicode(const std::string& s) __attribute__((visibility("default"))) : Box(unicode_cls), s(s) {}
 };
 
 class BoxedInstanceMethod : public Box {

--- a/test/tests/unicode.py
+++ b/test/tests/unicode.py
@@ -1,2 +1,21 @@
+# Unicode type
 x = u'abc'
 print type(x)
+# print isinstance(x, basestring)
+
+# Unicode representation (BMP).
+# XXX In order to make this test pass, a encoding needs to be specified, but we don't support that yet.
+
+# unicode_strings = [
+#     u'κόσμε',
+#     u'Вселена',
+#     u'우주',
+#     u'宇宙'
+# ]
+# for u in unicode_strings:
+#     print repr(u)
+
+# Single characters outside of the BMP.
+# XXX unichr() not implemented yet.
+# for ch in range(0x10000, 0x10ffff, 0xffab):
+#     print unichr(ch)

--- a/test/tests/unicode.py
+++ b/test/tests/unicode.py
@@ -1,0 +1,2 @@
+x = u'abc'
+print type(x)


### PR DESCRIPTION
This is a very preliminary PR to provide some support for unicode (#130), opened to solicit some feedback. Basically, this PR tries to do the bare minimum needed to get the unicode type working, together with its repr. On the command line, things like the following snippet work:
```
Pyston v0.2 (rev 42c3ecea3443), targeting Python 2.7.6
>> x = u'소주 한잔'
>> x
u'\uc18c\uc8fc \ud55c\uc794'
```
Since Pyston seems to be configured as a wide unicode build, the code just does some tricks to get unicode strings into UTF-32, and then wraps those into a `Unicode` instance. Calling into the existing CPython unicode implementation is then just a matter of passing in the underlying `const PyUnicode *` to the appropriate routine.

Does this sound like a viable approach? Should we instead try to support the Python 3 unicode implementation?

Things that I haven't addressed yet:
- [ ] Parsing via Pypa;
- [ ] When creating a unicode instance, `boxUnicode` iterates over the parsed string to convert it into a wide string. This can easily be avoided by reading in a wide string in the first place.
- [ ] There's no support for supplying an encoding string for a source file (and `compile` in parse_ast.py will complain if you do provide one), so that we can't run meaningful comparisons with Python.

I'm also not sure as to how much of `Objects/unicodeobject.c` I should try to include. I could definitely add that file in its entirety (surrounded by `#if 0 ... #endif`) but would rather do that as a separate PR, to avoid drowning out changes to the Pyston source tree.