### PR TITLE
Implement str.join(iterable)

### DIFF
--- a/src/runtime/str.cpp
+++ b/src/runtime/str.cpp
@@ -1311,19 +1311,15 @@ Box* strIsTitle(BoxedString* self) {
 Box* strJoin(BoxedString* self, Box* rhs) {
     assert(self->cls == str_cls);
 
-    if (rhs->cls == list_cls) {
-        BoxedList* list = static_cast<BoxedList*>(rhs);
-        std::ostringstream os;
-        for (int i = 0; i < list->size; i++) {
-            if (i > 0)
-                os << self->s;
-            BoxedString* elt_str = str(list->elts->elts[i]);
-            os << elt_str->s;
-        }
-        return boxString(os.str());
-    } else {
-        raiseExcHelper(TypeError, "");
+    std::ostringstream os;
+    int i = 0;
+    for (Box* e : rhs->pyElements()) {
+        if (i > 0)
+            os << self->s;
+        os << str(e)->s;
+        ++i;
     }
+    return boxString(os.str());
 }
 
 Box* strReplace(Box* _self, Box* _old, Box* _new, Box** _args) {

--- a/test/tests/str_functions.py
+++ b/test/tests/str_functions.py
@@ -1,4 +1,5 @@
 print "-".join(["hello", "world"])
+print "-".join(("hello", "world"))
 
 print repr(chr(0) + chr(180))
 print repr('"')


### PR DESCRIPTION
This small change will be needed by ```locale``` which gets imported by ```optparse```.

I split it out into a separate pull request because I think this is a performance regression and I would like to discuss a idea I have: 
- I would like to extend ```pyElements()``` to not use the generic iterable protocol when we know the class.
This should give us the same speed as a specialized implementation for every known iterable type while still preserving the the shortness of just a ```for (Box* e : rhs->pyElements()) ```.



