### PR TITLE
builtin functions

### DIFF
--- a/src/capi/types.h
+++ b/src/capi/types.h
@@ -83,7 +83,7 @@ public:
         return rtn;
     }
 
-    static Box* callInternal(BoxedFunction* func, CallRewriteArgs* rewrite_args, ArgPassSpec argspec, Box* arg1,
+    static Box* callInternal(BoxedFunctionBase* func, CallRewriteArgs* rewrite_args, ArgPassSpec argspec, Box* arg1,
                              Box* arg2, Box* arg3, Box** args, const std::vector<const std::string*>* keyword_names);
 };
 

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -121,7 +121,7 @@ typedef ValuedCompilerVariable<llvm::Value*> ConcreteCompilerVariable;
 class Box;
 class BoxedClass;
 class BoxedModule;
-class BoxedFunction;
+class BoxedFunctionBase;
 
 class ICGetattr;
 struct ICSlotInfo;
@@ -277,7 +277,7 @@ public:
     // of the normal dispatch through the functionlist.
     // This can be used to implement functions which know how to rewrite themselves,
     // such as typeCall.
-    typedef Box* (*InternalCallable)(BoxedFunction*, CallRewriteArgs*, ArgPassSpec, Box*, Box*, Box*, Box**,
+    typedef Box* (*InternalCallable)(BoxedFunctionBase*, CallRewriteArgs*, ArgPassSpec, Box*, Box*, Box*, Box**,
                                      const std::vector<const std::string*>*);
     InternalCallable internal_callable = NULL;
 

--- a/src/runtime/builtin_modules/builtins.cpp
+++ b/src/runtime/builtin_modules/builtins.cpp
@@ -986,7 +986,8 @@ void setupBuiltins() {
 
     builtins_module->giveAttr("__debug__", False);
 
-    builtins_module->giveAttr("print", new BoxedFunction(boxRTFunction((void*)print, NONE, 0, 0, true, true)));
+    builtins_module->giveAttr("print",
+                              new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)print, NONE, 0, 0, true, true)));
 
     notimplemented_cls = new BoxedHeapClass(object_cls, NULL, 0, sizeof(Box), false, "NotImplementedType");
     notimplemented_cls->giveAttr("__repr__", new BoxedFunction(boxRTFunction((void*)notimplementedRepr, STR, 1)));
@@ -997,8 +998,8 @@ void setupBuiltins() {
     builtins_module->giveAttr("NotImplemented", NotImplemented);
     builtins_module->giveAttr("NotImplementedType", notimplemented_cls);
 
-    builtins_module->giveAttr("all", new BoxedFunction(boxRTFunction((void*)all, BOXED_BOOL, 1)));
-    builtins_module->giveAttr("any", new BoxedFunction(boxRTFunction((void*)any, BOXED_BOOL, 1)));
+    builtins_module->giveAttr("all", new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)all, BOXED_BOOL, 1)));
+    builtins_module->giveAttr("any", new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)any, BOXED_BOOL, 1)));
 
     BaseException = makeBuiltinException(object_cls, "BaseException", sizeof(BoxedException));
     Exception = makeBuiltinException(BaseException, "Exception");
@@ -1049,53 +1050,54 @@ void setupBuiltins() {
     EnvironmentError->giveAttr("__str__",
                                new BoxedFunction(boxRTFunction((void*)BoxedEnvironmentError::__str__, UNKNOWN, 1)));
 
-    repr_obj = new BoxedFunction(boxRTFunction((void*)repr, UNKNOWN, 1));
+    repr_obj = new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)repr, UNKNOWN, 1));
     builtins_module->giveAttr("repr", repr_obj);
-    len_obj = new BoxedFunction(boxRTFunction((void*)len, UNKNOWN, 1));
+    len_obj = new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)len, UNKNOWN, 1));
     builtins_module->giveAttr("len", len_obj);
-    hash_obj = new BoxedFunction(boxRTFunction((void*)hash, UNKNOWN, 1));
+    hash_obj = new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)hash, UNKNOWN, 1));
     builtins_module->giveAttr("hash", hash_obj);
-    abs_obj = new BoxedFunction(boxRTFunction((void*)abs_, UNKNOWN, 1));
+    abs_obj = new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)abs_, UNKNOWN, 1));
     builtins_module->giveAttr("abs", abs_obj);
