### PR TITLE
cmake ignore gcc warnings in from_cpython

### DIFF
--- a/from_cpython/CMakeLists.txt
+++ b/from_cpython/CMakeLists.txt
@@ -23,5 +23,5 @@ file(GLOB_RECURSE STDOBJECT_SRCS Objects structseq.c capsule.c stringobject.c ex
 # compile specified files in from_cpython/Python
 file(GLOB_RECURSE STDPYTHON_SRCS Python getargs.c pyctype.c formatter_string.c pystrtod.c dtoa.c formatter_unicode.c structmember.c)
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-missing-field-initializers -Wno-tautological-compare -Wno-type-limits")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-missing-field-initializers -Wno-tautological-compare -Wno-type-limits -Wno-unused-result -Wno-strict-aliasing")
 add_library(FROM_CPYTHON OBJECT ${STDMODULE_SRCS} ${STDOBJECT_SRCS} ${STDPYTHON_SRCS})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,8 +30,9 @@ endif()
 
 add_library(PYSTON_OBJECTS OBJECT codegen/profiling/profiling.cpp ${ANALYSIS_SRCS} ${ASM_WRITING_SRCS} ${CAPI_SRCS} ${CODEGEN_SRCS} ${CODEGEN_IRGEN_SRCS} ${CODEGEN_OPT_SRCS} ${CORE_SRCS} ${GC_SRCS} ${RUNTIME_BUILTIN_MODULES_SRCS} ${RUNTIME_SRCS} ${OPTIONAL_SRCS})
 add_dependencies(PYSTON_OBJECTS libunwind pypa ${LLVM_LIBS})
+
 add_library(PYSTON_MAIN_OBJECT OBJECT jit.cpp)
-add_dependencies(PYSTON_MAIN_OBJECT ${LLVM_LIBS})
+add_dependencies(PYSTON_MAIN_OBJECT libunwind pypa ${LLVM_LIBS})
 
 # build stdlib
 add_subdirectory(runtime/inline)


### PR DESCRIPTION
-added -Wno-unused-result and -Wno-strict-aliasing for gcc 4.8.2 compatibility