### PR TITLE
fixed deopt bug involving closures

### DIFF
--- a/src/codegen/unwinding.cpp
+++ b/src/codegen/unwinding.cpp
@@ -582,7 +582,9 @@ BoxedDict* getLocals(bool only_user_visible, bool includeClosure) {
             }
 
             for (const auto& p : cf->location_map->names) {
-                if (p.first[0] == '!')
+                if (p.first[0] == '!' && (only_user_visible
+                                          || !(p.first == PASSED_GENERATOR_NAME || p.first == PASSED_CLOSURE_NAME
+                                               || p.first == CREATED_CLOSURE_NAME)))
                     continue;
 
                 if (only_user_visible && p.first[0] == '#')

--- a/test/tests/deopt_tests.py
+++ b/test/tests/deopt_tests.py
@@ -11,6 +11,8 @@ except ImportError:
     pass
 
 def main():
+    var_in_closure1 = 0
+    
     def f(o):
         print "starting"
 
@@ -23,6 +25,12 @@ def main():
             print e
         print o.d
         print sorted(locals().items())
+
+        print var_in_closure1
+        var_in_closure2 = 1
+        def g():
+            print var_in_closure2
+        g()
 
         print "Done"
 


### PR DESCRIPTION
I noticed that we weren't setting `passed_closure` or `created_closure` in the `ASTInterpreter` after a deopt. I fixed the issue and added a regression test in `deopt_tests.py`.