-    builtins_module->giveAttr("hex", new BoxedFunction(boxRTFunction((void*)hexFunc, UNKNOWN, 1)));
-    builtins_module->giveAttr("oct", new BoxedFunction(boxRTFunction((void*)octFunc, UNKNOWN, 1)));
+    builtins_module->giveAttr("hex", new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)hexFunc, UNKNOWN, 1)));
+    builtins_module->giveAttr("oct", new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)octFunc, UNKNOWN, 1)));
 
-    min_obj = new BoxedFunction(boxRTFunction((void*)min, UNKNOWN, 1, 0, true, false));
+    min_obj = new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)min, UNKNOWN, 1, 0, true, false));
     builtins_module->giveAttr("min", min_obj);
 
-    max_obj = new BoxedFunction(boxRTFunction((void*)max, UNKNOWN, 1, 0, true, false));
+    max_obj = new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)max, UNKNOWN, 1, 0, true, false));
     builtins_module->giveAttr("max", max_obj);
 
-    builtins_module->giveAttr("sum",
-                              new BoxedFunction(boxRTFunction((void*)sum, UNKNOWN, 2, 1, false, false), { boxInt(0) }));
+    builtins_module->giveAttr(
+        "sum", new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)sum, UNKNOWN, 2, 1, false, false), { boxInt(0) }));
 
-    id_obj = new BoxedFunction(boxRTFunction((void*)id, BOXED_INT, 1));
+    id_obj = new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)id, BOXED_INT, 1));
     builtins_module->giveAttr("id", id_obj);
-    chr_obj = new BoxedFunction(boxRTFunction((void*)chr, STR, 1));
+    chr_obj = new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)chr, STR, 1));
     builtins_module->giveAttr("chr", chr_obj);
-    ord_obj = new BoxedFunction(boxRTFunction((void*)ord, BOXED_INT, 1));
+    ord_obj = new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)ord, BOXED_INT, 1));
     builtins_module->giveAttr("ord", ord_obj);
-    trap_obj = new BoxedFunction(boxRTFunction((void*)trap, UNKNOWN, 0));
+    trap_obj = new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)trap, UNKNOWN, 0));
     builtins_module->giveAttr("trap", trap_obj);
-    builtins_module->giveAttr("dump", new BoxedFunction(boxRTFunction((void*)pydump, UNKNOWN, 1)));
+    builtins_module->giveAttr("dump", new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)pydump, UNKNOWN, 1)));
+
+    builtins_module->giveAttr("getattr", new BoxedBuiltinFunctionOrMethod(
+                                             boxRTFunction((void*)getattrFunc, UNKNOWN, 3, 1, false, false), { NULL }));
 
     builtins_module->giveAttr(
-        "getattr", new BoxedFunction(boxRTFunction((void*)getattrFunc, UNKNOWN, 3, 1, false, false), { NULL }));
+        "setattr", new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)setattrFunc, UNKNOWN, 3, 0, false, false)));
 
-    builtins_module->giveAttr("setattr",
-                              new BoxedFunction(boxRTFunction((void*)setattrFunc, UNKNOWN, 3, 0, false, false)));
-
-    Box* hasattr_obj = new BoxedFunction(boxRTFunction((void*)hasattr, BOXED_BOOL, 2));
+    Box* hasattr_obj = new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)hasattr, BOXED_BOOL, 2));
     builtins_module->giveAttr("hasattr", hasattr_obj);
 
 
-    Box* isinstance_obj = new BoxedFunction(boxRTFunction((void*)isinstance_func, BOXED_BOOL, 2));
+    Box* isinstance_obj = new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)isinstance_func, BOXED_BOOL, 2));
     builtins_module->giveAttr("isinstance", isinstance_obj);
 
-    Box* issubclass_obj = new BoxedFunction(boxRTFunction((void*)issubclass_func, BOXED_BOOL, 2));
+    Box* issubclass_obj = new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)issubclass_func, BOXED_BOOL, 2));
     builtins_module->giveAttr("issubclass", issubclass_obj);
 
-    builtins_module->giveAttr("__import__", new BoxedFunction(boxRTFunction((void*)bltinImport, UNKNOWN, 1)));
+    builtins_module->giveAttr("__import__",
+                              new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)bltinImport, UNKNOWN, 1)));
 
     enumerate_cls
         = new BoxedHeapClass(object_cls, &BoxedEnumerate::gcHandler, 0, sizeof(BoxedEnumerate), false, "enumerate");
