### PR TITLE
rewrite classmethod calls and more compare cases

### DIFF
--- a/src/runtime/list.cpp
+++ b/src/runtime/list.cpp
@@ -602,7 +602,6 @@ extern "C" void listIteratorGCHandler(GCVisitor* v, Box* b) {
 }
 
 extern "C" Box* listNew(Box* cls, Box* container) {
-    assert(cls == list_cls);
 
     if (container == None)
         return new BoxedList();

--- a/src/runtime/objmodel.cpp
+++ b/src/runtime/objmodel.cpp
@@ -58,6 +58,7 @@
 #define ATTRLIST_KIND_OFFSET ((char*)&(((HCAttrs::AttrList*)0x01)->gc_header.kind_id) - (char*)0x1)
 #define INSTANCEMETHOD_FUNC_OFFSET ((char*)&(((BoxedInstanceMethod*)0x01)->func) - (char*)0x1)
 #define INSTANCEMETHOD_OBJ_OFFSET ((char*)&(((BoxedInstanceMethod*)0x01)->obj) - (char*)0x1)
+#define CLASSMETHOD_CALLABLE_OFFSET ((char*)&(((BoxedClassmethod*)0x01)->cm_callable) - (char*)0x1)
 #define BOOL_B_OFFSET ((char*)&(((BoxedBool*)0x01)->n) - (char*)0x1)
 #define INT_N_OFFSET ((char*)&(((BoxedInt*)0x01)->n) - (char*)0x1)
 
@@ -705,7 +706,7 @@ Box* nondataDescriptorInstanceSpecialCases(GetattrRewriteArgs* rewrite_args, Box
 
             if (rewrite_args) {
                 r_im_self = rewrite_args->obj->getAttr(BOX_CLS_OFFSET);
-                r_im_func = r_descr->getAttr(offsetof(BoxedClassmethod, cm_callable));
+                r_im_func = r_descr->getAttr(CLASSMETHOD_CALLABLE_OFFSET);
                 r_im_func->addGuardNotEq(0);
             }
         } else if (descr->cls == instancemethod_cls) {
@@ -792,6 +793,40 @@ Box* descriptorClsSpecialCases(GetattrRewriteArgs* rewrite_args, BoxedClass* cls
             rewrite_args->out_success = true;
             rewrite_args->out_rtn = r_descr;
         }
+        return descr;
+    }
+
+    // Special case: classmethod descriptor
+    if (descr->cls == classmethod_cls) {
+        if (rewrite_args)
+            r_descr->addAttrGuard(BOX_CLS_OFFSET, (uint64_t)descr->cls);
+
+        BoxedClassmethod* cm = static_cast<BoxedClassmethod*>(descr);
+        Box* im_func = cm->cm_callable;
+
+        RewriterVar* r_im_self = NULL;
+
+        if (rewrite_args)
+            r_im_self = rewrite_args->obj->getAttr(BOX_CLS_OFFSET);
+
+        if (!for_call) {
+            if (rewrite_args) {
+                RewriterVar* r_im_func = r_descr->getAttr(CLASSMETHOD_CALLABLE_OFFSET);
+                r_im_func->addGuardNotEq(0);
+
+                rewrite_args->out_rtn
+                    = rewrite_args->rewriter->call(false, (void*)boxInstanceMethod, r_im_self, r_im_func);
+                rewrite_args->out_success = true;
+            }
+            return boxInstanceMethod(cls, im_func);
+        }
+
+        if (rewrite_args) {
+            *r_bind_obj_out = r_im_self;
+            rewrite_args->out_success = true;
+            rewrite_args->out_rtn = r_descr;
+        }
+        *bind_obj_out = cls;
         return descr;
     }
 
@@ -1753,7 +1788,7 @@ extern "C" bool nonzero(Box* obj) {
     if (func == NULL) {
         ASSERT(isUserDefined(obj->cls) || obj->cls == classobj_cls || obj->cls == type_cls
                    || isSubclass(obj->cls, Exception) || obj->cls == file_cls || obj->cls == traceback_cls
-                   || obj->cls == instancemethod_cls || obj->cls == module_cls,
+                   || obj->cls == instancemethod_cls || obj->cls == classmethod_cls || obj->cls == module_cls,
                "%s.__nonzero__", getTypeName(obj)); // TODO
 
         // TODO should rewrite these?
@@ -2163,7 +2198,7 @@ extern "C" Box* callattrInternal(Box* obj, const std::string* attr, LookupScope 
         // I *think* this check is here to limit the recursion nesting for rewriting, and originates
         // from a time when we didn't have silent-abort-when-patchpoint-full.
         if (val->cls != function_cls && val->cls != builtin_function_or_method_cls && val->cls != instancemethod_cls
-            && val->cls != capifunc_cls) {
+            && val->cls != classmethod_cls && val->cls != capifunc_cls) {
             rewrite_args = NULL;
             REWRITE_ABORTED("");
         }
@@ -2724,7 +2759,8 @@ Box* runtimeCallInternal(Box* obj, CallRewriteArgs* rewrite_args, ArgPassSpec ar
                          Box** args, const std::vector<const std::string*>* keyword_names) {
     int npassed_args = argspec.totalPassed();
 
-    if (obj->cls != function_cls && obj->cls != builtin_function_or_method_cls && obj->cls != instancemethod_cls) {
+    if (obj->cls != function_cls && obj->cls != builtin_function_or_method_cls && obj->cls != instancemethod_cls
+        && obj->cls != classmethod_cls) {
         Box* rtn;
         if (rewrite_args) {
             // TODO is this ok?
@@ -2770,6 +2806,17 @@ Box* runtimeCallInternal(Box* obj, CallRewriteArgs* rewrite_args, ArgPassSpec ar
         }
         Box* res = callable(f, rewrite_args, argspec, arg1, arg2, arg3, args, keyword_names);
         return res;
+    } else if (obj->cls == classmethod_cls) {
+        // TODO it's dumb but I should implement patchpoints here as well
+        // duplicated with callattr
+        BoxedClassmethod* cm = static_cast<BoxedClassmethod*>(obj);
+
+        if (rewrite_args && !rewrite_args->func_guarded) {
+            rewrite_args->obj->addAttrGuard(CLASSMETHOD_CALLABLE_OFFSET, (intptr_t)cm->cm_callable);
+        }
+
+        Box* rtn = runtimeCall(cm->cm_callable, argspec, arg1, arg2, arg3, args, keyword_names);
+        return rtn;
     } else if (obj->cls == instancemethod_cls) {
         // TODO it's dumb but I should implement patchpoints here as well
         // duplicated with callattr
@@ -3126,7 +3173,6 @@ Box* compareInternal(Box* lhs, Box* rhs, int op_type, CompareRewriteArgs* rewrit
     }
 
     const std::string& op_name = getOpName(op_type);
-
     Box* lrtn;
     if (rewrite_args) {
         CallRewriteArgs crewrite_args(rewrite_args->rewriter, rewrite_args->lhs, rewrite_args->destination);
@@ -3153,18 +3199,48 @@ Box* compareInternal(Box* lhs, Box* rhs, int op_type, CompareRewriteArgs* rewrit
         }
     }
 
-    // TODO patch these cases
+    const std::string& rop_name = getReverseOpName(op_type);
+    Box* rrtn;
     if (rewrite_args) {
-        assert(rewrite_args->out_success == false);
-        rewrite_args = NULL;
-        REWRITE_ABORTED("");
+        CallRewriteArgs crewrite_args(rewrite_args->rewriter, rewrite_args->rhs, rewrite_args->destination);
+        crewrite_args.arg1 = rewrite_args->lhs;
+        rrtn = callattrInternal1(rhs, &rop_name, CLASS_ONLY, &crewrite_args, ArgPassSpec(1), lhs);
+
+        if (!crewrite_args.out_success)
+            rewrite_args = NULL;
+        else if (rrtn)
+            rewrite_args->out_rtn = crewrite_args.out_rtn;
+    } else {
+        rrtn = callattrInternal1(rhs, &rop_name, CLASS_ONLY, NULL, ArgPassSpec(1), lhs);
     }
 
-    std::string rop_name = getReverseOpName(op_type);
-    Box* rrtn = callattrInternal1(rhs, &rop_name, CLASS_ONLY, NULL, ArgPassSpec(1), lhs);
-    if (rrtn != NULL && rrtn != NotImplemented)
-        return rrtn;
+    if (rrtn != NULL) {
+        if (rrtn != NotImplemented) {
+            bool can_patchpoint = !isUserDefined(lhs->cls) && !isUserDefined(rhs->cls);
+            if (rewrite_args) {
+                if (can_patchpoint) {
+                    rewrite_args->out_success = true;
+                }
+            }
+            return rrtn;
+        }
+    }
 
+    // for cases where we don't have a __eq__/__neq__ method, just
+    // embed the comparison as we do for Is/IsNot above
+    if (!lrtn && !rrtn && rewrite_args) {
+        assert(rewrite_args->out_success == false);
+        if (op_type == AST_TYPE::Eq || AST_TYPE::NotEq) {
+            rewrite_args->out_success = true;
+            RewriterVar* cmpres
+                = rewrite_args->lhs->cmp((AST_TYPE::AST_TYPE)op_type, rewrite_args->rhs, rewrite_args->destination);
+            rewrite_args->out_rtn = rewrite_args->rewriter->call(false, (void*)boxBool, cmpres);
+        } else {
+            // TODO rewrite other compare ops
+            rewrite_args = NULL;
+            REWRITE_ABORTED("");
+        }
+    }
 
     if (op_type == AST_TYPE::Eq)
         return boxBool(lhs == rhs);
@@ -3450,6 +3526,9 @@ extern "C" Box* getPystonIter(Box* o) {
 }
 
 Box* getiter(Box* o) {
+    static StatCounter slowpath_delattr("slowpath_getiter");
+    slowpath_delattr.log();
+
     // TODO add rewriting to this?  probably want to try to avoid this path though
     Box* r = callattrInternal0(o, &iter_str, LookupScope::CLASS_ONLY, NULL, ArgPassSpec(0));
     if (r)

--- a/src/runtime/objmodel.cpp
+++ b/src/runtime/objmodel.cpp
@@ -3230,7 +3230,7 @@ Box* compareInternal(Box* lhs, Box* rhs, int op_type, CompareRewriteArgs* rewrit
     // embed the comparison as we do for Is/IsNot above
     if (!lrtn && !rrtn && rewrite_args) {
         assert(rewrite_args->out_success == false);
-        if (op_type == AST_TYPE::Eq || AST_TYPE::NotEq) {
+        if (op_type == AST_TYPE::Eq || op_type == AST_TYPE::NotEq) {
             rewrite_args->out_success = true;
             RewriterVar* cmpres
                 = rewrite_args->lhs->cmp((AST_TYPE::AST_TYPE)op_type, rewrite_args->rhs, rewrite_args->destination);

--- a/src/runtime/objmodel.cpp
+++ b/src/runtime/objmodel.cpp
@@ -3197,6 +3197,10 @@ Box* compareInternal(Box* lhs, Box* rhs, int op_type, CompareRewriteArgs* rewrit
             }
             return lrtn;
         }
+
+        // if the function returned anything, we have to abort the rewrite
+        rewrite_args = NULL;
+        REWRITE_ABORTED("");
     }
 
     const std::string& rop_name = getReverseOpName(op_type);
@@ -3224,6 +3228,10 @@ Box* compareInternal(Box* lhs, Box* rhs, int op_type, CompareRewriteArgs* rewrit
             }
             return rrtn;
         }
+
+        // if the function returned anything, we have to abort the rewrite
+        rewrite_args = NULL;
+        REWRITE_ABORTED("");
     }
 
     // for cases where we don't have a __eq__/__neq__ method, just


### PR DESCRIPTION
deltablue makes a lot of `@classmethod` calls.  rewrite those.
    
also, for compares, rewrite when there's a reverse compare function, and
also when neither function is present and we're comparing with `Eq`/`NotEq`.

helps deltablue, chaos, fasta, and spectral_norm

```
         pyston (calibration)                      :    1.0s baseline: 1.0 (+0.0%)
         pyston nbody_med.py                       :    2.2s baseline: 2.2 (+0.9%)
         pyston interp2.py                         :    4.0s baseline: 4.1 (-3.2%)
         pyston raytrace.py                        :    7.6s baseline: 7.7 (-0.3%)
         pyston nbody.py                           :    8.2s baseline: 8.2 (+0.6%)
         pyston fannkuch.py                        :    6.2s baseline: 6.2 (+0.2%)
         pyston chaos.py                           :   20.6s baseline: 21.4 (-4.0%)
         pyston spectral_norm.py                   :   17.1s baseline: 18.0 (-5.2%)
         pyston fasta.py                           :    6.1s baseline: 6.3 (-4.0%)
         pyston pidigits.py                        :    4.2s baseline: 4.3 (-0.7%)
         pyston richards.py                        :    1.8s baseline: 1.8 (+1.7%)
         pyston deltablue.py                       :    2.5s baseline: 2.5 (-2.9%)
         pyston sre_parse_parse.py                 :    1.9s baseline: 1.9 (-0.1%)
         pyston (geomean-f6d7)                     :    5.5s baseline: 5.6 (-1.6%)
```