### PR TITLE
Use cpythons isinstance and issubclass implementation

### DIFF
--- a/from_cpython/Include/dictobject.h
+++ b/from_cpython/Include/dictobject.h
@@ -122,13 +122,8 @@ PyAPI_DATA(PyTypeObject*) dictitems_cls;
 PyAPI_DATA(PyTypeObject*) dictvalues_cls;
 #define PyDictValues_Type (*dictvalues_cls)
 
-// Pyston changes: these aren't direct macros any more [they potentially could be though]
-PyAPI_FUNC(bool) _PyDict_Check(PyObject*) PYSTON_NOEXCEPT;
-#define PyDict_Check(op) _PyDict_Check((PyObject*)(op))
-#if 0
 #define PyDict_Check(op) \
                  PyType_FastSubclass(Py_TYPE(op), Py_TPFLAGS_DICT_SUBCLASS)
-#endif
 #define PyDict_CheckExact(op) (Py_TYPE(op) == &PyDict_Type)
 #define PyDictKeys_Check(op) (Py_TYPE(op) == &PyDictKeys_Type)
 #define PyDictItems_Check(op) (Py_TYPE(op) == &PyDictItems_Type)

--- a/from_cpython/Include/intobject.h
+++ b/from_cpython/Include/intobject.h
@@ -36,13 +36,11 @@ typedef struct _PyIntObject PyIntObject;
 PyAPI_DATA(PyTypeObject*) int_cls;
 #define PyInt_Type (*int_cls)
 
-// Pyston changes: these aren't direct macros any more [they potentially could be though]
-PyAPI_FUNC(bool) _PyInt_Check(PyObject*) PYSTON_NOEXCEPT;
-#define PyInt_Check(op) _PyInt_Check((PyObject*)(op))
-#if 0
+// Pyston change: (op)->ob_type --> Py_TYPE(op)
+// #define PyInt_Check(op) \
+// 		 PyType_FastSubclass((op)->ob_type, Py_TPFLAGS_INT_SUBCLASS)
 #define PyInt_Check(op) \
-		 PyType_FastSubclass((op)->ob_type, Py_TPFLAGS_INT_SUBCLASS)
-#endif
+        PyType_FastSubclass(Py_TYPE(op), Py_TPFLAGS_INT_SUBCLASS)
 #define PyInt_CheckExact(op) (Py_TYPE(op) == &PyInt_Type)
 
 PyAPI_FUNC(PyObject *) PyInt_FromString(const char*, char**, int) PYSTON_NOEXCEPT;

--- a/from_cpython/Include/listobject.h
+++ b/from_cpython/Include/listobject.h
@@ -48,13 +48,8 @@ typedef struct _PyListObject PyListObject;
 PyAPI_DATA(PyTypeObject*) list_cls;
 #define PyList_Type (*list_cls)
 
-// Pyston changes: these aren't direct macros any more [they potentially could be though]
-PyAPI_FUNC(bool) _PyList_Check(PyObject*) PYSTON_NOEXCEPT;
-#define PyList_Check(op) _PyList_Check((PyObject*)(op))
-#if 0
 #define PyList_Check(op) \
 		PyType_FastSubclass(Py_TYPE(op), Py_TPFLAGS_LIST_SUBCLASS)
-#endif
 #define PyList_CheckExact(op) (Py_TYPE(op) == &PyList_Type)
 
 PyAPI_FUNC(PyObject *) PyList_New(Py_ssize_t size) PYSTON_NOEXCEPT;

--- a/from_cpython/Include/longobject.h
+++ b/from_cpython/Include/longobject.h
@@ -20,13 +20,8 @@ typedef struct _PyLongObject PyLongObject;
 PyAPI_DATA(PyTypeObject*) long_cls;
 #define PyLong_Type (*long_cls)
 
-// Pyston changes: these aren't direct macros any more [they potentially could be though]
-PyAPI_FUNC(bool) _PyLong_Check(PyObject*) PYSTON_NOEXCEPT;
-#define PyLong_Check(op) _PyLong_Check((PyObject*)(op))
-#if 0
 #define PyLong_Check(op) \
 		PyType_FastSubclass(Py_TYPE(op), Py_TPFLAGS_LONG_SUBCLASS)