@@ -1115,38 +1117,42 @@ void setupBuiltins() {
     CLFunction* sorted_func = createRTFunction(1, 0, false, false);
     addRTFunction(sorted_func, (void*)sortedList, LIST, { LIST });
     addRTFunction(sorted_func, (void*)sorted, LIST, { UNKNOWN });
-    builtins_module->giveAttr("sorted", new BoxedFunction(sorted_func));
+    builtins_module->giveAttr("sorted", new BoxedBuiltinFunctionOrMethod(sorted_func));
 
     builtins_module->giveAttr("True", True);
     builtins_module->giveAttr("False", False);
 
-    range_obj = new BoxedFunction(boxRTFunction((void*)range, LIST, 3, 2, false, false), { NULL, NULL });
+    range_obj = new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)range, LIST, 3, 2, false, false), { NULL, NULL });
     builtins_module->giveAttr("range", range_obj);
 
     setupXrange();
     builtins_module->giveAttr("xrange", xrange_cls);
 
-    open_obj = new BoxedFunction(boxRTFunction((void*)open, typeFromClass(file_cls), 2, 1, false, false),
-                                 { boxStrConstant("r") });
+    open_obj = new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)open, typeFromClass(file_cls), 2, 1, false, false),
+                                                { boxStrConstant("r") });
     builtins_module->giveAttr("open", open_obj);
 
-    builtins_module->giveAttr("globals", new BoxedFunction(boxRTFunction((void*)globals, UNKNOWN, 0, 0, false, false)));
-    builtins_module->giveAttr("locals", new BoxedFunction(boxRTFunction((void*)locals, UNKNOWN, 0, 0, false, false)));
+    builtins_module->giveAttr(
+        "globals", new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)globals, UNKNOWN, 0, 0, false, false)));
+    builtins_module->giveAttr(
+        "locals", new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)locals, UNKNOWN, 0, 0, false, false)));
 
-    builtins_module->giveAttr("iter", new BoxedFunction(boxRTFunction((void*)getiter, UNKNOWN, 1, 0, false, false)));
+    builtins_module->giveAttr(
+        "iter", new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)getiter, UNKNOWN, 1, 0, false, false)));
 
-    builtins_module->giveAttr("divmod", new BoxedFunction(boxRTFunction((void*)divmod, UNKNOWN, 2)));
+    builtins_module->giveAttr("divmod", new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)divmod, UNKNOWN, 2)));
 
-    builtins_module->giveAttr("execfile", new BoxedFunction(boxRTFunction((void*)execfile, UNKNOWN, 1)));
+    builtins_module->giveAttr("execfile", new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)execfile, UNKNOWN, 1)));
 
-    builtins_module->giveAttr("map", new BoxedFunction(boxRTFunction((void*)map2, LIST, 2)));
-    builtins_module->giveAttr("reduce",
-                              new BoxedFunction(boxRTFunction((void*)reduce, UNKNOWN, 3, 1, false, false), { NULL }));
-    builtins_module->giveAttr("filter", new BoxedFunction(boxRTFunction((void*)filter2, LIST, 2)));
-    builtins_module->giveAttr("zip", new BoxedFunction(boxRTFunction((void*)zip2, LIST, 2)));
-    builtins_module->giveAttr("dir", new BoxedFunction(boxRTFunction((void*)dir, LIST, 1, 1, false, false), { NULL }));
-    builtins_module->giveAttr("vars",
-                              new BoxedFunction(boxRTFunction((void*)vars, LIST, 1, 1, false, false), { NULL }));
+    builtins_module->giveAttr("map", new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)map2, LIST, 2)));
+    builtins_module->giveAttr("reduce", new BoxedBuiltinFunctionOrMethod(
+                                            boxRTFunction((void*)reduce, UNKNOWN, 3, 1, false, false), { NULL }));
+    builtins_module->giveAttr("filter", new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)filter2, LIST, 2)));
+    builtins_module->giveAttr("zip", new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)zip2, LIST, 2)));
+    builtins_module->giveAttr(
+        "dir", new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)dir, LIST, 1, 1, false, false), { NULL }));
+    builtins_module->giveAttr(
+        "vars", new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)vars, LIST, 1, 1, false, false), { NULL }));
     builtins_module->giveAttr("object", object_cls);
     builtins_module->giveAttr("str", str_cls);
     builtins_module->giveAttr("basestring", basestring_cls);

