### PR TITLE
expose module __dict__ as an attr wrapper

### DIFF
--- a/src/runtime/types.cpp
+++ b/src/runtime/types.cpp
@@ -2025,6 +2025,15 @@ BoxedModule* createModule(const std::string& name, const std::string& fn) {
     d->d[b_name] = module;
 
     module->giveAttr("__doc__", None);
+
+    // not strictly correct, as the value of __dict__ is not a
+    // BoxedDict, and also doing it this way makes the following work
+    // in pyston but not cpython:
+    //
+    // import sys
+    // sys.__dict__['__dict__']
+    module->giveAttr("__dict__", makeAttrWrapper(module));
+
     return module;
 }
 


### PR DESCRIPTION
warnings.py access sys.__dict__ in warn().

before:

```
>> import warnings
>> warnings.warn("hi")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>:
  File "/home/vagrant/pyston-build/from_cpython/Lib/warnings.py", line 194, in warn:
    globals = sys.__dict__
AttributeError: 'module' object has no attribute '__dict__'
```

after:

```
>> import warnings
>> warnings.warn("hi")
/home/vagrant/pyston-build/__builtin__:1: UserWarning: hi
None
```
