### PR TITLE
Mark enumerate_cls as safe for type call rewriting

### DIFF
--- a/src/runtime/objmodel.cpp
+++ b/src/runtime/objmodel.cpp
@@ -3617,7 +3617,7 @@ Box* typeCallInternal(BoxedFunction* f, CallRewriteArgs* rewrite_args, ArgPassSp
 
         allowable_news.push_back(object_new);
 
-        for (BoxedClass* allowed_cls : { xrange_cls }) {
+        for (BoxedClass* allowed_cls : { enumerate_cls, xrange_cls }) {
             auto new_obj = typeLookup(allowed_cls, _new_str, NULL);
             gc::registerPermanentRoot(new_obj);
             allowable_news.push_back(new_obj);

--- a/src/runtime/types.h
+++ b/src/runtime/types.h
@@ -78,9 +78,9 @@ extern "C" Box* getSysStdout();
 
 extern "C" {
 extern BoxedClass* object_cls, *type_cls, *bool_cls, *int_cls, *long_cls, *float_cls, *str_cls, *function_cls,
-    *none_cls, *instancemethod_cls, *list_cls, *slice_cls, *module_cls, *dict_cls, *tuple_cls, *file_cls, *xrange_cls,
-    *member_cls, *method_cls, *closure_cls, *generator_cls, *complex_cls, *basestring_cls, *unicode_cls, *property_cls,
-    *staticmethod_cls, *classmethod_cls, *attrwrapper_cls;
+    *none_cls, *instancemethod_cls, *list_cls, *slice_cls, *module_cls, *dict_cls, *tuple_cls, *file_cls,
+    *enumerate_cls, *xrange_cls, *member_cls, *method_cls, *closure_cls, *generator_cls, *complex_cls, *basestring_cls,
+    *unicode_cls, *property_cls, *staticmethod_cls, *classmethod_cls, *attrwrapper_cls;
 }
 extern "C" {
 extern Box* None, *NotImplemented, *True, *False;


### PR DESCRIPTION
Reduces slowpath_typecall from 40000 to 30 for spectral_norm