### PR TITLE
Add third GC arena

### DIFF
--- a/minibenchmarks/pidigits.py
+++ b/minibenchmarks/pidigits.py
@@ -1,0 +1,39 @@
+import time
+
+PIDIGITS_LEN = 1500
+
+def pidigits(length):
+    i = k = ns = 0
+    k1 = 1
+    n,a,d,t,u = 1,0,1,0,0
+    while(True):
+        k += 1
+        t = n<<1
+        n *= k
+        a += t
+        k1 += 2
+        a *= k1
+        d *= k1
+        if a >= n:
+            t,u = divmod(n*3 + a,d)
+            u += n
+            if d > u:
+                ns = ns*10 + t
+                i += 1
+                if i % 10 == 0:
+                    ns = 0
+                if i >= length:
+                    break
+                a -= d*t
+                a *= 10
+                n *= 10
+
+def main(n):
+    l = []
+    for i in range(n):
+        t0 = time.time()
+        pidigits(PIDIGITS_LEN)
+        l.append(time.time() - t0)
+    return l
+
+main(100)

--- a/src/gc/gc_alloc.h
+++ b/src/gc/gc_alloc.h
@@ -51,6 +51,11 @@ extern "C" inline void* gc_alloc(size_t bytes, GCKind kind_id) {
 #endif
 
     GCAllocation* alloc = global_heap.alloc(alloc_bytes);
+
+#ifndef NVALGRIND
+    VALGRIND_DISABLE_ERROR_REPORTING;
+#endif
+
     alloc->kind_id = kind_id;
     alloc->gc_flags = 0;
 
@@ -67,7 +72,10 @@ extern "C" inline void* gc_alloc(size_t bytes, GCKind kind_id) {
     }
 
     void* r = alloc->user_data;
+
 #ifndef NVALGRIND
+    VALGRIND_ENABLE_ERROR_REPORTING;
+
     if (ENABLE_REDZONES) {
         r = ((char*)r) + REDZONE_SIZE;
     }

--- a/src/gc/heap.cpp
+++ b/src/gc/heap.cpp
@@ -17,7 +17,6 @@
 #include <cstdlib>
 #include <cstring>
 #include <stdint.h>
-#include <sys/mman.h>
 
 #include "core/common.h"
 #include "core/util.h"
@@ -33,6 +32,35 @@
 
 namespace pyston {
 namespace gc {
+
+void _doFree(GCAllocation* al);
+
+// these template functions are for both large and huge sections
+template <class ListT> inline void unlinkNode(ListT* node) {
+    *node->prev = node->next;
+    if (node->next)
+        node->next->prev = node->prev;
+}
+
+template <class ListT, typename Free>
+inline void sweepHeap(ListT* head, std::function<void(GCAllocation*)> __free, Free free_func) {
+    auto cur = head;
+    while (cur) {
+        GCAllocation* al = cur->data;
+        if (isMarked(al)) {
+            clearMark(al);
+            cur = cur->next;
+        } else {
+            __free(al);
+
+            unlinkNode(cur);
+
+            auto to_free = cur;
+            cur = cur->next;
+            free_func(to_free);
+        }
+    }
+}
 
 static unsigned bytesAllocatedSinceCollection;
 static __thread unsigned thread_bytesAllocatedSinceCollection;
@@ -64,279 +92,7 @@ void registerGCManagedBytes(size_t bytes) {
 
 Heap global_heap;
 
-#define PAGE_SIZE 4096
-class Arena {
-private:
-    void* start;
-    void* cur;
-
-public:
-    constexpr Arena(void* start) : start(start), cur(start) {}
-
-    void* doMmap(size_t size) {
-        assert(size % PAGE_SIZE == 0);
-        // printf("mmap %ld\n", size);
-
-        void* mrtn = mmap(cur, size, PROT_READ | PROT_WRITE, MAP_FIXED | MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-        assert((uintptr_t)mrtn != -1 && "failed to allocate memory from OS");
-        ASSERT(mrtn == cur, "%p %p\n", mrtn, cur);
-        cur = (uint8_t*)cur + size;
-        return mrtn;
-    }
-
-    bool contains(void* addr) { return start <= addr && addr < cur; }
-};
-
-static Arena small_arena((void*)0x1270000000L);
-static Arena large_arena((void*)0x2270000000L);
-
-struct LargeObj {
-    LargeObj* next, **prev;
-    size_t obj_size;
-    GCAllocation data[0];
-
-    int mmap_size() {
-        size_t total_size = obj_size + sizeof(LargeObj);
-        total_size = (total_size + PAGE_SIZE - 1) & ~(PAGE_SIZE - 1);
-        return total_size;
-    }
-
-    int capacity() { return mmap_size() - sizeof(LargeObj); }
-
-    static LargeObj* fromAllocation(GCAllocation* alloc) {
-        char* rtn = (char*)alloc - offsetof(LargeObj, data);
-        assert((uintptr_t)rtn % PAGE_SIZE == 0);
-        return reinterpret_cast<LargeObj*>(rtn);
-    }
-};
-
-GCAllocation* Heap::allocLarge(size_t size) {
-    registerGCManagedBytes(size);
-
-    LOCK_REGION(lock);
-
-    size_t total_size = size + sizeof(LargeObj);
-    total_size = (total_size + PAGE_SIZE - 1) & ~(PAGE_SIZE - 1);
-    LargeObj* rtn = (LargeObj*)large_arena.doMmap(total_size);
-    rtn->obj_size = size;
-
-    rtn->next = large_head;
-    if (rtn->next)
-        rtn->next->prev = &rtn->next;
-    rtn->prev = &large_head;
-    large_head = rtn;
-
-    return rtn->data;
-}
-
-static Block* alloc_block(uint64_t size, Block** prev) {
-    Block* rtn = (Block*)small_arena.doMmap(sizeof(Block));
-    assert(rtn);
-    rtn->size = size;
-    rtn->num_obj = BLOCK_SIZE / size;
-    rtn->min_obj_index = (BLOCK_HEADER_SIZE + size - 1) / size;
-    rtn->atoms_per_obj = size / ATOM_SIZE;
-    rtn->prev = prev;
-    rtn->next = NULL;
-
-#ifndef NVALGRIND
-// Not sure if this mempool stuff is better than the malloc-like interface:
-// VALGRIND_CREATE_MEMPOOL(rtn, 0, true);
-#endif
-
-    // printf("Allocated new block %p\n", rtn);
-
-    // Don't think I need to do this:
-    rtn->isfree.setAllZero();
-    rtn->next_to_check.reset();
-
-    int num_objects = rtn->numObjects();
-    int num_lost = rtn->minObjIndex();
-    int atoms_per_object = rtn->atomsPerObj();
-    for (int i = num_lost * atoms_per_object; i < num_objects * atoms_per_object; i += atoms_per_object) {
-        rtn->isfree.set(i);
-        // printf("%d %d\n", idx, bit);
-    }
-
-    // printf("%d %d %d\n", num_objects, num_lost, atoms_per_object);
-    // for (int i =0; i < BITFIELD_ELTS; i++) {
-    // printf("%d: %lx\n", i, rtn->isfree[i]);
-    //}
-    return rtn;
-}
-
-static void insertIntoLL(Block** next_pointer, Block* next) {
-    assert(next_pointer);
-    assert(next);
-    assert(!next->next);
-    assert(!next->prev);
-
-    next->next = *next_pointer;
-    if (next->next)
-        next->next->prev = &next->next;
-    *next_pointer = next;
-    next->prev = next_pointer;
-}
-
-static void removeFromLL(Block* b) {
-    if (b->next)
-        b->next->prev = b->prev;
-    *b->prev = b->next;
-
-    b->next = NULL;
-    b->prev = NULL;
-}
-
-Heap::ThreadBlockCache::~ThreadBlockCache() {
-    LOCK_REGION(heap->lock);
-
-    for (int i = 0; i < NUM_BUCKETS; i++) {
-        while (Block* b = cache_free_heads[i]) {
-            removeFromLL(b);
-            insertIntoLL(&heap->heads[i], b);
-        }
-
-        while (Block* b = cache_full_heads[i]) {
-            removeFromLL(b);
-            insertIntoLL(&heap->full_heads[i], b);
-        }
-    }
-}
-
-static GCAllocation* allocFromBlock(Block* b) {
-    int idx = b->isfree.scanForNext(b->next_to_check);
-    if (idx == -1)
-        return NULL;
-
-    void* rtn = &b->atoms[idx];
-    return reinterpret_cast<GCAllocation*>(rtn);
-}
-
-static Block* claimBlock(size_t rounded_size, Block** free_head) {
-    Block* free_block = *free_head;
-    if (free_block) {
-        removeFromLL(free_block);
-        return free_block;
-    }
-
-    return alloc_block(rounded_size, NULL);
-}
-
-GCAllocation* Heap::allocSmall(size_t rounded_size, int bucket_idx) {
-    registerGCManagedBytes(rounded_size);
-
-    Block** free_head = &heads[bucket_idx];
-    Block** full_head = &full_heads[bucket_idx];
-
-    ThreadBlockCache* cache = thread_caches.get();
-
-    Block** cache_head = &cache->cache_free_heads[bucket_idx];
-
-    // static __thread int gc_allocs = 0;
-    // if (++gc_allocs == 128) {
-    // static StatCounter sc_total("gc_allocs");
-    // sc_total.log(128);
-    // gc_allocs = 0;
-    //}
-
-    while (true) {
-        while (Block* cache_block = *cache_head) {
-            GCAllocation* rtn = allocFromBlock(cache_block);
-            if (rtn)
-                return rtn;
-
-            removeFromLL(cache_block);
-            insertIntoLL(&cache->cache_full_heads[bucket_idx], cache_block);
-        }
-
-        // Not very useful to count the cache misses if we don't count the total attempts:
-        // static StatCounter sc_fallback("gc_allocs_cachemiss");
-        // sc_fallback.log();
-
-        LOCK_REGION(lock);
-
-        assert(*cache_head == NULL);
-
-        // should probably be called allocBlock:
-        Block* myblock = claimBlock(rounded_size, &heads[bucket_idx]);
-        assert(myblock);
-        assert(!myblock->next);
-        assert(!myblock->prev);
-
-        // printf("%d claimed new block %p with %d objects\n", threading::gettid(), myblock, myblock->numObjects());
-
-        insertIntoLL(cache_head, myblock);
-    }
-}
-
-void _freeFrom(GCAllocation* alloc, Block* b) {
-    assert(b == Block::forPointer(alloc));
-
-    size_t size = b->size;
-    int offset = (char*)alloc - (char*)b;
-    assert(offset % size == 0);
-    int atom_idx = offset / ATOM_SIZE;
-
-    assert(!b->isfree.isSet(atom_idx));
-    b->isfree.toggle(atom_idx);
-
-#ifndef NVALGRIND
-// VALGRIND_MEMPOOL_FREE(b, ptr);
-#endif
-}
-
-static void _freeLargeObj(LargeObj* lobj) {
-    *lobj->prev = lobj->next;
-    if (lobj->next)
-        lobj->next->prev = lobj->prev;
-
-    int r = munmap(lobj, lobj->mmap_size());
-    assert(r == 0);
-}
-
-static void _doFree(GCAllocation* al) {
-    if (VERBOSITY() >= 2)
-        printf("Freeing %p\n", al->user_data);
-
-    if (al->kind_id == GCKind::PYTHON) {
-        Box* b = (Box*)al->user_data;
-
-        ASSERT(b->cls->tp_dealloc == NULL, "%s", getTypeName(b));
-        if (b->cls->simple_destructor)
-            b->cls->simple_destructor(b);
-    }
-}
-
-void Heap::free(GCAllocation* al) {
-    _doFree(al);
-
-    if (large_arena.contains(al)) {
-        LargeObj* lobj = LargeObj::fromAllocation(al);
-        _freeLargeObj(lobj);
-        return;
-    }
-
-    assert(small_arena.contains(al));
-    Block* b = Block::forPointer(al);
-    _freeFrom(al, b);
-}
-
-GCAllocation* Heap::realloc(GCAllocation* al, size_t bytes) {
-    if (large_arena.contains(al)) {
-        LargeObj* lobj = LargeObj::fromAllocation(al);
-
-        int capacity = lobj->capacity();
-        if (capacity >= bytes && capacity < bytes * 2)
-            return al;
-
-        GCAllocation* rtn = alloc(bytes);
-        memcpy(rtn, al, std::min(bytes, lobj->obj_size));
-
-        _freeLargeObj(lobj);
-        return rtn;
-    }
-
-    assert(small_arena.contains(al));
+GCAllocation* SmallArena::realloc(GCAllocation* al, size_t bytes) {
     Block* b = Block::forPointer(al);
 
     size_t size = b->size;
@@ -344,7 +100,7 @@ GCAllocation* Heap::realloc(GCAllocation* al, size_t bytes) {
     if (size >= bytes && size < bytes * 2)
         return al;
 
-    GCAllocation* rtn = alloc(bytes);
+    GCAllocation* rtn = heap->alloc(bytes);
 
 #ifndef NVALGRIND
     VALGRIND_DISABLE_ERROR_REPORTING;
@@ -354,24 +110,11 @@ GCAllocation* Heap::realloc(GCAllocation* al, size_t bytes) {
     memcpy(rtn, al, std::min(bytes, size));
 #endif
 
-    _freeFrom(al, b);
+    _free(al, b);
     return rtn;
 }
 
-GCAllocation* Heap::getAllocationFromInteriorPointer(void* ptr) {
-    if (large_arena.contains(ptr)) {
-        LargeObj* cur = large_head;
-        while (cur) {
-            if (ptr >= cur && ptr < &cur->data[cur->obj_size])
-                return &cur->data[0];
-            cur = cur->next;
-        }
-        return NULL;
-    }
-
-    if (!small_arena.contains(ptr))
-        return NULL;
-
+GCAllocation* SmallArena::allocationFrom(void* ptr) {
     Block* b = Block::forPointer(ptr);
     size_t size = b->size;
     int offset = (char*)ptr - (char*)b;
@@ -388,7 +131,7 @@ GCAllocation* Heap::getAllocationFromInteriorPointer(void* ptr) {
     return reinterpret_cast<GCAllocation*>(&b->atoms[atom_idx]);
 }
 
-static Block** freeChain(Block** head) {
+SmallArena::Block** SmallArena::freeChain(Block** head) {
     while (Block* b = *head) {
         int num_objects = b->numObjects();
         int first_obj = b->minObjIndex();
@@ -418,7 +161,8 @@ static Block** freeChain(Block** head) {
     return head;
 }
 
-void Heap::freeUnmarked() {
+
+void SmallArena::freeUnmarked() {
     thread_caches.forEachValue([this](ThreadBlockCache* cache) {
         for (int bidx = 0; bidx < NUM_BUCKETS; bidx++) {
             Block* h = cache->cache_free_heads[bidx];
@@ -458,27 +202,440 @@ void Heap::freeUnmarked() {
             insertIntoLL(chain_end, b);
         }
     }
+}
 
-    LargeObj* cur = large_head;
-    while (cur) {
-        GCAllocation* al = cur->data;
-        if (isMarked(al)) {
-            clearMark(al);
-        } else {
-            _doFree(al);
 
-            *cur->prev = cur->next;
-            if (cur->next)
-                cur->next->prev = cur->prev;
+#define LARGE_BLOCK_NUM_CHUNKS ((BLOCK_SIZE >> CHUNK_BITS) - 1)
 
-            LargeObj* to_free = cur;
-            cur = cur->next;
-            _freeLargeObj(to_free);
-            continue;
+#define LARGE_BLOCK_FOR_OBJ(obj) ((LargeBlock*)((int64_t)(obj) & ~(int64_t)(BLOCK_SIZE - 1)))
+#define LARGE_CHUNK_INDEX(obj, section) (((char*)(obj) - (char*)(section)) >> CHUNK_BITS)
+
+int64_t los_memory_usage = 0;
+
+static int64_t large_object_count = 0;
+static int large_block_count = 0;
+
+void LargeArena::add_free_chunk(LargeFreeChunk* free_chunks, size_t size) {
+    size_t num_chunks = size >> CHUNK_BITS;
+
+    free_chunks->size = size;
+
+    if (num_chunks >= NUM_FREE_LISTS)
+        num_chunks = 0;
+    free_chunks->next_size = free_lists[num_chunks];
+    free_lists[num_chunks] = free_chunks;
+}
+
+LargeArena::LargeFreeChunk* LargeArena::get_from_size_list(LargeFreeChunk** list, size_t size) {
+    LargeFreeChunk* free_chunks = NULL;
+    LargeBlock* section;
+    size_t i, num_chunks, start_index;
+
+    assert((size & (CHUNK_SIZE - 1)) == 0);
+
+    while (*list) {
+        free_chunks = *list;
+        if (free_chunks->size >= size)
+            break;
+        list = &(*list)->next_size;
+    }
+
+    if (!*list)
+        return NULL;
+
+    *list = free_chunks->next_size;
+
+    if (free_chunks->size > size)
+        add_free_chunk((LargeFreeChunk*)((char*)free_chunks + size), free_chunks->size - size);
+
+    num_chunks = size >> CHUNK_BITS;
+
+    section = LARGE_BLOCK_FOR_OBJ(free_chunks);
+
+    start_index = LARGE_CHUNK_INDEX(free_chunks, section);
+    for (i = start_index; i < start_index + num_chunks; ++i) {
+        assert(section->free_chunk_map[i]);
+        section->free_chunk_map[i] = 0;
+    }
+
+    section->num_free_chunks -= size >> CHUNK_BITS;
+    assert(section->num_free_chunks >= 0);
+
+    return free_chunks;
+}
+
+LargeArena::LargeObj* LargeArena::_allocInternal(size_t size) {
+    LargeBlock* section;
+    LargeFreeChunk* free_chunks;
+    size_t num_chunks;
+
+    size += CHUNK_SIZE - 1;
+    size &= ~(CHUNK_SIZE - 1);
+
+    num_chunks = size >> CHUNK_BITS;
+
+    assert(size > 0 && size - sizeof(LargeObj) <= ALLOC_SIZE_LIMIT);
+    assert(num_chunks > 0);
+
+retry:
+    if (num_chunks >= NUM_FREE_LISTS) {
+        free_chunks = get_from_size_list(&free_lists[0], size);
+    } else {
+        size_t i;
+        for (i = num_chunks; i < NUM_FREE_LISTS; ++i) {
+            free_chunks = get_from_size_list(&free_lists[i], size);
+            if (free_chunks)
+                break;
         }
+        if (!free_chunks)
+            free_chunks = get_from_size_list(&free_lists[0], size);
+    }
 
+    if (free_chunks)
+        return (LargeObj*)free_chunks;
+
+    section = (LargeBlock*)doMmap(BLOCK_SIZE);
+
+    if (!section)
+        return NULL;
+
+    free_chunks = (LargeFreeChunk*)((char*)section + CHUNK_SIZE);
+    free_chunks->size = BLOCK_SIZE - CHUNK_SIZE;
+    free_chunks->next_size = free_lists[0];
+    free_lists[0] = free_chunks;
+
+    section->num_free_chunks = LARGE_BLOCK_NUM_CHUNKS;
+
+    section->free_chunk_map = (unsigned char*)section + sizeof(LargeBlock);
+    assert(sizeof(LargeBlock) + LARGE_BLOCK_NUM_CHUNKS + 1 <= CHUNK_SIZE);
+    section->free_chunk_map[0] = 0;
+    memset(section->free_chunk_map + 1, 1, LARGE_BLOCK_NUM_CHUNKS);
+
+    section->next = blocks;
+    blocks = section;
+
+    ++large_block_count;
+
+    goto retry;
+}
+
+void LargeArena::_freeInternal(LargeObj* obj, size_t size) {
+    LargeBlock* section = LARGE_BLOCK_FOR_OBJ(obj);
+    size_t num_chunks, i, start_index;
+
+    size += CHUNK_SIZE - 1;
+    size &= ~(CHUNK_SIZE - 1);
+
+    num_chunks = size >> CHUNK_BITS;
+
+    assert(size > 0 && size - sizeof(LargeObj) <= ALLOC_SIZE_LIMIT);
+    assert(num_chunks > 0);
+
+    section->num_free_chunks += num_chunks;
+    assert(section->num_free_chunks <= LARGE_BLOCK_NUM_CHUNKS);
+
+    /*
+     * We could free the LOS section here if it's empty, but we
+     * can't unless we also remove its free chunks from the fast
+     * free lists.  Instead, we do it in los_sweep().
+     */
+
+    start_index = LARGE_CHUNK_INDEX(obj, section);
+    for (i = start_index; i < start_index + num_chunks; ++i) {
+        assert(!section->free_chunk_map[i]);
+        section->free_chunk_map[i] = 1;
+    }
+
+    add_free_chunk((LargeFreeChunk*)obj, size);
+}
+
+void LargeArena::_free(LargeObj* obj) {
+    unlinkNode(obj);
+    _freeInternal(obj, obj->size);
+}
+
+void LargeArena::freeUnmarked() {
+    sweepHeap(head, _doFree, [this](LargeObj* ptr) { _freeInternal(ptr, ptr->size); });
+}
+
+GCAllocation* LargeArena::alloc(size_t size) {
+    registerGCManagedBytes(size);
+
+    LOCK_REGION(heap->lock);
+
+    // printf ("allocLarge %zu\n", size);
+
+    LargeObj* obj = _allocInternal(size + sizeof(GCAllocation) + sizeof(LargeObj));
+
+    obj->size = size;
+
+    obj->next = head;
+    if (obj->next)
+        obj->next->prev = &obj->next;
+    obj->prev = &head;
+    head = obj;
+    large_object_count++;
+
+    return obj->data;
+}
+
+GCAllocation* LargeArena::realloc(GCAllocation* al, size_t bytes) {
+    LargeObj* obj = (LargeObj*)((char*)al - offsetof(LargeObj, data));
+    int size = obj->size;
+    if (size >= bytes && size < bytes * 2)
+        return al;
+
+    GCAllocation* rtn = heap->alloc(bytes);
+    memcpy(rtn, al, std::min(bytes, obj->size));
+
+    _free(obj);
+    return rtn;
+}
+
+void LargeArena::free(GCAllocation* al) {
+    LargeObj* obj = (LargeObj*)((char*)al - offsetof(LargeObj, data));
+    _free(obj);
+}
+
+GCAllocation* LargeArena::allocationFrom(void* ptr) {
+    LargeObj* obj = NULL;
+
+    for (obj = head; obj; obj = obj->next) {
+        char* end = (char*)&obj->data + obj->size;
+
+        if (ptr >= obj->data && ptr < end) {
+            return &obj->data[0];
+        }
+    }
+    return NULL;
+}
+
+void HugeArena::freeUnmarked() {
+    sweepHeap(head, _doFree, [this](HugeObj* ptr) { _freeHugeObj(ptr); });
+}
+
+GCAllocation* HugeArena::alloc(size_t size) {
+    registerGCManagedBytes(size);
+
+    LOCK_REGION(heap->lock);
+
+    size_t total_size = size + sizeof(HugeObj);
+    total_size = (total_size + PAGE_SIZE - 1) & ~(PAGE_SIZE - 1);
+    HugeObj* rtn = (HugeObj*)doMmap(total_size);
+    rtn->obj_size = size;
+
+    rtn->next = head;
+    if (rtn->next)
+        rtn->next->prev = &rtn->next;
+    rtn->prev = &head;
+    head = rtn;
+    return rtn->data;
+}
+
+GCAllocation* HugeArena::realloc(GCAllocation* al, size_t bytes) {
+    HugeObj* lobj = HugeObj::fromAllocation(al);
+
+    int capacity = lobj->capacity();
+    if (capacity >= bytes && capacity < bytes * 2)
+        return al;
+
+    GCAllocation* rtn = heap->alloc(bytes);
+    memcpy(rtn, al, std::min(bytes, lobj->obj_size));
+
+    _freeHugeObj(lobj);
+    return rtn;
+}
+
+void HugeArena::_freeHugeObj(HugeObj* lobj) {
+    unlinkNode(lobj);
+    int r = munmap(lobj, lobj->mmap_size());
+    assert(r == 0);
+}
+
+
+void HugeArena::free(GCAllocation* al) {
+    HugeObj* lobj = HugeObj::fromAllocation(al);
+    _freeHugeObj(lobj);
+}
+
+GCAllocation* HugeArena::allocationFrom(void* ptr) {
+    HugeObj* cur = head;
+    while (cur) {
+        if (ptr >= cur && ptr < &cur->data[cur->obj_size])
+            return &cur->data[0];
         cur = cur->next;
     }
+    return NULL;
+}
+
+SmallArena::Block* SmallArena::alloc_block(uint64_t size, Block** prev) {
+    Block* rtn = (Block*)doMmap(sizeof(Block));
+    assert(rtn);
+    rtn->size = size;
+    rtn->num_obj = BLOCK_SIZE / size;
+    rtn->min_obj_index = (BLOCK_HEADER_SIZE + size - 1) / size;
+    rtn->atoms_per_obj = size / ATOM_SIZE;
+    rtn->prev = prev;
+    rtn->next = NULL;
+
+#ifndef NVALGRIND
+// Not sure if this mempool stuff is better than the malloc-like interface:
+// VALGRIND_CREATE_MEMPOOL(rtn, 0, true);
+#endif
+
+    // printf("Allocated new block %p\n", rtn);
+
+    // Don't think I need to do this:
+    rtn->isfree.setAllZero();
+    rtn->next_to_check.reset();
+
+    int num_objects = rtn->numObjects();
+    int num_lost = rtn->minObjIndex();
+    int atoms_per_object = rtn->atomsPerObj();
+    for (int i = num_lost * atoms_per_object; i < num_objects * atoms_per_object; i += atoms_per_object) {
+        rtn->isfree.set(i);
+        // printf("%d %d\n", idx, bit);
+    }
+
+    // printf("%d %d %d\n", num_objects, num_lost, atoms_per_object);
+    // for (int i =0; i < BITFIELD_ELTS; i++) {
+    // printf("%d: %lx\n", i, rtn->isfree[i]);
+    //}
+    return rtn;
+}
+
+void SmallArena::insertIntoLL(Block** next_pointer, Block* next) {
+    assert(next_pointer);
+    assert(next);
+    assert(!next->next);
+    assert(!next->prev);
+
+    next->next = *next_pointer;
+    if (next->next)
+        next->next->prev = &next->next;
+    *next_pointer = next;
+    next->prev = next_pointer;
+}
+
+void SmallArena::removeFromLL(Block* b) {
+    unlinkNode(b);
+    b->next = NULL;
+    b->prev = NULL;
+}
+
+SmallArena::ThreadBlockCache::~ThreadBlockCache() {
+    LOCK_REGION(heap->lock);
+
+    for (int i = 0; i < NUM_BUCKETS; i++) {
+        while (Block* b = cache_free_heads[i]) {
+            small->removeFromLL(b);
+            small->insertIntoLL(&small->heads[i], b);
+        }
+
+        while (Block* b = cache_full_heads[i]) {
+            small->removeFromLL(b);
+            small->insertIntoLL(&small->full_heads[i], b);
+        }
+    }
+}
+
+GCAllocation* SmallArena::allocFromBlock(Block* b) {
+    int idx = b->isfree.scanForNext(b->next_to_check);
+    if (idx == -1)
+        return NULL;
+
+    void* rtn = &b->atoms[idx];
+    return reinterpret_cast<GCAllocation*>(rtn);
+}
+
+SmallArena::Block* SmallArena::claimBlock(size_t rounded_size, Block** free_head) {
+    Block* free_block = *free_head;
+    if (free_block) {
+        removeFromLL(free_block);
+        return free_block;
+    }
+
+    return alloc_block(rounded_size, NULL);
+}
+
+GCAllocation* SmallArena::_alloc(size_t rounded_size, int bucket_idx) {
+    registerGCManagedBytes(rounded_size);
+
+    Block** free_head = &heads[bucket_idx];
+    Block** full_head = &full_heads[bucket_idx];
+
+    ThreadBlockCache* cache = thread_caches.get();
+
+    Block** cache_head = &cache->cache_free_heads[bucket_idx];
+
+    // static __thread int gc_allocs = 0;
+    // if (++gc_allocs == 128) {
+    // static StatCounter sc_total("gc_allocs");
+    // sc_total.log(128);
+    // gc_allocs = 0;
+    //}
+
+    while (true) {
+        while (Block* cache_block = *cache_head) {
+            GCAllocation* rtn = allocFromBlock(cache_block);
+            if (rtn)
+                return rtn;
+
+            removeFromLL(cache_block);
+            insertIntoLL(&cache->cache_full_heads[bucket_idx], cache_block);
+        }
+
+        // Not very useful to count the cache misses if we don't count the total attempts:
+        // static StatCounter sc_fallback("gc_allocs_cachemiss");
+        // sc_fallback.log();
+
+        LOCK_REGION(heap->lock);
+
+        assert(*cache_head == NULL);
+
+        // should probably be called allocBlock:
+        Block* myblock = claimBlock(rounded_size, &heads[bucket_idx]);
+        assert(myblock);
+        assert(!myblock->next);
+        assert(!myblock->prev);
+
+        // printf("%d claimed new block %p with %d objects\n", threading::gettid(), myblock, myblock->numObjects());
+
+        insertIntoLL(cache_head, myblock);
+    }
+}
+
+void SmallArena::_free(GCAllocation* alloc, Block* b) {
+    assert(b == Block::forPointer(alloc));
+
+    size_t size = b->size;
+    int offset = (char*)alloc - (char*)b;
+    assert(offset % size == 0);
+    int atom_idx = offset / ATOM_SIZE;
+
+    assert(!b->isfree.isSet(atom_idx));
+    b->isfree.toggle(atom_idx);
+
+#ifndef NVALGRIND
+// VALGRIND_MEMPOOL_FREE(b, ptr);
+#endif
+}
+
+void _doFree(GCAllocation* al) {
+    if (VERBOSITY() >= 2)
+        printf("Freeing %p\n", al->user_data);
+
+    if (al->kind_id == GCKind::PYTHON) {
+        Box* b = (Box*)al->user_data;
+
+        ASSERT(b->cls->tp_dealloc == NULL, "%s", getTypeName(b));
+        if (b->cls->simple_destructor)
+            b->cls->simple_destructor(b);
+    }
+}
+
+void Heap::destroyContents(GCAllocation* al) {
+    _doFree(al);
 }
 
 void dumpHeapStatistics() {
@@ -527,7 +684,7 @@ void addStatistic(HeapStatistics* stats, GCAllocation* al, int nbytes) {
 }
 
 // TODO: copy-pasted from freeChain
-void getChainStatistics(HeapStatistics* stats, Block** head) {
+void SmallArena::getChainStatistics(HeapStatistics* stats, Block** head) {
     while (Block* b = *head) {
         int num_objects = b->numObjects();
         int first_obj = b->minObjIndex();
@@ -550,32 +707,50 @@ void getChainStatistics(HeapStatistics* stats, Block** head) {
 }
 
 // TODO: copy-pasted from freeUnmarked()
+void SmallArena::getStatistics(HeapStatistics* stats) {
+    thread_caches.forEachValue([this, stats](ThreadBlockCache* cache) {
+        for (int bidx = 0; bidx < NUM_BUCKETS; bidx++) {
+            Block* h = cache->cache_free_heads[bidx];
+
+            getChainStatistics(stats, &cache->cache_free_heads[bidx]);
+            getChainStatistics(stats, &cache->cache_full_heads[bidx]);
+        }
+    });
+
+    for (int bidx = 0; bidx < NUM_BUCKETS; bidx++) {
+        getChainStatistics(stats, &heads[bidx]);
+        getChainStatistics(stats, &full_heads[bidx]);
+    }
+}
+
+void LargeArena::getStatistics(HeapStatistics* stats) {
+    LargeObj* cur = head;
+    while (cur) {
+        GCAllocation* al = cur->data;
+        addStatistic(stats, al, cur->size);
+
+        cur = cur->next;
+    }
+}
+
+void HugeArena::getStatistics(HeapStatistics* stats) {
+    HugeObj* cur = head;
+    while (cur) {
+        GCAllocation* al = cur->data;
+        addStatistic(stats, al, cur->capacity());
+
+        cur = cur->next;
+    }
+}
+
 void Heap::dumpHeapStatistics() {
     threading::GLPromoteRegion _lock;
 
     HeapStatistics stats;
 
-    thread_caches.forEachValue([this, &stats](ThreadBlockCache* cache) {
-        for (int bidx = 0; bidx < NUM_BUCKETS; bidx++) {
-            Block* h = cache->cache_free_heads[bidx];
-
-            getChainStatistics(&stats, &cache->cache_free_heads[bidx]);
-            getChainStatistics(&stats, &cache->cache_full_heads[bidx]);
-        }
-    });
-
-    for (int bidx = 0; bidx < NUM_BUCKETS; bidx++) {
-        getChainStatistics(&stats, &heads[bidx]);
-        getChainStatistics(&stats, &full_heads[bidx]);
-    }
-
-    LargeObj* cur = large_head;
-    while (cur) {
-        GCAllocation* al = cur->data;
-        addStatistic(&stats, al, cur->capacity());
-
-        cur = cur->next;
-    }
+    small_arena.getStatistics(&stats);
+    large_arena.getStatistics(&stats);
+    huge_arena.getStatistics(&stats);
 
     stats.conservative.print("conservative");
     stats.untracked.print("untracked");

--- a/src/gc/heap.cpp
+++ b/src/gc/heap.cpp
@@ -35,7 +35,7 @@ namespace gc {
 
 void _doFree(GCAllocation* al);
 
-// lots of linked lists around here, so let's just use template functions for them all
+// lots of linked lists around here, so let's just use template functions for operations on them.
 template <class ListT> inline void nullNextPrev(ListT* node) {
     node->next = NULL;
     node->prev = NULL;
@@ -67,6 +67,13 @@ template <class ListT> inline void insertIntoLL(ListT** next_pointer, ListT* nex
     next->prev = next_pointer;
 }
 
+template <class ListT, typename Func> inline void forEach(ListT* list, Func func) {
+    auto cur = list;
+    while (cur) {
+        func(cur);
+        cur = cur->next;
+    }
+}
 
 template <class ListT, typename Free> inline void sweepList(ListT* head, Free free_func) {
     auto cur = head;
@@ -576,13 +583,7 @@ void LargeArena::freeUnmarked() {
 }
 
 void LargeArena::getStatistics(HeapStatistics* stats) {
-    LargeObj* cur = head;
-    while (cur) {
-        GCAllocation* al = cur->data;
-        addStatistic(stats, al, cur->size);
-
-        cur = cur->next;
-    }
+    forEach(head, [stats](LargeObj* obj) { addStatistic(stats, obj->data, obj->size); });
 }
 
 
@@ -774,13 +775,7 @@ void HugeArena::freeUnmarked() {
 }
 
 void HugeArena::getStatistics(HeapStatistics* stats) {
-    HugeObj* cur = head;
-    while (cur) {
-        GCAllocation* al = cur->data;
-        addStatistic(stats, al, cur->capacity());
-
-        cur = cur->next;
-    }
+    forEach(head, [stats](HugeObj* obj) { addStatistic(stats, obj->data, obj->capacity()); });
 }
 
 void HugeArena::_freeHugeObj(HugeObj* lobj) {

--- a/src/gc/heap.h
+++ b/src/gc/heap.h
@@ -105,7 +105,6 @@ static constexpr size_t NUM_BUCKETS = sizeof(sizes) / sizeof(sizes[0]);
 
 class SmallArena : public Arena<SMALL_ARENA_START> {
 public:
-
 private:
     template <int N> class Bitmap {
         static_assert(N % 64 == 0, "");

--- a/src/gc/heap.h
+++ b/src/gc/heap.h
@@ -389,6 +389,12 @@ public:
     Heap() : small_arena(this), large_arena(this), huge_arena(this) {}
 
     GCAllocation* realloc(GCAllocation* alloc, size_t bytes) {
+
+        // TODO(toshok): there is duplicate code in each of the
+        // ::realloc methods to test whether the allocation can be
+        // reused.  Would be nice to factor it all out here into this
+        // method.
+
         if (large_arena.contains(alloc)) {
             return large_arena.realloc(alloc, bytes);
         } else if (huge_arena.contains(alloc)) {

--- a/test/unittests/gc.cpp
+++ b/test/unittests/gc.cpp
@@ -68,6 +68,9 @@ TEST(alloc, alloc64) { testAlloc(64); }
 TEST(alloc, alloc128) { testAlloc(128); }
 TEST(alloc, alloc258) { testAlloc(258); }
 TEST(alloc, alloc3584) { testAlloc(3584); }
+TEST(alloc, alloc4096) { testAlloc(4096); }
+TEST(alloc, alloc8192) { testAlloc(8192); }
+TEST(alloc, alloc16384) { testAlloc(16384); }
 
 TEST(alloc, largeallocs) {
     int s1 = 1 << 20;


### PR DESCRIPTION
The diff is kinda hard to deal with, but the biggest piece of this change is the addition of another arena (Large, between the old Small/Large with the old Large renamed to Huge.)

I also added some template functions to help factor out the shared code across all arenas.

pidigits was the motivating benchmark for this change, but almost all benchmarks show some improvement:

```
Saving results as 'three_arena'
         pyston (calibration)                      :    1.0s baseline: 1.0 (+0.0%)
         pyston nbody_med.py                       :    3.0s baseline: 3.0 (-0.6%)
         pyston interp2.py                         :    6.4s baseline: 6.7 (-4.5%)
         pyston raytrace.py                        :    7.8s baseline: 7.8 (-0.3%)
         pyston nbody.py                           :   11.0s baseline: 11.1 (-0.8%)
         pyston fannkuch.py                        :    7.4s baseline: 7.2 (+3.5%)
         pyston chaos.py                           :   24.4s baseline: 25.1 (-2.9%)
         pyston spectral_norm.py                   :   38.2s baseline: 40.0 (-4.5%)
         pyston fasta.py                           :   20.8s baseline: 21.3 (-2.3%)
         pyston pidigits.py                        :    4.7s baseline: 18.5 (-74.7%)
         pyston richards.py                        :   11.9s baseline: 11.9 (+0.1%)
         pyston deltablue.py                       :    2.6s baseline: 2.6 (+1.3%)
         pyston sre_parse_parse.py                 :    1.9s baseline: 1.9 (-0.2%)
         pyston (geomean-f6d7)                     :    9.1s baseline: 10.4 (-12.7%)
```

`fannkuch.py` is showing `SmallArena::_alloc` at the top of the perf report at 17.84%.
