### PR TITLE
Don't emit duplicate attr guards

### DIFF
--- a/src/asm_writing/rewriter.cpp
+++ b/src/asm_writing/rewriter.cpp
@@ -174,6 +174,8 @@ void Rewriter::_addGuardNotEq(RewriterVar* var, uint64_t val) {
 }
 
 void RewriterVar::addAttrGuard(int offset, uint64_t val, bool negate) {
+    if (!attr_guards.insert(std::make_tuple(offset, val, negate)).second)
+        return; // duplicate guard detected
     rewriter->addAction([=]() { rewriter->_addAttrGuard(this, offset, val, negate); }, { this }, ActionType::GUARD);
 }
 

--- a/src/asm_writing/rewriter.h
+++ b/src/asm_writing/rewriter.h
@@ -17,6 +17,9 @@
 
 #include <map>
 #include <memory>
+#include <tuple>
+
+#include "llvm/ADT/SmallSet.h"
 
 #include "asm_writing/assembler.h"
 #include "asm_writing/icinfo.h"
@@ -247,6 +250,8 @@ private:
     // Indicates if this variable is an arg, and if so, what location the arg is from.
     bool is_arg;
     Location arg_loc;
+
+    llvm::SmallSet<std::tuple<int, uint64_t, bool>, 4> attr_guards; // used to detect duplicate guards
 
     // Gets a copy of this variable in a register, spilling/reloading if necessary.
     // TODO have to be careful with the result since the interface doesn't guarantee


### PR DESCRIPTION
The reason for the speedup of spectral_norm is that we can now rewrite some stuff which did not fit inside the patchpoint before.
```
pyston (calibration)                      :    0.8s stock2: 0.8 (+2.5%)
pyston interp2.py                         :    5.9s stock2: 6.2 (-4.5%)
pyston raytrace.py                        :    6.9s stock2: 7.0 (-1.6%)
pyston nbody.py                           :    9.8s stock2: 9.6 (+1.9%)
pyston fannkuch.py                        :    7.0s stock2: 6.9 (+2.6%)
pyston chaos.py                           :   20.6s stock2: 21.6 (-4.6%)
pyston spectral_norm.py                   :   27.9s stock2: 34.2 (-18.6%)
pyston fasta.py                           :   17.1s stock2: 17.8 (-4.5%)
pyston pidigits.py                        :    4.4s stock2: 4.5 (-1.0%)
pyston richards.py                        :   10.4s stock2: 10.2 (+2.2%)
pyston deltablue.py                       :    2.2s stock2: 2.2 (-1.9%)
pyston (geomean-0b9f)                     :    8.8s stock2: 9.1 (-3.2%)
```
