### PR TITLE
Some eval and exec improvements

### DIFF
--- a/src/analysis/function_analysis.cpp
+++ b/src/analysis/function_analysis.cpp
@@ -340,6 +340,8 @@ public:
         return true;
     }
 
+    virtual bool visit_exec(AST_Exec* node) { return true; }
+
     friend class DefinednessBBAnalyzer;
 };
 
@@ -376,7 +378,8 @@ DefinednessAnalysis::DefinednessAnalysis(const ParamNames& arg_names, CFG* cfg, 
     for (const auto& p : results) {
         RequiredSet required;
         for (const auto& p2 : p.second) {
-            if (scope_info->refersToGlobal(p2.first))
+            ScopeInfo::VarScopeType vst = scope_info->getScopeTypeOfName(p2.first);
+            if (vst == ScopeInfo::VarScopeType::GLOBAL || vst == ScopeInfo::VarScopeType::NAME)
                 continue;
 
             // printf("%d %s %d\n", p.first->idx, p2.first.c_str(), p2.second);

--- a/src/analysis/scoping_analysis.cpp
+++ b/src/analysis/scoping_analysis.cpp
@@ -111,13 +111,73 @@ public:
     InternedString internString(llvm::StringRef s) override { abort(); }
 };
 
+typedef llvm::DenseSet<InternedString> StrSet;
+
+// Handles the scope in eval or exec
+// For example for exec, if you write
+// exec "global a ; print a ; print b"
+// It will give `a` the GLOBAL scope type and `b` the NAME type.
+// (For eval, you can't have global statements, so it will just
+// mark everything NAME.)
+class EvalExprScopeInfo : public ScopeInfo {
+private:
+    StrSet forced_globals;
+
+    struct GlobalStmtVisitor : NoopASTVisitor {
+        StrSet& result;
+        GlobalStmtVisitor(StrSet& result) : result(result) {}
+
+        bool visit_functiondef(AST_FunctionDef*) override { return true; }
+        bool visit_classdef(AST_ClassDef*) override { return true; }
+
+        bool visit_global(AST_Global* global_stmt) override {
+            for (InternedString name : global_stmt->names) {
+                result.insert(name);
+            }
+            return true;
+        }
+    };
+
+public:
+    EvalExprScopeInfo() {}
+
+    EvalExprScopeInfo(AST* node) {
+        // Find all the global statements in the node's scope (not delving into FuncitonDefs
+        // or ClassDefs) and put the names in `forced_globals`.
+        GlobalStmtVisitor visitor(forced_globals);
+        node->accept(&visitor);
+    }
+
+    ScopeInfo* getParent() override { return NULL; }
+
+    bool createsClosure() override { return false; }
+    bool takesClosure() override { return false; }
+    bool passesThroughClosure() override { return false; }
+
+    VarScopeType getScopeTypeOfName(InternedString name) override {
+        if (isCompilerCreatedName(name))
+            return VarScopeType::FAST;
+        else if (forced_globals.find(name) != forced_globals.end())
+            return VarScopeType::GLOBAL;
+        else
+            return VarScopeType::NAME;
+    }
+
+    bool usesNameLookup() override { return true; }
+
+    bool isPassedToViaClosure(InternedString name) override { return false; }
+
+    bool areLocalsFromModule() override { return false; }
+
+    InternedString mangleName(InternedString id) override { return id; }
+    InternedString internString(llvm::StringRef s) override { abort(); }
+};
+
 struct ScopingAnalysis::ScopeNameUsage {
     AST* node;
     ScopeNameUsage* parent;
     const std::string* private_name;
     ScopingAnalysis* scoping;
-
-    typedef llvm::DenseSet<InternedString> StrSet;
 
     // Properties determined from crawling the scope:
     StrSet read;
@@ -648,8 +708,6 @@ void ScopingAnalysis::processNameUsages(ScopingAnalysis::NameUsageMap* usages) {
         ScopeInfo* parent_info = this->scopes[(usage->parent == NULL) ? this->parent_module : usage->parent->node];
 
         switch (node->type) {
-            case AST_TYPE::Expression:
-            case AST_TYPE::Suite:
             case AST_TYPE::ClassDef: {
                 ScopeInfoBase* scopeInfo
                     = new ScopeInfoBase(parent_info, usage, usage->node, true /* usesNameLookup */);
@@ -723,12 +781,11 @@ ScopingAnalysis::ScopingAnalysis(AST_Module* m) : parent_module(m), interned_str
 }
 
 ScopingAnalysis::ScopingAnalysis(AST_Expression* e) : interned_strings(*e->interned_strings.get()) {
-    auto scope_info = getScopeInfoForNode(e);
-    scopes[e] = scope_info;
+    // It's an expression, so it can't have a `global` statement
+    scopes[e] = new EvalExprScopeInfo();
 }
 
 ScopingAnalysis::ScopingAnalysis(AST_Suite* s) : interned_strings(*s->interned_strings.get()) {
-    auto scope_info = getScopeInfoForNode(s);
-    scopes[s] = scope_info;
+    scopes[s] = new EvalExprScopeInfo(s);
 }
 }

--- a/src/analysis/scoping_analysis.cpp
+++ b/src/analysis/scoping_analysis.cpp
@@ -105,6 +105,8 @@ public:
 
     bool isPassedToViaClosure(InternedString name) override { return false; }
 
+    bool areLocalsFromModule() override { return true; }
+
     InternedString mangleName(InternedString id) override { return id; }
     InternedString internString(llvm::StringRef s) override { abort(); }
 };
@@ -244,6 +246,8 @@ public:
 
         return usage->got_from_closure.count(name) > 0 || usage->passthrough_accesses.count(name) > 0;
     }
+
+    bool areLocalsFromModule() override { return false; }
 
     InternedString mangleName(const InternedString id) override {
         return pyston::mangleName(id, usage->private_name, usage->scoping->getInternedStrings());

--- a/src/analysis/scoping_analysis.h
+++ b/src/analysis/scoping_analysis.h
@@ -114,6 +114,8 @@ public:
     // `exec` or `eval` scope.
     virtual bool usesNameLookup() = 0;
 
+    virtual bool areLocalsFromModule() = 0;
+
     virtual InternedString mangleName(InternedString id) = 0;
     virtual InternedString internString(llvm::StringRef) = 0;
 };

--- a/src/analysis/type_analysis.cpp
+++ b/src/analysis/type_analysis.cpp
@@ -587,6 +587,14 @@ private:
             _visit_alias(alias);
     }
 
+    void visit_exec(AST_Exec* node) override {
+        getType(node->body);
+        if (node->globals)
+            getType(node->globals);
+        if (node->locals)
+            getType(node->locals);
+    }
+
     void visit_invoke(AST_Invoke* node) override { node->stmt->accept_stmt(this); }
 
     void visit_jump(AST_Jump* node) override {}

--- a/src/codegen/ast_interpreter.cpp
+++ b/src/codegen/ast_interpreter.cpp
@@ -1095,15 +1095,7 @@ Value ASTInterpreter::visit_name(AST_Name* node) {
             return Value();
         }
         case ScopeInfo::VarScopeType::NAME: {
-            assert(frame_info.boxedLocals->cls == dict_cls);
-            auto& d = static_cast<BoxedDict*>(frame_info.boxedLocals)->d;
-            auto it = d.find(boxString(node->id.str()));
-            if (it != d.end()) {
-                Box* value = it->second;
-                return value;
-            }
-
-            return getGlobal(source_info->parent_module, &node->id.str());
+            return boxedLocalsGet(frame_info.boxedLocals, node->id.c_str(), source_info->parent_module);
         }
         default:
             abort();
@@ -1170,7 +1162,6 @@ Box* astInterpretFunctionEval(CompiledFunction* cf, Box* boxedLocals) {
 
     ASTInterpreter interpreter(cf);
     interpreter.initArguments(0, NULL, NULL, NULL, NULL, NULL, NULL);
-    RELEASE_ASSERT(boxedLocals->cls == dict_cls, "we don't support non-dicts here yet");
     interpreter.setBoxedLocals(boxedLocals);
     Value v = ASTInterpreter::execute(interpreter);
 

--- a/src/codegen/ast_interpreter.h
+++ b/src/codegen/ast_interpreter.h
@@ -15,6 +15,8 @@
 #ifndef PYSTON_CODEGEN_ASTINTERPRETER_H
 #define PYSTON_CODEGEN_ASTINTERPRETER_H
 
+#include "codegen/unwinding.h"
+
 namespace pyston {
 
 namespace gc {
@@ -33,9 +35,9 @@ extern const void* interpreter_instr_addr;
 
 Box* astInterpretFunction(CompiledFunction* f, int nargs, Box* closure, Box* generator, Box* arg1, Box* arg2, Box* arg3,
                           Box** args);
-Box* astInterpretFunctionEval(CompiledFunction* cf, BoxedDict* locals);
+Box* astInterpretFunctionEval(CompiledFunction* cf, Box* boxedLocals);
 Box* astInterpretFrom(CompiledFunction* cf, AST_expr* after_expr, AST_stmt* enclosing_stmt, Box* expr_val,
-                      BoxedDict* locals);
+                      FrameStackState frame_state);
 
 AST_stmt* getCurrentStatementForInterpretedFrame(void* frame_ptr);
 CompiledFunction* getCFForInterpretedFrame(void* frame_ptr);

--- a/src/codegen/codegen.cpp
+++ b/src/codegen/codegen.cpp
@@ -41,6 +41,7 @@ SourceInfo::SourceInfo(BoxedModule* m, ScopingAnalysis* scoping, AST* ast, const
         case AST_TYPE::Lambda:
         case AST_TYPE::Module:
         case AST_TYPE::Expression:
+        case AST_TYPE::Suite:
             is_generator = false;
             break;
         case AST_TYPE::FunctionDef:

--- a/src/codegen/codegen.h
+++ b/src/codegen/codegen.h
@@ -70,7 +70,7 @@ struct GlobalState {
     llvm::Type* llvm_class_type, *llvm_class_type_ptr;
     llvm::Type* llvm_opaque_type;
     llvm::Type* llvm_str_type_ptr;
-    llvm::Type* frame_info_type;
+    llvm::Type* llvm_frame_info_type;
     llvm::Type* llvm_clfunction_type_ptr, *llvm_closure_type_ptr, *llvm_generator_type_ptr;
     llvm::Type* llvm_module_type_ptr, *llvm_bool_type_ptr;
     llvm::Type* llvm_excinfo_type;

--- a/src/codegen/compvars.cpp
+++ b/src/codegen/compvars.cpp
@@ -1818,10 +1818,31 @@ public:
 
     Box* deserializeFromFrame(const FrameVals& vals) override {
         assert(vals.size() == numFrameArgs());
-        abort();
+        return reinterpret_cast<Box*>(vals[0]);
     }
 } _GENERATOR;
 ConcreteCompilerType* GENERATOR = &_GENERATOR;
+
+class FrameInfoType : public ConcreteCompilerType {
+public:
+    llvm::Type* llvmType() override { return g.llvm_frame_info_type->getPointerTo(); }
+    std::string debugName() override { return "FrameInfo"; }
+
+    ConcreteCompilerType* getConcreteType() override { return this; }
+    ConcreteCompilerType* getBoxType() override { return FRAME_INFO; }
+
+    void drop(IREmitter& emitter, VAR* var) override {
+        // pass
+    }
+    void grab(IREmitter& emitter, VAR* var) override {
+        // pass
+    }
+
+    Box* deserializeFromFrame(const FrameVals& vals) override {
+        RELEASE_ASSERT(false, "should not be called"); // This function shouldn't be called.
+    }
+} _FRAME_INFO;
+ConcreteCompilerType* FRAME_INFO = &_FRAME_INFO;
 
 class StrConstantType : public ValuedCompilerType<const std::string*> {
 public:

--- a/src/codegen/irgen/future.cpp
+++ b/src/codegen/irgen/future.cpp
@@ -31,39 +31,12 @@ const std::map<std::string, FutureOption> future_options
         { "nested_scopes", { version_hex(2, 1, 0), version_hex(2, 2, 0), FF_NESTED_SCOPES } },
         { "with_statement", { version_hex(2, 5, 0), version_hex(3, 6, 0), FF_WITH_STATEMENT } } };
 
-// Helper function:
-void raiseSyntaxError(const char* file, AST* node_at, const char* msg, ...) {
-    va_list ap;
-    va_start(ap, msg);
-
-    char buf[1024];
-    vsnprintf(buf, sizeof(buf), msg, ap);
-
-
-    // TODO I'm not sure that it's safe to raise an exception here, since I think
-    // there will be things that end up not getting cleaned up.
-    // Then again, there are a huge number of things that don't get cleaned up even
-    // if an exception doesn't get thrown...
-
-    // TODO output is still a little wrong, should be, for example
-    //
-    //  File "../test/tests/future_non_existent.py", line 1
-    //    from __future__ import rvalue_references # should cause syntax error
-    //
-    // but instead it is
-    //
-    // Traceback (most recent call last):
-    //  File "../test/tests/future_non_existent.py", line -1, in :
-    //    from __future__ import rvalue_references # should cause syntax error
-    ::pyston::raiseSyntaxError(buf, node_at->lineno, node_at->col_offset, file, "");
-}
-
 void raiseFutureImportErrorNotFound(const char* file, AST* node, const char* name) {
-    raiseSyntaxError(file, node, "future feature %s is not defined", name);
+    raiseSyntaxErrorHelper(file, "", node, "future feature %s is not defined", name);
 }
 
 void raiseFutureImportErrorNotBeginning(const char* file, AST* node) {
-    raiseSyntaxError(file, node, "from __future__ imports must occur at the beginning of the file");
+    raiseSyntaxErrorHelper(file, "", node, "from __future__ imports must occur at the beginning of the file");
 }
 
 class BadFutureImportVisitor : public NoopASTVisitor {

--- a/src/codegen/irgen/hooks.h
+++ b/src/codegen/irgen/hooks.h
@@ -37,7 +37,8 @@ void compileAndRunModule(AST_Module* m, BoxedModule* bm);
 // will we always want to generate unique function names? (ie will this function always be reasonable?)
 CompiledFunction* cfForMachineFunctionName(const std::string&);
 
-Box* runEval(const char* code, BoxedDict* locals, BoxedModule* module);
+extern "C" Box* exec(Box* boxedCode);
+extern "C" Box* eval(Box* boxedCode);
 }
 
 #endif

--- a/src/codegen/irgen/irgenerator.h
+++ b/src/codegen/irgen/irgenerator.h
@@ -46,6 +46,7 @@ typedef std::unordered_map<InternedString, ConcreteCompilerVariable*> ConcreteSy
 extern const std::string CREATED_CLOSURE_NAME;
 extern const std::string PASSED_CLOSURE_NAME;
 extern const std::string PASSED_GENERATOR_NAME;
+extern const std::string FRAME_INFO_PTR_NAME;
 
 
 // Class that holds state of the current IR generation, that might not be local
@@ -61,13 +62,16 @@ private:
 
     llvm::AllocaInst* scratch_space;
     llvm::Value* frame_info;
+    llvm::Value* boxed_locals;
+    llvm::Value* frame_info_arg;
     int scratch_size;
+
 
 public:
     IRGenState(CompiledFunction* cf, SourceInfo* source_info, ParamNames* param_names, GCBuilder* gc,
                llvm::MDNode* func_dbg_info)
         : cf(cf), source_info(source_info), param_names(param_names), gc(gc), func_dbg_info(func_dbg_info),
-          scratch_space(NULL), frame_info(NULL), scratch_size(0) {
+          scratch_space(NULL), frame_info(NULL), frame_info_arg(NULL), scratch_size(0) {
         assert(cf->func);
         assert(!cf->clfunc); // in this case don't need to pass in sourceinfo
     }
@@ -82,6 +86,7 @@ public:
 
     llvm::Value* getScratchSpace(int min_bytes);
     llvm::Value* getFrameInfoVar();
+    llvm::Value* getBoxedLocalsVar();
 
     ConcreteCompilerType* getReturnType() { return cf->getReturnType(); }
 
@@ -93,6 +98,8 @@ public:
     llvm::MDNode* getFuncDbgInfo() { return func_dbg_info; }
 
     ParamNames* getParamNames() { return param_names; }
+
+    void setFrameInfoArgument(llvm::Value* v) { frame_info_arg = v; }
 };
 
 class IRGenerator {

--- a/src/codegen/pypa-parser.cpp
+++ b/src/codegen/pypa-parser.cpp
@@ -633,10 +633,9 @@ struct stmt_dispatcher {
         AST_Exec* ptr = new AST_Exec();
         location(ptr, e);
         ptr->body = readItem(e.body, interned_strings);
-        if (e.globals)
-            ptr->globals = readItem(e.globals, interned_strings);
-        if (e.locals)
-            ptr->locals = readItem(e.locals, interned_strings);
+        ptr->globals = e.globals ? readItem(e.globals, interned_strings) : NULL;
+        ptr->locals = e.locals ? readItem(e.locals, interned_strings) : NULL;
+        assert(ptr->globals || !ptr->locals);
         return ptr;
     }
 

--- a/src/codegen/runtime_hooks.cpp
+++ b/src/codegen/runtime_hooks.cpp
@@ -150,8 +150,8 @@ void initGlobalFuncs(GlobalState& g) {
     g.llvm_excinfo_type = g.stdlib_module->getTypeByName("struct.pyston::ExcInfo");
     assert(g.llvm_excinfo_type);
 
-    g.frame_info_type = g.stdlib_module->getTypeByName("struct.pyston::FrameInfo");
-    assert(g.frame_info_type);
+    g.llvm_frame_info_type = g.stdlib_module->getTypeByName("struct.pyston::FrameInfo");
+    assert(g.llvm_frame_info_type);
 
 #define GET(N) g.funcs.N = getFunc((void*)N, STRINGIFY(N))
 
@@ -221,6 +221,11 @@ void initGlobalFuncs(GlobalState& g) {
     GET(printFloat);
     GET(listAppendInternal);
     GET(getSysStdout);
+
+    GET(exec);
+    GET(boxedLocalsSet);
+    GET(boxedLocalsGet);
+    GET(boxedLocalsDel);
 
     g.funcs.runtimeCall = getFunc((void*)runtimeCall, "runtimeCall");
     g.funcs.runtimeCall0 = addFunc((void*)runtimeCall, g.llvm_value_type_ptr, g.llvm_value_type_ptr, g.i32);

--- a/src/codegen/runtime_hooks.h
+++ b/src/codegen/runtime_hooks.h
@@ -46,6 +46,8 @@ struct GlobalFuncs {
     llvm::Value* runtimeCall0, *runtimeCall1, *runtimeCall2, *runtimeCall3, *runtimeCall, *runtimeCallN;
     llvm::Value* callattr0, *callattr1, *callattr2, *callattr3, *callattr, *callattrN;
     llvm::Value* reoptCompiledFunc, *compilePartialFunc;
+    llvm::Value* exec;
+    llvm::Value* boxedLocalsSet, *boxedLocalsGet, *boxedLocalsDel;
 
     llvm::Value* __cxa_begin_catch, *__cxa_end_catch;
     llvm::Value* raise0, *raise3;

--- a/src/codegen/unwinding.h
+++ b/src/codegen/unwinding.h
@@ -21,14 +21,18 @@
 
 namespace pyston {
 
+class Box;
+class BoxedDict;
 class BoxedModule;
+class BoxedTraceback;
+struct FrameInfo;
+
 BoxedModule* getCurrentModule();
 
-class BoxedTraceback;
 BoxedTraceback* getTraceback();
 
-class BoxedDict;
-BoxedDict* getLocals(bool only_user_visible, bool includeClosure);
+// Adds stack locals and closure locals into the locals dict, and returns it.
+Box* fastLocalsToBoxedLocals();
 
 // Fetches a writeable pointer to the frame-local excinfo object,
 // calculating it if necessary (from previous frames).
@@ -39,6 +43,23 @@ struct ExecutionPoint {
     AST_stmt* current_stmt;
 };
 ExecutionPoint getExecutionPoint();
+
+struct FrameStackState {
+    // This includes all # variables (but not the ! ones).
+    // Therefore, it's not the same as the BoxedLocals.
+    // This also means that it contains
+    // CREATED_CLOSURE_NAME, PASSED_CLOSURE_NAME, and GENERATOR_NAME.
+    BoxedDict* locals;
+
+    // The frame_info is a pointer to the frame_info on the stack, so it is invalid
+    // after the frame ends.
+    FrameInfo* frame_info;
+
+    FrameStackState(BoxedDict* locals, FrameInfo* frame_info) : locals(locals), frame_info(frame_info) {}
+};
+
+// Returns all the stack locals, including hidden ones.
+FrameStackState getFrameStackState();
 }
 
 #endif

--- a/src/core/ast.cpp
+++ b/src/core/ast.cpp
@@ -700,6 +700,14 @@ void AST_Expression::accept(ASTVisitor* v) {
     body->accept(v);
 }
 
+void AST_Suite::accept(ASTVisitor* v) {
+    bool skip = v->visit_suite(this);
+    if (skip)
+        return;
+
+    visitVector(body, v);
+}
+
 void AST_Name::accept(ASTVisitor* v) {
     bool skip = v->visit_name(this);
 }
@@ -1537,6 +1545,15 @@ bool PrintVisitor::visit_module(AST_Module* node) {
 bool PrintVisitor::visit_expression(AST_Expression* node) {
     node->body->accept(this);
     printf("\n");
+    return true;
+}
+
+bool PrintVisitor::visit_suite(AST_Suite* node) {
+    for (int i = 0; i < node->body.size(); i++) {
+        printIndent();
+        node->body[i]->accept(this);
+        printf("\n");
+    }
     return true;
 }
 

--- a/src/core/ast.h
+++ b/src/core/ast.h
@@ -23,6 +23,7 @@
 
 #include "llvm/ADT/StringRef.h"
 
+#include "analysis/scoping_analysis.h"
 #include "core/common.h"
 #include "core/stringpool.h"
 
@@ -120,6 +121,7 @@ enum AST_TYPE {
     Ellipsis = 87,
     Expression = 88,
     SetComp = 89,
+    Suite = 90,
 
     // Pseudo-nodes that are specific to this compiler:
     Branch = 200,
@@ -674,6 +676,20 @@ public:
     static const AST_TYPE::AST_TYPE TYPE = AST_TYPE::Module;
 };
 
+class AST_Suite : public AST {
+public:
+    std::unique_ptr<InternedStringPool> interned_strings;
+
+    std::vector<AST_stmt*> body;
+
+    virtual void accept(ASTVisitor* v);
+
+    AST_Suite(std::unique_ptr<InternedStringPool> interned_strings)
+        : AST(AST_TYPE::Suite), interned_strings(std::move(interned_strings)) {}
+
+    static const AST_TYPE::AST_TYPE TYPE = AST_TYPE::Suite;
+};
+
 class AST_Name : public AST_expr {
 public:
     AST_TYPE::AST_TYPE ctx_type;
@@ -682,20 +698,14 @@ public:
     // The resolved scope of this name.  Kind of hacky to be storing it in the AST node;
     // in CPython it ends up getting "cached" by being translated into one of a number of
     // different bytecodes.
-    // We don't have a separate bytecode representation, so just store it in here for now.
-    enum LookupType {
-        UNKNOWN,
-        GLOBAL,
-        CLOSURE,
-        FAST_LOCAL,
-        LOCAL,
-    } lookup_type;
+    ScopeInfo::VarScopeType lookup_type;
 
     virtual void accept(ASTVisitor* v);
     virtual void* accept_expr(ExprVisitor* v);
 
     AST_Name(InternedString id, AST_TYPE::AST_TYPE ctx_type, int lineno, int col_offset = 0)
-        : AST_expr(AST_TYPE::Name, lineno, col_offset), ctx_type(ctx_type), id(id), lookup_type(UNKNOWN) {}
+        : AST_expr(AST_TYPE::Name, lineno, col_offset), ctx_type(ctx_type), id(id),
+          lookup_type(ScopeInfo::VarScopeType::UNKNOWN) {}
 
     static const AST_TYPE::AST_TYPE TYPE = AST_TYPE::Name;
 };
@@ -1079,6 +1089,7 @@ public:
     virtual bool visit_exec(AST_Exec* node) { RELEASE_ASSERT(0, ""); }
     virtual bool visit_expr(AST_Expr* node) { RELEASE_ASSERT(0, ""); }
     virtual bool visit_expression(AST_Expression* node) { RELEASE_ASSERT(0, ""); }
+    virtual bool visit_suite(AST_Suite* node) { RELEASE_ASSERT(0, ""); }
     virtual bool visit_extslice(AST_ExtSlice* node) { RELEASE_ASSERT(0, ""); }
     virtual bool visit_for(AST_For* node) { RELEASE_ASSERT(0, ""); }
     virtual bool visit_functiondef(AST_FunctionDef* node) { RELEASE_ASSERT(0, ""); }
@@ -1149,6 +1160,7 @@ public:
     virtual bool visit_exec(AST_Exec* node) { return false; }
     virtual bool visit_expr(AST_Expr* node) { return false; }
     virtual bool visit_expr(AST_Expression* node) { return false; }
+    virtual bool visit_suite(AST_Suite* node) { return false; }
     virtual bool visit_extslice(AST_ExtSlice* node) { return false; }
     virtual bool visit_for(AST_For* node) { return false; }
     virtual bool visit_functiondef(AST_FunctionDef* node) { return false; }
@@ -1294,6 +1306,7 @@ public:
     virtual bool visit_exec(AST_Exec* node);
     virtual bool visit_expr(AST_Expr* node);
     virtual bool visit_expression(AST_Expression* node);
+    virtual bool visit_suite(AST_Suite* node);
     virtual bool visit_extslice(AST_ExtSlice* node);
     virtual bool visit_for(AST_For* node);
     virtual bool visit_functiondef(AST_FunctionDef* node);

--- a/src/core/cfg.cpp
+++ b/src/core/cfg.cpp
@@ -1800,7 +1800,16 @@ public:
         return true;
     }
 
-    bool visit_exec(AST_Exec* node) override { raiseExcHelper(SyntaxError, "'exec' currently not supported"); }
+    bool visit_exec(AST_Exec* node) override {
+        AST_Exec* astexec = new AST_Exec();
+        astexec->lineno = node->lineno;
+        astexec->col_offset = node->col_offset;
+        astexec->body = remapExpr(node->body);
+        astexec->globals = remapExpr(node->globals);
+        astexec->locals = remapExpr(node->locals);
+        push_back(astexec);
+        return true;
+    }
 
     bool visit_while(AST_While* node) override {
         assert(curblock);

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -110,7 +110,8 @@ typedef ValuedCompilerType<llvm::Value*> ConcreteCompilerType;
 ConcreteCompilerType* typeFromClass(BoxedClass*);
 
 extern ConcreteCompilerType* INT, *BOXED_INT, *LONG, *FLOAT, *BOXED_FLOAT, *VOID, *UNKNOWN, *BOOL, *STR, *NONE, *LIST,
-    *SLICE, *MODULE, *DICT, *BOOL, *BOXED_BOOL, *BOXED_TUPLE, *SET, *FROZENSET, *CLOSURE, *GENERATOR, *BOXED_COMPLEX;
+    *SLICE, *MODULE, *DICT, *BOOL, *BOXED_BOOL, *BOXED_TUPLE, *SET, *FROZENSET, *CLOSURE, *GENERATOR, *BOXED_COMPLEX,
+    *FRAME_INFO;
 extern CompilerType* UNDEF;
 
 class CompilerVariable;
@@ -535,6 +536,7 @@ void addToSysArgv(const char* str);
 // The traceback given to the user will include this,
 // even though the execution didn't actually arrive there.
 void raiseSyntaxError(const char* msg, int lineno, int col_offset, const std::string& file, const std::string& func);
+void raiseSyntaxErrorHelper(const std::string& file, const std::string& func, AST* node_at, const char* msg, ...);
 
 struct LineInfo {
 public:
@@ -564,7 +566,9 @@ struct FrameInfo {
     // - This makes frame entering+leaving faster at the expense of slower exceptions.
     ExcInfo exc;
 
-    FrameInfo(ExcInfo exc) : exc(exc) {}
+    Box* boxedLocals;
+
+    FrameInfo(ExcInfo exc) : exc(exc), boxedLocals(NULL) {}
 };
 
 struct CallattrFlags {

--- a/src/runtime/builtin_modules/builtins.cpp
+++ b/src/runtime/builtin_modules/builtins.cpp
@@ -683,16 +683,6 @@ Box* zip2(Box* container1, Box* container2) {
     return rtn;
 }
 
-Box* eval(Box* code) {
-    // TODO implement full functionality (args and stuff)
-    RELEASE_ASSERT(code->cls == str_cls, "eval not implemented for non-strings");
-
-    BoxedDict* locals = getLocals(true /* only_user_visible */, true /* includeClosure */);
-    BoxedModule* module = getCurrentModule();
-
-    return runEval(static_cast<BoxedString*>(code)->s.c_str(), locals, module);
-}
-
 static Box* callable(Box* obj) {
     Box* r = PyBool_FromLong((long)PyCallable_Check(obj));
     checkAndThrowCAPIException();
@@ -859,7 +849,7 @@ Box* globals() {
 }
 
 Box* locals() {
-    return getLocals(true /* filter */, true /* includeClosure */);
+    return fastLocalsToBoxedLocals();
 }
 
 Box* divmod(Box* lhs, Box* rhs) {

--- a/src/runtime/inline/link_forcer.cpp
+++ b/src/runtime/inline/link_forcer.cpp
@@ -15,6 +15,7 @@
 // This file is for forcing the inclusion of function declarations into the stdlib.
 // This is so that the types of the functions are available to the compiler.
 
+#include "codegen/irgen/hooks.h"
 #include "core/types.h"
 #include "gc/heap.h"
 #include "runtime/complex.h"
@@ -119,6 +120,8 @@ void force() {
     FORCE(mod_float_float);
     FORCE(pow_float_float);
 
+    FORCE(exec);
+
     FORCE(dump);
 
     FORCE(boxFloat);
@@ -126,6 +129,10 @@ void force() {
     FORCE(createModule);
 
     FORCE(gc::sizes);
+
+    FORCE(boxedLocalsSet);
+    FORCE(boxedLocalsGet);
+    FORCE(boxedLocalsDel);
 
     // FORCE(listIter);
 }

--- a/src/runtime/objmodel.cpp
+++ b/src/runtime/objmodel.cpp
@@ -4450,20 +4450,34 @@ Box* coerceUnicodeToStr(Box* unicode) {
     return r;
 }
 
+// TODO Make these fast, do inline caches and stuff
+
 extern "C" void boxedLocalsSet(Box* boxedLocals, const char* attr, Box* val) {
     setitem(boxedLocals, boxString(attr), val);
 }
 
 extern "C" Box* boxedLocalsGet(Box* boxedLocals, const char* attr, BoxedModule* parent_module) {
     assert(parent_module->cls == module_cls);
-
     assert(boxedLocals != NULL);
-    RELEASE_ASSERT(boxedLocals->cls == dict_cls, "we don't support non-dict here yet");
-    auto& d = static_cast<BoxedDict*>(boxedLocals)->d;
-    auto it = d.find(boxString(attr));
-    if (it != d.end()) {
-        Box* value = it->second;
-        return value;
+
+    if (boxedLocals->cls == dict_cls) {
+        auto& d = static_cast<BoxedDict*>(boxedLocals)->d;
+        auto it = d.find(boxString(attr));
+        if (it != d.end()) {
+            Box* value = it->second;
+            return value;
+        }
+    } else {
+        try {
+            return getitem(boxedLocals, boxString(attr));
+        } catch (ExcInfo e) {
+            // TODO should check the exact semantic here but it's something like:
+            // If it throws a KeyError, then the variable doesn't exist so move on
+            // and check the globals (below); otherwise, just propogate the exception.
+            if (!isInstance(e.value, KeyError)) {
+                throw;
+            }
+        }
     }
 
     // TODO exception name?

--- a/src/runtime/objmodel.h
+++ b/src/runtime/objmodel.h
@@ -167,5 +167,9 @@ inline std::tuple<Box*, Box*, Box*, Box**> getTupleFromArgsArray(Box** args, int
     Box** argtuple = num_args >= 4 ? &args[3] : nullptr;
     return std::make_tuple(arg1, arg2, arg3, argtuple);
 }
+
+extern "C" void boxedLocalsSet(Box* boxedLocals, const char* attr, Box* val);
+extern "C" Box* boxedLocalsGet(Box* boxedLocals, const char* attr, BoxedModule* parent_module);
+extern "C" void boxedLocalsDel(Box* boxedLocals, const char* attr);
 }
 #endif

--- a/src/runtime/stacktrace.cpp
+++ b/src/runtime/stacktrace.cpp
@@ -123,6 +123,32 @@ void raiseSyntaxError(const char* msg, int lineno, int col_offset, const std::st
     raiseRaw(ExcInfo(exc->cls, exc, new BoxedTraceback(std::move(entries))));
 }
 
+void raiseSyntaxErrorHelper(const std::string& file, const std::string& func, AST* node_at, const char* msg, ...) {
+    va_list ap;
+    va_start(ap, msg);
+
+    char buf[1024];
+    vsnprintf(buf, sizeof(buf), msg, ap);
+
+
+    // TODO I'm not sure that it's safe to raise an exception here, since I think
+    // there will be things that end up not getting cleaned up.
+    // Then again, there are a huge number of things that don't get cleaned up even
+    // if an exception doesn't get thrown...
+
+    // TODO output is still a little wrong, should be, for example
+    //
+    //  File "../test/tests/future_non_existent.py", line 1
+    //    from __future__ import rvalue_references # should cause syntax error
+    //
+    // but instead it is
+    //
+    // Traceback (most recent call last):
+    //  File "../test/tests/future_non_existent.py", line -1, in :
+    //    from __future__ import rvalue_references # should cause syntax error
+    raiseSyntaxError(buf, node_at->lineno, node_at->col_offset, file, "");
+}
+
 void _printStacktrace() {
     printTraceback(getTraceback());
 }

--- a/test/tests/deopt_generator_tests.py
+++ b/test/tests/deopt_generator_tests.py
@@ -11,10 +11,14 @@ except ImportError:
     pass
 
 def main():
-    var_in_closure1 = 0
-    
-    def f(o):
-        print "starting f"
+    class C(object):
+        def __repr__(self):
+            return "<C>"
+
+    def f_gen(o):
+        print "starting f_gen, yielding:"
+
+        yield 8
 
         try:
             print o.a
@@ -26,17 +30,8 @@ def main():
         print o.d
         print sorted(locals().items())
 
-        print var_in_closure1
-        var_in_closure2 = 1
-        def g():
-            print var_in_closure2
-        g()
-
-        print "Done"
-
-    class C(object):
-        def __repr__(self):
-            return "<C>"
+        print "yielding again:"
+        yield 9
 
     c = C()
     c.a = 1
@@ -60,24 +55,8 @@ def main():
             c.b = 0
             c.d = 1.0
 
-        f(c)
+        g = f_gen(c)
+        print 'yielded(1):', g.next()
+        print 'yielded(2):', g.next()
 
-    # Regression test reduced from subprocess.py:
-    import types
-    def f2(self, args):
-        if isinstance(args, types.StringTypes):
-            pass
-
-        try:
-            self.pid
-        except:
-            pass
-
-    c = C()
-    c.pid = 1
-    for i in xrange(2000):
-        f2(c, None)
-
-        if i == 1500:
-            c.pid = 1.0
 main()

--- a/test/tests/deopt_namescope_tests.py
+++ b/test/tests/deopt_namescope_tests.py
@@ -1,0 +1,66 @@
+# skip-if: '-O' in EXTRA_JIT_ARGS
+# statcheck: 4 <= noninit_count('num_deopt') < 50
+# statcheck: 1 <= stats["num_osr_exits"] <= 2
+
+try:
+    import __pyston__
+    __pyston__.setOption("OSR_THRESHOLD_BASELINE", 50)
+    __pyston__.setOption("REOPT_THRESHOLD_BASELINE", 50)
+    __pyston__.setOption("SPECULATION_THRESHOLD", 10)
+except ImportError:
+    pass
+
+# This test makes sure that the boxedLocals survive a deopt.
+# TODO Write a test case to make sure exc_info survives the deopt.
+
+def f_with_name_scoping(o):
+    print "starting f"
+
+    exec "k = 5"
+    l = 6
+
+    try:
+        print o.a
+        if o.b:
+            raise Exception('')
+    except Exception, e:
+        print o.c
+        print e
+    print o.d
+    print sorted(locals().items())
+
+    print "k =", k
+    print l
+
+    print "Done"
+
+def main():
+    class C(object):
+        def __repr__(self):
+            return "<C>"
+
+    c = C()
+    c.a = 1
+    c.b = 0
+    c.c = 3
+    c.d = 4
+
+    for i in xrange(300):
+        print i
+
+        if i == 60:
+            c.a = []
+
+        if i == 120:
+            c.b = 1
+
+        if i == 180:
+            c.c = []
+
+        if i == 240:
+            c.b = 0
+            c.d = 1.0
+
+        f_with_name_scoping(c)
+
+main()

--- a/test/tests/eval_test.py
+++ b/test/tests/eval_test.py
@@ -1,5 +1,3 @@
-# TODO lots of eval functionality not implemented
-
 print eval("3 + 4")
 
 a = 5
@@ -85,10 +83,10 @@ o = 300
 print 'eval eval o', eval("eval('o')")
 
 # This works in the global scope but not in the local scope, because o1 is a global:
-# print eval("[(lambda p1 : p1 + o1)(5) for o1 in range(5)]")
+print eval("[(lambda p1 : p1 + o1)(5) for o1 in range(5)]")
 def lambda_func():
     try:
-        pass #print eval("[(lambda p2 : p2 + o2)(5) for o2 in range(5)]")
+        print eval("[(lambda p2 : p2 + o2)(5) for o2 in range(5)]")
     except NameError as e:
         print e.message
 lambda_func()
@@ -106,9 +104,9 @@ def func2():
 
     print 'shadow3', eval("shadow3 + sum([2 for shadow3 in range(5)]) + shadow3")
 func2()
-#print 'shadow1', shadow2
-#print 'shadow2', shadow2
-#print 'shadow3', shadow3
+print 'shadow1', shadow2
+print 'shadow2', shadow2
+print 'shadow3', shadow3
 
 
 def func3():
@@ -123,15 +121,11 @@ def func3():
         print 'NameError', e.message
 func3()
 
-"""
-
 changing_global = -1
 def print_changing_global():
     print 'changing_global is', changing_global
     return 0
 eval("[print_changing_global() for changing_global in range(5)]")
-
-"""
 
 def do_changing_local():
     # this won't get modified:

--- a/test/tests/eval_test.py
+++ b/test/tests/eval_test.py
@@ -5,17 +5,17 @@ print eval("3 + 4")
 a = 5
 print eval("a")
 
-#print eval("[b for b in range(5)]")
-#print b
+print eval("[b for b in range(5)]")
+print b
 
-#c = 2
-#print eval("[c for c in range(5)]")
-#print c
+c = 2
+print eval("[c for c in range(5)]")
+print c
 
-#try:
-#    print eval("int('abc')")
-#except ValueError:
-#    print 'got ValueError'
+try:
+    print eval("int('abc')")
+except ValueError:
+    print 'got ValueError'
 
 d = 19
 e = 20
@@ -85,7 +85,7 @@ o = 300
 print 'eval eval o', eval("eval('o')")
 
 # This works in the global scope but not in the local scope, because o1 is a global:
-#print eval("[(lambda p1 : p1 + o1)(5) for o1 in range(5)]")
+# print eval("[(lambda p1 : p1 + o1)(5) for o1 in range(5)]")
 def lambda_func():
     try:
         pass #print eval("[(lambda p2 : p2 + o2)(5) for o2 in range(5)]")

--- a/test/tests/eval_test.py
+++ b/test/tests/eval_test.py
@@ -84,7 +84,14 @@ print eval("eval('3 + 2342')")
 o = 300
 print 'eval eval o', eval("eval('o')")
 
-#print eval("[(lambda p : p + o)(5) for o in range(5)]")
+# This works in the global scope but not in the local scope, because o1 is a global:
+#print eval("[(lambda p1 : p1 + o1)(5) for o1 in range(5)]")
+def lambda_func():
+    try:
+        pass #print eval("[(lambda p2 : p2 + o2)(5) for o2 in range(5)]")
+    except NameError as e:
+        print e.message
+lambda_func()
 
 shadow1 = 1000
 shadow2 = 1000

--- a/test/tests/exec_basic.py
+++ b/test/tests/exec_basic.py
@@ -1,0 +1,5 @@
+exec """print 'hi'
+a = 5
+print a"""
+
+exec ""

--- a/test/tests/exec_parsing.py
+++ b/test/tests/exec_parsing.py
@@ -1,6 +1,0 @@
-# We need to be able to parse files with exec statements in them,
-# even if we don't support the actual exec statement yet.
-
-
-def dont_run_me():
-    exec "1/0"

--- a/test/tests/exec_set_local.py
+++ b/test/tests/exec_set_local.py
@@ -1,0 +1,4 @@
+def f():
+    exec "a = 5"
+    print a
+f()

--- a/test/tests/globals_func.py
+++ b/test/tests/globals_func.py
@@ -18,3 +18,8 @@ except NameError:
 # You're allowed to assign through globals and have it affect the module:
 globals()['x'] = 1
 print x
+
+# locals should do the same as globals
+print locals()['x']
+locals()['x'] = 2
+print x

--- a/test/tests/misc_scoping.py
+++ b/test/tests/misc_scoping.py
@@ -1,0 +1,208 @@
+# expected: fail
+
+def f():
+    print eval("[a for a in xrange(2)]")
+    print eval("a")
+f()
+
+def f():
+    a = 0
+    b = 0
+    e = 0
+    r = 0
+    def g():
+        def h():
+            print b
+            print e
+        print a
+
+        c = 0
+        print c
+
+        eval("[a for a in xrange(2)]")
+        eval("[c for c in xrange(2)]")
+        eval("[d for d in xrange(2)]")
+        eval("[e for e in xrange(2)]")
+
+        print a
+        print c
+
+        # d not found, because it's read as a stack variable
+        try:
+            print d
+        except NameError:
+            print 'd not found'
+
+        # but d it *is* in the locals()
+        # On the other hand, a, c, and e don't get over-written
+        # and b appears even though it only gets passed-through.
+        # So it should look like:
+        # a:0, b:0, c:0, d:2, e:0
+        print locals()
+
+    def unused():
+        print r
+    g()
+f()
+
+def meh(l):
+    l['a'] = 5
+    return 3
+
+def f():
+    print eval("meh(locals()) + a")
+f()
+
+def f():
+    print eval("meh(locals()) + a", globals(), {})
+f()
+
+def f():
+    d = locals()
+    a = 2
+    d['a'] = 3
+    print a
+    print d
+f()
+
+def f():
+    exec "print 'hi'"
+    d = locals()
+    a = 2
+    d['a'] = 3
+    print a
+    print d
+f()
+
+def f():
+    d = locals()
+    a = 2
+    d['a'] = 3
+    print a
+    print d
+    exec "print 'hi'"
+f()
+
+def f(arg):
+    a = 2
+    d = locals()
+    print d
+    a = 3
+    print d
+    locals()
+    print d
+    del a
+    print d
+    locals()
+    print d
+f(12)
+
+def f(arg):
+    exec "r = 12"
+    a = 2
+    d = locals()
+    print d
+    a = 3
+    print d
+    locals()
+    print d
+    del a
+    print d
+    locals()
+    print d
+f(12)
+
+
+def f():
+    a = 5
+    def g():
+        print a
+    print locals()
+f()
+
+def f():
+    def g():
+        a = 0
+        def h():
+            print a
+            print locals()
+            yield 12
+            print locals()
+            yield 13
+        yield h
+        a = 1
+        yield 2
+    gen = g()
+    h1 = gen.next()
+    hgen = h1()
+
+    hgen.next()
+    gen.next()
+    hgen.next()
+f()
+
+foo = 0 
+class C(object):
+    try:
+        del foo
+    except NameError:
+        print 'foo NameError'
+
+foo = 0
+class C(object):
+    foo = 1
+    print foo
+    del foo
+    print foo
+
+class C(object):
+    a = 2
+    d = locals()
+    print d
+    a = 3
+    print d
+    locals()
+    print d
+    del a
+    print d
+
+def f(moo):
+    class C(object):
+        a = 2
+        d = locals()
+        print d
+        a = 3
+        print d
+        locals()
+        print d
+        del a
+        print d
+        print moo
+f(2134)
+
+some_glob = 2
+def f():
+    global some_glob
+    def g():
+        exec "some_glob = 5"
+        print some_glob
+    g()
+f()
+
+some_glob = 2
+def f():
+    def g():
+        global some_glob
+        exec "some_glob = 5"
+        print some_glob
+    g()
+f()
+
+some_glob = 2
+def f():
+    global some_glob
+    exec "some_glob = 5"
+    def g():
+        print some_glob
+    g()
+f()

--- a/test/tests/name_forcing_syntax_error.py
+++ b/test/tests/name_forcing_syntax_error.py
@@ -1,0 +1,213 @@
+# We could just have a file for each, but if we Do these in execs,
+# we don't need separate files for each, and that makes it easier
+# to just spam all the permutations.
+
+# The logic beyond this error message is oddly complicated.
+
+cases = [
+
+# protip: delete this first """ to get your editor to syntax-highlight the code
+
+"""
+
+# This should compile fine
+def f():
+    a = 0
+    exec "b = 0"
+
+""", """
+# This should compile fine
+def addpackage(sitedir, name, known_paths):
+    print a
+    exec "b = 0"
+
+""", """
+
+def f():
+    exec "a = 5"
+    def g():
+        print a
+""", """
+
+def f():
+    exec "a = 5"
+    def g():
+        def h():
+            print a
+
+""", """
+
+def f():
+    exec "a = 5"
+    class C(object):
+        def h():
+            print a
+""", """
+
+def f():
+    exec "a = 5"
+    def g():
+        b = 2
+        def h():
+            print b
+""", """
+
+def f():
+    def g():
+        print a
+        exec "a = 5"
+""", """
+
+def f():
+    from string import *
+    def g():
+        print a
+""", """
+
+def f():
+    from string import *
+    def g():
+        def h():
+            print a
+""", """
+
+def f():
+    from string import *
+    class C(object):
+        def h():
+            print a
+""", """
+
+def f():
+    from string import *
+    def g():
+        b = 2
+        def h():
+            print b
+""", """
+
+def f():
+    def g():
+        print a
+        from string import *
+""", """
+
+def f():
+    exec "a = 5"
+    from string import *
+    def g():
+        print a
+""", """
+
+def f():
+    from string import *
+    exec "a = 5"
+    def g():
+        print a
+""", """
+
+def f():
+    def g():
+        print a
+        from string import *
+        exec "a = 5"
+""", """
+
+def f():
+    def g():
+        print a
+        exec "a = 5"
+        from string import *
+
+""", """
+
+def f():
+    def g():
+        exec "a = 5"
+
+""", """
+
+class C(object):
+    def g():
+        a = 5
+        exec "a = 5"
+
+""", """
+
+class C(object):
+    def g():
+        exec "a = 5"
+
+""", """
+def f():
+    exec "a = 5"
+    return {b for b in xrange(3)}
+""", """
+def f():
+    exec "a = 5"
+    return [b for b in xrange(3)]
+""", """
+def f():
+    exec "a = 5"
+    return {b:b for b in xrange(3)}
+""", """
+def f():
+    exec "a = 5"
+    return {c for b in xrange(3)}
+""", """
+def f():
+    exec "a = 5"
+    return [c for b in xrange(3)]
+""", """
+def f():
+    exec "a = 5"
+    return {c:b for b in xrange(3)}
+""", """
+def f():
+    global a
+    def g():
+        print a
+        exec ""
+""", """
+def f():
+    global a
+    exec ""
+    def g():
+        print a
+""", """
+def f():
+    global a
+    def g():
+        a = 0
+        def h():
+            exec ""
+            print a
+""", """
+def f():
+    a = 0
+    def g():
+        global a
+        def h():
+            exec ""
+            print a
+""", """
+def f():
+    a = 0
+    def g():
+        exec ""
+        def h():
+            print a
+"""
+
+]
+
+#import traceback
+
+for case in cases:
+    print case
+    try:
+        exec case
+    except SyntaxError as se:
+        print se.message
+        # TODO uncomment this
+        # traceback.print_exc()

--- a/test/tests/name_mangling.py
+++ b/test/tests/name_mangling.py
@@ -79,6 +79,25 @@ class MyClass(object):
 
 class MyClass(object):
     try:
+        from __foo import __bar
+    except ImportError, e:
+        print e
+
+#TODO enable this once we support `import *` in functions
+#class MyClass(object):
+#    try:
+#        from __foo import *
+#    except ImportError, e:
+#        print e
+
+class MyClass(object):
+    try:
+        from sys import __bar
+    except ImportError, e:
+        print e
+
+class MyClass(object):
+    try:
         # Except if it's a dotted name:
         import __foo.__bar
     except ImportError, e:

--- a/test/tests/osr_frameinfo.py
+++ b/test/tests/osr_frameinfo.py
@@ -1,0 +1,28 @@
+try:
+    import __pyston__
+    __pyston__.setOption("OSR_THRESHOLD_BASELINE", 50)
+except ImportError:
+    pass
+
+def f1(x):
+    exec """
+for i in xrange(x):
+    pass
+print x
+"""
+
+f1(200)
+
+def f3():
+    exec """
+def f2(x):
+    def inner():
+        return x
+    return inner
+"""
+
+    g = f2(200)
+    for i in xrange(200):
+        g()
+    print g()
+f3()

--- a/test/unittests/analysis.cpp
+++ b/test/unittests/analysis.cpp
@@ -26,14 +26,14 @@ TEST_F(AnalysisTest, augassign) {
     AST_Module* module = caching_parse_file(fn.c_str());
     assert(module);
 
-    ScopingAnalysis *scoping = runScopingAnalysis(module);
+    ScopingAnalysis *scoping = new ScopingAnalysis(module);
 
     assert(module->body[0]->type == AST_TYPE::FunctionDef);
     AST_FunctionDef* func = static_cast<AST_FunctionDef*>(module->body[0]);
 
     ScopeInfo* scope_info = scoping->getScopeInfoForNode(func);
-    ASSERT_FALSE(scope_info->refersToGlobal(module->interned_strings->get("a")));
-    ASSERT_FALSE(scope_info->refersToGlobal(module->interned_strings->get("b")));
+    ASSERT_FALSE(scope_info->getScopeTypeOfName(module->interned_strings->get("a")) == ScopeInfo::VarScopeType::GLOBAL);
+    ASSERT_FALSE(scope_info->getScopeTypeOfName(module->interned_strings->get("b")) == ScopeInfo::VarScopeType::GLOBAL);
 
     SourceInfo* si = new SourceInfo(createModule("__main__", fn), scoping, func, func->body);
 


### PR DESCRIPTION
Depends on #349 (*cough*)

This PR
- Implements `locals()` (more) correctly for module-level scope by just returning the same things as `globals()` (the `attrwrapper` thing)
- Since this is passed to `eval` or `exec`, I have to add support for `boxedLocals` being an arbitrary object, not necessarily a `dict`
- Fix the scope rules for the top-level of `eval` and `exec`--previously, these were treated like a function, but they should be treated more like a module scope and independently descending into the child scopes.

All these changes together let us uncomment everything in `eval_test.py` and have it pass.

(This has all of #349 in it, so just look at the last 2 commits)