### PR TITLE
use llvm::SmallVector to reduce allocations

### DIFF
--- a/src/asm_writing/rewriter.cpp
+++ b/src/asm_writing/rewriter.cpp
@@ -511,20 +511,23 @@ void Rewriter::_loadConst(RewriterVar* result, int64_t val, Location dest) {
 }
 
 RewriterVar* Rewriter::call(bool can_call_into_python, void* func_addr) {
-    std::vector<RewriterVar*> args = {};
-    std::vector<RewriterVar*> args_xmm = {};
+    RewriterVar::SmallVector args;
+    RewriterVar::SmallVector args_xmm;
     return call(can_call_into_python, func_addr, args, args_xmm);
 }
 
 RewriterVar* Rewriter::call(bool can_call_into_python, void* func_addr, RewriterVar* arg0) {
-    std::vector<RewriterVar*> args = { arg0 };
-    std::vector<RewriterVar*> args_xmm = {};
+    RewriterVar::SmallVector args;
+    RewriterVar::SmallVector args_xmm;
+    args.push_back(arg0);
     return call(can_call_into_python, func_addr, args, args_xmm);
 }
 
 RewriterVar* Rewriter::call(bool can_call_into_python, void* func_addr, RewriterVar* arg0, RewriterVar* arg1) {
-    std::vector<RewriterVar*> args = { arg0, arg1 };
-    std::vector<RewriterVar*> args_xmm = {};
+    RewriterVar::SmallVector args;
+    RewriterVar::SmallVector args_xmm;
+    args.push_back(arg0);
+    args.push_back(arg1);
     return call(can_call_into_python, func_addr, args, args_xmm);
 }
 
@@ -536,8 +539,8 @@ static const Location caller_save_registers[]{
     assembler::XMM11, assembler::XMM12, assembler::XMM13, assembler::XMM14, assembler::XMM15,
 };
 
-RewriterVar* Rewriter::call(bool can_call_into_python, void* func_addr, const std::vector<RewriterVar*>& args,
-                            const std::vector<RewriterVar*>& args_xmm) {
+RewriterVar* Rewriter::call(bool can_call_into_python, void* func_addr, const RewriterVar::SmallVector& args,
+                            const RewriterVar::SmallVector& args_xmm) {
     RewriterVar* result = createNewVar();
     std::vector<RewriterVar*> uses;
     for (RewriterVar* v : args) {
@@ -554,7 +557,7 @@ RewriterVar* Rewriter::call(bool can_call_into_python, void* func_addr, const st
 }
 
 void Rewriter::_call(RewriterVar* result, bool can_call_into_python, void* func_addr,
-                     const std::vector<RewriterVar*>& args, const std::vector<RewriterVar*>& args_xmm) {
+                     const RewriterVar::SmallVector& args, const RewriterVar::SmallVector& args_xmm) {
     // TODO figure out why this is here -- what needs to be done differently
     // if can_call_into_python is true?
     // assert(!can_call_into_python);

--- a/src/asm_writing/rewriter.h
+++ b/src/asm_writing/rewriter.h
@@ -214,6 +214,8 @@ class RewriterAction;
 // you can't forward-declare that :/
 class RewriterVar {
 public:
+    typedef llvm::SmallVector<RewriterVar*, 8> SmallVector;
+
     void addGuard(uint64_t val);
     void addGuardNotEq(uint64_t val);
     void addAttrGuard(int offset, uint64_t val, bool negate = false);
@@ -386,8 +388,8 @@ private:
 
     void _trap();
     void _loadConst(RewriterVar* result, int64_t val, Location loc);
-    void _call(RewriterVar* result, bool can_call_into_python, void* func_addr, const std::vector<RewriterVar*>& args,
-               const std::vector<RewriterVar*>& args_xmm);
+    void _call(RewriterVar* result, bool can_call_into_python, void* func_addr, const RewriterVar::SmallVector& args,
+               const RewriterVar::SmallVector& args_xmm);
     void _add(RewriterVar* result, RewriterVar* a, int64_t b, Location dest);
     int _allocate(RewriterVar* result, int n);
     void _allocateAndCopy(RewriterVar* result, RewriterVar* array, int n);
@@ -452,8 +454,8 @@ public:
     // This causes some extra bookkeeping to prevent, ex this patchpoint to be rewritten when
     // entered recursively.  Setting to false disables this for slightly better performance, but
     // it's not huge so if in doubt just pass "true".
-    RewriterVar* call(bool can_call_into_python, void* func_addr, const std::vector<RewriterVar*>& args,
-                      const std::vector<RewriterVar*>& args_xmm = std::vector<RewriterVar*>());
+    RewriterVar* call(bool can_call_into_python, void* func_addr, const RewriterVar::SmallVector& args,
+                      const RewriterVar::SmallVector& args_xmm = RewriterVar::SmallVector());
     RewriterVar* call(bool can_call_into_python, void* func_addr);
     RewriterVar* call(bool can_call_into_python, void* func_addr, RewriterVar* arg0);
     RewriterVar* call(bool can_call_into_python, void* func_addr, RewriterVar* arg0, RewriterVar* arg1);


### PR DESCRIPTION
using this for the std::vector's we use during calls helps some, with the biggest reduction being -10% on raytrace.

```
         pyston (calibration)                      :    1.0s baseline: 1.0 (+0.1%)
         pyston nbody_med.py                       :    2.1s baseline: 2.2 (-2.2%)
         pyston interp2.py                         :    4.1s baseline: 4.0 (+0.7%)
         pyston raytrace.py                        :    6.7s baseline: 7.6 (-10.8%)
         pyston nbody.py                           :    7.8s baseline: 8.0 (-2.3%)
         pyston fannkuch.py                        :    6.3s baseline: 6.2 (+1.8%)
         pyston chaos.py                           :   20.1s baseline: 20.7 (-3.2%)
         pyston spectral_norm.py                   :   16.8s baseline: 16.5 (+2.1%)
         pyston fasta.py                           :    5.8s baseline: 5.9 (-2.2%)
         pyston pidigits.py                        :    4.2s baseline: 4.3 (-3.0%)
         pyston richards.py                        :    1.8s baseline: 1.8 (-1.5%)
         pyston deltablue.py                       :    2.5s baseline: 2.4 (+4.5%)
         pyston sre_parse_parse.py                 :    1.9s baseline: 1.9 (-0.1%)
         pyston (geomean-f6d7)                     :    5.4s baseline: 5.4 (-1.5%)
```

I need to figure out the best way to get find all the remaining ones. 