### PR TITLE
Add sys.getdefaultencoding and sys.getfilesystemencoding

### DIFF
--- a/src/runtime/builtin_modules/builtins.cpp
+++ b/src/runtime/builtin_modules/builtins.cpp
@@ -50,7 +50,7 @@ const char* Py_FileSystemDefaultEncoding = "mbcs";
 #elif defined(__APPLE__)
 const char* Py_FileSystemDefaultEncoding = "utf-8";
 #else
-const char* Py_FileSystemDefaultEncoding = NULL; /* use default */
+const char* Py_FileSystemDefaultEncoding = "UTF-8"; // Pyston change: modified to UTF-8
 #endif
 }
 

--- a/src/runtime/builtin_modules/sys.cpp
+++ b/src/runtime/builtin_modules/sys.cpp
@@ -99,6 +99,16 @@ Box* getSysStdout() {
     return sys_stdout;
 }
 
+Box* sysGetDefaultEncoding() {
+    return boxStrConstant(PyUnicode_GetDefaultEncoding());
+}
+
+Box* sysGetFilesystemEncoding() {
+    if (Py_FileSystemDefaultEncoding)
+        return boxStrConstant(Py_FileSystemDefaultEncoding);
+    return None;
+}
+
 extern "C" int PySys_SetObject(const char* name, PyObject* v) noexcept {
     try {
         if (!v) {
@@ -255,6 +265,14 @@ void setupSys() {
     // TODO supposed to pass argv0, main_addr to this function:
     main_fn = llvm::sys::fs::getMainExecutable(NULL, NULL);
     sys_module->giveAttr("executable", boxString(main_fn.str()));
+
+    sys_module->giveAttr(
+        "getdefaultencoding",
+        new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)sysGetDefaultEncoding, STR, 0), "getdefaultencoding"));
+
+    sys_module->giveAttr("getfilesystemencoding",
+                         new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)sysGetFilesystemEncoding, STR, 0),
+                                                          "getfilesystemencoding"));
 
     // TODO: should configure this in a better way
     sys_module->giveAttr("prefix", boxStrConstant("/usr"));

--- a/test/tests/sys_test.py
+++ b/test/tests/sys_test.py
@@ -8,3 +8,5 @@ print os.path.exists(sys.executable)
 print sys.prefix, sys.exec_prefix
 print sys.copyright[-200:]
 print sys.byteorder
+print sys.getdefaultencoding()
+print sys.getfilesystemencoding()


### PR DESCRIPTION
I hard coded the file system encoding to be UTF-8 on non windows systems.
Initially I replicated the behavior of CPython and imported the functions but then I thought it's overkill.
As far as I know every linux system we care about uses UTF-8 for file names. The CPython code retrieves on startup with ```nl_langinfo()``` the encoding and then tries to load the corresponding encoder (--> we would run a lot of additional python code shortly after ```setupRuntime()```.
Did I miss something?

 
