### PR TITLE
remove the larger buckets, and hoist some math out of loops.

### DIFF
--- a/src/gc/heap.cpp
+++ b/src/gc/heap.cpp
@@ -359,8 +359,8 @@ SmallArena::Block** SmallArena::_freeChain(Block** head) {
         int first_obj = b->minObjIndex();
         int atoms_per_obj = b->atomsPerObj();
 
-        for (int obj_idx = first_obj; obj_idx < num_objects; obj_idx++) {
-            int atom_idx = obj_idx * atoms_per_obj;
+        for (int atom_idx = first_obj * atoms_per_obj; atom_idx < num_objects * atoms_per_obj;
+             atom_idx += atoms_per_obj) {
 
             if (b->isfree.isSet(atom_idx))
                 continue;
@@ -507,8 +507,8 @@ void SmallArena::_getChainStatistics(HeapStatistics* stats, Block** head) {
         int first_obj = b->minObjIndex();
         int atoms_per_obj = b->atomsPerObj();
 
-        for (int obj_idx = first_obj; obj_idx < num_objects; obj_idx++) {
-            int atom_idx = obj_idx * atoms_per_obj;
+        for (int atom_idx = first_obj * atoms_per_obj; atom_idx < num_objects * atoms_per_obj;
+             atom_idx += atoms_per_obj) {
 
             if (b->isfree.isSet(atom_idx))
                 continue;

--- a/src/gc/heap.h
+++ b/src/gc/heap.h
@@ -102,8 +102,8 @@ constexpr uintptr_t HUGE_ARENA_START = 0x3270000000L;
 // bitmap for objects of a given size (constant for the block)
 //
 static const size_t sizes[] = {
-    16,  32,  48,  64,  80,  96,   112,  128,  160,  192,  224,  256,  320,  384,
-    448, 512, 640, 768, 896, 1024, 1280, 1536, 1792, 2048, 2560, 3072, 3584, // 4096,
+    16,  32,  48,  64,  80,  96,  112, 128, 160, 192,
+    224, 256, 320, 384, 448, 512, 640, 768, 896, 1024 //, 1280, 1536, 1792, 2048, 2560, 3072, 3584, // 4096,
 };
 static constexpr size_t NUM_BUCKETS = sizeof(sizes) / sizeof(sizes[0]);
 


### PR DESCRIPTION
For some reason the larger bucket sizes are causing a large perf hit
in spectral_norm.  It's unclear exactly why this is happening, but
theories are legion.  More investigation is warranted, but this gets us
back from the perf regression.

Also hoist the atom_idx calculation out of a couple of loops that were
iterating over object indices.

```
         pyston (calibration)                      :    1.0s baseline: 1.0 (+1.7%)
         pyston nbody_med.py                       :    2.8s baseline: 2.9 (-4.3%)
         pyston interp2.py                         :    6.5s baseline: 6.5 (-0.4%)
         pyston raytrace.py                        :    8.1s baseline: 8.0 (+0.3%)
         pyston nbody.py                           :   10.3s baseline: 10.7 (-3.3%)
         pyston fannkuch.py                        :    7.3s baseline: 7.1 (+1.8%)
         pyston chaos.py                           :   24.6s baseline: 24.8 (-0.6%)
         pyston spectral_norm.py                   :   30.7s baseline: 37.6 (-18.3%)
         pyston fasta.py                           :   20.5s baseline: 20.5 (-0.1%)
         pyston pidigits.py                        :    4.2s baseline: 4.7 (-10.2%)
         pyston richards.py                        :   12.1s baseline: 12.1 (+0.1%)
         pyston deltablue.py                       :    2.6s baseline: 2.6 (+0.2%)
         pyston sre_parse_parse.py                 :    1.9s baseline: 1.9 (+0.6%)
         pyston (geomean-f6d7)                     :    8.7s baseline: 9.0 (-3.3%)
```