### PR TITLE
split the getattr/setattr of softspace into two try blocks

### DIFF
--- a/src/runtime/objmodel.cpp
+++ b/src/runtime/objmodel.cpp
@@ -180,6 +180,7 @@ extern "C" bool softspace(Box* b, bool newval) {
     }
 
     bool r;
+    Box* gotten = NULL;
     try {
         Box* gotten = getattrInternal(b, "softspace", NULL);
         if (!gotten) {
@@ -187,6 +188,11 @@ extern "C" bool softspace(Box* b, bool newval) {
         } else {
             r = nonzero(gotten);
         }
+    } catch (ExcInfo e) {
+        r = 0;
+    }
+
+    try {
         setattr(b, "softspace", boxInt(newval));
     } catch (ExcInfo e) {
         r = 0;

--- a/test/tests/softspace.py
+++ b/test/tests/softspace.py
@@ -1,0 +1,20 @@
+# expected: fail
+
+import sys
+
+old_stdout = sys.stdout
+
+class SoftspaceTest(object):
+    def write(self, str):
+        print >>old_stdout, self.softspace
+        old_stdout.write(str)
+
+sys.stdout = SoftspaceTest()
+
+print "hello"
+print "world"
+
+print "hello", "world"
+
+print "hello",
+print "world",


### PR DESCRIPTION
cpython can be observed setting softspace on an object even if it doesn't start with it.
the getattrInternal in softspace() throws an exception the first time through since the
attribute isn't present.  if we don't turn around and set it on the object, we throw
every time we print, which causes a pretty large perf regression in fasta (from ~6 seconds to ~17 seconds.)