### PR TITLE
More gc perf changes

### DIFF
--- a/src/core/types.h
+++ b/src/core/types.h
@@ -349,17 +349,17 @@ namespace gc {
 enum class GCKind : uint8_t {
     PYTHON = 1,
     CONSERVATIVE = 2,
-    UNTRACKED = 3,
+    PRECISE = 3,
+    UNTRACKED = 4,
+    HIDDEN_CLASS = 5,
 };
 
 extern "C" void* gc_alloc(size_t nbytes, GCKind kind);
 }
 
-class ConservativeGCObject {
+template <gc::GCKind gc_kind> class GCAllocated {
 public:
-    void* operator new(size_t size) __attribute__((visibility("default"))) {
-        return gc_alloc(size, gc::GCKind::CONSERVATIVE);
-    }
+    void* operator new(size_t size) __attribute__((visibility("default"))) { return gc_alloc(size, gc_kind); }
     void operator delete(void* ptr) __attribute__((visibility("default"))) { abort(); }
 };
 
@@ -372,7 +372,7 @@ struct DelattrRewriteArgs;
 
 struct HCAttrs {
 public:
-    struct AttrList : ConservativeGCObject {
+    struct AttrList : public GCAllocated<gc::GCKind::PRECISE> {
         Box* attrs[0];
     };
 

--- a/src/gc/collector.cpp
+++ b/src/gc/collector.cpp
@@ -256,6 +256,9 @@ static void markPhase() {
         } else if (kind_id == GCKind::CONSERVATIVE) {
             uint32_t bytes = al->kind_data;
             visitor.visitPotentialRange((void**)p, (void**)((char*)p + bytes));
+        } else if (kind_id == GCKind::PRECISE) {
+            uint32_t bytes = al->kind_data;
+            visitor.visitRange((void**)p, (void**)((char*)p + bytes));
         } else if (kind_id == GCKind::PYTHON) {
             Box* b = reinterpret_cast<Box*>(p);
             BoxedClass* cls = b->cls;
@@ -268,6 +271,9 @@ static void markPhase() {
                 ASSERT(cls->gc_visit, "%s", getTypeName(b)->c_str());
                 cls->gc_visit(&visitor, b);
             }
+        } else if (kind_id == GCKind::HIDDEN_CLASS) {
+            HiddenClass* hcls = reinterpret_cast<HiddenClass*>(p);
+            hcls->gc_visit(&visitor);
         } else {
             RELEASE_ASSERT(0, "Unhandled kind: %d", (int)kind_id);
         }

--- a/src/gc/heap.cpp
+++ b/src/gc/heap.cpp
@@ -130,6 +130,9 @@ static Block* alloc_block(uint64_t size, Block** prev) {
     Block* rtn = (Block*)small_arena.doMmap(sizeof(Block));
     assert(rtn);
     rtn->size = size;
+    rtn->num_obj = BLOCK_SIZE / size;
+    rtn->min_obj_index = (BLOCK_HEADER_SIZE + size - 1) / size;
+    rtn->atoms_per_obj = size / ATOM_SIZE;
     rtn->prev = prev;
     rtn->next = NULL;
 
@@ -371,7 +374,7 @@ GCAllocation* Heap::getAllocationFromInteriorPointer(void* ptr) {
     if (obj_idx < b->minObjIndex() || obj_idx >= b->numObjects())
         return NULL;
 
-    int atom_idx = obj_idx * (size / ATOM_SIZE);
+    int atom_idx = obj_idx * b->atomsPerObj();
 
     if (b->isfree.isSet(atom_idx))
         return NULL;


### PR DESCRIPTION
with these two changes (on top of the TraceStack change already merged), I see this with average gc_collections_us timings:

before == master before TraceStack was merged.

raytrace:
  before: 2126265.8
  after: 1125626.9
  reduction: 47%

fannkuch:
  before: 2456650.1
  after: 464613.6
  reduction: 81%

spectral_norm:
  before: 7679691.6
  after: 1970772.3
  reduction: 74%

chaos:
  before: 9389854.3
  after: 3874241.5
  reduction: 58%