### PR TITLE
make functools.wrap() work

### DIFF
--- a/src/runtime/builtin_modules/builtins.cpp
+++ b/src/runtime/builtin_modules/builtins.cpp
@@ -459,7 +459,7 @@ Box* getattrFunc(Box* obj, Box* _str, Box* default_value) {
 
     Box* rtn = NULL;
     try {
-        rtn = getattrInternal(obj, str->s, NULL);
+        rtn = getattr(obj, str->s.c_str());
     } catch (ExcInfo e) {
         if (!e.matches(AttributeError))
             throw e;

--- a/src/runtime/types.cpp
+++ b/src/runtime/types.cpp
@@ -951,6 +951,23 @@ public:
         HCAttrs* attrs = self->b->getHCAttrsPtr();
         return boxInt(attrs->hcls->attr_offsets.size());
     }
+
+    static Box* update(Box* _self, Box* _container) {
+        RELEASE_ASSERT(_self->cls == attrwrapper_cls, "");
+        AttrWrapper* self = static_cast<AttrWrapper*>(_self);
+
+        if (_container->cls == attrwrapper_cls) {
+            AttrWrapper* container = static_cast<AttrWrapper*>(_container);
+            HCAttrs* attrs = container->b->getHCAttrsPtr();
+
+            for (const auto& p : attrs->hcls->attr_offsets) {
+                self->b->setattr(p.first, attrs->attr_list->attrs[p.second], NULL);
+            }
+        } else {
+            RELEASE_ASSERT(0, "not implemented");
+        }
+        return None;
+    }
 };
 
 Box* makeAttrWrapper(Box* b) {
@@ -1285,6 +1302,7 @@ void setupRuntime() {
     attrwrapper_cls->giveAttr("values", new BoxedFunction(boxRTFunction((void*)AttrWrapper::values, LIST, 1)));
     attrwrapper_cls->giveAttr("items", new BoxedFunction(boxRTFunction((void*)AttrWrapper::items, LIST, 1)));
     attrwrapper_cls->giveAttr("__len__", new BoxedFunction(boxRTFunction((void*)AttrWrapper::len, BOXED_INT, 1)));
+    attrwrapper_cls->giveAttr("update", new BoxedFunction(boxRTFunction((void*)AttrWrapper::update, NONE, 2)));
     attrwrapper_cls->freeze();
 
     // sys is the first module that needs to be set up, due to modules

--- a/test/tests/functools_test.py
+++ b/test/tests/functools_test.py
@@ -3,3 +3,18 @@ import functools
 f = functools.partial(lambda *args: args, 1, 23)
 print f("hello")
 print f("world", 5)
+
+
+def foo(x=1, y=2):
+    print ' inside foo:', x, y
+    return
+def wrapper(f):
+    @functools.wraps(f)
+    def decorated(x=2, y=3):
+        f(x, y)
+    return decorated
+for f in [foo, wrapper(foo)]:
+    print f.__name__
+    f()
+    f(3)
+


### PR DESCRIPTION
With this small patch applied we should be able to successfully ```import optparse``` even after #293 is applied (but this patch depends on #292 too)
The suggested order to apply the patches would be:
- #292
- this one
- #293