-#endif
 #define PyLong_CheckExact(op) (Py_TYPE(op) == &PyLong_Type)
 
 PyAPI_FUNC(PyObject *) PyLong_FromLong(long) PYSTON_NOEXCEPT;

--- a/from_cpython/Include/object.h
+++ b/from_cpython/Include/object.h
@@ -503,13 +503,8 @@ PyAPI_DATA(PyTypeObject*) type_cls;
 PyAPI_DATA(PyTypeObject*) object_cls;
 #define PyBaseObject_Type (*object_cls)
 
-// Pyston changes: these aren't direct macros any more [they potentially could be though]
-PyAPI_FUNC(bool) _PyType_Check(PyObject*) PYSTON_NOEXCEPT;
-#define PyType_Check(op) _PyType_Check((PyObject*)(op))
-#if 0
 #define PyType_Check(op) \
     PyType_FastSubclass(Py_TYPE(op), Py_TPFLAGS_TYPE_SUBCLASS)
-#endif
 #define PyType_CheckExact(op) (Py_TYPE(op) == &PyType_Type)
 
 PyAPI_FUNC(int) PyType_Ready(PyTypeObject *) PYSTON_NOEXCEPT;
@@ -691,8 +686,6 @@ manually remove this flag though!
 #define Py_TPFLAGS_HAVE_NEWBUFFER (1L<<21)
 
 /* These flags are used to determine if a type is a subclass. */
-// Pyston change: we're not setting any of these, so let's comment them out
-#if 0
 #define Py_TPFLAGS_INT_SUBCLASS         (1L<<23)
 #define Py_TPFLAGS_LONG_SUBCLASS        (1L<<24)
 #define Py_TPFLAGS_LIST_SUBCLASS        (1L<<25)
@@ -702,7 +695,6 @@ manually remove this flag though!
 #define Py_TPFLAGS_DICT_SUBCLASS        (1L<<29)
 #define Py_TPFLAGS_BASE_EXC_SUBCLASS    (1L<<30)
 #define Py_TPFLAGS_TYPE_SUBCLASS        (1L<<31)
-#endif
 
 #define Py_TPFLAGS_DEFAULT_EXTERNAL ( \
                  Py_TPFLAGS_HAVE_GETCHARBUFFER | \

--- a/from_cpython/Include/sliceobject.h
+++ b/from_cpython/Include/sliceobject.h
@@ -39,10 +39,7 @@ PyAPI_DATA(PyTypeObject*) slice_cls;
 PyAPI_DATA(PyTypeObject*) ellipsis_cls;
 #define PyEllipsis_Type (*ellipsis_cls)
 
-// Pyston changes: these aren't direct macros any more [they potentially could be though]
-//#define PySlice_Check(op) (Py_TYPE(op) == &PySlice_Type)
-PyAPI_FUNC(bool) _PySlice_Check(PyObject*) PYSTON_NOEXCEPT;
-#define PySlice_Check(op) _PySlice_Check((PyObject*)(op))
+#define PySlice_Check(op) (Py_TYPE(op) == &PySlice_Type)
 
 PyAPI_FUNC(PyObject *) PySlice_New(PyObject* start, PyObject* stop,
                                   PyObject* step) PYSTON_NOEXCEPT;

--- a/from_cpython/Include/stringobject.h
+++ b/from_cpython/Include/stringobject.h
@@ -64,13 +64,8 @@ PyAPI_DATA(PyTypeObject*) basestring_cls;
 PyAPI_DATA(PyTypeObject*) str_cls;
 #define PyString_Type (*str_cls)
 
-// Pyston changes: these aren't direct macros any more [they potentially could be though]
-PyAPI_FUNC(bool) _PyString_Check(PyObject*) PYSTON_NOEXCEPT;
-#define PyString_Check(op) _PyString_Check((PyObject*)(op))
-#if 0
 #define PyString_Check(op) \
                  PyType_FastSubclass(Py_TYPE(op), Py_TPFLAGS_STRING_SUBCLASS)
