### PR TITLE
Add compvars and rewriting support for GET_ITER nodes 

### DIFF
--- a/src/analysis/type_analysis.cpp
+++ b/src/analysis/type_analysis.cpp
@@ -365,8 +365,9 @@ private:
                 return BOOL;
             case AST_LangPrimitive::LOCALS:
                 return DICT;
-            case AST_LangPrimitive::LANDINGPAD:
             case AST_LangPrimitive::GET_ITER:
+                return getType(node->args[0])->getPystonIterType();
+            case AST_LangPrimitive::LANDINGPAD:
             case AST_LangPrimitive::IMPORT_FROM:
             case AST_LangPrimitive::IMPORT_STAR:
             case AST_LangPrimitive::IMPORT_NAME:

--- a/src/codegen/compvars.h
+++ b/src/codegen/compvars.h
@@ -112,7 +112,7 @@ public:
     }
 
     virtual CompilerVariable* callattr(IREmitter& emitter, const OpInfo& info, VAR* var, const std::string* attr,
-                                       bool clsonly, struct ArgPassSpec argspec,
+                                       CallattrFlags flags, struct ArgPassSpec argspec,
                                        const std::vector<CompilerVariable*>& args,
                                        const std::vector<const std::string*>* keyword_names) {
         printf("callattr not defined for %s\n", debugName().c_str());
@@ -254,8 +254,9 @@ public:
         = 0;
     virtual void setattr(IREmitter& emitter, const OpInfo& info, const std::string* attr, CompilerVariable* v) = 0;
     virtual void delattr(IREmitter& emitter, const OpInfo& info, const std::string* attr) = 0;
-    virtual CompilerVariable* callattr(IREmitter& emitter, const OpInfo& info, const std::string* attr, bool clsonly,
-                                       struct ArgPassSpec argspec, const std::vector<CompilerVariable*>& args,
+    virtual CompilerVariable* callattr(IREmitter& emitter, const OpInfo& info, const std::string* attr,
+                                       CallattrFlags flags, struct ArgPassSpec argspec,
+                                       const std::vector<CompilerVariable*>& args,
                                        const std::vector<const std::string*>* keyword_names) = 0;
     virtual CompilerVariable* call(IREmitter& emitter, const OpInfo& info, struct ArgPassSpec argspec,
                                    const std::vector<CompilerVariable*>& args,
@@ -330,10 +331,10 @@ public:
         type->delattr(emitter, info, this, attr);
     }
 
-    CompilerVariable* callattr(IREmitter& emitter, const OpInfo& info, const std::string* attr, bool clsonly,
+    CompilerVariable* callattr(IREmitter& emitter, const OpInfo& info, const std::string* attr, CallattrFlags flags,
                                struct ArgPassSpec argspec, const std::vector<CompilerVariable*>& args,
                                const std::vector<const std::string*>* keyword_names) override {
-        return type->callattr(emitter, info, this, attr, clsonly, argspec, args, keyword_names);
+        return type->callattr(emitter, info, this, attr, flags, argspec, args, keyword_names);
     }
     CompilerVariable* call(IREmitter& emitter, const OpInfo& info, struct ArgPassSpec argspec,
                            const std::vector<CompilerVariable*>& args,

--- a/src/codegen/irgen.h
+++ b/src/codegen/irgen.h
@@ -68,7 +68,10 @@ public:
     virtual IRBuilder* getBuilder() = 0;
     virtual GCBuilder* getGC() = 0;
     virtual CompiledFunction* currentFunction() = 0;
+    virtual llvm::BasicBlock* currentBasicBlock() = 0;
     virtual llvm::BasicBlock* createBasicBlock(const char* name = "") = 0;
+
+    virtual void setCurrentBasicBlock(llvm::BasicBlock*) = 0;
 
     virtual llvm::Value* getScratch(int num_bytes) = 0;
     virtual void releaseScratch(llvm::Value*) = 0;

--- a/src/codegen/irgen/irgenerator.cpp
+++ b/src/codegen/irgen/irgenerator.cpp
@@ -457,8 +457,9 @@ private:
                         ConcreteCompilerVariable* converted = p.second->makeConverted(emitter, p.second->getBoxType());
 
                         // TODO super dumb that it reallocates the name again
+                        CallattrFlags flags = {.cls_only = true, .null_on_nonexistent = false };
                         CompilerVariable* _r
-                            = rtn->callattr(emitter, getEmptyOpInfo(unw_info), &setitem_str, true, ArgPassSpec(2),
+                            = rtn->callattr(emitter, getEmptyOpInfo(unw_info), &setitem_str, flags, ArgPassSpec(2),
                                             { makeStr(new std::string(p.first.str())), converted }, NULL);
                         converted->decvref(emitter);
                         _r->decvref(emitter);
@@ -474,8 +475,9 @@ private:
                         emitter.getBuilder()->SetInsertPoint(was_defined);
                         ConcreteCompilerVariable* converted = p.second->makeConverted(emitter, p.second->getBoxType());
                         // TODO super dumb that it reallocates the name again
+                        CallattrFlags flags = {.cls_only = true, .null_on_nonexistent = false };
                         CompilerVariable* _r
-                            = rtn->callattr(emitter, getEmptyOpInfo(unw_info), &setitem_str, true, ArgPassSpec(2),
+                            = rtn->callattr(emitter, getEmptyOpInfo(unw_info), &setitem_str, flags, ArgPassSpec(2),
                                             { makeStr(new std::string(p.first.str())), converted }, NULL);
                         converted->decvref(emitter);
                         _r->decvref(emitter);
@@ -744,8 +746,8 @@ private:
 
         CompilerVariable* rtn;
         if (is_callattr) {
-            rtn = func->callattr(emitter, getOpInfoForNode(node, unw_info), attr, callattr_clsonly, argspec, args,
-                                 keyword_names);
+            CallattrFlags flags = {.cls_only = callattr_clsonly, .null_on_nonexistent = false };
+            rtn = func->callattr(emitter, getOpInfoForNode(node, unw_info), attr, flags, argspec, args, keyword_names);
         } else {
             rtn = func->call(emitter, getOpInfoForNode(node, unw_info), argspec, args, keyword_names);
         }
@@ -972,8 +974,8 @@ private:
 
         for (int i = 0; i < node->elts.size(); i++) {
             CompilerVariable* elt = elts[i];
-
-            CompilerVariable* r = rtn->callattr(emitter, getOpInfoForNode(node, unw_info), &add_str, true,
+            CallattrFlags flags = {.cls_only = true, .null_on_nonexistent = false };
+            CompilerVariable* r = rtn->callattr(emitter, getOpInfoForNode(node, unw_info), &add_str, flags,
                                                 ArgPassSpec(1), { elt }, NULL);
             r->decvref(emitter);
             elt->decvref(emitter);
@@ -1636,8 +1638,8 @@ private:
 
             curblock = ss_block;
             emitter.getBuilder()->SetInsertPoint(ss_block);
-
-            auto r = dest->callattr(emitter, getOpInfoForNode(node, unw_info), &write_str, false, ArgPassSpec(1),
+            CallattrFlags flags = {.cls_only = false, .null_on_nonexistent = false };
+            auto r = dest->callattr(emitter, getOpInfoForNode(node, unw_info), &write_str, flags, ArgPassSpec(1),
                                     { makeStr(&space_str) }, NULL);
             r->decvref(emitter);
 
@@ -1650,7 +1652,7 @@ private:
             llvm::Value* v = emitter.createCall(unw_info, g.funcs.str, converted->getValue());
             v = emitter.getBuilder()->CreateBitCast(v, g.llvm_value_type_ptr);
             auto s = new ConcreteCompilerVariable(STR, v, true);
-            r = dest->callattr(emitter, getOpInfoForNode(node, unw_info), &write_str, false, ArgPassSpec(1), { s },
+            r = dest->callattr(emitter, getOpInfoForNode(node, unw_info), &write_str, flags, ArgPassSpec(1), { s },
                                NULL);
             s->decvref(emitter);
             r->decvref(emitter);
@@ -1658,7 +1660,8 @@ private:
         }
 
         if (node->nl) {
-            auto r = dest->callattr(emitter, getOpInfoForNode(node, unw_info), &write_str, false, ArgPassSpec(1),
+            CallattrFlags flags = {.cls_only = false, .null_on_nonexistent = false };
+            auto r = dest->callattr(emitter, getOpInfoForNode(node, unw_info), &write_str, flags, ArgPassSpec(1),
                                     { makeStr(&newline_str) }, NULL);
             r->decvref(emitter);
 

--- a/src/codegen/runtime_hooks.cpp
+++ b/src/codegen/runtime_hooks.cpp
@@ -207,7 +207,7 @@ void initGlobalFuncs(GlobalState& g) {
     GET(str);
     GET(isinstance);
     GET(yield);
-    GET(getPystonIter);
+    GET(getiterHelper);
 
     GET(unpackIntoArray);
     GET(raiseAttributeError);

--- a/src/codegen/runtime_hooks.h
+++ b/src/codegen/runtime_hooks.h
@@ -37,7 +37,7 @@ struct GlobalFuncs {
         *createUserClass, *createClosure, *createGenerator, *createLong, *createSet, *createPureImaginary;
     llvm::Value* getattr, *setattr, *delattr, *delitem, *delGlobal, *nonzero, *binop, *compare, *augbinop, *unboxedLen,
         *getitem, *getclsattr, *getGlobal, *setitem, *unaryop, *import, *importFrom, *importStar, *repr, *str,
-        *isinstance, *yield, *getPystonIter;
+        *isinstance, *yield, *getiterHelper;
 
     llvm::Value* unpackIntoArray, *raiseAttributeError, *raiseAttributeErrorStr, *raiseNotIterableError,
         *assertNameDefined, *assertFail;

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -559,6 +559,11 @@ struct FrameInfo {
 
     FrameInfo(ExcInfo exc) : exc(exc) {}
 };
+
+struct CallattrFlags {
+    bool cls_only : 1;
+    bool null_on_nonexistent : 1;
+};
 }
 
 #endif

--- a/src/runtime/inline/link_forcer.cpp
+++ b/src/runtime/inline/link_forcer.cpp
@@ -88,7 +88,7 @@ void force() {
     FORCE(str);
     FORCE(isinstance);
     FORCE(yield);
-    FORCE(getPystonIter);
+    FORCE(getiterHelper);
 
     FORCE(unpackIntoArray);
     FORCE(raiseAttributeError);

--- a/src/runtime/objmodel.cpp
+++ b/src/runtime/objmodel.cpp
@@ -3461,6 +3461,41 @@ extern "C" void delattr(Box* obj, const char* attr) {
     delattr_internal(obj, attr, true, NULL);
 }
 
+extern "C" Box* createBoxedIterWrapper(Box* o) {
+    return new BoxedIterWrapper(o);
+}
+
+extern "C" Box* createBoxedIterWrapperIfNeeded(Box* o) {
+    std::unique_ptr<Rewriter> rewriter(Rewriter::createRewriter(
+        __builtin_extract_return_addr(__builtin_return_address(0)), 1, "createBoxedIterWrapperIfNeeded"));
+
+    if (rewriter.get()) {
+        RewriterVar* r_o = rewriter->getArg(0);
+        RewriterVar* r_cls = r_o->getAttr(BOX_CLS_OFFSET);
+        GetattrRewriteArgs rewrite_args(rewriter.get(), r_cls, rewriter->getReturnDestination());
+        Box* r = typeLookup(o->cls, hasnext_str, &rewrite_args);
+        if (!rewrite_args.out_success) {
+            rewriter.reset(NULL);
+        } else if (r) {
+            rewrite_args.out_rtn->addGuard((uint64_t)r);
+            if (rewrite_args.out_success) {
+                rewriter->commitReturning(r_o);
+                return o;
+            }
+        } else if (!r) {
+            RewriterVar* var = rewriter.get()->call(true, (void*)createBoxedIterWrapper, rewriter->getArg(0));
+            if (rewrite_args.out_success) {
+                rewriter->commitReturning(var);
+                return createBoxedIterWrapper(o);
+            }
+        }
+    }
+
+    if (typeLookup(o->cls, hasnext_str, NULL) == NULL)
+        return new BoxedIterWrapper(o);
+    return o;
+}
+
 extern "C" Box* getPystonIter(Box* o) {
     Box* r = getiter(o);
     if (typeLookup(r->cls, hasnext_str, NULL) == NULL)
@@ -3468,17 +3503,18 @@ extern "C" Box* getPystonIter(Box* o) {
     return r;
 }
 
+extern "C" Box* getiterHelper(Box* o) {
+    if (typeLookup(o->cls, getitem_str, NULL))
+        return new BoxedSeqIter(o, 0);
+    raiseExcHelper(TypeError, "'%s' object is not iterable", getTypeName(o));
+}
+
 Box* getiter(Box* o) {
     // TODO add rewriting to this?  probably want to try to avoid this path though
     Box* r = callattrInternal0(o, &iter_str, LookupScope::CLASS_ONLY, NULL, ArgPassSpec(0));
     if (r)
         return r;
-
-    if (typeLookup(o->cls, getitem_str, NULL)) {
-        return new BoxedSeqIter(o, 0);
-    }
-
-    raiseExcHelper(TypeError, "'%s' object is not iterable", getTypeName(o));
+    return getiterHelper(o);
 }
 
 llvm::iterator_range<BoxIterator> Box::pyElements() {

--- a/src/runtime/objmodel.h
+++ b/src/runtime/objmodel.h
@@ -87,6 +87,8 @@ extern "C" BoxedClosure* createClosure(BoxedClosure* parent_closure);
 
 Box* getiter(Box* o);
 extern "C" Box* getPystonIter(Box* o);
+extern "C" Box* getiterHelper(Box* o);
+extern "C" Box* createBoxedIterWrapperIfNeeded(Box* o);
 
 extern "C" void dump(void* p);
 

--- a/src/runtime/objmodel.h
+++ b/src/runtime/objmodel.h
@@ -52,10 +52,6 @@ extern "C" void setattr(Box* obj, const char* attr, Box* attr_val);
 extern "C" void delattr(Box* obj, const char* attr);
 extern "C" bool nonzero(Box* obj);
 extern "C" Box* runtimeCall(Box*, ArgPassSpec, Box*, Box*, Box*, Box**, const std::vector<const std::string*>*);
-struct CallattrFlags {
-    bool cls_only : 1;
-    bool null_on_nonexistent : 1;
-};
 extern "C" Box* callattr(Box*, const std::string*, CallattrFlags, ArgPassSpec, Box*, Box*, Box*, Box**,
                          const std::vector<const std::string*>*);
 extern "C" BoxedString* str(Box* obj);

--- a/src/runtime/types.h
+++ b/src/runtime/types.h
@@ -226,7 +226,7 @@ public:
     // that we can't rely on for extension classes.
     bool is_pyston_class;
 
-    bool hasGenericGetattr() { return tp_getattr != NULL; }
+    bool hasGenericGetattr() { return tp_getattr == NULL; }
 
     void freeze();
 

--- a/test/tests/xrange.py
+++ b/test/tests/xrange.py
@@ -2,7 +2,7 @@
 #
 # statcheck: "-O" in EXTRA_JIT_ARGS or 'slowpath_getclsattr' in stats or 'slowpath_callattr' in stats
 # statcheck: stats.get('slowpath_getclsattr', 0) <= 20
-# statcheck: stats.get('slowpath_callattr', 0) <= 20
+# statcheck: stats.get('slowpath_callattr', 0) <= 22
 
 for i in xrange(1000):
     print i


### PR DESCRIPTION
If the type analysis successfully determines that the __iter__() and __hasnext__()
methods we can now replace them with direct calls to the destination.
Else we create a patchpoint and do a rewrite.

- I'm not sure if there is a cleaner way todo this?
- I inverted the check inside ```BoxdedClass::hasGenericGetattr()``` because I think this is a bug. 
- inside the compvar code I'm now passing the ```CallattrFlags``` around instead of the ```bool clsonly```
- only the most common case gets rewriten. e.g. if the object does not implement "__iter__" I fallback and call  a helper function
``` 
pyston (calibration)                      :    0.8s baseline2: 0.8 (+2.7%)
pyston interp2.py                         :    3.4s baseline2: 3.7 (-8.9%)
pyston raytrace.py                        :    6.7s baseline2: 6.7 (-0.3%)
pyston nbody.py                           :    7.0s baseline2: 7.8 (-10.4%)
pyston fannkuch.py                        :    5.9s baseline2: 5.9 (-0.4%)
pyston chaos.py                           :   15.7s baseline2: 18.0 (-12.7%)
pyston spectral_norm.py                   :   16.9s baseline2: 16.9 (-0.0%)
pyston fasta.py                           :    5.8s baseline2: 5.4 (+5.8%)
pyston pidigits.py                        :    4.2s baseline2: 4.2 (-0.4%)
pyston richards.py                        :    1.4s baseline2: 1.5 (-5.0%)
pyston deltablue.py                       :    2.1s baseline2: 2.1 (+0.2%)
pyston (geomean-0b9f)                     :    5.3s baseline2: 5.5 (-3.4%)
```

