### PR TITLE
give all CLFunctions a ParamNames (renamed from ArgNames) including buil...

### DIFF
--- a/src/analysis/function_analysis.cpp
+++ b/src/analysis/function_analysis.cpp
@@ -235,10 +235,10 @@ private:
     typedef DefinednessAnalysis::DefinitionLevel DefinitionLevel;
 
     CFG* cfg;
-    const SourceInfo::ArgNames& arg_names;
+    const ParamNames& arg_names;
 
 public:
-    DefinednessBBAnalyzer(CFG* cfg, const SourceInfo::ArgNames& arg_names) : cfg(cfg), arg_names(arg_names) {}
+    DefinednessBBAnalyzer(CFG* cfg, const ParamNames& arg_names) : cfg(cfg), arg_names(arg_names) {}
 
     virtual DefinitionLevel merge(DefinitionLevel from, DefinitionLevel into) const {
         assert(from != DefinednessAnalysis::Undefined);
@@ -343,13 +343,13 @@ public:
 void DefinednessBBAnalyzer::processBB(Map& starting, CFGBlock* block) const {
     DefinednessVisitor visitor(starting);
 
-    if (block == cfg->getStartingBlock() && arg_names.args) {
-        for (auto e : (*arg_names.args))
+    if (block == cfg->getStartingBlock()) {
+        for (auto e : arg_names.args)
             visitor._doSet(e);
-        if (arg_names.vararg->size())
-            visitor._doSet(*arg_names.vararg);
-        if (arg_names.kwarg->size())
-            visitor._doSet(*arg_names.kwarg);
+        if (arg_names.vararg.size())
+            visitor._doSet(arg_names.vararg);
+        if (arg_names.kwarg.size())
+            visitor._doSet(arg_names.kwarg);
     }
 
     for (int i = 0; i < block->body.size(); i++) {
@@ -364,7 +364,7 @@ void DefinednessBBAnalyzer::processBB(Map& starting, CFGBlock* block) const {
     }
 }
 
-DefinednessAnalysis::DefinednessAnalysis(const SourceInfo::ArgNames& arg_names, CFG* cfg, ScopeInfo* scope_info)
+DefinednessAnalysis::DefinednessAnalysis(const ParamNames& arg_names, CFG* cfg, ScopeInfo* scope_info)
     : scope_info(scope_info) {
     Timer _t("DefinednessAnalysis()", 10);
 
@@ -397,8 +397,7 @@ const DefinednessAnalysis::RequiredSet& DefinednessAnalysis::getDefinedNamesAtEn
     return defined_at_end[block];
 }
 
-PhiAnalysis::PhiAnalysis(const SourceInfo::ArgNames& arg_names, CFG* cfg, LivenessAnalysis* liveness,
-                         ScopeInfo* scope_info)
+PhiAnalysis::PhiAnalysis(const ParamNames& arg_names, CFG* cfg, LivenessAnalysis* liveness, ScopeInfo* scope_info)
     : definedness(arg_names, cfg, scope_info), liveness(liveness) {
     Timer _t("PhiAnalysis()", 10);
 
@@ -476,8 +475,7 @@ LivenessAnalysis* computeLivenessInfo(CFG* cfg) {
     return new LivenessAnalysis(cfg);
 }
 
-PhiAnalysis* computeRequiredPhis(const SourceInfo::ArgNames& args, CFG* cfg, LivenessAnalysis* liveness,
-                                 ScopeInfo* scope_info) {
+PhiAnalysis* computeRequiredPhis(const ParamNames& args, CFG* cfg, LivenessAnalysis* liveness, ScopeInfo* scope_info) {
     return new PhiAnalysis(args, cfg, liveness, scope_info);
 }
 }

--- a/src/analysis/function_analysis.h
+++ b/src/analysis/function_analysis.h
@@ -75,7 +75,7 @@ private:
     ScopeInfo* scope_info;
 
 public:
-    DefinednessAnalysis(const SourceInfo::ArgNames& args, CFG* cfg, ScopeInfo* scope_info);
+    DefinednessAnalysis(const ParamNames& param_names, CFG* cfg, ScopeInfo* scope_info);
 
     DefinitionLevel isDefinedAtEnd(const std::string& name, CFGBlock* block);
     const RequiredSet& getDefinedNamesAtEnd(CFGBlock* block);
@@ -91,7 +91,7 @@ private:
     std::unordered_map<CFGBlock*, const RequiredSet> required_phis;
 
 public:
-    PhiAnalysis(const SourceInfo::ArgNames&, CFG* cfg, LivenessAnalysis* liveness, ScopeInfo* scope_info);
+    PhiAnalysis(const ParamNames&, CFG* cfg, LivenessAnalysis* liveness, ScopeInfo* scope_info);
 
     bool isRequired(const std::string& name, CFGBlock* block);
     bool isRequiredAfter(const std::string& name, CFGBlock* block);
@@ -102,7 +102,7 @@ public:
 };
 
 LivenessAnalysis* computeLivenessInfo(CFG*);
-PhiAnalysis* computeRequiredPhis(const SourceInfo::ArgNames&, CFG*, LivenessAnalysis*, ScopeInfo* scope_Info);
+PhiAnalysis* computeRequiredPhis(const ParamNames&, CFG*, LivenessAnalysis*, ScopeInfo* scope_Info);
 }
 
 #endif

--- a/src/analysis/type_analysis.cpp
+++ b/src/analysis/type_analysis.cpp
@@ -670,7 +670,7 @@ public:
         return changed;
     }
 
-    static PropagatingTypeAnalysis* doAnalysis(CFG* cfg, const SourceInfo::ArgNames& arg_names,
+    static PropagatingTypeAnalysis* doAnalysis(CFG* cfg, const ParamNames& arg_names,
                                                const std::vector<ConcreteCompilerType*>& arg_types,
                                                SpeculationLevel speculation, ScopeInfo* scope_info) {
         Timer _t("PropagatingTypeAnalysis::doAnalysis()");
@@ -681,29 +681,24 @@ public:
 
         assert(arg_names.totalParameters() == arg_types.size());
 
-        if (arg_names.args) {
-            TypeMap& initial_types = starting_types[cfg->getStartingBlock()];
-            int i = 0;
+        TypeMap& initial_types = starting_types[cfg->getStartingBlock()];
+        int i = 0;
 
-            for (; i < arg_names.args->size(); i++) {
-                AST_expr* arg = (*arg_names.args)[i];
-                RELEASE_ASSERT(arg->type == AST_TYPE::Name, "");
-                AST_Name* arg_name = ast_cast<AST_Name>(arg);
-                initial_types[arg_name->id] = unboxedType(arg_types[i]);
-            }
-
-            if (arg_names.vararg->size()) {
-                initial_types[*arg_names.vararg] = unboxedType(arg_types[i]);
-                i++;
-            }
-
-            if (arg_names.kwarg->size()) {
-                initial_types[*arg_names.kwarg] = unboxedType(arg_types[i]);
-                i++;
-            }
-
-            assert(i == arg_types.size());
+        for (; i < arg_names.args.size(); i++) {
+            initial_types[arg_names.args[i]] = unboxedType(arg_types[i]);
         }
+
+        if (arg_names.vararg.size()) {
+            initial_types[arg_names.vararg] = unboxedType(arg_types[i]);
+            i++;
+        }
+
+        if (arg_names.kwarg.size()) {
+            initial_types[arg_names.kwarg] = unboxedType(arg_types[i]);
+            i++;
+        }
+
+        assert(i == arg_types.size());
 
         std::unordered_set<CFGBlock*> in_queue;
         std::priority_queue<CFGBlock*, std::vector<CFGBlock*>, CFGBlockMinIndex> queue;
@@ -785,9 +780,9 @@ public:
 
 
 // public entry point:
-TypeAnalysis* doTypeAnalysis(CFG* cfg, const SourceInfo::ArgNames& arg_names,
-                             const std::vector<ConcreteCompilerType*>& arg_types, EffortLevel::EffortLevel effort,
-                             TypeAnalysis::SpeculationLevel speculation, ScopeInfo* scope_info) {
+TypeAnalysis* doTypeAnalysis(CFG* cfg, const ParamNames& arg_names, const std::vector<ConcreteCompilerType*>& arg_types,
+                             EffortLevel::EffortLevel effort, TypeAnalysis::SpeculationLevel speculation,
+                             ScopeInfo* scope_info) {
     // if (effort == EffortLevel::INTERPRETED) {
     // return new NullTypeAnalysis();
     //}

--- a/src/analysis/type_analysis.h
+++ b/src/analysis/type_analysis.h
@@ -42,7 +42,7 @@ public:
 };
 
 // TypeAnalysis* analyze(CFG *cfg, std::unordered_map<std::string, ConcreteCompilerType*> arg_types);
-TypeAnalysis* doTypeAnalysis(CFG* cfg, const SourceInfo::ArgNames& arg_names,
+TypeAnalysis* doTypeAnalysis(CFG* cfg, const ParamNames& param_names,
                              const std::vector<ConcreteCompilerType*>& arg_types, EffortLevel::EffortLevel effort,
                              TypeAnalysis::SpeculationLevel speculation, ScopeInfo* scope_info);
 }

--- a/src/codegen/ast_interpreter.cpp
+++ b/src/codegen/ast_interpreter.cpp
@@ -254,21 +254,19 @@ void ASTInterpreter::initArguments(int nargs, BoxedClosure* _closure, BoxedGener
     for (int i = 3; i < nargs; ++i)
         argsArray.push_back(args[i - 3]);
 
+    const ParamNames& param_names = compiled_func->clfunc->param_names;
+
     int i = 0;
-    if (source_info->arg_names.args) {
-        for (AST_expr* e : *source_info->arg_names.args) {
-            RELEASE_ASSERT(e->type == AST_TYPE::Name, "not implemented");
-            AST_Name* name = (AST_Name*)e;
-            doStore(name->id, argsArray[i++]);
-        }
+    for (const std::string& name : param_names.args) {
+        doStore(name, argsArray[i++]);
     }
 
-    if (source_info->arg_names.vararg && !source_info->arg_names.vararg->empty()) {
-        doStore(*source_info->arg_names.vararg, argsArray[i++]);
+    if (!param_names.vararg.empty()) {
+        doStore(param_names.vararg, argsArray[i++]);
     }
 
-    if (source_info->arg_names.kwarg && !source_info->arg_names.kwarg->empty()) {
-        doStore(*source_info->arg_names.kwarg, argsArray[i++]);
+    if (!param_names.kwarg.empty()) {
+        doStore(param_names.kwarg, argsArray[i++]);
     }
 }
 
@@ -315,8 +313,8 @@ void ASTInterpreter::eraseDeadSymbols() {
         source_info->liveness = computeLivenessInfo(source_info->cfg);
 
     if (source_info->phis == NULL)
-        source_info->phis
-            = computeRequiredPhis(source_info->arg_names, source_info->cfg, source_info->liveness, scope_info);
+        source_info->phis = computeRequiredPhis(compiled_func->clfunc->param_names, source_info->cfg,
+                                                source_info->liveness, scope_info);
 
     std::vector<std::string> dead_symbols;
     for (auto&& it : sym_table) {

--- a/src/codegen/codegen.cpp
+++ b/src/codegen/codegen.cpp
@@ -34,7 +34,7 @@ namespace pyston {
 DS_DEFINE_RWLOCK(codegen_rwlock);
 
 SourceInfo::SourceInfo(BoxedModule* m, ScopingAnalysis* scoping, AST* ast, const std::vector<AST_stmt*>& body)
-    : parent_module(m), scoping(scoping), ast(ast), cfg(NULL), liveness(NULL), phis(NULL), arg_names(ast), body(body) {
+    : parent_module(m), scoping(scoping), ast(ast), cfg(NULL), liveness(NULL), phis(NULL), body(body) {
     switch (ast->type) {
         case AST_TYPE::ClassDef:
         case AST_TYPE::Lambda:

--- a/src/codegen/irgen.cpp
+++ b/src/codegen/irgen.cpp
@@ -663,7 +663,7 @@ static void emitBBs(IRGenState* irstate, const char* bb_type, GuardList& out_gua
                 emitter->getBuilder()->SetInsertPoint(llvm_entry_blocks[source->cfg->getStartingBlock()]);
             }
 
-            generator->doFunctionEntry(source->arg_names, cf->spec->arg_types);
+            generator->doFunctionEntry(*irstate->getParamNames(), cf->spec->arg_types);
 
             // Function-entry safepoint:
             // TODO might be more efficient to do post-call safepoints?
@@ -1085,7 +1085,7 @@ static std::string getUniqueFunctionName(std::string nameprefix, EffortLevel::Ef
     return os.str();
 }
 
-CompiledFunction* doCompile(SourceInfo* source, const OSREntryDescriptor* entry_descriptor,
+CompiledFunction* doCompile(SourceInfo* source, ParamNames* param_names, const OSREntryDescriptor* entry_descriptor,
                             EffortLevel::EffortLevel effort, FunctionSpecialization* spec, std::string nameprefix) {
     Timer _t("in doCompile");
     Timer _t2;
@@ -1107,7 +1107,7 @@ CompiledFunction* doCompile(SourceInfo* source, const OSREntryDescriptor* entry_
     ////
     // Initializing the llvm-level structures:
 
-    int nargs = source->arg_names.totalParameters();
+    int nargs = param_names->totalParameters();
     ASSERT(nargs == spec->arg_types.size(), "%d %ld", nargs, spec->arg_types.size());
 
 
@@ -1155,8 +1155,8 @@ CompiledFunction* doCompile(SourceInfo* source, const OSREntryDescriptor* entry_
     TypeAnalysis::SpeculationLevel speculation_level = TypeAnalysis::NONE;
     if (ENABLE_SPECULATION && effort >= EffortLevel::MODERATE)
         speculation_level = TypeAnalysis::SOME;
-    TypeAnalysis* types = doTypeAnalysis(source->cfg, source->arg_names, spec->arg_types, effort, speculation_level,
-                                         source->getScopeInfo());
+    TypeAnalysis* types
+        = doTypeAnalysis(source->cfg, *param_names, spec->arg_types, effort, speculation_level, source->getScopeInfo());
 
     _t2.split();
 
@@ -1172,7 +1172,7 @@ CompiledFunction* doCompile(SourceInfo* source, const OSREntryDescriptor* entry_
         computeBlockSetClosure(full_blocks, partial_blocks);
     }
 
-    IRGenState irstate(cf, source, getGCBuilder(), dbg_funcinfo);
+    IRGenState irstate(cf, source, param_names, getGCBuilder(), dbg_funcinfo);
 
     emitBBs(&irstate, "opt", guards, GuardList(), types, entry_descriptor, full_blocks, partial_blocks);
 
@@ -1194,7 +1194,7 @@ CompiledFunction* doCompile(SourceInfo* source, const OSREntryDescriptor* entry_
         assert(deopt_full_blocks.size() || deopt_partial_blocks.size());
 
         irgen_us += _t2.split();
-        TypeAnalysis* deopt_types = doTypeAnalysis(source->cfg, source->arg_names, spec->arg_types, effort,
+        TypeAnalysis* deopt_types = doTypeAnalysis(source->cfg, *param_names, spec->arg_types, effort,
                                                    TypeAnalysis::NONE, source->getScopeInfo());
         _t2.split();
 

--- a/src/codegen/irgen.h
+++ b/src/codegen/irgen.h
@@ -94,7 +94,7 @@ extern const std::string PASSED_GENERATOR_NAME;
 std::string getIsDefinedName(const std::string& name);
 bool isIsDefinedName(const std::string& name);
 
-CompiledFunction* doCompile(SourceInfo* source, const OSREntryDescriptor* entry_descriptor,
+CompiledFunction* doCompile(SourceInfo* source, ParamNames* param_names, const OSREntryDescriptor* entry_descriptor,
                             EffortLevel::EffortLevel effort, FunctionSpecialization* spec, std::string nameprefix);
 
 // A common pattern is to branch based off whether a variable is defined but only if it is

--- a/src/codegen/irgen/irgenerator.cpp
+++ b/src/codegen/irgen/irgenerator.cpp
@@ -2413,9 +2413,8 @@ public:
         return CLOSURE;
     }
 
-    void doFunctionEntry(const SourceInfo::ArgNames& arg_names,
-                         const std::vector<ConcreteCompilerType*>& arg_types) override {
-        assert(arg_names.totalParameters() == arg_types.size());
+    void doFunctionEntry(const ParamNames& param_names, const std::vector<ConcreteCompilerType*>& arg_types) override {
+        assert(param_names.totalParameters() == arg_types.size());
 
         auto scope_info = irstate->getScopeInfo();
 
@@ -2467,26 +2466,24 @@ public:
         }
 
         assert(AI == irstate->getLLVMFunction()->arg_end());
-        assert(python_parameters.size() == arg_names.totalParameters());
+        assert(python_parameters.size() == param_names.totalParameters());
 
-        if (arg_names.args) {
-            int i = 0;
-            for (; i < arg_names.args->size(); i++) {
-                loadArgument((*arg_names.args)[i], arg_types[i], python_parameters[i], UnwindInfo::cantUnwind());
-            }
-
-            if (arg_names.vararg->size()) {
-                loadArgument(*arg_names.vararg, arg_types[i], python_parameters[i], UnwindInfo::cantUnwind());
-                i++;
-            }
-
-            if (arg_names.kwarg->size()) {
-                loadArgument(*arg_names.kwarg, arg_types[i], python_parameters[i], UnwindInfo::cantUnwind());
-                i++;
-            }
-
-            assert(i == arg_types.size());
+        int i = 0;
+        for (; i < param_names.args.size(); i++) {
+            loadArgument(param_names.args[i], arg_types[i], python_parameters[i], UnwindInfo::cantUnwind());
         }
+
+        if (param_names.vararg.size()) {
+            loadArgument(param_names.vararg, arg_types[i], python_parameters[i], UnwindInfo::cantUnwind());
+            i++;
+        }
+
+        if (param_names.kwarg.size()) {
+            loadArgument(param_names.kwarg, arg_types[i], python_parameters[i], UnwindInfo::cantUnwind());
+            i++;
+        }
+
+        assert(i == arg_types.size());
     }
 
     void run(const CFGBlock* block) override {

--- a/src/codegen/irgen/irgenerator.h
+++ b/src/codegen/irgen/irgenerator.h
@@ -54,6 +54,7 @@ class IRGenState {
 private:
     CompiledFunction* cf;
     SourceInfo* source_info;
+    ParamNames* param_names;
     GCBuilder* gc;
     llvm::MDNode* func_dbg_info;
 
@@ -62,9 +63,10 @@ private:
     int scratch_size;
 
 public:
-    IRGenState(CompiledFunction* cf, SourceInfo* source_info, GCBuilder* gc, llvm::MDNode* func_dbg_info)
-        : cf(cf), source_info(source_info), gc(gc), func_dbg_info(func_dbg_info), scratch_space(NULL), frame_info(NULL),
-          scratch_size(0) {
+    IRGenState(CompiledFunction* cf, SourceInfo* source_info, ParamNames* param_names, GCBuilder* gc,
+               llvm::MDNode* func_dbg_info)
+        : cf(cf), source_info(source_info), param_names(param_names), gc(gc), func_dbg_info(func_dbg_info),
+          scratch_space(NULL), frame_info(NULL), scratch_size(0) {
         assert(cf->func);
         assert(!cf->clfunc); // in this case don't need to pass in sourceinfo
     }
@@ -91,6 +93,8 @@ public:
     ScopeInfo* getScopeInfoForNode(AST* node);
 
     llvm::MDNode* getFuncDbgInfo() { return func_dbg_info; }
+
+    ParamNames* getParamNames() { return param_names; }
 };
 
 class GuardList {
@@ -193,8 +197,8 @@ public:
 
     virtual ~IRGenerator() {}
 
-    virtual void doFunctionEntry(const SourceInfo::ArgNames& arg_names,
-                                 const std::vector<ConcreteCompilerType*>& arg_types) = 0;
+    virtual void doFunctionEntry(const ParamNames& param_names, const std::vector<ConcreteCompilerType*>& arg_types)
+        = 0;
 
     virtual void giveLocalSymbol(const std::string& name, CompilerVariable* var) = 0;
     virtual void copySymbolsFrom(SymbolTable* st) = 0;

--- a/src/runtime/builtin_modules/builtins.cpp
+++ b/src/runtime/builtin_modules/builtins.cpp
@@ -425,7 +425,9 @@ Box* notimplementedRepr(Box* self) {
     return boxStrConstant("NotImplemented");
 }
 
-Box* sorted(Box* obj) {
+Box* sorted(Box* obj, Box* key, Box* cmp, Box** args) {
+    Box* reverse = args[0];
+
     BoxedList* rtn = new BoxedList();
     for (Box* e : obj->pyElements()) {
         listAppendInternal(rtn, e);
@@ -1115,10 +1117,10 @@ void setupBuiltins() {
     builtins_module->giveAttr("enumerate", enumerate_cls);
 
 
-    CLFunction* sorted_func = createRTFunction(1, 0, false, false);
-    addRTFunction(sorted_func, (void*)sortedList, LIST, { LIST });
-    addRTFunction(sorted_func, (void*)sorted, LIST, { UNKNOWN });
-    builtins_module->giveAttr("sorted", new BoxedFunction(sorted_func));
+    CLFunction* sorted_func = createRTFunction(4, 3, false, false, ParamNames({ "", "cmp", "key", "reverse" }, "", ""));
+    addRTFunction(sorted_func, (void*)sortedList, LIST, { LIST, UNKNOWN, UNKNOWN, UNKNOWN });
+    addRTFunction(sorted_func, (void*)sorted, LIST, { UNKNOWN, UNKNOWN, UNKNOWN, UNKNOWN });
+    builtins_module->giveAttr("sorted", new BoxedFunction(sorted_func, { None, None, False }));
 
     builtins_module->giveAttr("True", True);
     builtins_module->giveAttr("False", False);
@@ -1129,8 +1131,9 @@ void setupBuiltins() {
     setupXrange();
     builtins_module->giveAttr("xrange", xrange_cls);
 
-    open_obj = new BoxedFunction(boxRTFunction((void*)open, typeFromClass(file_cls), 2, 1, false, false),
-                                 { boxStrConstant("r") });
+    open_obj = new BoxedFunction(
+        boxRTFunction((void*)open, typeFromClass(file_cls), 2, 1, false, false, ParamNames({ "name", "mode" }, "", "")),
+        { boxStrConstant("r") });
     builtins_module->giveAttr("open", open_obj);
 
     builtins_module->giveAttr("globals", new BoxedFunction(boxRTFunction((void*)globals, UNKNOWN, 0, 0, false, false)));

--- a/test/tests/builtin_keywords.py
+++ b/test/tests/builtin_keywords.py
@@ -1,0 +1,2 @@
+f = open(**{"name": "/dev/null", "mode": "r"})
+print repr(f.read())


### PR DESCRIPTION
Make `boxRTFunction` accept a `ParamNames` argument so the builtin functions can have param names too. I added a test case for `sorted` although it doesn't actually work because (it accepts the keyword argument, but the functionality in `sorted` isn't implemented).

This is a large diff because I modified every call to `boxRTFunction` with an empty `ParamNames` object.