### PR TITLE
add support for relative imports, and bring our import api closer to cpython

### DIFF
--- a/src/core/cfg.cpp
+++ b/src/core/cfg.cpp
@@ -1280,6 +1280,9 @@ public:
             import->args.push_back(new AST_Num());
             static_cast<AST_Num*>(import->args[0])->num_type = AST_Num::INT;
 
+            // level == 0 means only check sys path for imports, nothing package-relative,
+            // level == -1 means check both sys path and relative for imports.
+            // so if `from __future__ import absolute_import` was used in the file, set level to 0
             int level;
             if (!(future_flags & FF_ABSOLUTE_IMPORT))
                 level = -1;
@@ -1329,7 +1332,9 @@ public:
         import->args.push_back(new AST_Num());
         static_cast<AST_Num*>(import->args[0])->num_type = AST_Num::INT;
 
-        // I don't quite understand this but this is what CPython does:
+        // level == 0 means only check sys path for imports, nothing package-relative,
+        // level == -1 means check both sys path and relative for imports.
+        // so if `from __future__ import absolute_import` was used in the file, set level to 0
         int level;
         if (node->level == 0 && !(future_flags & FF_ABSOLUTE_IMPORT))
             level = -1;

--- a/src/core/cfg.cpp
+++ b/src/core/cfg.cpp
@@ -1279,7 +1279,13 @@ public:
 
             import->args.push_back(new AST_Num());
             static_cast<AST_Num*>(import->args[0])->num_type = AST_Num::INT;
-            static_cast<AST_Num*>(import->args[0])->n_int = -1;
+
+            int level;
+            if (!(future_flags & FF_ABSOLUTE_IMPORT))
+                level = -1;
+            else
+                level = 0;
+            static_cast<AST_Num*>(import->args[0])->n_int = level;
             import->args.push_back(new AST_LangPrimitive(AST_LangPrimitive::NONE));
             import->args.push_back(new AST_Str(a->name.str()));
 
