### PR TITLE
Rewriter: Optimize contant value loading

### DIFF
--- a/src/asm_writing/assembler.h
+++ b/src/asm_writing/assembler.h
@@ -136,6 +136,8 @@ public:
     void cmp(Indirect mem, Immediate imm);
     void cmp(Indirect mem, Register reg);
 
+    void lea(Indirect mem, Register reg);
+
     void test(Register reg1, Register reg2);
 
     void jmp_cond(JumpDestination dest, ConditionCode condition);

--- a/src/asm_writing/rewriter.cpp
+++ b/src/asm_writing/rewriter.cpp
@@ -135,12 +135,98 @@ void RewriterVar::addGuard(uint64_t val) {
     rewriter->addAction([=]() { rewriter->_addGuard(this, val); }, { this }, ActionType::GUARD);
 }
 
+Rewriter::ConstLoader::ConstLoader(Rewriter* rewriter) : rewriter(rewriter) {
+    invalidateAll();
+}
+
+bool Rewriter::ConstLoader::tryRegRegMove(uint64_t val, assembler::Register dst_reg) {
+    // copy the value if there is a register which contains already the value
+    bool found_value = false;
+    assembler::Register src_reg = findConst(val, found_value);
+    if (found_value) {
+        if (src_reg != dst_reg)
+            rewriter->assembler->mov(src_reg, dst_reg);
+        setKnownValue(dst_reg, val);
+        return true;
+    }
+    return false;
+}
+
+bool Rewriter::ConstLoader::tryLea(uint64_t val, assembler::Register dst_reg) {
+    // for large constants it maybe beneficial to create the value with a LEA from a known const value
+    if (isLargeConstant(val)) {
+        for (int reg_num = 0; reg_num < assembler::Register::numRegs(); ++reg_num) {
+            if (!hasKnownValue(assembler::Register(reg_num)))
+                continue;
+
+            int64_t offset = val - last_known_value[reg_num];
+            if (isLargeConstant(offset))
+                continue; // LEA can only handle small offsets
+
+            rewriter->assembler->lea(assembler::Indirect(assembler::Register(reg_num), offset), dst_reg);
+            setKnownValue(dst_reg, val);
+            return true;
+        }
+        // TODO: maybe add RIP relative LEA
+    }
+    return false;
+}
+
+void Rewriter::ConstLoader::moveImmediate(uint64_t val, assembler::Register dst_reg) {
+    // fallback use a normal: mov reg, imm
+    rewriter->assembler->mov(assembler::Immediate(val), dst_reg);
+    setKnownValue(dst_reg, val);
+}
+
+void Rewriter::ConstLoader::invalidateAll() {
+    for (int reg_num = 0; reg_num < assembler::Register::numRegs(); ++reg_num)
+        last_known_value[reg_num] = unknown_value;
+}
+
+assembler::Register Rewriter::ConstLoader::findConst(uint64_t val, bool& found_value) {
+    found_value = false;
+
+    if (unknown_value == val)
+        return assembler::Register(0);
+
+    for (int reg_num = 0; reg_num < assembler::Register::numRegs(); ++reg_num) {
+        if (last_known_value[reg_num] == val) {
+            found_value = true;
+            return assembler::Register(reg_num);
+        }
+    }
+
+    return assembler::Register(0);
+}
+
+void Rewriter::ConstLoader::loadConstIntoReg(uint64_t val, assembler::Register dst_reg) {
+    if (tryRegRegMove(val, dst_reg))
+        return;
+
+    if (tryLea(val, dst_reg))
+        return;
+
+    moveImmediate(val, dst_reg);
+}
+
+assembler::Register Rewriter::ConstLoader::loadConst(uint64_t val, Location otherThan) {
+    bool found_value = false;
+    assembler::Register reg = findConst(val, found_value);
+    if (found_value)
+        return reg;
+
+    reg = rewriter->allocReg(Location::any(), otherThan);
+    if (tryLea(val, reg))
+        return reg;
+
+    moveImmediate(val, reg);
+    return reg;
+}
+
 void Rewriter::_addGuard(RewriterVar* var, uint64_t val) {
     assembler::Register var_reg = var->getInReg();
     if (isLargeConstant(val)) {
-        assembler::Register reg = allocReg(Location::any(), /* otherThan */ var_reg);
-        assert(reg != var_reg);
-        assembler->mov(assembler::Immediate(val), reg);
+        assembler::Register reg = const_loader.loadConst(val, /* otherThan */ var_reg);
         assembler->cmp(var_reg, reg);
     } else {
         assembler->cmp(var_reg, assembler::Immediate(val));
@@ -159,9 +245,7 @@ void RewriterVar::addGuardNotEq(uint64_t val) {
 void Rewriter::_addGuardNotEq(RewriterVar* var, uint64_t val) {
     assembler::Register var_reg = var->getInReg();
     if (isLargeConstant(val)) {
-        assembler::Register reg = allocReg(Location::any(), /* otherThan */ var_reg);
-        assert(var_reg != reg);
-        assembler->mov(assembler::Immediate(val), reg);
+        assembler::Register reg = const_loader.loadConst(val, /* otherThan */ var_reg);
         assembler->cmp(var_reg, reg);
     } else {
         assembler->cmp(var_reg, assembler::Immediate(val));
@@ -182,9 +266,7 @@ void RewriterVar::addAttrGuard(int offset, uint64_t val, bool negate) {
 void Rewriter::_addAttrGuard(RewriterVar* var, int offset, uint64_t val, bool negate) {
     assembler::Register var_reg = var->getInReg();
     if (isLargeConstant(val)) {
-        assembler::Register reg = allocReg(Location::any(), /* otherThan */ var_reg);
-        assert(reg != var_reg);
-        assembler->mov(assembler::Immediate(val), reg);
+        assembler::Register reg = const_loader.loadConst(val, /* otherThan */ var_reg);
         assembler->cmp(assembler::Indirect(var_reg, offset), reg);
     } else {
         assembler->cmp(assembler::Indirect(var_reg, offset), assembler::Immediate(val));
@@ -385,6 +467,7 @@ assembler::Register RewriterVar::getInReg(Location dest, bool allow_constant_in_
                 assert(dest_reg != reg); // should have been caught by the previous case
 
                 rewriter->assembler->mov(reg, dest_reg);
+                rewriter->const_loader.copy(reg, dest_reg);
                 rewriter->addLocationToVar(this, dest_reg);
                 return dest_reg;
             } else {
@@ -503,7 +586,7 @@ RewriterVar* Rewriter::loadConst(int64_t val, Location dest) {
 
 void Rewriter::_loadConst(RewriterVar* result, int64_t val, Location dest) {
     assembler::Register reg = allocReg(dest);
-    assembler->mov(assembler::Immediate(val), reg);
+    const_loader.loadConstIntoReg(val, reg);
     result->initializeInReg(reg);
 
     result->releaseIfNoUses();
@@ -710,8 +793,9 @@ void Rewriter::_call(RewriterVar* result, bool can_call_into_python, void* func_
     }
 #endif
 
-    assembler->mov(assembler::Immediate(func_addr), r);
+    const_loader.loadConstIntoReg((uint64_t)func_addr, r);
     assembler->callq(r);
+    const_loader.invalidateAll(); // TODO: we only need to invalidate the clobbered regs
 
     assert(vars_by_location.count(assembler::RAX) == 0);
     result->initializeInReg(assembler::RAX);
@@ -1170,6 +1254,8 @@ void Rewriter::spillRegister(assembler::Register reg, Location preserve) {
             continue;
 
         assembler->mov(reg, new_reg);
+        const_loader.copy(reg, new_reg);
+
         addLocationToVar(var, new_reg);
         removeLocationFromVar(var, reg);
         return;
@@ -1210,9 +1296,21 @@ assembler::Register Rewriter::allocReg(Location dest, Location otherThan) {
         int best = -1;
         bool found = false;
         assembler::Register best_reg(0);
+
+        // prefer registers which don't have a known const value
+        for (assembler::Register reg : allocatable_regs) {
+            if (Location(reg) != otherThan) {
+                if (!const_loader.hasKnownValue(reg) && vars_by_location.count(reg) == 0) {
+                    const_loader.invalidate(reg);
+                    return reg;
+                }
+            }
+        }
+
         for (assembler::Register reg : allocatable_regs) {
             if (Location(reg) != otherThan) {
                 if (vars_by_location.count(reg) == 0) {
+                    const_loader.invalidate(reg);
                     return reg;
                 }
                 RewriterVar* var = vars_by_location[reg];
@@ -1231,6 +1329,7 @@ assembler::Register Rewriter::allocReg(Location dest, Location otherThan) {
         assert(found);
         spillRegister(best_reg, /* preserve */ otherThan);
         assert(vars_by_location.count(best_reg) == 0);
+        const_loader.invalidate(best_reg);
         return best_reg;
     } else if (dest.type == Location::Register) {
         assembler::Register reg(dest.regnum);
@@ -1240,6 +1339,7 @@ assembler::Register Rewriter::allocReg(Location dest, Location otherThan) {
         }
 
         assert(vars_by_location.count(reg) == 0);
+        const_loader.invalidate(reg);
         return reg;
     } else {
         RELEASE_ASSERT(0, "%d", dest.type);
@@ -1356,8 +1456,9 @@ TypeRecorder* Rewriter::getTypeRecorder() {
 }
 
 Rewriter::Rewriter(ICSlotRewrite* rewrite, int num_args, const std::vector<int>& live_outs)
-    : rewrite(rewrite), assembler(rewrite->getAssembler()), return_location(rewrite->returnRegister()),
-      added_changing_action(false), marked_inside_ic(false), last_guard_action(-1), done_guarding(false) {
+    : rewrite(rewrite), assembler(rewrite->getAssembler()), const_loader(this),
+      return_location(rewrite->returnRegister()), added_changing_action(false), marked_inside_ic(false),
+      last_guard_action(-1), done_guarding(false) {
     initPhaseCollecting();
 
 #ifndef NDEBUG

--- a/src/asm_writing/rewriter.h
+++ b/src/asm_writing/rewriter.h
@@ -121,8 +121,8 @@ namespace pyston {
 // Replacement for unordered_map<Location, T>
 template <class T> class LocMap {
 private:
-    static const int N_REGS = 16;
-    static const int N_XMM = 16;
+    static const int N_REGS = assembler::Register::numRegs();
+    static const int N_XMM = assembler::XMMRegister::numRegs();
     static const int N_SCRATCH = 16;
     static const int N_STACK = 16;
 
@@ -304,9 +304,44 @@ enum class ActionType { NORMAL, GUARD, MUTATION };
 
 class Rewriter : public ICSlotRewrite::CommitHook {
 private:
+    // Helps generating the best code for loading a const integer value.
+    // By keeping track of the last known value of every register and reusing it.
+    class ConstLoader {
+    private:
+        uint64_t last_known_value[assembler::Register::numRegs()];
+        const uint64_t unknown_value = 0;
+        Rewriter* rewriter;
+
+        bool tryRegRegMove(uint64_t val, assembler::Register dst_reg);
+        bool tryLea(uint64_t val, assembler::Register dst_reg);
+        void moveImmediate(uint64_t val, assembler::Register dst_reg);
+
+    public:
+        ConstLoader(Rewriter* rewriter);
+
+        bool hasKnownValue(assembler::Register reg) const { return last_known_value[reg.regnum] != unknown_value; }
+        uint64_t getKnownValue(assembler::Register reg) const { return last_known_value[reg.regnum]; }
+        void setKnownValue(assembler::Register reg, uint64_t val) { last_known_value[reg.regnum] = val; }
+        void invalidate(assembler::Register reg) { setKnownValue(reg, unknown_value); }
+        void invalidateAll();
+        void copy(assembler::Register src_reg, assembler::Register dst_reg) {
+            setKnownValue(dst_reg, getKnownValue(src_reg));
+        }
+
+        // Searches if the specified value is already loaded into a register and if so it return the register
+        assembler::Register findConst(uint64_t val, bool& found_value);
+
+        // Loads the constant into the specified register
+        void loadConstIntoReg(uint64_t val, assembler::Register reg);
+
+        // Loads the constant into any register or if already in a register just return it
+        assembler::Register loadConst(uint64_t val, Location otherThan = Location::any());
+    };
+
+
     std::unique_ptr<ICSlotRewrite> rewrite;
     assembler::Assembler* assembler;
-
+    ConstLoader const_loader;
     std::vector<RewriterVar*> vars;
 
     const Location return_location;

--- a/src/asm_writing/types.h
+++ b/src/asm_writing/types.h
@@ -40,6 +40,8 @@ struct Register {
     bool operator!=(const Register& rhs) const { return !(*this == rhs); }
 
     void dump() const;
+
+    static constexpr int numRegs() { return 16; }
 };
 
 const Register RAX(0);
@@ -81,6 +83,8 @@ struct XMMRegister {
     bool operator!=(const XMMRegister& rhs) const { return !(*this == rhs); }
 
     void dump() const { printf("XMM%d\n", regnum); }
+
+    static constexpr int numRegs() { return 16; }
 };
 
 const XMMRegister XMM0(0);


### PR DESCRIPTION
- Reuse a register if it already contains the specified value
- Generate LEA when beneficial

I checked with the Intel® Architecture Code Analyzer that the generated code using ```LEA reg, reg+offset``` has the exact same performance as a ```mov reg, imm``` (checked Sandy Bridge and Haswell)

The main motivation for this patch is that I would like to generate smaller patchpoints.

With this patch:
```ASM
<+0x00ee>        48 b8 08 a0 00 70 12 00 00 00  movabs rax,0x127000a008
<+0x00f8>        48 3b 07                       cmp    rax,QWORD PTR [rdi]
<+0x00fb>        0f 85 ec 01 00 00              jne    0x7ffff7fd02ed <eval_A_e1_4+749>
<+0x0101>        48 3b 06                       cmp    rax,QWORD PTR [rsi]
<+0x0104>        0f 85 e3 01 00 00              jne    0x7ffff7fd02ed <eval_A_e1_4+749>
<+0x010a>        48 8b 0f                       mov    rcx,QWORD PTR [rdi]
<+0x010d>        4c 8d 80 00 e4 ff ff           lea    r8,[rax-0x1c00]
<+0x0114>        4c 3b 01                       cmp    r8,QWORD PTR [rcx]
<+0x0117>        0f 85 d0 01 00 00              jne    0x7ffff7fd02ed <eval_A_e1_4+749>
<+0x011d>        4c 8d 88 00 7b ff ff           lea    r9,[rax-0x8500]
<+0x0124>        4c 3b 89 80 01 00 00           cmp    r9,QWORD PTR [rcx+0x180]
<+0x012b>        0f 85 bc 01 00 00              jne    0x7ffff7fd02ed <eval_A_e1_4+749>
<+0x0131>        48 8b 89 88 01 00 00           mov    rcx,QWORD PTR [rcx+0x188]
<+0x0138>        48 8b 49 08                    mov    rcx,QWORD PTR [rcx+0x8]
<+0x013c>        4c 8d 90 00 14 00 00           lea    r10,[rax+0x1400]
<+0x0143>        4c 3b 11                       cmp    r10,QWORD PTR [rcx]
<+0x0146>        0f 85 a1 01 00 00              jne    0x7ffff7fd02ed <eval_A_e1_4+749>
<+0x014c>        4c 8d 98 60 2e 01 00           lea    r11,[rax+0x12e60]
<+0x0153>        49 39 cb                       cmp    r11,rcx
<+0x0156>        0f 85 91 01 00 00              jne    0x7ffff7fd02ed <eval_A_e1_4+749>
<+0x015c>        48 b9 3c 4d 32 02 00 00 00 00  movabs rcx,0x2324d3c
<+0x0166>        ff 01                          inc    DWORD PTR [rcx]
<+0x0168>        49 bb 10 10 88 00 00 00 00 00  movabs r11,0x881010
<+0x0172>        41 ff d3                       call   r11
<+0x0175>        48 b9 3c 4d 32 02 00 00 00 00  movabs rcx,0x2324d3c
<+0x017f>        ff 09                          dec    DWORD PTR [rcx]
<+0x0181>        e9 c6 07 00 00                 jmp    0x7ffff7fd094c <eval_A_e1_4+2380>
```

Without:
```ASM
<+0x00ee>        48 b8 08 a0 00 70 12 00 00 00  movabs rax,0x127000a008
<+0x00f8>        48 3b 07                       cmp    rax,QWORD PTR [rdi]
<+0x00fb>        0f 85 ec 01 00 00              jne    0x7ffff7fd02ed <eval_A_e1_4+749>
<+0x0101>        48 b8 08 a0 00 70 12 00 00 00  movabs rax,0x127000a008
<+0x010b>        48 3b 06                       cmp    rax,QWORD PTR [rsi]
<+0x010e>        0f 85 d9 01 00 00              jne    0x7ffff7fd02ed <eval_A_e1_4+749>
<+0x0114>        48 8b 07                       mov    rax,QWORD PTR [rdi]
<+0x0117>        48 b9 08 84 00 70 12 00 00 00  movabs rcx,0x1270008408
<+0x0121>        48 3b 08                       cmp    rcx,QWORD PTR [rax]
<+0x0124>        0f 85 c3 01 00 00              jne    0x7ffff7fd02ed <eval_A_e1_4+749>
<+0x012a>        48 b9 08 1b 00 70 12 00 00 00  movabs rcx,0x1270001b08
<+0x0134>        48 3b 88 80 01 00 00           cmp    rcx,QWORD PTR [rax+0x180]
<+0x013b>        0f 85 ac 01 00 00              jne    0x7ffff7fd02ed <eval_A_e1_4+749>
<+0x0141>        48 8b 80 88 01 00 00           mov    rax,QWORD PTR [rax+0x188]
<+0x0148>        48 8b 40 08                    mov    rax,QWORD PTR [rax+0x8]
<+0x014c>        48 b9 08 b4 00 70 12 00 00 00  movabs rcx,0x127000b408
<+0x0156>        48 3b 08                       cmp    rcx,QWORD PTR [rax]
<+0x0159>        0f 85 8e 01 00 00              jne    0x7ffff7fd02ed <eval_A_e1_4+749>
<+0x015f>        48 b9 68 ce 01 70 12 00 00 00  movabs rcx,0x127001ce68
<+0x0169>        48 39 c1                       cmp    rcx,rax
<+0x016c>        0f 85 7b 01 00 00              jne    0x7ffff7fd02ed <eval_A_e1_4+749>
<+0x0172>        48 b8 ac 21 3e 02 00 00 00 00  movabs rax,0x23e21ac
<+0x017c>        ff 00                          inc    DWORD PTR [rax]
<+0x017e>        49 bb f0 02 88 00 00 00 00 00  movabs r11,0x8802f0
<+0x0188>        41 ff d3                       call   r11
<+0x018b>        48 b9 ac 21 3e 02 00 00 00 00  movabs rcx,0x23e21ac
<+0x0195>        ff 09                          dec    DWORD PTR [rcx]
<+0x0197>        e9 b0 07 00 00                 jmp    0x7ffff7fd094c <eval_A_e1_4+2380>
```

Looking for suggestions from some one more familiar with the rewriter how to improve this patch.


