### PR TITLE
don't let AttributeError exceptions bubble out of softspace.  fixes fasta.py

### DIFF
--- a/src/runtime/file.cpp
+++ b/src/runtime/file.cpp
@@ -974,7 +974,7 @@ extern "C" int PyFile_SoftSpace(PyObject* f, int newflag) noexcept {
     try {
         return softspace(f, newflag);
     } catch (ExcInfo e) {
-        abort();
+        return 0;
     }
 }
 

--- a/test/tests/no-softspace.py
+++ b/test/tests/no-softspace.py
@@ -1,0 +1,20 @@
+
+import sys
+
+import hashlib
+class HashOutput:
+    def __init__(self):
+        self.m = hashlib.md5()
+    def write(self, string):
+        self.m.update(string)
+    def md5hash(self):
+        return self.m.hexdigest()
+
+hash_output = HashOutput()
+old_stdout = sys.stdout
+sys.stdout = hash_output
+
+print "Hello World!"
+
+sys.stdout = old_stdout
+print hash_output.md5hash()


### PR DESCRIPTION
PyFile_Softspace (according to cpython docs) returns 0 and clears all errors if there was a problem getting or setting "softspace".  It's pretty clear that the rest of the codebase assumes as much from softspace as well.  We might be able to also wrap isSubclass in the try{} block and add noexcept, but I'm not sure if the isSubclass check would cause cpython to fail.

without this change we abort because of the catch block in PyFile_Softspace.  fixing that to return 0 bubbles Attribute errors from a few places (ast_interpreter.cpp, jitted code, etc.)