@@ -1316,8 +1322,6 @@ public:
     }
 
     bool visit_importfrom(AST_ImportFrom* node) override {
-        RELEASE_ASSERT(node->level == 0, "");
-
         AST_LangPrimitive* import = new AST_LangPrimitive(AST_LangPrimitive::IMPORT_NAME);
         import->lineno = node->lineno;
         import->col_offset = node->col_offset;

--- a/src/runtime/builtin_modules/builtins.cpp
+++ b/src/runtime/builtin_modules/builtins.cpp
@@ -472,9 +472,6 @@ Box* bltinImport(Box* name, Box* globals, Box* locals, Box** args) {
     Box* fromlist = args[0];
     Box* level = args[1];
 
-    RELEASE_ASSERT(globals == None, "not implemented");
-    RELEASE_ASSERT(locals == None, "not implemented");
-
     if (name->cls != str_cls) {
         raiseExcHelper(TypeError, "__import__() argument 1 must be string, not %s", getTypeName(name));
     }
@@ -483,7 +480,7 @@ Box* bltinImport(Box* name, Box* globals, Box* locals, Box** args) {
         raiseExcHelper(TypeError, "an integer is required");
     }
 
-    return import(((BoxedInt*)level)->n, fromlist, &static_cast<BoxedString*>(name)->s);
+    return importModuleLevel(&static_cast<BoxedString*>(name)->s, globals, fromlist, ((BoxedInt*)level)->n);
 }
 
 Box* delattrFunc(Box* obj, Box* _str) {

--- a/src/runtime/capi.cpp
+++ b/src/runtime/capi.cpp
@@ -838,7 +838,7 @@ extern "C" PyObject* PyImport_Import(PyObject* module_name) noexcept {
     RELEASE_ASSERT(module_name->cls == str_cls, "");
 
     try {
-        return import(-1, None, &static_cast<BoxedString*>(module_name)->s);
+        return importModuleLevel(&static_cast<BoxedString*>(module_name)->s, None, None, -1);
     } catch (ExcInfo e) {
         Py_FatalError("unimplemented");
     }

--- a/src/runtime/import.h
+++ b/src/runtime/import.h
@@ -20,6 +20,7 @@
 namespace pyston {
 
 extern "C" Box* import(int level, Box* from_imports, const std::string* module_name);
+extern Box* importModuleLevel(std::string* module_name, Box* globals, Box* from_imports, int level);
 }
 
 #endif

--- a/test/tests/name_mangling.py
+++ b/test/tests/name_mangling.py
@@ -82,9 +82,7 @@ class MyClass(object):
         # Except if it's a dotted name:
         import __foo.__bar
     except ImportError, e:
-        # CPython says "no module named __foo.__bar__" but Pyston (and PyPy) say "no module named __foo".
-        # Canonicalize it slightly:
-        print e.message.split('.')[0]
+        print e.message
 
 # names inside classes with mangled names don't get the mangled class name:
 class MyClass(object):

--- a/test/tests/package_import_in_nonpackage.py
+++ b/test/tests/package_import_in_nonpackage.py
@@ -1,7 +1,4 @@
-# expected: fail
-# - crashes rather than throws an error
-
 try:
     from . import doesnt_exist
-except ImportError, e:
+except ValueError, e:
     print e

--- a/test/tests/package_test.py
+++ b/test/tests/package_test.py
@@ -1,10 +1,7 @@
-# expected: fail
-# - packages not supported
-# - intra-package imports ("from . import foo") not supported
-# - "from __future__ import absolute_import" not supported
+import os
 
 import test_package
-print test_package
+print 1, test_package.__name__, os.path.normpath(test_package.__file__)
 
 import test_package.intrapackage_import
 import test_package.absolute_import

--- a/test/tests/relative_import1.py
+++ b/test/tests/relative_import1.py
@@ -1,0 +1,1 @@
+import relative_import1_pkg

--- a/test/tests/relative_import1_pkg/__init__.py
+++ b/test/tests/relative_import1_pkg/__init__.py
@@ -1,0 +1,4 @@
+# Import names from pkg.string
+from .string import name1, name2
+# Import pkg.string
+#from . import string

--- a/test/tests/relative_import1_pkg/string.py
+++ b/test/tests/relative_import1_pkg/string.py
@@ -1,0 +1,7 @@
+print "string.py"
+
+def name1():
+    pass
+
+def name2():
+    pass

--- a/test/tests/relative_import2.py
+++ b/test/tests/relative_import2.py
@@ -1,0 +1,1 @@
+from relative_import2_pkg import foo

--- a/test/tests/relative_import2_pkg/__init__.py
+++ b/test/tests/relative_import2_pkg/__init__.py
@@ -1,0 +1,1 @@
+print "hello"

--- a/test/tests/relative_import2_pkg/foo.py
+++ b/test/tests/relative_import2_pkg/foo.py
@@ -1,0 +1,1 @@
+print "more?"

--- a/test/tests/relative_import3.py
+++ b/test/tests/relative_import3.py
@@ -1,0 +1,1 @@
+import relative_import3_pkg

--- a/test/tests/relative_import3_pkg/A/__init__.py
+++ b/test/tests/relative_import3_pkg/A/__init__.py
@@ -1,0 +1,1 @@
+print "A.__init__"

--- a/test/tests/relative_import3_pkg/A/stuff.py
+++ b/test/tests/relative_import3_pkg/A/stuff.py
@@ -1,0 +1,6 @@
+print "A.stuff"
+
+all = [ 'func1' ]
+
+def func1():
+    pass

--- a/test/tests/relative_import3_pkg/B/__init__.py
+++ b/test/tests/relative_import3_pkg/B/__init__.py
@@ -1,0 +1,1 @@
+print "B.__init__"

--- a/test/tests/relative_import3_pkg/B/name2.py
+++ b/test/tests/relative_import3_pkg/B/name2.py
@@ -1,0 +1,1 @@
+print "B.name2"

--- a/test/tests/relative_import3_pkg/C.py
+++ b/test/tests/relative_import3_pkg/C.py
@@ -1,0 +1,7 @@
+
+print "C.py"
+
+all = ['name1']
+
+def name1():
+    pass

--- a/test/tests/relative_import3_pkg/C/__init__.py
+++ b/test/tests/relative_import3_pkg/C/__init__.py
@@ -1,0 +1,1 @@
+print "C.__init__"

--- a/test/tests/relative_import3_pkg/C/name1.py
+++ b/test/tests/relative_import3_pkg/C/name1.py
@@ -1,0 +1,5 @@
+
+#from . import name3
+#from ..B import name2
+
+print "C.name1.py"

--- a/test/tests/relative_import3_pkg/C/name3.py
+++ b/test/tests/relative_import3_pkg/C/name3.py
@@ -1,0 +1,1 @@
+print "C.name3.py"

--- a/test/tests/relative_import3_pkg/__init__.py
+++ b/test/tests/relative_import3_pkg/__init__.py
@@ -1,0 +1,3 @@
+print "relative_import3_package.__init__"
+from A.stuff import func1
+from C import name1

--- a/test/tests/relative_import4.py
+++ b/test/tests/relative_import4.py
@@ -1,0 +1,1 @@
+import relative_import4_pkg

--- a/test/tests/relative_import4_pkg/__init__.py
+++ b/test/tests/relative_import4_pkg/__init__.py
@@ -1,0 +1,3 @@
+import re
+
+print type(re.compile)

--- a/test/tests/test_package/absolute_import.py
+++ b/test/tests/test_package/absolute_import.py
@@ -1,3 +1,4 @@
+import os
 import import_target
 
-print import_target
+print 3, import_target.__name__, os.path.normpath(import_target.__file__)

--- a/test/tests/test_package/absolute_import_with_future.py
+++ b/test/tests/test_package/absolute_import_with_future.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+import os
 import import_target
 
-print import_target
+print 4, import_target.__name__, os.path.normpath(import_target.__file__)

--- a/test/tests/test_package/intrapackage_import.py
+++ b/test/tests/test_package/intrapackage_import.py
@@ -1,2 +1,3 @@
+import os
 from . import import_target
-print import_target
+print 2, import_target.__name__, os.path.normpath(import_target.__file__)


### PR DESCRIPTION
most of the changes are to support `from .foo import bar`, but there were other fixes along the way (absolute imports from within a package).  I also added the path parameter to imp.find_module while I was at it.

With this change `import json` gets past its relative imports.