### PR TITLE
Implement vararg map()

### DIFF
--- a/src/codegen/ast_interpreter.cpp
+++ b/src/codegen/ast_interpreter.cpp
@@ -450,11 +450,9 @@ Value ASTInterpreter::visit_jump(AST_Jump* node) {
             }
 
             CompiledFunction* partial_func = compilePartialFuncInternal(&exit);
-            Box* arg1 = arg_array.size() >= 1 ? arg_array[0] : 0;
-            Box* arg2 = arg_array.size() >= 2 ? arg_array[1] : 0;
-            Box* arg3 = arg_array.size() >= 3 ? arg_array[2] : 0;
-            Box** args = arg_array.size() >= 4 ? &arg_array[3] : 0;
-            return partial_func->call(arg1, arg2, arg3, args);
+            auto arg_tuple = getTupleFromArgsArray(&arg_array[0], arg_array.size());
+            return partial_func->call(std::get<0>(arg_tuple), std::get<1>(arg_tuple), std::get<2>(arg_tuple),
+                                      std::get<3>(arg_tuple));
         }
     }
 

--- a/src/runtime/objmodel.h
+++ b/src/runtime/objmodel.h
@@ -148,5 +148,13 @@ static const char* objectNewParameterTypeErrorMsg() {
 }
 
 bool exceptionMatches(const ExcInfo& e, BoxedClass* cls);
+
+inline std::tuple<Box*, Box*, Box*, Box**> getTupleFromArgsArray(Box** args, int num_args) {
+    Box* arg1 = num_args >= 1 ? args[0] : nullptr;
+    Box* arg2 = num_args >= 2 ? args[1] : nullptr;
+    Box* arg3 = num_args >= 3 ? args[2] : nullptr;
+    Box** argtuple = num_args >= 4 ? &args[3] : nullptr;
+    return std::make_tuple(arg1, arg2, arg3, argtuple);
+}
 }
 #endif

--- a/test/tests/map.py
+++ b/test/tests/map.py
@@ -1,5 +1,15 @@
-def f(x):
-    print "f(%s)" % x
-    return -x
+def f(*args):
+    print "f(",
+    for a in args:
+        print a,
+    print ")"
+    
+    s = -1
+    try:
+        s = sum(args)
+    except:
+        pass
+    return s
 
 print map(f, range(10))
+print map(f, range(9), range(20, 31), range(30, 40), range(40, 50), range(60, 70))


### PR DESCRIPTION
in addition I added a small helper function for unpacking our function call argument array.
We could also call ```std::tie(arg1, arg2, arg3, args) =  getTupleFromArgsArray(a, size)``` instead of the ```std::arg<>``` calls.