-#endif
 #define PyString_CheckExact(op) (Py_TYPE(op) == &PyString_Type)
 
 PyAPI_FUNC(PyObject *) PyString_FromStringAndSize(const char *, Py_ssize_t) PYSTON_NOEXCEPT;

--- a/from_cpython/Include/tupleobject.h
+++ b/from_cpython/Include/tupleobject.h
@@ -41,13 +41,8 @@ typedef struct _PyTupleObject PyTupleObject;
 PyAPI_DATA(PyTypeObject*) tuple_cls;
 #define PyTuple_Type (*tuple_cls)
 
-// Pyston changes: these aren't direct macros any more [they potentially could be though]
-PyAPI_FUNC(bool) _PyTuple_Check(PyObject*) PYSTON_NOEXCEPT;
-#define PyTuple_Check(op) _PyTuple_Check((PyObject*)(op))
-#if 0
 #define PyTuple_Check(op) \
                  PyType_FastSubclass(Py_TYPE(op), Py_TPFLAGS_TUPLE_SUBCLASS)
-#endif
 #define PyTuple_CheckExact(op) (Py_TYPE(op) == &PyTuple_Type)
 
 PyAPI_FUNC(PyObject *) PyTuple_New(Py_ssize_t size) PYSTON_NOEXCEPT;

