### PR TITLE
colocate string and tuple data

### DIFF
--- a/src/capi/descrobject.cpp
+++ b/src/capi/descrobject.cpp
@@ -43,7 +43,7 @@ Box* BoxedMethodDescriptor::__call__(BoxedMethodDescriptor* self, Box* obj, Boxe
 
     Box* rtn;
     if (call_flags == METH_NOARGS) {
-        assert(varargs->elts.size() == 0);
+        assert(varargs->size() == 0);
         assert(kwargs->d.size() == 0);
         rtn = (Box*)self->method->ml_meth(obj, NULL);
     } else if (call_flags == METH_VARARGS) {
@@ -53,7 +53,7 @@ Box* BoxedMethodDescriptor::__call__(BoxedMethodDescriptor* self, Box* obj, Boxe
         rtn = (Box*)((PyCFunctionWithKeywords)self->method->ml_meth)(obj, varargs, kwargs);
     } else if (call_flags == METH_O) {
         assert(kwargs->d.size() == 0);
-        assert(varargs->elts.size() == 1);
+        assert(varargs->size() == 1);
         rtn = (Box*)self->method->ml_meth(obj, varargs->elts[0]);
     } else {
         RELEASE_ASSERT(0, "0x%x", call_flags);

--- a/src/capi/float.cpp
+++ b/src/capi/float.cpp
@@ -29,17 +29,17 @@ static float_format_type double_format, float_format;
 static float_format_type detected_double_format, detected_float_format;
 
 static PyObject* float_getformat(PyTypeObject* v, PyObject* arg) noexcept {
-    char* s;
     float_format_type r;
+
+    BoxedString* str = static_cast<BoxedString*>(arg);
 
     if (!PyString_Check(arg)) {
         PyErr_Format(PyExc_TypeError, "__getformat__() argument must be string, not %.500s", Py_TYPE(arg)->tp_name);
         return NULL;
     }
-    s = PyString_AS_STRING(arg);
-    if (strcmp(s, "double") == 0) {
+    if (str->s == "double") {
         r = double_format;
-    } else if (strcmp(s, "float") == 0) {
+    } else if (str->s == "float") {
         r = float_format;
     } else {
         PyErr_SetString(PyExc_ValueError, "__getformat__() argument 1 must be "
@@ -49,11 +49,11 @@ static PyObject* float_getformat(PyTypeObject* v, PyObject* arg) noexcept {
 
     switch (r) {
         case unknown_format:
-            return PyString_FromString("unknown");
+            return static_cast<PyObject*>(boxStrConstant("unknown"));
         case ieee_little_endian_format:
-            return PyString_FromString("IEEE, little-endian");
+            return static_cast<PyObject*>(boxStrConstant("IEEE, little-endian"));
         case ieee_big_endian_format:
-            return PyString_FromString("IEEE, big-endian");
+            return static_cast<PyObject*>(boxStrConstant("IEEE, big-endian"));
         default:
             Py_FatalError("insane float_format or double_format");
             return NULL;

--- a/src/capi/object.cpp
+++ b/src/capi/object.cpp
@@ -421,9 +421,9 @@ extern "C" PyObject* PyObject_SelfIter(PyObject* obj) noexcept {
 extern "C" int PyObject_GenericSetAttr(PyObject* obj, PyObject* name, PyObject* value) noexcept {
     try {
         if (value == NULL)
-            delattrGeneric(obj, static_cast<BoxedString*>(name)->s, NULL);
+            delattrGeneric(obj, std::string(static_cast<BoxedString*>(name)->s), NULL);
         else
-            setattrGeneric(obj, static_cast<BoxedString*>(name)->s.c_str(), value, NULL);
+            setattrGeneric(obj, std::string(static_cast<BoxedString*>(name)->s), value, NULL);
     } catch (ExcInfo e) {
         setCAPIException(e);
         return -1;

--- a/src/capi/types.h
+++ b/src/capi/types.h
@@ -68,11 +68,11 @@ public:
             rtn = (Box*)((PyCFunctionWithKeywords)self->func)(self->passthrough, varargs, kwargs);
         } else if (self->ml_flags == METH_NOARGS) {
             assert(kwargs->d.size() == 0);
-            assert(varargs->elts.size() == 0);
+            assert(varargs->size() == 0);
             rtn = (Box*)self->func(self->passthrough, NULL);
         } else if (self->ml_flags == METH_O) {
             assert(kwargs->d.size() == 0);
-            assert(varargs->elts.size() == 1);
+            assert(varargs->size() == 1);
             rtn = (Box*)self->func(self->passthrough, varargs->elts[0]);
         } else {
             RELEASE_ASSERT(0, "0x%x", self->ml_flags);

--- a/src/codegen/compvars.cpp
+++ b/src/codegen/compvars.cpp
@@ -2203,20 +2203,20 @@ public:
     Box* deserializeFromFrame(const FrameVals& vals) override {
         assert(vals.size() == numFrameArgs());
 
-        BoxedTuple::GCVector elts;
+        BoxedTuple* rtn = BoxedTuple::create(elt_types.size());
+        int rtn_idx = 0;
         int cur_idx = 0;
         for (auto e : elt_types) {
             int num_args = e->numFrameArgs();
             // TODO: inefficient to make these copies
             FrameVals sub_vals(vals.begin() + cur_idx, vals.begin() + cur_idx + num_args);
 
-            elts.push_back(e->deserializeFromFrame(sub_vals));
+            rtn->elts[rtn_idx++] = e->deserializeFromFrame(sub_vals);
 
             cur_idx += num_args;
         }
         assert(cur_idx == vals.size());
-
-        return new BoxedTuple(std::move(elts));
+        return rtn;
     }
 
     int numFrameArgs() override {

--- a/src/codegen/irgen/hooks.cpp
+++ b/src/codegen/irgen/hooks.cpp
@@ -364,7 +364,7 @@ Box* eval(Box* boxedCode) {
     // TODO should have a cleaner interface that can parse the Expression directly
     // TODO this memory leaks
     RELEASE_ASSERT(boxedCode->cls == str_cls, "");
-    const char* code = static_cast<BoxedString*>(boxedCode)->s.c_str();
+    const char* code = static_cast<BoxedString*>(boxedCode)->s.data();
     AST_Module* parsedModule = parse_string(code);
     RELEASE_ASSERT(parsedModule->body[0]->type == AST_TYPE::Expr, "");
     AST_Expression* parsedExpr = new AST_Expression(std::move(parsedModule->interned_strings));
@@ -385,7 +385,7 @@ Box* exec(Box* boxedCode) {
 
     // TODO same issues as in `eval`
     RELEASE_ASSERT(boxedCode->cls == str_cls, "");
-    const char* code = static_cast<BoxedString*>(boxedCode)->s.c_str();
+    const char* code = static_cast<BoxedString*>(boxedCode)->s.data();
     AST_Module* parsedModule = parse_string(code);
     AST_Suite* parsedSuite = new AST_Suite(std::move(parsedModule->interned_strings));
     parsedSuite->body = parsedModule->body;

--- a/src/codegen/pypa-parser.cpp
+++ b/src/codegen/pypa-parser.cpp
@@ -850,12 +850,12 @@ pypa::String pypaUnicodeEscapeDecoder(pypa::String s, bool raw_prefix, bool& err
         checkAndThrowCAPIException();
         BoxedString* str_utf8 = (BoxedString*)PyUnicode_AsUTF8String(unicode);
         checkAndThrowCAPIException();
-        return str_utf8->s;
+        return std::string(str_utf8->s);
     } catch (ExcInfo e) {
         error = true;
         BoxedString* error_message = str(e.value);
         if (error_message && error_message->cls == str_cls)
-            return error_message->s;
+            return std::string(error_message->s);
         return "Encountered an unknown error inside pypaUnicodeEscapeDecoder";
     }
 }

--- a/src/jit.cpp
+++ b/src/jit.cpp
@@ -166,7 +166,7 @@ static int main(int argc, char** argv) {
     if (!Py_NoSiteFlag) {
         try {
             std::string module_name = "site";
-            importModuleLevel(&module_name, None, None, 0);
+            importModuleLevel(module_name, None, None, 0);
         } catch (ExcInfo e) {
             e.printExcAndTraceback();
             return 1;

--- a/src/runtime/builtin_modules/pyston.cpp
+++ b/src/runtime/builtin_modules/pyston.cpp
@@ -43,7 +43,7 @@ static Box* setOption(Box* option, Box* value) {
     else CHECK(REOPT_THRESHOLD_BASELINE);
     else CHECK(OSR_THRESHOLD_BASELINE);
     else CHECK(SPECULATION_THRESHOLD);
-    else raiseExcHelper(ValueError, "unknown option name '%s", option_string->s.c_str());
+    else raiseExcHelper(ValueError, "unknown option name '%s", option_string->s.data());
 
     return None;
 }

--- a/src/runtime/builtin_modules/sys.cpp
+++ b/src/runtime/builtin_modules/sys.cpp
@@ -43,7 +43,7 @@ Box* sysExcInfo() {
     assert(exc->type);
     assert(exc->value);
     assert(exc->traceback);
-    return new BoxedTuple({ exc->type, exc->value, exc->traceback });
+    return BoxedTuple::create({ exc->type, exc->value, exc->traceback });
 }
 
 Box* sysExcClear() {
@@ -184,7 +184,7 @@ void prependToSysPath(const std::string& path) {
     BoxedList* sys_path = getSysPath();
     static std::string attr = "insert";
     callattr(sys_path, &attr, CallattrFlags({.cls_only = false, .null_on_nonexistent = false }), ArgPassSpec(2),
-             boxInt(0), new BoxedString(path), NULL, NULL, NULL);
+             boxInt(0), boxString(path), NULL, NULL, NULL);
 }
 
 static BoxedClass* sys_flags_cls;
@@ -258,7 +258,7 @@ void setupSys() {
 
     sys_module->giveAttr("warnoptions", new BoxedList());
     sys_module->giveAttr("py3kwarning", False);
-    sys_module->giveAttr("byteorder", new BoxedString(isLittleEndian() ? "little" : "big"));
+    sys_module->giveAttr("byteorder", boxStrConstant(isLittleEndian() ? "little" : "big"));
 
     sys_module->giveAttr("platform", boxStrConstant("unknown")); // seems like a reasonable, if poor, default
 
@@ -293,14 +293,14 @@ void setupSys() {
     sys_module->giveAttr("hexversion", boxInt(PY_VERSION_HEX));
     // TODO: this should be a "sys.version_info" object, not just a tuple (ie can access fields by name)
     sys_module->giveAttr("version_info",
-                         new BoxedTuple({ boxInt(PYTHON_VERSION_MAJOR), boxInt(PYTHON_VERSION_MINOR),
-                                          boxInt(PYTHON_VERSION_MICRO), boxStrConstant("beta"), boxInt(0) }));
+                         BoxedTuple::create({ boxInt(PYTHON_VERSION_MAJOR), boxInt(PYTHON_VERSION_MINOR),
+                                              boxInt(PYTHON_VERSION_MICRO), boxStrConstant("beta"), boxInt(0) }));
 
     sys_module->giveAttr("maxint", boxInt(PYSTON_INT_MAX));
     sys_module->giveAttr("maxsize", boxInt(PY_SSIZE_T_MAX));
 
     sys_flags_cls = new BoxedHeapClass(object_cls, BoxedSysFlags::gcHandler, 0, 0, sizeof(BoxedSysFlags), false,
-                                       new BoxedString("flags"));
+                                       static_cast<BoxedString*>(boxString("flags")));
     sys_flags_cls->giveAttr("__new__",
                             new BoxedFunction(boxRTFunction((void*)BoxedSysFlags::__new__, UNKNOWN, 1, 0, true, true)));
 #define ADD(name)                                                                                                      \
@@ -311,7 +311,7 @@ void setupSys() {
     ADD(no_user_site);
 #undef ADD
 
-    sys_flags_cls->tp_mro = new BoxedTuple({ sys_flags_cls, object_cls });
+    sys_flags_cls->tp_mro = BoxedTuple::create({ sys_flags_cls, object_cls });
     sys_flags_cls->freeze();
 
     sys_module->giveAttr("flags", new BoxedSysFlags());
@@ -326,7 +326,8 @@ void setupSysEnd() {
     std::sort<decltype(builtin_module_names)::iterator, PyLt>(builtin_module_names.begin(), builtin_module_names.end(),
                                                               PyLt());
 
-    sys_module->giveAttr("builtin_module_names", new BoxedTuple(std::move(builtin_module_names)));
+    sys_module->giveAttr("builtin_module_names",
+                         BoxedTuple::create(builtin_module_names.size(), &builtin_module_names[0]));
     sys_flags_cls->finishInitialization();
 }
 }

--- a/src/runtime/capi.cpp
+++ b/src/runtime/capi.cpp
@@ -250,7 +250,7 @@ extern "C" PyObject* PyObject_GetAttr(PyObject* o, PyObject* attr_name) noexcept
     }
 
     try {
-        return getattr(o, static_cast<BoxedString*>(attr_name)->s.c_str());
+        return getattr(o, static_cast<BoxedString*>(attr_name)->data());
     } catch (ExcInfo e) {
         setCAPIException(e);
         return NULL;
@@ -258,7 +258,7 @@ extern "C" PyObject* PyObject_GetAttr(PyObject* o, PyObject* attr_name) noexcept
 }
 
 extern "C" PyObject* PyObject_GenericGetAttr(PyObject* o, PyObject* name) noexcept {
-    Box* r = getattrInternalGeneric(o, static_cast<BoxedString*>(name)->s.c_str(), NULL, false, false, NULL, NULL);
+    Box* r = getattrInternalGeneric(o, static_cast<BoxedString*>(name)->data(), NULL, false, false, NULL, NULL);
     if (!r)
         PyErr_Format(PyExc_AttributeError, "'%.50s' object has no attribute '%.400s'", o->cls->tp_name,
                      PyString_AS_STRING(name));
@@ -879,7 +879,8 @@ extern "C" PyObject* PyImport_Import(PyObject* module_name) noexcept {
     RELEASE_ASSERT(module_name->cls == str_cls, "");
 
     try {
-        return importModuleLevel(&static_cast<BoxedString*>(module_name)->s, None, None, -1);
+        std::string _module_name = static_cast<BoxedString*>(module_name)->s;
+        return importModuleLevel(_module_name, None, None, -1);
     } catch (ExcInfo e) {
         Py_FatalError("unimplemented");
     }

--- a/src/runtime/code.cpp
+++ b/src/runtime/code.cpp
@@ -55,12 +55,12 @@ public:
 
         BoxedTuple::GCVector elts;
         for (auto sr : param_names.args)
-            elts.push_back(new BoxedString(sr));
+            elts.push_back(boxString(sr));
         if (param_names.vararg.size())
-            elts.push_back(new BoxedString(param_names.vararg));
+            elts.push_back(boxString(param_names.vararg));
         if (param_names.kwarg.size())
-            elts.push_back(new BoxedString(param_names.kwarg));
-        return new BoxedTuple(std::move(elts));
+            elts.push_back(boxString(param_names.kwarg));
+        return BoxedTuple::create(elts.size(), &elts[0]);
     }
 
     static Box* flags(Box* b, void*) {

--- a/src/runtime/file.cpp
+++ b/src/runtime/file.cpp
@@ -195,7 +195,7 @@ BoxedFile::BoxedFile(FILE* f, std::string fname, const char* fmode, int (*close)
       f_bufptr(0),
       f_setbuf(0),
       unlocked_count(0) {
-    Box* r = fill_file_fields(this, f, new BoxedString(fname), fmode, close);
+    Box* r = fill_file_fields(this, f, boxString(fname), fmode, close);
     checkAndThrowCAPIException();
     assert(r == this);
 }
@@ -823,17 +823,17 @@ Box* fileNew(BoxedClass* cls, Box* s, Box* m) {
         raiseExcHelper(TypeError, "");
     }
 
-    const std::string& fn = static_cast<BoxedString*>(s)->s;
-    const std::string& mode = static_cast<BoxedString*>(m)->s;
+    auto fn = static_cast<BoxedString*>(s);
+    auto mode = static_cast<BoxedString*>(m);
 
-    FILE* f = fopen(fn.c_str(), mode.c_str());
+    FILE* f = fopen(fn->data(), mode->data());
     if (!f) {
-        PyErr_SetFromErrnoWithFilename(IOError, fn.c_str());
+        PyErr_SetFromErrnoWithFilename(IOError, fn->data());
         throwCAPIException();
         abort(); // unreachable;
     }
 
-    return new BoxedFile(f, fn, PyString_AsString(m));
+    return new BoxedFile(f, fn->s, PyString_AsString(m));
 }
 
 static PyObject* file_readlines(BoxedFile* f, PyObject* args) noexcept {

--- a/src/runtime/import.h
+++ b/src/runtime/import.h
@@ -20,7 +20,7 @@
 namespace pyston {
 
 extern "C" Box* import(int level, Box* from_imports, const std::string* module_name);
-extern Box* importModuleLevel(std::string* module_name, Box* globals, Box* from_imports, int level);
+extern Box* importModuleLevel(const std::string& module_name, Box* globals, Box* from_imports, int level);
 }
 
 #endif

--- a/src/runtime/inline/dict.cpp
+++ b/src/runtime/inline/dict.cpp
@@ -66,8 +66,7 @@ Box* dictIterNext(Box* s) {
     } else if (self->type == BoxedDictIterator::ValueIterator) {
         rtn = self->it->second;
     } else if (self->type == BoxedDictIterator::ItemIterator) {
-        BoxedTuple::GCVector elts{ self->it->first, self->it->second };
-        rtn = new BoxedTuple(std::move(elts));
+        rtn = BoxedTuple::create({ self->it->first, self->it->second });
     }
     ++self->it;
     return rtn;

--- a/src/runtime/inline/tuple.cpp
+++ b/src/runtime/inline/tuple.cpp
@@ -40,14 +40,14 @@ i1 tupleiterHasnextUnboxed(Box* s) {
     assert(s->cls == tuple_iterator_cls);
     BoxedTupleIterator* self = static_cast<BoxedTupleIterator*>(s);
 
-    return self->pos < self->t->elts.size();
+    return self->pos < self->t->size();
 }
 
 Box* tupleiterNext(Box* s) {
     assert(s->cls == tuple_iterator_cls);
     BoxedTupleIterator* self = static_cast<BoxedTupleIterator*>(s);
 
-    if (!(self->pos >= 0 && self->pos < self->t->elts.size())) {
+    if (!(self->pos >= 0 && self->pos < self->t->size())) {
         raiseExcHelper(StopIteration, "");
     }
 

--- a/src/runtime/int.cpp
+++ b/src/runtime/int.cpp
@@ -873,7 +873,7 @@ extern "C" BoxedString* intRepr(BoxedInt* v) {
 
     char buf[80];
     int len = snprintf(buf, 80, "%ld", v->n);
-    return new BoxedString(std::string(buf, len));
+    return static_cast<BoxedString*>(boxString(llvm::StringRef(buf, len)));
 }
 
 extern "C" Box* intHash(BoxedInt* self) {
@@ -898,7 +898,7 @@ extern "C" Box* intHex(BoxedInt* self) {
         len = snprintf(buf, sizeof(buf), "-0x%lx", std::abs(self->n));
     else
         len = snprintf(buf, sizeof(buf), "0x%lx", self->n);
-    return new BoxedString(std::string(buf, len));
+    return boxStringRef(llvm::StringRef(buf, len));
 }
 
 extern "C" Box* intOct(BoxedInt* self) {
@@ -913,7 +913,7 @@ extern "C" Box* intOct(BoxedInt* self) {
         len = snprintf(buf, sizeof(buf), "-%#lo", std::abs(self->n));
     else
         len = snprintf(buf, sizeof(buf), "%#lo", self->n);
-    return new BoxedString(std::string(buf, len));
+    return boxString(llvm::StringRef(buf, len));
 }
 
 extern "C" Box* intTrunc(BoxedInt* self) {
@@ -942,8 +942,8 @@ static Box* _intNew(Box* val, Box* base) {
 
         BoxedString* s = static_cast<BoxedString*>(val);
 
-        RELEASE_ASSERT(s->s.size() == strlen(s->s.c_str()), "");
-        Box* r = PyInt_FromString(s->s.c_str(), NULL, base_n);
+        RELEASE_ASSERT(s->size() == strlen(s->data()), "");
+        Box* r = PyInt_FromString(s->data(), NULL, base_n);
         if (!r)
             throwCAPIException();
         return r;

--- a/src/runtime/iterators.cpp
+++ b/src/runtime/iterators.cpp
@@ -80,11 +80,11 @@ private:
     static bool hasnext(BoxedList* o, uint64_t i) { return i < o->size; }
     static Box* getValue(BoxedList* o, uint64_t i) { return o->elts->elts[i]; }
 
-    static bool hasnext(BoxedTuple* o, uint64_t i) { return i < o->elts.size(); }
+    static bool hasnext(BoxedTuple* o, uint64_t i) { return i < o->size(); }
     static Box* getValue(BoxedTuple* o, uint64_t i) { return o->elts[i]; }
 
-    static bool hasnext(BoxedString* o, uint64_t i) { return i < o->s.size(); }
-    static Box* getValue(BoxedString* o, uint64_t i) { return new BoxedString(std::string(1, o->s[i])); }
+    static bool hasnext(BoxedString* o, uint64_t i) { return i < o->size(); }
+    static Box* getValue(BoxedString* o, uint64_t i) { return boxString(llvm::StringRef(o->data() + i, 1)); }
 
 public:
     BoxIteratorIndex(T* obj) : obj(obj), index(0) {

--- a/src/runtime/long.cpp
+++ b/src/runtime/long.cpp
@@ -268,7 +268,7 @@ extern "C" PyAPI_FUNC(PyObject*) _PyLong_Format(PyObject* aa, int base, int addL
         os << "L";
 
     os.flush();
-    auto rtn = new BoxedString(std::move(str));
+    auto rtn = boxString(str);
     free(buf);
     return rtn;
 }
@@ -451,7 +451,7 @@ BoxedLong* _longNew(Box* val, Box* _base) {
             raiseExcHelper(TypeError, "long() arg2 must be >= 2 and <= 36");
         }
 
-        int r = mpz_init_set_str(rtn->n, s->s.c_str(), base);
+        int r = mpz_init_set_str(rtn->n, s->data(), base);
         RELEASE_ASSERT(r == 0, "");
     } else {
         if (isSubclass(val->cls, long_cls)) {
@@ -936,7 +936,7 @@ extern "C" Box* longDivmod(BoxedLong* lhs, Box* _rhs) {
         mpz_init(q->n);
         mpz_init(r->n);
         mpz_fdiv_qr(q->n, r->n, lhs->n, rhs->n);
-        return new BoxedTuple({ q, r });
+        return BoxedTuple::create({ q, r });
     } else if (isSubclass(_rhs->cls, int_cls)) {
         BoxedInt* rhs = static_cast<BoxedInt*>(_rhs);
 
@@ -948,7 +948,7 @@ extern "C" Box* longDivmod(BoxedLong* lhs, Box* _rhs) {
         mpz_init(q->n);
         mpz_init_set_si(r->n, rhs->n);
         mpz_fdiv_qr(q->n, r->n, lhs->n, r->n);
-        return new BoxedTuple({ q, r });
+        return BoxedTuple::create({ q, r });
     } else {
         return NotImplemented;
     }

--- a/src/runtime/set.cpp
+++ b/src/runtime/set.cpp
@@ -14,7 +14,7 @@
 
 #include "runtime/set.h"
 
-#include <sstream>
+#include <llvm/Support/raw_ostream.h>
 
 #include "gc/collector.h"
 #include "runtime/objmodel.h"
@@ -97,7 +97,8 @@ Box* setNew(Box* _cls, Box* container) {
 }
 
 static Box* _setRepr(BoxedSet* self, const char* type_name) {
-    std::ostringstream os("");
+    std::string O("");
+    llvm::raw_string_ostream os(O);
 
     os << type_name << "([";
     bool first = true;
@@ -232,7 +233,7 @@ Box* setUpdate(BoxedSet* self, BoxedTuple* args) {
     assert(self->cls == set_cls);
     assert(args->cls == tuple_cls);
 
-    for (auto l : args->elts) {
+    for (auto l : *args) {
         if (l->cls == set_cls) {
             BoxedSet* s2 = static_cast<BoxedSet*>(l);
             self->s.insert(s2->s.begin(), s2->s.end());

--- a/src/runtime/str.cpp
+++ b/src/runtime/str.cpp
@@ -46,16 +46,29 @@ extern "C" PyObject* string_splitlines(PyStringObject* self, PyObject* args) noe
 
 namespace pyston {
 
-BoxedString::BoxedString(const char* s, size_t n) : s(s, n) {
-    gc::registerGCManagedBytes(this->s.size());
+BoxedString::BoxedString(const char* s, size_t n) : s(storage(), n) {
+    if (s) {
+        memmove(data(), s, n);
+        data()[n] = 0;
+    } else {
+        memset(data(), 0, n + 1);
+    }
 }
 
-BoxedString::BoxedString(std::string&& s) : s(std::move(s)) {
-    gc::registerGCManagedBytes(this->s.size());
+BoxedString::BoxedString(llvm::StringRef lhs, llvm::StringRef rhs) : s(storage(), lhs.size() + rhs.size()) {
+    memmove(data(), lhs.data(), lhs.size());
+    memmove(data() + lhs.size(), rhs.data(), rhs.size());
+    data()[lhs.size() + rhs.size()] = 0;
 }
 
-BoxedString::BoxedString(const std::string& s) : s(s) {
-    gc::registerGCManagedBytes(this->s.size());
+BoxedString::BoxedString(llvm::StringRef s) : s(storage(), s.size()) {
+    memmove(data(), s.data(), s.size());
+    data()[s.size()] = 0;
+}
+
+BoxedString::BoxedString(size_t n, char c) : s(storage(), n) {
+    memset(data(), c, n);
+    data()[n] = 0;
 }
 
 extern "C" char PyString_GetItem(PyObject* op, ssize_t n) noexcept {
@@ -318,11 +331,11 @@ extern "C" Box* strAdd(BoxedString* lhs, Box* _rhs) {
     }
 
     BoxedString* rhs = static_cast<BoxedString*>(_rhs);
-    return new BoxedString(lhs->s + rhs->s);
+    return new (lhs->size() + rhs->size()) BoxedString(lhs->s, rhs->s);
 }
 
 extern "C" PyObject* PyString_InternFromString(const char* s) noexcept {
-    return new BoxedString(s);
+    return boxString(s);
 }
 
 extern "C" void PyString_InternInPlace(PyObject**) noexcept {
@@ -1086,12 +1099,12 @@ extern "C" Box* strMul(BoxedString* lhs, Box* rhs) {
         return NotImplemented;
 
     // TODO: use createUninitializedString and getWriteableStringContents
-    int sz = lhs->s.size();
+    int sz = lhs->size();
     std::string buf(sz * n, '\0');
     for (int i = 0; i < n; i++) {
-        memcpy(&buf[sz * i], lhs->s.c_str(), sz);
+        memcpy(&buf[sz * i], lhs->data(), sz);
     }
-    return new BoxedString(std::move(buf));
+    return boxString(buf);
 }
 
 extern "C" Box* strLt(BoxedString* lhs, Box* rhs) {
@@ -1160,8 +1173,8 @@ extern "C" Box* strNe(BoxedString* lhs, Box* rhs) {
 static Box* pad(BoxedString* self, Box* width, Box* fillchar, int justType) {
     assert(width->cls == int_cls);
     assert(isSubclass(fillchar->cls, str_cls));
-    assert(static_cast<BoxedString*>(fillchar)->s.size() == 1);
-    int64_t curWidth = self->s.size();
+    assert(static_cast<BoxedString*>(fillchar)->size() == 1);
+    int64_t curWidth = self->size();
     int64_t targetWidth = static_cast<BoxedInt*>(width)->n;
 
     if (curWidth >= targetWidth) {
@@ -1169,7 +1182,7 @@ static Box* pad(BoxedString* self, Box* width, Box* fillchar, int justType) {
             return self;
         } else {
             // If self isn't a string but a subclass of str, then make a new string to return
-            return new BoxedString(self->s);
+            return boxString(self->s);
         }
     }
 
@@ -1195,9 +1208,7 @@ static Box* pad(BoxedString* self, Box* width, Box* fillchar, int justType) {
     }
 
     // TODO this is probably slow
-    std::string res = std::string(padLeft, c) + self->s + std::string(padRight, c);
-
-    return new BoxedString(std::move(res));
+    return boxStringTwine(llvm::Twine(std::string(padLeft, c)) + self->s + std::string(padRight, c));
 }
 extern "C" Box* strLjust(BoxedString* lhs, Box* width, Box* fillchar) {
     return pad(lhs, width, fillchar, JUST_LEFT);
@@ -1212,7 +1223,7 @@ extern "C" Box* strCenter(BoxedString* lhs, Box* width, Box* fillchar) {
 extern "C" Box* strLen(BoxedString* self) {
     assert(isSubclass(self->cls, str_cls));
 
-    return boxInt(self->s.size());
+    return boxInt(self->size());
 }
 
 extern "C" Box* strStr(BoxedString* self) {
@@ -1221,7 +1232,7 @@ extern "C" Box* strStr(BoxedString* self) {
     if (self->cls == str_cls)
         return self;
 
-    return new BoxedString(self->s);
+    return boxString(self->s);
 }
 
 static bool _needs_escaping[256]
@@ -1249,7 +1260,7 @@ extern "C" PyObject* PyString_Repr(PyObject* obj, int smartquotes) noexcept {
 
     std::ostringstream os("");
 
-    const std::string& s = self->s;
+    llvm::StringRef s(self->s);
     char quote = '\'';
     if (smartquotes && s.find('\'', 0) != std::string::npos && s.find('\"', 0) == std::string::npos) {
         quote = '\"';
@@ -1491,14 +1502,14 @@ extern "C" size_t unicodeHashUnboxed(PyUnicodeObject* self) {
 extern "C" Box* strHash(BoxedString* self) {
     assert(isSubclass(self->cls, str_cls));
 
-    StringHash<std::string> H;
-    return boxInt(H(self->s));
+    StringHash<char> H;
+    return boxInt(H(self->data(), self->size()));
 }
 
 extern "C" Box* strNonzero(BoxedString* self) {
     ASSERT(isSubclass(self->cls, str_cls), "%s", self->cls->tp_name);
 
-    return boxBool(self->s.size() != 0);
+    return boxBool(self->size() != 0);
 }
 
 extern "C" Box* strNew(BoxedClass* cls, Box* obj) {
@@ -1510,7 +1521,9 @@ extern "C" Box* strNew(BoxedClass* cls, Box* obj) {
     if (cls == str_cls)
         return rtn;
 
-    return new (cls) BoxedString(static_cast<BoxedString*>(rtn)->s);
+    BoxedString* _rtn = static_cast<BoxedString*>(rtn);
+
+    return new (cls, _rtn->size()) BoxedString(_rtn->s);
 }
 
 extern "C" Box* basestringNew(BoxedClass* cls, Box* args, Box* kwargs) {
@@ -1520,7 +1533,7 @@ extern "C" Box* basestringNew(BoxedClass* cls, Box* args, Box* kwargs) {
 Box* _strSlice(BoxedString* self, i64 start, i64 stop, i64 step, i64 length) {
     assert(isSubclass(self->cls, str_cls));
 
-    const std::string& s = self->s;
+    llvm::StringRef s = self->s;
 
     assert(step != 0);
     if (step > 0) {
@@ -1531,18 +1544,18 @@ Box* _strSlice(BoxedString* self, i64 start, i64 stop, i64 step, i64 length) {
         assert(-1 <= stop);
     }
 
-    std::string chars;
-    if (length > 0) {
-        chars.resize(length);
-        copySlice(&chars[0], &s[0], start, step, length);
-    }
-    return boxString(std::move(chars));
+    if (length == 0)
+        return EmptyString;
+
+    BoxedString* bs = new (length) BoxedString(nullptr, length);
+    copySlice(bs->data(), s.data(), start, step, length);
+    return bs;
 }
 
 Box* strIsAlpha(BoxedString* self) {
     assert(isSubclass(self->cls, str_cls));
 
-    const std::string& str(self->s);
+    llvm::StringRef str(self->s);
     if (str.empty())
         return False;
 
@@ -1557,7 +1570,7 @@ Box* strIsAlpha(BoxedString* self) {
 Box* strIsDigit(BoxedString* self) {
     assert(isSubclass(self->cls, str_cls));
 
-    const std::string& str(self->s);
+    llvm::StringRef str(self->s);
     if (str.empty())
         return False;
 
@@ -1572,7 +1585,7 @@ Box* strIsDigit(BoxedString* self) {
 Box* strIsAlnum(BoxedString* self) {
     assert(isSubclass(self->cls, str_cls));
 
-    const std::string& str(self->s);
+    llvm::StringRef str(self->s);
     if (str.empty())
         return False;
 
@@ -1587,7 +1600,7 @@ Box* strIsAlnum(BoxedString* self) {
 Box* strIsLower(BoxedString* self) {
     assert(isSubclass(self->cls, str_cls));
 
-    const std::string& str(self->s);
+    llvm::StringRef str(self->s);
     bool lowered = false;
 
     if (str.empty())
@@ -1609,7 +1622,7 @@ Box* strIsLower(BoxedString* self) {
 Box* strIsUpper(BoxedString* self) {
     assert(isSubclass(self->cls, str_cls));
 
-    const std::string& str(self->s);
+    llvm::StringRef str(self->s);
 
     if (str.empty())
         return False;
@@ -1628,7 +1641,7 @@ Box* strIsUpper(BoxedString* self) {
 Box* strIsSpace(BoxedString* self) {
     assert(isSubclass(self->cls, str_cls));
 
-    const std::string& str(self->s);
+    llvm::StringRef str(self->s);
     if (str.empty())
         return False;
 
@@ -1643,7 +1656,7 @@ Box* strIsSpace(BoxedString* self) {
 Box* strIsTitle(BoxedString* self) {
     assert(isSubclass(self->cls, str_cls));
 
-    const std::string& str(self->s);
+    llvm::StringRef str(self->s);
 
     if (str.empty())
         return False;
@@ -1678,9 +1691,49 @@ Box* strIsTitle(BoxedString* self) {
 Box* strJoin(BoxedString* self, Box* rhs) {
     assert(isSubclass(self->cls, str_cls));
 
+    int i = 0;
+    if (rhs->cls == str_cls) {
+        BoxedString* srhs = static_cast<BoxedString*>(rhs);
+        size_t rtn_len = self->size() * (srhs->size() - 1) + srhs->size();
+        BoxedString* rtn = new (rtn_len) BoxedString(nullptr, rtn_len);
+        char* p = rtn->data();
+        for (auto c : srhs->s) {
+            if (i > 0) {
+                memmove(p, self->data(), self->size());
+                p += self->size();
+            }
+            *p++ = c;
+            ++i;
+        }
+        return rtn;
+    } else if (rhs->cls == list_cls) {
+        BoxedList* lrhs = static_cast<BoxedList*>(rhs);
+        size_t rtn_len = self->size() * (lrhs->size - 1);
+
+        for (int l = 0; l < lrhs->size; l++) {
+            // if we hit anything but a string (unicode objects can be here), bail out since we're
+            // going to pay the cost of converting the unicode to string objects anyway.
+            if (lrhs->elts->elts[l]->cls != str_cls)
+                goto fallback;
+            rtn_len += static_cast<BoxedString*>(lrhs->elts->elts[l])->size();
+        }
+        BoxedString* rtn = new (rtn_len) BoxedString(nullptr, rtn_len);
+        char* p = rtn->data();
+        for (i = 0; i < lrhs->size; i++) {
+            if (i > 0) {
+                memmove(p, self->data(), self->size());
+                p += self->size();
+            }
+            auto lrhs_el = static_cast<BoxedString*>(lrhs->elts->elts[i]);
+            memmove(p, lrhs_el->data(), lrhs_el->size());
+            p += lrhs_el->size();
+        }
+        return rtn;
+    }
+
+fallback:
     std::string output_str;
     llvm::raw_string_ostream os(output_str);
-    int i = 0;
     for (Box* e : rhs->pyElements()) {
         if (i > 0)
             os << self->s;
@@ -1731,10 +1784,10 @@ Box* strReplace(Box* _self, Box* _old, Box* _new, Box** _args) {
         start_pos = s.find(old->s, start_pos);
         if (start_pos == std::string::npos)
             break;
-        s.replace(start_pos, old->s.length(), new_->s);
-        start_pos += new_->s.length(); // Handles case where 'to' is a substring of 'from'
+        s.replace(start_pos, old->size(), new_->s);
+        start_pos += new_->size(); // Handles case where 'to' is a substring of 'from'
     }
-    return new BoxedString(std::move(s));
+    return boxString(s);
 }
 
 Box* strPartition(BoxedString* self, BoxedString* sep) {
@@ -1743,13 +1796,12 @@ Box* strPartition(BoxedString* self, BoxedString* sep) {
 
     size_t found_idx = self->s.find(sep->s);
     if (found_idx == std::string::npos)
-        return new BoxedTuple({ self, boxStrConstant(""), boxStrConstant("") });
+        return BoxedTuple::create({ self, EmptyString, EmptyString });
 
 
-    return new BoxedTuple({ boxStrConstantSize(self->s.c_str(), found_idx),
-                            boxStrConstantSize(self->s.c_str() + found_idx, sep->s.size()),
-                            boxStrConstantSize(self->s.c_str() + found_idx + sep->s.size(),
-                                               self->s.size() - found_idx - sep->s.size()) });
+    return BoxedTuple::create(
+        { boxStrConstantSize(self->data(), found_idx), boxStrConstantSize(self->data() + found_idx, sep->size()),
+          boxStrConstantSize(self->data() + found_idx + sep->size(), self->size() - found_idx - sep->size()) });
 }
 
 Box* strRpartition(BoxedString* self, BoxedString* sep) {
@@ -1758,13 +1810,11 @@ Box* strRpartition(BoxedString* self, BoxedString* sep) {
 
     size_t found_idx = self->s.rfind(sep->s);
     if (found_idx == std::string::npos)
-        return new BoxedTuple({ boxStrConstant(""), boxStrConstant(""), self });
+        return BoxedTuple::create({ EmptyString, EmptyString, self });
 
-
-    return new BoxedTuple({ boxStrConstantSize(self->s.c_str(), found_idx),
-                            boxStrConstantSize(self->s.c_str() + found_idx, sep->s.size()),
-                            boxStrConstantSize(self->s.c_str() + found_idx + sep->s.size(),
-                                               self->s.size() - found_idx - sep->s.size()) });
+    return BoxedTuple::create(
+        { boxStrConstantSize(self->data(), found_idx), boxStrConstantSize(self->data() + found_idx, sep->size()),
+          boxStrConstantSize(self->data() + found_idx + sep->size(), self->size() - found_idx - sep->size()) });
 }
 
 extern "C" PyObject* _do_string_format(PyObject* self, PyObject* args, PyObject* kwargs);
@@ -1781,11 +1831,13 @@ Box* strFormat(BoxedString* self, BoxedTuple* args, BoxedDict* kwargs) {
 
 Box* strStrip(BoxedString* self, Box* chars) {
     assert(isSubclass(self->cls, str_cls));
+    auto str = self->s;
 
     if (isSubclass(chars->cls, str_cls)) {
-        return new BoxedString(llvm::StringRef(self->s).trim(static_cast<BoxedString*>(chars)->s));
+        auto chars_str = static_cast<BoxedString*>(chars)->s;
+        return boxStringRef(str.trim(chars_str));
     } else if (chars->cls == none_cls) {
-        return new BoxedString(llvm::StringRef(self->s).trim(" \t\n\r\f\v"));
+        return boxStringRef(str.trim(" \t\n\r\f\v"));
     } else {
         raiseExcHelper(TypeError, "strip arg must be None, str or unicode");
     }
@@ -1793,11 +1845,13 @@ Box* strStrip(BoxedString* self, Box* chars) {
 
 Box* strLStrip(BoxedString* self, Box* chars) {
     assert(isSubclass(self->cls, str_cls));
+    auto str = self->s;
 
     if (isSubclass(chars->cls, str_cls)) {
-        return new BoxedString(llvm::StringRef(self->s).ltrim(static_cast<BoxedString*>(chars)->s));
+        auto chars_str = static_cast<BoxedString*>(chars)->s;
+        return boxStringRef(str.ltrim(chars_str));
     } else if (chars->cls == none_cls) {
-        return new BoxedString(llvm::StringRef(self->s).ltrim(" \t\n\r\f\v"));
+        return boxStringRef(str.ltrim(" \t\n\r\f\v"));
     } else {
         raiseExcHelper(TypeError, "lstrip arg must be None, str or unicode");
     }
@@ -1805,11 +1859,13 @@ Box* strLStrip(BoxedString* self, Box* chars) {
 
 Box* strRStrip(BoxedString* self, Box* chars) {
     assert(isSubclass(self->cls, str_cls));
+    auto str = self->s;
 
     if (isSubclass(chars->cls, str_cls)) {
-        return new BoxedString(llvm::StringRef(self->s).rtrim(static_cast<BoxedString*>(chars)->s));
+        auto chars_str = static_cast<BoxedString*>(chars)->s;
+        return boxStringRef(str.rtrim(chars_str));
     } else if (chars->cls == none_cls) {
-        return new BoxedString(llvm::StringRef(self->s).rtrim(" \t\n\r\f\v"));
+        return boxStringRef(str.rtrim(" \t\n\r\f\v"));
     } else {
         raiseExcHelper(TypeError, "rstrip arg must be None, str or unicode");
     }
@@ -1871,7 +1927,7 @@ Box* strTranslate(BoxedString* self, BoxedString* table, BoxedString* delete_cha
     if (have_table) {
         if (!isSubclass(table->cls, str_cls))
             raiseExcHelper(TypeError, "expected a character buffer object");
-        if (table->s.size() != 256)
+        if (table->size() != 256)
             raiseExcHelper(ValueError, "translation table must be 256 characters long");
     }
 
@@ -1880,30 +1936,37 @@ Box* strTranslate(BoxedString* self, BoxedString* table, BoxedString* delete_cha
         if (!delete_set.count(c))
             str.append(1, have_table ? table->s[(unsigned char)c] : c);
     }
-    return boxString(std::move(str));
+    return boxString(str);
 }
 
 Box* strLower(BoxedString* self) {
     assert(isSubclass(self->cls, str_cls));
-    return boxString(llvm::StringRef(self->s).lower());
+
+    BoxedString* rtn = static_cast<BoxedString*>(boxString(self->s));
+    for (int i = 0; i < rtn->size(); i++)
+        rtn->data()[i] = std::tolower(rtn->data()[i]);
+    return rtn;
 }
 
 Box* strUpper(BoxedString* self) {
     assert(isSubclass(self->cls, str_cls));
-    return boxString(llvm::StringRef(self->s).upper());
+    BoxedString* rtn = static_cast<BoxedString*>(boxString(self->s));
+    for (int i = 0; i < rtn->size(); i++)
+        rtn->data()[i] = std::toupper(rtn->data()[i]);
+    return rtn;
 }
 
 Box* strSwapcase(BoxedString* self) {
-    std::string s(self->s);
-
-    for (auto& i : s) {
-        if (std::islower(i))
-            i = std::toupper(i);
-        else if (std::isupper(i))
-            i = std::tolower(i);
+    assert(isSubclass(self->cls, str_cls));
+    BoxedString* rtn = static_cast<BoxedString*>(boxString(self->s));
+    for (int i = 0; i < rtn->size(); i++) {
+        char c = rtn->data()[i];
+        if (std::islower(c))
+            rtn->data()[i] = std::toupper(c);
+        else if (std::isupper(c))
+            rtn->data()[i] = std::tolower(c);
     }
-
-    return boxString(s);
+    return rtn;
 }
 
 Box* strContains(BoxedString* self, Box* elt) {
@@ -1927,6 +1990,16 @@ Box* strContains(BoxedString* self, Box* elt) {
     return True;
 }
 
+// compares (a+a_pos, len) with (str)
+// if len == npos, compare to the end of a
+static int compareStringRefs(llvm::StringRef a, size_t a_pos, size_t len, llvm::StringRef str) {
+    if (len == llvm::StringRef::npos)
+        len = a.size() - a_pos;
+    if (a_pos + len > a.size())
+        throw std::out_of_range("pos+len out of range");
+    return llvm::StringRef(a.data() + a_pos, len).compare(str);
+}
+
 Box* strStartswith(BoxedString* self, Box* elt, Box* start, Box** _args) {
     Box* end = _args[0];
 
@@ -1948,7 +2021,7 @@ Box* strStartswith(BoxedString* self, Box* elt, Box* start, Box** _args) {
     }
 
     if (isSubclass(elt->cls, tuple_cls)) {
-        for (auto e : static_cast<BoxedTuple*>(elt)->elts) {
+        for (auto e : *static_cast<BoxedTuple*>(elt)) {
             auto b = strStartswith(self, e, start, _args);
             assert(b->cls == bool_cls);
             if (b == True)
@@ -1970,7 +2043,7 @@ Box* strStartswith(BoxedString* self, Box* elt, Box* start, Box** _args) {
 
     BoxedString* sub = static_cast<BoxedString*>(elt);
 
-    Py_ssize_t n = self->s.size();
+    Py_ssize_t n = self->size();
     iend = std::min(iend, n);
     if (iend < 0)
         iend += n;
@@ -1985,9 +2058,9 @@ Box* strStartswith(BoxedString* self, Box* elt, Box* start, Box** _args) {
     Py_ssize_t compare_len = iend - istart;
     if (compare_len < 0)
         return False;
-    if (sub->s.size() > compare_len)
+    if (sub->size() > compare_len)
         return False;
-    return boxBool(self->s.compare(istart, sub->s.size(), sub->s) == 0);
+    return boxBool(compareStringRefs(self->s, istart, sub->size(), sub->s) == 0);
 }
 
 Box* strEndswith(BoxedString* self, Box* elt, Box* start, Box** _args) {
@@ -2019,7 +2092,7 @@ Box* strEndswith(BoxedString* self, Box* elt, Box* start, Box** _args) {
     }
 
     if (isSubclass(elt->cls, tuple_cls)) {
-        for (auto e : static_cast<BoxedTuple*>(elt)->elts) {
+        for (auto e : *static_cast<BoxedTuple*>(elt)) {
             auto b = strEndswith(self, e, start, _args);
             assert(b->cls == bool_cls);
             if (b == True)
@@ -2033,7 +2106,7 @@ Box* strEndswith(BoxedString* self, Box* elt, Box* start, Box** _args) {
 
     BoxedString* sub = static_cast<BoxedString*>(elt);
 
-    Py_ssize_t n = self->s.size();
+    Py_ssize_t n = self->size();
     iend = std::min(iend, n);
     if (iend < 0)
         iend += n;
@@ -2048,11 +2121,11 @@ Box* strEndswith(BoxedString* self, Box* elt, Box* start, Box** _args) {
     Py_ssize_t compare_len = iend - istart;
     if (compare_len < 0)
         return False;
-    if (sub->s.size() > compare_len)
+    if (sub->size() > compare_len)
         return False;
     // XXX: this line is the only difference between startswith and endswith:
-    istart += compare_len - sub->s.size();
-    return boxBool(self->s.compare(istart, sub->s.size(), sub->s) == 0);
+    istart += compare_len - sub->size();
+    return boxBool(compareStringRefs(self->s, istart, sub->size(), sub->s) == 0);
 }
 
 Box* strDecode(BoxedString* self, Box* encoding, Box* error) {
@@ -2075,7 +2148,7 @@ Box* strDecode(BoxedString* self, Box* encoding, Box* error) {
         raiseExcHelper(TypeError, "decode() argument 2 must be string, not '%s'", getTypeName(error_str));
 
     Box* result
-        = PyCodec_Decode(self, encoding_str ? encoding_str->s.c_str() : NULL, error_str ? error_str->s.c_str() : NULL);
+        = PyCodec_Decode(self, encoding_str ? encoding_str->data() : NULL, error_str ? error_str->data() : NULL);
     checkAndThrowCAPIException();
     return result;
 }
@@ -2099,8 +2172,8 @@ Box* strEncode(BoxedString* self, Box* encoding, Box* error) {
     if (error_str && !isSubclass(error_str->cls, str_cls))
         raiseExcHelper(TypeError, "encode() argument 2 must be string, not '%s'", getTypeName(error_str));
 
-    Box* result = PyCodec_Encode(self, encoding_str ? encoding_str->s.c_str() : PyUnicode_GetDefaultEncoding(),
-                                 error_str ? error_str->s.c_str() : NULL);
+    Box* result = PyCodec_Encode(self, encoding_str ? encoding_str->data() : PyUnicode_GetDefaultEncoding(),
+                                 error_str ? error_str->data() : NULL);
     checkAndThrowCAPIException();
     return result;
 }
@@ -2111,7 +2184,7 @@ extern "C" Box* strGetitem(BoxedString* self, Box* slice) {
     if (isSubclass(slice->cls, int_cls)) {
         BoxedInt* islice = static_cast<BoxedInt*>(slice);
         int64_t n = islice->n;
-        int size = self->s.size();
+        int size = self->size();
         if (n < 0)
             n = size + n;
 
@@ -2120,12 +2193,12 @@ extern "C" Box* strGetitem(BoxedString* self, Box* slice) {
         }
 
         char c = self->s[n];
-        return new BoxedString(std::string(1, c));
+        return boxStringRef(llvm::StringRef(&c, 1));
     } else if (slice->cls == slice_cls) {
         BoxedSlice* sslice = static_cast<BoxedSlice*>(slice);
 
         i64 start, stop, step, length;
-        parseSlice(sslice, self->s.size(), &start, &stop, &step, &length);
+        parseSlice(sslice, self->size(), &start, &stop, &step, &length);
         return _strSlice(self, start, stop, step, length);
     } else {
         raiseExcHelper(TypeError, "string indices must be integers, not %s", getTypeName(slice));
@@ -2169,7 +2242,7 @@ public:
 
         char c = *self->it;
         ++self->it;
-        return new BoxedString(std::string(1, c));
+        return boxStringRef(llvm::StringRef(&c, 1));
     }
 };
 
@@ -2222,18 +2295,11 @@ extern "C" int PyString_AsStringAndSize(register PyObject* obj, register char** 
 
 BoxedString* createUninitializedString(ssize_t n) {
     // I *think* this should avoid doing any copies, by using move constructors:
-    return new BoxedString(std::string(n, '\x00'));
+    return new (n) BoxedString(n, 0);
 }
 
 char* getWriteableStringContents(BoxedString* s) {
-    // After doing some reading, I think this is ok:
-    // http://stackoverflow.com/questions/14290795/why-is-modifying-a-string-through-a-retrieved-pointer-to-its-data-not-allowed
-    // In C++11, std::string is required to store its data contiguously.
-    // It looks like it's also required to make it available to write via the [] operator.
-    // - Taking a look at GCC's libstdc++, calling operator[] on a non-const string will return
-    //   a writeable reference, and "unshare" the string.
-    // So surprisingly, this looks ok!
-    return &s->s[0];
+    return s->data();
 }
 
 extern "C" PyObject* PyString_FromStringAndSize(const char* s, ssize_t n) noexcept {
@@ -2251,7 +2317,7 @@ extern "C" char* PyString_AsString(PyObject* o) noexcept {
 
 extern "C" Py_ssize_t PyString_Size(PyObject* op) noexcept {
     if (isSubclass(op->cls, str_cls))
-        return static_cast<BoxedString*>(op)->s.size();
+        return static_cast<BoxedString*>(op)->size();
 
     char* _s;
     Py_ssize_t len;
@@ -2266,7 +2332,27 @@ extern "C" int _PyString_Resize(PyObject** pv, Py_ssize_t newsize) noexcept {
     assert(pv);
     assert(isSubclass((*pv)->cls, str_cls));
     BoxedString* s = static_cast<BoxedString*>(*pv);
-    s->s.resize(newsize, '\0');
+
+    if (newsize == s->size())
+        return 0;
+
+    if (newsize < s->size()) {
+        // XXX resize the box (by reallocating) smaller if it makes sense
+        s->s = llvm::StringRef(s->data(), newsize);
+        s->data()[newsize] = 0;
+        return 0;
+    }
+
+    BoxedString* resized;
+
+    if (s->cls == str_cls)
+        resized = new (newsize) BoxedString(newsize, 0); // we need an uninitialized string, but this will memset
+    else
+        resized = new (s->cls, newsize)
+            BoxedString(newsize, 0); // we need an uninitialized string, but this will memset
+    memmove(resized->data(), s->data(), s->size());
+
+    *pv = resized;
     return 0;
 }
 
@@ -2426,8 +2512,8 @@ static int string_print(PyObject* _op, FILE* fp, int flags) noexcept {
         // Pyston change
         // char *data = op->ob_sval;
         // Py_ssize_t size = Py_SIZE(op);
-        const char* data = op->s.c_str();
-        Py_ssize_t size = op->s.size();
+        const char* data = op->data();
+        Py_ssize_t size = op->size();
         Py_BEGIN_ALLOW_THREADS while (size > INT_MAX) {
             /* Very long strings cannot be written atomically.
              * But don't write exactly INT_MAX bytes at a time
@@ -2451,12 +2537,12 @@ static int string_print(PyObject* _op, FILE* fp, int flags) noexcept {
     quote = '\'';
     // Pyston change
     // if (memchr(op->ob_sval, '\'', Py_SIZE(op)) && !memchr(op->ob_sval, '"', Py_SIZE(op)))
-    if (memchr(op->s.c_str(), '\'', Py_SIZE(op)) && !memchr(op->s.c_str(), '"', Py_SIZE(op)))
+    if (memchr(op->data(), '\'', Py_SIZE(op)) && !memchr(op->data(), '"', Py_SIZE(op)))
         quote = '"';
 
     // Pyston change
     // str_len = Py_SIZE(op);
-    str_len = op->s.size();
+    str_len = op->size();
     Py_BEGIN_ALLOW_THREADS fputc(quote, fp);
     for (i = 0; i < str_len; i++) {
         /* Since strings are immutable and the caller should have a
@@ -2489,8 +2575,8 @@ static Py_ssize_t string_buffer_getreadbuf(PyObject* self, Py_ssize_t index, con
     RELEASE_ASSERT(isSubclass(self->cls, str_cls), "");
 
     auto s = static_cast<BoxedString*>(self);
-    *ptr = s->s.c_str();
-    return s->s.size();
+    *ptr = s->data();
+    return s->size();
 }
 
 static Py_ssize_t string_buffer_getsegcount(PyObject* o, Py_ssize_t* lenp) noexcept {
@@ -2510,7 +2596,7 @@ static Py_ssize_t string_buffer_getcharbuf(PyStringObject* self, Py_ssize_t inde
 
 static int string_buffer_getbuffer(BoxedString* self, Py_buffer* view, int flags) noexcept {
     assert(isSubclass(self->cls, str_cls));
-    return PyBuffer_FillInfo(view, (PyObject*)self, &self->s[0], self->s.size(), 1, flags);
+    return PyBuffer_FillInfo(view, (PyObject*)self, self->data(), self->size(), 1, flags);
 }
 
 static PyBufferProcs string_as_buffer = {
@@ -2521,13 +2607,6 @@ static PyBufferProcs string_as_buffer = {
     (getbufferproc)string_buffer_getbuffer,   //
     (releasebufferproc)NULL,
 };
-
-void strDestructor(Box* b) {
-    assert(isSubclass(b->cls, str_cls));
-    BoxedString* self = static_cast<BoxedString*>(b);
-
-    self->s.~basic_string();
-}
 
 static PyMethodDef string_methods[] = {
     { "count", (PyCFunction)string_count, METH_VARARGS, NULL },
@@ -2543,7 +2622,6 @@ static PyMethodDef string_methods[] = {
 };
 
 void setupStr() {
-    str_cls->simple_destructor = strDestructor;
     str_cls->tp_flags |= Py_TPFLAGS_HAVE_NEWBUFFER;
 
     str_iterator_cls = BoxedHeapClass::create(type_cls, object_cls, &strIteratorGCHandler, 0, 0,
@@ -2617,7 +2695,7 @@ void setupStr() {
     str_cls->giveAttr("__eq__", new BoxedFunction(boxRTFunction((void*)strEq, UNKNOWN, 2)));
     str_cls->giveAttr("__ne__", new BoxedFunction(boxRTFunction((void*)strNe, UNKNOWN, 2)));
 
-    BoxedString* spaceChar = new BoxedString(" ");
+    BoxedString* spaceChar = boxStrConstant(" ");
     str_cls->giveAttr("ljust",
                       new BoxedFunction(boxRTFunction((void*)strLjust, UNKNOWN, 3, 1, false, false), { spaceChar }));
     str_cls->giveAttr("rjust",
@@ -2638,8 +2716,8 @@ void setupStr() {
         str_cls->giveAttr(md.ml_name, new BoxedMethodDescriptor(&md, str_cls));
     }
 
-    str_cls->giveAttr("__new__", new BoxedFunction(boxRTFunction((void*)strNew, UNKNOWN, 2, 1, false, false),
-                                                   { boxStrConstant("") }));
+    str_cls->giveAttr("__new__",
+                      new BoxedFunction(boxRTFunction((void*)strNew, UNKNOWN, 2, 1, false, false), { EmptyString }));
 
     str_cls->freeze();
 

--- a/src/runtime/super.cpp
+++ b/src/runtime/super.cpp
@@ -51,7 +51,7 @@ public:
     }
 };
 
-static const std::string class_str("__class__");
+static const char* class_str = "__class__";
 
 Box* superGetattribute(Box* _s, Box* _attr) {
     RELEASE_ASSERT(_s->cls == super_cls, "");
@@ -101,7 +101,7 @@ Box* superGetattribute(Box* _s, Box* _attr) {
                 continue;
             res = PyDict_GetItem(dict, name);
 #endif
-            res = tmp->getattr(attr->s);
+            res = tmp->getattr(std::string(attr->s));
 
             if (res != NULL) {
 // Pyston change:
@@ -128,7 +128,7 @@ Box* superGetattribute(Box* _s, Box* _attr) {
         }
     }
 
-    Box* r = typeLookup(s->cls, attr->s, NULL);
+    Box* r = typeLookup(s->cls, std::string(attr->s), NULL);
     // TODO implement this
     RELEASE_ASSERT(r, "should call the equivalent of objectGetattr here");
     return processDescriptor(r, s, s->cls);
@@ -139,10 +139,11 @@ Box* superRepr(Box* _s) {
     BoxedSuper* s = static_cast<BoxedSuper*>(_s);
 
     if (s->obj_type) {
-        return boxString("<super: <class '" + std::string(s->type ? getNameOfClass(s->type) : "NULL") + "'>, <"
-                         + std::string(getNameOfClass(s->obj_type)) + " object>>");
+        return boxStringTwine(llvm::Twine("<super: <class '") + (s->type ? getNameOfClass(s->type) : "NULL") + "'>, <"
+                              + getNameOfClass(s->obj_type) + " object>>");
     } else {
-        return boxString("<super: <class '" + std::string(s->type ? getNameOfClass(s->type) : "NULL") + "'>, <NULL>>");
+        return boxStringTwine(llvm::Twine("<super: <class '") + (s->type ? getNameOfClass(s->type) : "NULL")
+                              + "'>, <NULL>>");
     }
 }
 

--- a/src/runtime/traceback.cpp
+++ b/src/runtime/traceback.cpp
@@ -98,7 +98,7 @@ Box* BoxedTraceback::getLines(Box* b) {
         BoxedList* lines = new BoxedList();
         lines->ensure(tb->lines.size());
         for (auto line : tb->lines) {
-            auto l = new BoxedTuple({ boxString(line->file), boxString(line->func), boxInt(line->line) });
+            auto l = BoxedTuple::create({ boxString(line->file), boxString(line->func), boxInt(line->line) });
             listAppendInternal(lines, l);
         }
         tb->py_lines = lines;


### PR DESCRIPTION
There's a lot of commits here, but most of them are squashable.  The crux of the change is both BoxedTuple and BoxedString have specialized `operator new`s that calculate the size of the Boxed structure as well as any additional data (Box*'s for the BoxedTuple, chars for BoxedString).

This should reduce the number of calls to our allocator by at least a half for these types.  In order to keep more of the BoxedString code the same, I added `pyston::String` which can mostly be described as "an llvm::StringRef that exposes a std::string api".  One difference is that `pyston::String`'s data can be owned (malloced/freed by pyston::String), which happens using `operator+`, etc.  It's normal mode is unowned (its use in BoxedString).

Also some effort goes to calculating the number of elements (tuple elements, characters) in the result before doing the allocation for the box, so we don't have to realloc.  This means we need non-ctor allocation paths (we already had them for BoxedString, in the boxString* family).  For BoxedTuple, I added static BoxedTuple::Create() overloads.

performance numbers initially were pretty crazy (-10% for interp2), but changes on master have brought them down to a more modest level (I haven't investigated to see which change(s) on master caused this.)  Current comparison shows:

```
              pyston (calibration)                      :    1.0s baseline: 1.0 (+0.0%)
              pyston interp2.py                         :    3.8s baseline: 3.9 (-2.5%)
              pyston raytrace.py                        :    6.4s baseline: 6.3 (+1.0%)
              pyston nbody.py                           :    8.7s baseline: 8.5 (+2.7%)
              pyston fannkuch.py                        :    6.6s baseline: 6.6 (+0.4%)
              pyston chaos.py                           :   20.1s baseline: 19.9 (+1.4%)
              pyston spectral_norm.py                   :   21.1s baseline: 22.5 (-6.2%)
              pyston fasta.py                           :    4.9s baseline: 5.3 (-6.9%)
              pyston pidigits.py                        :    5.1s baseline: 5.0 (+1.6%)
              pyston richards.py                        :    1.9s baseline: 1.8 (+1.0%)
              pyston deltablue.py                       :    2.0s baseline: 2.0 (-0.2%)
              pyston (geomean-0b9f)                     :    6.0s baseline: 6.0 (-0.8%)
```