### PR TITLE
intern BoxedFloats for -2, -1, 0, 1, 2, inf, -inf, nan

### DIFF
--- a/src/runtime/float.cpp
+++ b/src/runtime/float.cpp
@@ -23,6 +23,16 @@
 
 namespace pyston {
 
+BoxedFloat* floatZero;
+BoxedFloat* floatNegZero;
+BoxedFloat* floatOne;
+BoxedFloat* floatNegOne;
+BoxedFloat* floatTwo;
+BoxedFloat* floatNegTwo;
+BoxedFloat* floatNaN;
+BoxedFloat* floatInf;
+BoxedFloat* floatNegInf;
+
 extern "C" PyObject* PyFloat_FromDouble(double d) noexcept {
     return boxFloat(d);
 }
@@ -548,9 +558,9 @@ BoxedFloat* _floatNew(Box* a) {
     if (a->cls == float_cls) {
         return static_cast<BoxedFloat*>(a);
     } else if (isSubclass(a->cls, float_cls)) {
-        return new BoxedFloat(static_cast<BoxedFloat*>(a)->d);
+        return static_cast<BoxedFloat*>(boxFloat((static_cast<BoxedFloat*>(a)->d)));
     } else if (isSubclass(a->cls, int_cls)) {
-        return new BoxedFloat(static_cast<BoxedInt*>(a)->n);
+        return static_cast<BoxedFloat*>(boxFloat(static_cast<BoxedInt*>(a)->n));
     } else if (a->cls == str_cls) {
         const std::string& s = static_cast<BoxedString*>(a)->s;
         if (s == "nan")
@@ -562,7 +572,7 @@ BoxedFloat* _floatNew(Box* a) {
         if (s == "-inf")
             return new BoxedFloat(-INFINITY);
 
-        return new BoxedFloat(strtod(s.c_str(), NULL));
+        return static_cast<BoxedFloat*>(boxFloat(strtod(s.c_str(), NULL)));
     } else {
         static const std::string float_str("__float__");
         Box* r = callattr(a, &float_str, CallattrFlags({.cls_only = true, .null_on_nonexistent = true }),
@@ -674,6 +684,33 @@ void setupFloat() {
     float_cls->giveAttr("__str__", new BoxedFunction(boxRTFunction((void*)floatStr, STR, 1)));
     float_cls->giveAttr("__repr__", new BoxedFunction(boxRTFunction((void*)floatRepr, STR, 1)));
     float_cls->freeze();
+
+    floatZero = new BoxedFloat(0.0);
+    gc::registerPermanentRoot(floatZero);
+
+    floatNegZero = new BoxedFloat(-0.0);
+    gc::registerPermanentRoot(floatNegZero);
+
+    floatOne = new BoxedFloat(1.0);
+    gc::registerPermanentRoot(floatOne);
+
+    floatNegOne = new BoxedFloat(-1.0);
+    gc::registerPermanentRoot(floatNegOne);
+
+    floatTwo = new BoxedFloat(2.0);
+    gc::registerPermanentRoot(floatTwo);
+
+    floatNegTwo = new BoxedFloat(-2.0);
+    gc::registerPermanentRoot(floatNegTwo);
+
+    floatNaN = new BoxedFloat(NAN);
+    gc::registerPermanentRoot(floatNaN);
+
+    floatInf = new BoxedFloat(INFINITY);
+    gc::registerPermanentRoot(floatInf);
+
+    floatNegInf = new BoxedFloat(-INFINITY);
+    gc::registerPermanentRoot(floatNegInf);
 }
 
 void teardownFloat() {

--- a/src/runtime/float.h
+++ b/src/runtime/float.h
@@ -25,6 +25,16 @@ extern "C" double pow_float_float(double lhs, double rhs);
 class BoxedFloat;
 bool floatNonzeroUnboxed(BoxedFloat* self);
 
+extern BoxedFloat* floatZero;
+extern BoxedFloat* floatNegZero;
+extern BoxedFloat* floatOne;
+extern BoxedFloat* floatNegOne;
+extern BoxedFloat* floatTwo;
+extern BoxedFloat* floatNegTwo;
+extern BoxedFloat* floatNaN;
+extern BoxedFloat* floatInf;
+extern BoxedFloat* floatNegInf;
+
 std::string floatFmt(double x, int precision, char code);
 }
 

--- a/src/runtime/inline/boxing.cpp
+++ b/src/runtime/inline/boxing.cpp
@@ -15,6 +15,7 @@
 #include "runtime/inline/boxing.h"
 
 #include "runtime/int.h"
+#include "runtime/float.h"
 #include "runtime/objmodel.h"
 #include "runtime/types.h"
 
@@ -45,6 +46,26 @@ Box* boxString(const std::string& s) {
 }
 Box* boxString(std::string&& s) {
     return new BoxedString(std::move(s));
+}
+
+extern "C" Box* boxFloat(double d) {
+    if (d == 0.0)
+        return floatZero;
+    if (d == -0.0)
+        return floatNegZero;
+    if (d == 1.0)
+        return floatOne;
+    if (d == -1.0)
+        return floatNegOne;
+    if (isnan(d))
+      return floatNaN;
+    if (isinf(d)) {
+      if (d > 0)
+	return floatInf;
+      return floatNegInf;
+    }
+
+    return new BoxedFloat(d);
 }
 
 extern "C" double unboxFloat(Box* b) {

--- a/src/runtime/inline/boxing.h
+++ b/src/runtime/inline/boxing.h
@@ -21,11 +21,6 @@
 
 namespace pyston {
 
-extern "C" inline Box* boxFloat(double d) __attribute__((visibility("default")));
-extern "C" inline Box* boxFloat(double d) {
-    return new BoxedFloat(d);
-}
-
 extern "C" inline Box* boxComplex(double r, double i) __attribute__((visibility("default")));
 extern "C" inline Box* boxComplex(double r, double i) {
     return new BoxedComplex(r, i);


### PR DESCRIPTION
removes >1mil allocations from raytrace, reducing the number of collections from 279 to 268, reducing total gc_collection_us by ~7%.