### PR TITLE
Smaller changes to get more of virtualenv running

### DIFF
--- a/from_cpython/Objects/unicodeobject.c
+++ b/from_cpython/Objects/unicodeobject.c
@@ -1247,7 +1247,7 @@ PyObject *PyUnicode_Decode(const char *s,
         encoding = PyUnicode_GetDefaultEncoding();
 
     /* Shortcuts for common default encodings */
-    if (strcmp(encoding, "utf-8") == 0)
+    if (strcmp(encoding, "utf-8") == 0 || strcmp(encoding, "UTF-8") == 0) // Pyston change: added "UTF-8"
         return PyUnicode_DecodeUTF8(s, size, errors);
     else if (strcmp(encoding, "latin-1") == 0)
         return PyUnicode_DecodeLatin1(s, size, errors);
@@ -1359,7 +1359,7 @@ PyObject *PyUnicode_AsEncodedString(PyObject *unicode,
 
     /* Shortcuts for common default encodings */
     if (errors == NULL) {
-        if (strcmp(encoding, "utf-8") == 0)
+        if (strcmp(encoding, "utf-8") == 0 || strcmp(encoding, "UTF-8") == 0) // Pyston change: added "UTF-8"
             return PyUnicode_AsUTF8String(unicode);
         else if (strcmp(encoding, "latin-1") == 0)
             return PyUnicode_AsLatin1String(unicode);

--- a/src/runtime/str.cpp
+++ b/src/runtime/str.cpp
@@ -2093,9 +2093,6 @@ BoxedString* createUninitializedString(ssize_t n) {
 }
 
 char* getWriteableStringContents(BoxedString* s) {
-    if (s->s.size() == 0)
-        return NULL;
-
     // After doing some reading, I think this is ok:
     // http://stackoverflow.com/questions/14290795/why-is-modifying-a-string-through-a-retrieved-pointer-to-its-data-not-allowed
     // In C++11, std::string is required to store its data contiguously.

--- a/src/runtime/str.cpp
+++ b/src/runtime/str.cpp
@@ -290,8 +290,14 @@ extern "C" PyObject* PyString_FromFormat(const char* format, ...) noexcept {
     return ret;
 }
 
-extern "C" BoxedString* strAdd(BoxedString* lhs, Box* _rhs) {
+extern "C" Box* strAdd(BoxedString* lhs, Box* _rhs) {
     assert(lhs->cls == str_cls);
+
+    if (_rhs->cls == unicode_cls) {
+        Box* rtn = PyUnicode_Concat(lhs, _rhs);
+        checkAndThrowCAPIException();
+        return rtn;
+    }
 
     if (_rhs->cls != str_cls) {
         raiseExcHelper(TypeError, "cannot concatenate 'str' and '%s' objects", getTypeName(_rhs));

--- a/test/tests/unicode_test.py
+++ b/test/tests/unicode_test.py
@@ -27,6 +27,8 @@ print u'a' in c.__dict__
 print u'' == ''
 print '' == u''
 print hash(u'') == hash('')
+print "Hello " + u" World"
+print u"Hello " + " World"
 
 try:
     hasattr(object(), u"\u0180")


### PR DESCRIPTION
+ added unicode support to ```strAdd```
+ ```getWriteableStringContents``` return a pointer to the '\0' char when the string is empty. (Should be safe: http://www.cplusplus.com/reference/string/string/operator[]/)
+ Treat UTF-8 and utf-8 the same. Without this change we currently can't handle UTF-8 (uppercase) yet. I found it very confusing that utf-8 was working. I know that we have to implement the general dispatch function for unknown encodings too but I still think the case should not make a difference and for know this is enough to make it work.