--- a/src/runtime/builtin_modules/gc.cpp
+++ b/src/runtime/builtin_modules/gc.cpp
@@ -40,9 +40,9 @@ static Box* enable() {
 void setupGC() {
     BoxedModule* gc_module = createModule("gc", "__builtin__");
 
-    gc_module->giveAttr("__hex__", new BoxedFunction(boxRTFunction((void*)gcCollect, NONE, 0)));
-    gc_module->giveAttr("isenabled", new BoxedFunction(boxRTFunction((void*)isEnabled, BOXED_BOOL, 0)));
-    gc_module->giveAttr("disable", new BoxedFunction(boxRTFunction((void*)disable, NONE, 0)));
-    gc_module->giveAttr("enable", new BoxedFunction(boxRTFunction((void*)enable, NONE, 0)));
+    gc_module->giveAttr("__hex__", new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)gcCollect, NONE, 0)));
+    gc_module->giveAttr("isenabled", new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)isEnabled, BOXED_BOOL, 0)));
+    gc_module->giveAttr("disable", new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)disable, NONE, 0)));
+    gc_module->giveAttr("enable", new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)enable, NONE, 0)));
 }
 }

--- a/src/runtime/builtin_modules/sys.cpp
+++ b/src/runtime/builtin_modules/sys.cpp
@@ -224,9 +224,11 @@ void setupSys() {
     sys_module->giveAttr("stdin", new BoxedFile(stdin, "<stdin>", "r"));
     sys_module->giveAttr("stderr", new BoxedFile(stderr, "<stderr>", "w"));
 
-    sys_module->giveAttr("exc_info", new BoxedFunction(boxRTFunction((void*)sysExcInfo, BOXED_TUPLE, 0)));
-    sys_module->giveAttr("exc_clear", new BoxedFunction(boxRTFunction((void*)sysExcClear, NONE, 0)));
-    sys_module->giveAttr("exit", new BoxedFunction(boxRTFunction((void*)sysExit, NONE, 1, 1, false, false), { None }));
+    sys_module->giveAttr("exc_info",
+                         new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)sysExcInfo, BOXED_TUPLE, 0)));
+    sys_module->giveAttr("exc_clear", new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)sysExcClear, NONE, 0)));
+    sys_module->giveAttr(
+        "exit", new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)sysExit, NONE, 1, 1, false, false), { None }));
 
     sys_module->giveAttr("warnoptions", new BoxedList());
     sys_module->giveAttr("py3kwarning", False);

--- a/src/runtime/builtin_modules/thread.cpp
+++ b/src/runtime/builtin_modules/thread.cpp
@@ -139,10 +139,14 @@ Box* stackSize() {
 void setupThread() {
     thread_module = createModule("thread", "__builtin__");
 
-    thread_module->giveAttr("start_new_thread", new BoxedFunction(boxRTFunction((void*)startNewThread, BOXED_INT, 2)));
-    thread_module->giveAttr("allocate_lock", new BoxedFunction(boxRTFunction((void*)allocateLock, UNKNOWN, 0)));
-    thread_module->giveAttr("get_ident", new BoxedFunction(boxRTFunction((void*)getIdent, BOXED_INT, 0)));
-    thread_module->giveAttr("stack_size", new BoxedFunction(boxRTFunction((void*)stackSize, BOXED_INT, 0)));
+    thread_module->giveAttr("start_new_thread",
+                            new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)startNewThread, BOXED_INT, 2)));
+    thread_module->giveAttr("allocate_lock",
+                            new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)allocateLock, UNKNOWN, 0)));
+    thread_module->giveAttr("get_ident",
+                            new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)getIdent, BOXED_INT, 0)));
+    thread_module->giveAttr("stack_size",
+                            new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)stackSize, BOXED_INT, 0)));
 
     thread_lock_cls = new BoxedHeapClass(object_cls, NULL, 0, sizeof(BoxedThreadLock), false, "lock");
     thread_lock_cls->giveAttr("__module__", boxStrConstant("thread"));

--- a/src/runtime/capi.cpp
+++ b/src/runtime/capi.cpp
@@ -1442,8 +1442,8 @@ BoxedModule* importTestExtension(const std::string& name) {
     return m;
 }
 
