### PR TITLE
Use the pypa parser as the default parser.

### DIFF
--- a/src/core/options.cpp
+++ b/src/core/options.cpp
@@ -37,7 +37,7 @@ bool DUMPJIT = false;
 bool TRAP = false;
 bool USE_STRIPPED_STDLIB = true; // always true
 bool ENABLE_INTERPRETER = true;
-bool ENABLE_PYPA_PARSER = false;
+bool ENABLE_PYPA_PARSER = true;
 bool USE_REGALLOC_BASIC = true;
 
 int OSR_THRESHOLD_INTERPRETER = 200;

--- a/src/jit.cpp
+++ b/src/jit.cpp
@@ -109,7 +109,7 @@ static int main(int argc, char** argv) {
         } else if (code == 'b') {
             USE_REGALLOC_BASIC = false;
         } else if (code == 'x') {
-            ENABLE_PYPA_PARSER = true;
+            ENABLE_PYPA_PARSER = false;
         } else if (code == 'c') {
             command = optarg;
             // no more option parsing; the rest of our arguments go into sys.argv.

--- a/tools/astprint.cpp
+++ b/tools/astprint.cpp
@@ -15,7 +15,7 @@ int main(int argc, char const ** argv) {
     initCodegen();
 
     if(argc > 2 && argv[1][0] == '-' && argv[1][1] == 'x') {
-        ENABLE_PYPA_PARSER = true;
+        ENABLE_PYPA_PARSER = false;
     }
 
     std::string fn = argv[1 + int(argc > 2)];


### PR DESCRIPTION
Switches the meaning of -x.
In addition update to latest pypa version

@tjhance: I haven't tried it with your ```exec``` support patch. But I hope I fixed the missing newline issue you run into.  Please let me know if you still encounter problems.
@vinzenz: Thanks for writing the parser!