--- a/from_cpython/Include/unicodeobject.h
+++ b/from_cpython/Include/unicodeobject.h
@@ -426,13 +426,8 @@ typedef struct {
 
 PyAPI_DATA(PyTypeObject) PyUnicode_Type;
 
-// Pyston changes: these aren't direct macros any more [they potentially could be though]
-PyAPI_FUNC(bool) _PyUnicode_Check(PyObject*) PYSTON_NOEXCEPT;
-#define PyUnicode_Check(op) _PyUnicode_Check((PyObject*)(op))
-#if 0
 #define PyUnicode_Check(op) \
                  PyType_FastSubclass(Py_TYPE(op), Py_TPFLAGS_UNICODE_SUBCLASS)
-#endif
 #define PyUnicode_CheckExact(op) (Py_TYPE(op) == &PyUnicode_Type)
 
 /* Fast access macros */

--- a/from_cpython/Objects/exceptions.c
+++ b/from_cpython/Objects/exceptions.c
@@ -372,9 +372,6 @@ static PyGetSetDef BaseException_getset[] = {
     {NULL},
 };
 
-// Leave this in as a reminder in case we want to go back to using it:
-#define Py_TPFLAGS_BASE_EXC_SUBCLASS     (0)
-
 
 static PyTypeObject _PyExc_BaseException = {
     PyObject_HEAD_INIT(NULL)

--- a/from_cpython/Objects/unicodeobject.c
+++ b/from_cpython/Objects/unicodeobject.c
@@ -8842,9 +8842,6 @@ unicode_subtype_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     return (PyObject *)pnew;
 }
 
-// Pyston change: Leave this in as a reminder in case we want to go back to using it:
-#define Py_TPFLAGS_UNICODE_SUBCLASS     (0)
-
 PyDoc_STRVAR(unicode_doc,
              "unicode(object='') -> unicode object\n\
 unicode(string[, encoding[, errors]]) -> unicode object\n\

--- a/src/analysis/type_analysis.cpp
+++ b/src/analysis/type_analysis.cpp
@@ -361,7 +361,7 @@ private:
 
     void* visit_langprimitive(AST_LangPrimitive* node) override {
         switch (node->opcode) {
-            case AST_LangPrimitive::ISINSTANCE:
+            case AST_LangPrimitive::CHECK_EXC_MATCH:
                 return BOOL;
             case AST_LangPrimitive::LOCALS:
                 return DICT;

--- a/src/capi/abstract.cpp
+++ b/src/capi/abstract.cpp
@@ -346,12 +346,12 @@ static int recursive_isinstance(PyObject* inst, PyObject* cls) noexcept {
             return -1;
     }
     */
-    PyObject* __class__ = boxStrConstant("__class__");
 
     if (PyClass_Check(cls) && PyInstance_Check(inst)) {
         PyObject* inclass = static_cast<BoxedInstance*>(inst)->inst_cls;
         retval = PyClass_IsSubclass(inclass, cls);
     } else if (PyType_Check(cls)) {
+        PyObject* __class__ = boxStrConstant("__class__");
         retval = PyObject_TypeCheck(inst, (PyTypeObject*)cls);
         if (retval == 0) {
             PyObject* c = PyObject_GetAttr(inst, __class__);
@@ -364,6 +364,7 @@ static int recursive_isinstance(PyObject* inst, PyObject* cls) noexcept {
             }
         }
     } else {
+        PyObject* __class__ = boxStrConstant("__class__");
         if (!check_class(cls, "isinstance() arg 2 must be a class, type,"
                               " or tuple of classes and types"))
             return -1;
@@ -378,6 +379,10 @@ static int recursive_isinstance(PyObject* inst, PyObject* cls) noexcept {
     }
 
     return retval;
+}
+
+extern "C" int _PyObject_RealIsInstance(PyObject* inst, PyObject* cls) noexcept {
+    return recursive_isinstance(inst, cls);
 }
 
 extern "C" int PyObject_IsInstance(PyObject* inst, PyObject* cls) noexcept {
@@ -671,6 +676,10 @@ static int recursive_issubclass(PyObject* derived, PyObject* cls) noexcept {
     }
 
     return retval;
+}
+
+extern "C" int _PyObject_RealIsSubclass(PyObject* derived, PyObject* cls) noexcept {
+    return recursive_issubclass(derived, cls);
 }
 
 extern "C" int PyObject_IsSubclass(PyObject* derived, PyObject* cls) noexcept {

--- a/src/codegen/ast_interpreter.cpp
+++ b/src/codegen/ast_interpreter.cpp
@@ -540,13 +540,12 @@ Value ASTInterpreter::visit_langPrimitive(AST_LangPrimitive* node) {
         Box* traceback = last_exception.traceback ? last_exception.traceback : None;
         v = new BoxedTuple({ type, value, traceback });
         last_exception = ExcInfo(NULL, NULL, NULL);
-    } else if (node->opcode == AST_LangPrimitive::ISINSTANCE) {
-        assert(node->args.size() == 3);
+    } else if (node->opcode == AST_LangPrimitive::CHECK_EXC_MATCH) {
+        assert(node->args.size() == 2);
         Value obj = visit_expr(node->args[0]);
         Value cls = visit_expr(node->args[1]);
-        Value flags = visit_expr(node->args[2]);
 
-        v = boxBool(isinstance(obj.o, cls.o, unboxInt(flags.o)));
+        v = boxBool(exceptionMatches(obj.o, cls.o));
 
     } else if (node->opcode == AST_LangPrimitive::LOCALS) {
         assert(node->args.size() == 0);

--- a/src/codegen/irgen/irgenerator.cpp
+++ b/src/codegen/irgen/irgenerator.cpp
@@ -384,22 +384,18 @@ private:
 
     CompilerVariable* evalLangPrimitive(AST_LangPrimitive* node, UnwindInfo unw_info) {
         switch (node->opcode) {
-            case AST_LangPrimitive::ISINSTANCE: {
-                assert(node->args.size() == 3);
+            case AST_LangPrimitive::CHECK_EXC_MATCH: {
+                assert(node->args.size() == 2);
                 CompilerVariable* obj = evalExpr(node->args[0], unw_info);
                 CompilerVariable* cls = evalExpr(node->args[1], unw_info);
-                CompilerVariable* flags = evalExpr(node->args[2], unw_info);
 
                 ConcreteCompilerVariable* converted_obj = obj->makeConverted(emitter, obj->getBoxType());
                 ConcreteCompilerVariable* converted_cls = cls->makeConverted(emitter, cls->getBoxType());
-                ConcreteCompilerVariable* converted_flags = flags->makeConverted(emitter, INT);
                 obj->decvref(emitter);
                 cls->decvref(emitter);
-                flags->decvref(emitter);
 
-                llvm::Value* v = emitter.createCall(
-                    unw_info, g.funcs.isinstance,
-                    { converted_obj->getValue(), converted_cls->getValue(), converted_flags->getValue() });
+                llvm::Value* v = emitter.createCall(unw_info, g.funcs.exceptionMatches,
+                                                    { converted_obj->getValue(), converted_cls->getValue() });
                 assert(v->getType() == g.i1);
 
                 return boolFromI1(emitter, v);

--- a/src/codegen/runtime_hooks.cpp
+++ b/src/codegen/runtime_hooks.cpp
@@ -206,7 +206,7 @@ void initGlobalFuncs(GlobalState& g) {
     GET(importStar);
     GET(repr);
     GET(str);
-    GET(isinstance);
+    GET(exceptionMatches);
     GET(yield);
     GET(getiterHelper);
     GET(hasnext);

--- a/src/codegen/runtime_hooks.h
+++ b/src/codegen/runtime_hooks.h
@@ -38,7 +38,7 @@ struct GlobalFuncs {
         *decodeUTF8StringPtr;
     llvm::Value* getattr, *setattr, *delattr, *delitem, *delGlobal, *nonzero, *binop, *compare, *augbinop, *unboxedLen,
         *getitem, *getclsattr, *getGlobal, *setitem, *unaryop, *import, *importFrom, *importStar, *repr, *str,
-        *isinstance, *yield, *getiterHelper, *hasnext;
+        *exceptionMatches, *yield, *getiterHelper, *hasnext;
 
     llvm::Value* unpackIntoArray, *raiseAttributeError, *raiseAttributeErrorStr, *raiseNotIterableError,
         *assertNameDefined, *assertFail;

--- a/src/core/ast.cpp
+++ b/src/core/ast.cpp
@@ -1448,8 +1448,8 @@ bool PrintVisitor::visit_lambda(AST_Lambda* node) {
 bool PrintVisitor::visit_langprimitive(AST_LangPrimitive* node) {
     printf(":");
     switch (node->opcode) {
-        case AST_LangPrimitive::ISINSTANCE:
-            printf("ISINSTANCE");
+        case AST_LangPrimitive::CHECK_EXC_MATCH:
+            printf("CHECK_EXC_MATCH");
             break;
         case AST_LangPrimitive::LANDINGPAD:
             printf("LANDINGPAD");

--- a/src/core/ast.h
+++ b/src/core/ast.h
@@ -1014,13 +1014,11 @@ public:
 
 // "LangPrimitive" represents operations that "primitive" to the language,
 // but aren't directly *exactly* representable as normal Python.
-// ClsAttribute would fall into this category, as would isinstance (which
-// is not the same as the "isinstance" name since that could get redefined).
+// ClsAttribute would fall into this category.
 // These are basically bytecodes, framed as pseudo-AST-nodes.
 class AST_LangPrimitive : public AST_expr {
 public:
     enum Opcodes {
-        ISINSTANCE,
         LANDINGPAD,
         LOCALS,
         GET_ITER,
@@ -1029,6 +1027,7 @@ public:
         IMPORT_STAR,
         NONE,
         NONZERO,
+        CHECK_EXC_MATCH,
         SET_EXC_INFO,
         UNCACHE_EXC_INFO,
         HASNEXT,

--- a/src/core/cfg.cpp
+++ b/src/core/cfg.cpp
@@ -2082,11 +2082,9 @@ public:
                 if (exc_handler->type) {
                     AST_expr* handled_type = remapExpr(exc_handler->type);
 
-                    // TODO: this should be an EXCEPTION_MATCHES(exc_type_name)
-                    AST_LangPrimitive* is_caught_here = new AST_LangPrimitive(AST_LangPrimitive::ISINSTANCE);
+                    AST_LangPrimitive* is_caught_here = new AST_LangPrimitive(AST_LangPrimitive::CHECK_EXC_MATCH);
                     is_caught_here->args.push_back(_dup(exc_obj));
                     is_caught_here->args.push_back(handled_type);
-                    is_caught_here->args.push_back(makeNum(1)); // flag: false_on_noncls
 
                     AST_Branch* br = new AST_Branch();
                     br->test = callNonzero(remapExpr(is_caught_here));

--- a/src/runtime/builtin_modules/builtins.cpp
+++ b/src/runtime/builtin_modules/builtins.cpp
@@ -463,27 +463,17 @@ Box* sorted(Box* obj, Box* key, Box* cmp, Box** args) {
 }
 
 Box* isinstance_func(Box* obj, Box* cls) {
-    return boxBool(isinstance(obj, cls, 0));
+    int rtn = PyObject_IsInstance(obj, cls);
+    if (rtn < 0)
+        checkAndThrowCAPIException();
+    return boxBool(rtn);
 }
 
 Box* issubclass_func(Box* child, Box* parent) {
-    if (!isSubclass(child->cls, type_cls) && child->cls != classobj_cls)
-        raiseExcHelper(TypeError, "issubclass() arg 1 must be a class");
-
-    RELEASE_ASSERT(parent->cls != tuple_cls, "unsupported");
-
-    if (child->cls == classobj_cls) {
-        if (parent->cls != classobj_cls)
-            return False;
-
-        return boxBool(classobjIssubclass(static_cast<BoxedClassobj*>(child), static_cast<BoxedClassobj*>(parent)));
-    }
-
-    RELEASE_ASSERT(isSubclass(child->cls, type_cls), "");
-    if (!isSubclass(parent->cls, type_cls))
-        return False;
-
-    return boxBool(isSubclass(static_cast<BoxedClass*>(child), static_cast<BoxedClass*>(parent)));
+    int rtn = PyObject_IsSubclass(child, parent);
+    if (rtn < 0)
+        checkAndThrowCAPIException();
+    return boxBool(rtn);
 }
 
 Box* bltinImport(Box* name, Box* globals, Box* locals, Box** args) {

--- a/src/runtime/classobj.cpp
+++ b/src/runtime/classobj.cpp
@@ -28,21 +28,6 @@ extern "C" {
 BoxedClass* classobj_cls, *instance_cls;
 }
 
-bool classobjIssubclass(BoxedClassobj* child, BoxedClassobj* parent) {
-    if (child == parent)
-        return true;
-
-    for (auto e : child->bases->elts) {
-        if (e->cls == classobj_cls && classobjIssubclass(static_cast<BoxedClassobj*>(e), parent))
-            return true;
-    }
-    return false;
-}
-
-bool instanceIsinstance(BoxedInstance* obj, BoxedClassobj* cls) {
-    return classobjIssubclass(obj->inst_cls, cls);
-}
-
 static Box* classLookup(BoxedClassobj* cls, const std::string& attr) {
     Box* r = cls->getattr(attr);
     if (r)

--- a/src/runtime/classobj.h
+++ b/src/runtime/classobj.h
@@ -28,9 +28,6 @@ extern "C" {
 extern BoxedClass* classobj_cls, *instance_cls;
 }
 
-bool instanceIsinstance(BoxedInstance* obj, BoxedClassobj* cls);
-bool classobjIssubclass(BoxedClassobj* child, BoxedClassobj* parent);
-
 class BoxedClassobj : public Box {
 public:
     HCAttrs attrs;

--- a/src/runtime/inline/link_forcer.cpp
+++ b/src/runtime/inline/link_forcer.cpp
@@ -87,7 +87,7 @@ void force() {
     FORCE(importStar);
     FORCE(repr);
     FORCE(str);
-    FORCE(isinstance);
+    FORCE(exceptionMatches);
     FORCE(yield);
     FORCE(getiterHelper);
     FORCE(hasnext);

--- a/src/runtime/objmodel.h
+++ b/src/runtime/objmodel.h
@@ -61,7 +61,7 @@ extern "C" BoxedString* str(Box* obj);
 extern "C" BoxedString* repr(Box* obj);
 extern "C" BoxedString* reprOrNull(Box* obj); // similar to repr, but returns NULL on exception
 extern "C" BoxedString* strOrNull(Box* obj);  // similar to str, but returns NULL on exception
-extern "C" bool isinstance(Box* obj, Box* cls, int64_t flags);
+extern "C" bool exceptionMatches(Box* obj, Box* cls);
 extern "C" BoxedInt* hash(Box* obj);
 extern "C" Box* abs_(Box* obj);
 Box* open(Box* arg1, Box* arg2);

--- a/test/tests/binops_subclass.py
+++ b/test/tests/binops_subclass.py
@@ -1,5 +1,6 @@
 # expected: fail
-# - this particular check isn't implemented yet
+# - binop ordering is wrong, 
+#   should prefer executing a operation on the subclass first
 
 class M(type):
     def __instancecheck__(self, rhs):

--- a/test/tests/exception_subclasscheck.py
+++ b/test/tests/exception_subclasscheck.py
@@ -1,6 +1,3 @@
-# expected: fail
-# - don't support this stuff yet
-
 # Exception-catching is supposed to go through __subclasscheck__
 
 class MyException(Exception):
@@ -33,20 +30,12 @@ print 2
 print isinstance(1, E)
 print 3
 
-# This calls __subclasscheck__ twice...?
-try:
-    raise E()
-except E:
-    pass
-
-print 4
-
 try:
     raise Exception()
 except E:
     pass
 
-print 5
+print 4
 
 # Exceptions in __subclasscheck__ should get ignored:
 try:

--- a/test/tests/exception_subclasscheck2.py
+++ b/test/tests/exception_subclasscheck2.py
@@ -1,0 +1,18 @@
+# expected: fail
+# - CPython calls subclasscheck twice, while we call it once.
+#   Looks like this is because CPython calls PyErr_NormalizeException
+#   when the exception gets set.
+
+class M(type):
+    def __subclasscheck__(self, sub):
+        print "subclasscheck", sub
+        return True
+
+class E(Exception):
+    __metaclass__ = M
+
+# This calls __subclasscheck__ twice...?
+try:
+    raise E()
+except E:
+    pass

--- a/test/tests/oldstyle_classes.py
+++ b/test/tests/oldstyle_classes.py
@@ -223,3 +223,13 @@ print issubclass(LateSubclassing, C)
 print issubclass(LateSubclassing, D)
 print issubclass(LateSubclassing, E)
 
+# Mixed old and new style class inheritance
+class C():
+    pass
+class D(C):
+    pass
+class E(C, object):
+    pass
+print issubclass(D, C), isinstance(D(), C)
+print issubclass(E, C), isinstance(E(), C)
+print isinstance(E, object), isinstance(E(), object)

--- a/test/tests/subclasscheck_test.py
+++ b/test/tests/subclasscheck_test.py
@@ -1,0 +1,17 @@
+class M(type):
+    def __instancecheck__(self, rhs):
+        print "M.instancecheck",
+        return True
+    def __subclasscheck__(self, rhs):
+        print "M.subclasscheck",
+        return True
+
+class A(object):
+    __metaclass__ = M
+
+class B(A):
+    __metaclass__ = type
+
+print type(A), isinstance(A(), B), issubclass(A, B)
+print type(B), isinstance(B(), B), issubclass(B, B)
+print type(int), isinstance(int(), B), issubclass(int, B)

--- a/test/tests/subclasshook_test.py
+++ b/test/tests/subclasshook_test.py
@@ -1,0 +1,17 @@
+from abc import ABCMeta
+
+class SubClassHook:
+    __metaclass__ = ABCMeta
+    @classmethod
+    def __subclasshook__(cls, C):
+        return "test" in C.__dict__
+
+class C1(object):
+    pass
+
+class C2(object):
+    def test():
+        return 1
+
+for i in (C1, C2, int, SubClassHook):
+    print i, issubclass(i, SubClassHook), isinstance(i(), SubClassHook)


### PR DESCRIPTION
This commit removes our implementation of this functions,
because they could not handle mixing of old and new style classes.
And having two implementations with very similar name but different
results is very confusing.

Issues with this patch:
- in order to not have to change all our ```isSubclass()``` checks to the fast version, added if checks for the fast versions. They will not call ```__subclasscheck__```....
- I left the 3args ```isinstance``` function as is, because I'm not sure what exactly the excepected behaviour is. Maybe I should rename the ```AST_LangPrimitive::ISINSTANCE``` to ```AST_LangPrimitive::EXCEPTION_MATCHES``` and repalce the implementation with one which calls ```PyErr_GivenExceptionMatches()``` internally?
- The additional ```__subclasschecks__``` and ```__instancecheck__``` lookups decrease performance.