-Box* BoxedCApiFunction::callInternal(BoxedFunction* func, CallRewriteArgs* rewrite_args, ArgPassSpec argspec, Box* arg1,
-                                     Box* arg2, Box* arg3, Box** args,
+Box* BoxedCApiFunction::callInternal(BoxedFunctionBase* func, CallRewriteArgs* rewrite_args, ArgPassSpec argspec,
+                                     Box* arg1, Box* arg2, Box* arg3, Box** args,
                                      const std::vector<const std::string*>* keyword_names) {
     if (argspec != ArgPassSpec(2))
         return callFunc(func, rewrite_args, argspec, arg1, arg2, arg3, args, keyword_names);

--- a/src/runtime/generator.cpp
+++ b/src/runtime/generator.cpp
@@ -49,7 +49,7 @@ static void generatorEntry(BoxedGenerator* g) {
 
     try {
         // call body of the generator
-        BoxedFunction* func = g->function;
+        BoxedFunctionBase* func = g->function;
 
         Box** args = g->args ? &g->args->elts[0] : nullptr;
         callCLFunc(func->f, nullptr, func->f->numReceivedArgs(), func->closure, g, g->arg1, g->arg2, g->arg3, args);
@@ -138,14 +138,14 @@ extern "C" Box* yield(BoxedGenerator* obj, Box* value) {
 }
 
 
-extern "C" BoxedGenerator* createGenerator(BoxedFunction* function, Box* arg1, Box* arg2, Box* arg3, Box** args) {
+extern "C" BoxedGenerator* createGenerator(BoxedFunctionBase* function, Box* arg1, Box* arg2, Box* arg3, Box** args) {
     assert(function);
     assert(function->cls == function_cls);
     return new BoxedGenerator(function, arg1, arg2, arg3, args);
 }
 
 
-extern "C" BoxedGenerator::BoxedGenerator(BoxedFunction* function, Box* arg1, Box* arg2, Box* arg3, Box** args)
+extern "C" BoxedGenerator::BoxedGenerator(BoxedFunctionBase* function, Box* arg1, Box* arg2, Box* arg3, Box** args)
     : function(function), arg1(arg1), arg2(arg2), arg3(arg3), args(nullptr), entryExited(false), running(false),
       returnValue(nullptr), exception(nullptr, nullptr, nullptr) {
 

--- a/src/runtime/generator.h
+++ b/src/runtime/generator.h
@@ -25,7 +25,7 @@ extern BoxedClass* generator_cls;
 void setupGenerator();
 
 extern "C" Box* yield(BoxedGenerator* obj, Box* value);
-extern "C" BoxedGenerator* createGenerator(BoxedFunction* function, Box* arg1, Box* arg2, Box* arg3, Box** args);
+extern "C" BoxedGenerator* createGenerator(BoxedFunctionBase* function, Box* arg1, Box* arg2, Box* arg3, Box** args);
 }
 
 #endif

--- a/src/runtime/objmodel.h
+++ b/src/runtime/objmodel.h
@@ -100,11 +100,11 @@ struct BinopRewriteArgs;
 extern "C" Box* binopInternal(Box* lhs, Box* rhs, int op_type, bool inplace, BinopRewriteArgs* rewrite_args);
 
 struct CallRewriteArgs;
-Box* typeCallInternal(BoxedFunction* f, CallRewriteArgs* rewrite_args, ArgPassSpec argspec, Box* arg1, Box* arg2,
+Box* typeCallInternal(BoxedFunctionBase* f, CallRewriteArgs* rewrite_args, ArgPassSpec argspec, Box* arg1, Box* arg2,
                       Box* arg3, Box** args, const std::vector<const std::string*>* keyword_names);
 
-Box* callFunc(BoxedFunction* func, CallRewriteArgs* rewrite_args, ArgPassSpec argspec, Box* arg1, Box* arg2, Box* arg3,
-              Box** args, const std::vector<const std::string*>* keyword_names);
+Box* callFunc(BoxedFunctionBase* func, CallRewriteArgs* rewrite_args, ArgPassSpec argspec, Box* arg1, Box* arg2,
+              Box* arg3, Box** args, const std::vector<const std::string*>* keyword_names);
 
 enum LookupScope {
     CLASS_ONLY = 1,

--- a/src/runtime/types.h
+++ b/src/runtime/types.h
@@ -79,7 +79,8 @@ extern "C" {
 extern BoxedClass* object_cls, *type_cls, *bool_cls, *int_cls, *long_cls, *float_cls, *str_cls, *function_cls,
     *none_cls, *instancemethod_cls, *list_cls, *slice_cls, *module_cls, *dict_cls, *tuple_cls, *file_cls,
     *enumerate_cls, *xrange_cls, *member_cls, *method_cls, *closure_cls, *generator_cls, *complex_cls, *basestring_cls,
-    *unicode_cls, *property_cls, *staticmethod_cls, *classmethod_cls, *attrwrapper_cls, *getset_cls;
+    *unicode_cls, *property_cls, *staticmethod_cls, *classmethod_cls, *attrwrapper_cls, *getset_cls,
+    *builtin_function_or_method_cls;
 }
 extern "C" {
 extern Box* None, *NotImplemented, *True, *False;
@@ -448,7 +449,7 @@ public:
 };
 static_assert(sizeof(BoxedDict) == sizeof(PyDictObject), "");
 
-class BoxedFunction : public Box {
+class BoxedFunctionBase : public Box {
 public:
     HCAttrs attrs;
     CLFunction* f;
@@ -461,11 +462,29 @@ public:
     // Accessed via member descriptor
     Box* modname; // __module__
 
-    BoxedFunction(CLFunction* f);
+    BoxedFunctionBase(CLFunction* f);
+    BoxedFunctionBase(CLFunction* f, std::initializer_list<Box*> defaults, BoxedClosure* closure = NULL,
+                      bool isGenerator = false);
+};
+
+class BoxedFunction : public BoxedFunctionBase {
+public:
+    BoxedFunction(CLFunction* f) : BoxedFunctionBase(f) {}
     BoxedFunction(CLFunction* f, std::initializer_list<Box*> defaults, BoxedClosure* closure = NULL,
-                  bool isGenerator = false);
+                  bool isGenerator = false)
+        : BoxedFunctionBase(f, defaults, closure, isGenerator) {}
 
     DEFAULT_CLASS(function_cls);
+};
+
+class BoxedBuiltinFunctionOrMethod : public BoxedFunctionBase {
+public:
+    BoxedBuiltinFunctionOrMethod(CLFunction* f) : BoxedFunctionBase(f) {}
+    BoxedBuiltinFunctionOrMethod(CLFunction* f, std::initializer_list<Box*> defaults, BoxedClosure* closure = NULL,
+                                 bool isGenerator = false)
+        : BoxedFunctionBase(f, defaults, closure, isGenerator) {}
+
+    DEFAULT_CLASS(builtin_function_or_method_cls);
 };
 
 class BoxedModule : public Box {
@@ -577,7 +596,7 @@ public:
 class BoxedGenerator : public Box {
 public:
     HCAttrs attrs;
-    BoxedFunction* function;
+    BoxedFunctionBase* function;
     Box* arg1, *arg2, *arg3;
     GCdArray* args;
 
@@ -589,7 +608,7 @@ public:
     ucontext_t context, returnContext;
     void* stack_begin;
 
-    BoxedGenerator(BoxedFunction* function, Box* arg1, Box* arg2, Box* arg3, Box** args);
+    BoxedGenerator(BoxedFunctionBase* function, Box* arg1, Box* arg2, Box* arg3, Box** args);
 
     DEFAULT_CLASS(generator_cls);
 };

--- a/test/tests/builtins.py
+++ b/test/tests/builtins.py
@@ -78,3 +78,9 @@ class Iterable(object):
 i = Iterable()
 it = iter(i)
 print it is i
+
+# check that builtins don't bind
+class C(object):
+    s = sorted
+c = C()
+print c.s([3,2,1])


### PR DESCRIPTION
Implement the `builtin_function_or_method` type, which all the builtin functions are of (e.g., `sorted`).

Since we use the same calling convention for Python functions as our builtin C functions, I made a common base class, `BoxedFunctionBase` which has all the calling functionality, and two subclasses `BoxedFunction` and `BoxedBuilitinFunctionOrMethod`, each of which contributes the type, either `function_cls` or `builtin_function_or_method_cls`. (What a mouthful)

Difference is the attributes they have and stuff, e.g., `function_cls` is a descriptor which wraps itself in an `instancemethod`, and `builitin_function_or_method_cls` is not.