### PR TITLE
statically laid out closures

### DIFF
--- a/src/analysis/scoping_analysis.cpp
+++ b/src/analysis/scoping_analysis.cpp
@@ -103,9 +103,13 @@ public:
 
     bool usesNameLookup() override { return false; }
 
-    bool isPassedToViaClosure(InternedString name) override { return false; }
-
     bool areLocalsFromModule() override { return true; }
+
+    DerefInfo getDerefInfo(InternedString) override { RELEASE_ASSERT(0, "This should never get called"); }
+    size_t getClosureOffset(InternedString) override { RELEASE_ASSERT(0, "This should never get called"); }
+    size_t getClosureSize() override { RELEASE_ASSERT(0, "This should never get called"); }
+    std::vector<std::pair<InternedString, DerefInfo>> v;
+    const std::vector<std::pair<InternedString, DerefInfo>>& getAllDerefVarsAndInfo() override { return v; }
 
     InternedString mangleName(InternedString id) override { return id; }
     InternedString internString(llvm::StringRef s) override { abort(); }
@@ -165,9 +169,13 @@ public:
 
     bool usesNameLookup() override { return true; }
 
-    bool isPassedToViaClosure(InternedString name) override { return false; }
-
     bool areLocalsFromModule() override { return false; }
+
+    DerefInfo getDerefInfo(InternedString) override { RELEASE_ASSERT(0, "This should never get called"); }
+    size_t getClosureOffset(InternedString) override { RELEASE_ASSERT(0, "This should never get called"); }
+    size_t getClosureSize() override { RELEASE_ASSERT(0, "This should never get called"); }
+    std::vector<std::pair<InternedString, DerefInfo>> v;
+    const std::vector<std::pair<InternedString, DerefInfo>>& getAllDerefVarsAndInfo() override { return v; }
 
     InternedString mangleName(InternedString id) override { return id; }
     InternedString internString(llvm::StringRef s) override { abort(); }
@@ -257,11 +265,22 @@ private:
     AST* ast;
     bool usesNameLookup_;
 
+    llvm::DenseMap<InternedString, size_t> closure_offsets;
+
+    std::vector<std::pair<InternedString, DerefInfo>> allDerefVarsAndInfo;
+    bool allDerefVarsAndInfoCached;
+
 public:
     ScopeInfoBase(ScopeInfo* parent, ScopingAnalysis::ScopeNameUsage* usage, AST* ast, bool usesNameLookup)
-        : parent(parent), usage(usage), ast(ast), usesNameLookup_(usesNameLookup) {
+        : parent(parent), usage(usage), ast(ast), usesNameLookup_(usesNameLookup), allDerefVarsAndInfoCached(false) {
         assert(usage);
         assert(ast);
+
+        int i = 0;
+        for (auto& p : usage->referenced_from_nested) {
+            closure_offsets[p] = i;
+            i++;
+        }
     }
 
     ~ScopeInfoBase() override { delete this->usage; }
@@ -300,20 +319,67 @@ public:
 
     bool usesNameLookup() override { return usesNameLookup_; }
 
-    bool isPassedToViaClosure(InternedString name) override {
-        if (isCompilerCreatedName(name))
-            return false;
+    bool areLocalsFromModule() override { return false; }
 
-        return usage->got_from_closure.count(name) > 0 || usage->passthrough_accesses.count(name) > 0;
+    DerefInfo getDerefInfo(InternedString name) override {
+        assert(getScopeTypeOfName(name) == VarScopeType::DEREF);
+
+        // TODO pre-compute this?
+
+        size_t parentCounter = 0;
+        // Casting to a ScopeInfoBase* is okay because only a ScopeInfoBase can have a closure.
+        for (ScopeInfoBase* parent = static_cast<ScopeInfoBase*>(this->parent); parent != NULL;
+             parent = static_cast<ScopeInfoBase*>(parent->parent)) {
+            if (parent->createsClosure()) {
+                auto it = parent->closure_offsets.find(name);
+                if (it != parent->closure_offsets.end()) {
+                    return DerefInfo{.num_parents_from_passed_closure = parentCounter, .offset = it->second };
+                }
+                parentCounter++;
+            }
+        }
+
+        RELEASE_ASSERT(0, "Should not get here");
     }
 
-    bool areLocalsFromModule() override { return false; }
+    size_t getClosureOffset(InternedString name) override {
+        assert(getScopeTypeOfName(name) == VarScopeType::CLOSURE);
+        return closure_offsets[name];
+    }
+
+    size_t getClosureSize() override { return closure_offsets.size(); }
 
     InternedString mangleName(const InternedString id) override {
         return pyston::mangleName(id, usage->private_name, usage->scoping->getInternedStrings());
     }
 
     InternedString internString(llvm::StringRef s) override { return usage->scoping->getInternedStrings().get(s); }
+
+    const std::vector<std::pair<InternedString, DerefInfo>>& getAllDerefVarsAndInfo() override {
+        if (!allDerefVarsAndInfoCached) {
+            allDerefVarsAndInfoCached = true;
+
+            StrSet allDerefs = usage->got_from_closure;
+            for (InternedString name : usage->passthrough_accesses) {
+                if (allDerefs.find(name) != allDerefs.end()) {
+                    allDerefs.insert(name);
+                }
+            }
+
+            for (InternedString name : allDerefs) {
+                allDerefVarsAndInfo.push_back({ name, getDerefInfo(name) });
+            }
+
+            std::sort(allDerefVarsAndInfo.begin(), allDerefVarsAndInfo.end(), derefComparator);
+        }
+        return allDerefVarsAndInfo;
+    }
+
+private:
+    static bool derefComparator(const std::pair<InternedString, DerefInfo>& p1,
+                                const std::pair<InternedString, DerefInfo>& p2) {
+        return p1.second.num_parents_from_passed_closure < p2.second.num_parents_from_passed_closure;
+    };
 };
 
 class NameCollectorVisitor : public ASTVisitor {

--- a/src/analysis/scoping_analysis.cpp
+++ b/src/analysis/scoping_analysis.cpp
@@ -328,6 +328,8 @@ public:
 
         size_t parentCounter = 0;
         // Casting to a ScopeInfoBase* is okay because only a ScopeInfoBase can have a closure.
+        // We just walk up the scopes until we find the scope with this name. Count the number
+        // of parent links we follow, and then get the offset of the name.
         for (ScopeInfoBase* parent = static_cast<ScopeInfoBase*>(this->parent); parent != NULL;
              parent = static_cast<ScopeInfoBase*>(parent->parent)) {
             if (parent->createsClosure()) {
@@ -347,7 +349,10 @@ public:
         return closure_offsets[name];
     }
 
-    size_t getClosureSize() override { return closure_offsets.size(); }
+    size_t getClosureSize() override {
+        assert(createsClosure());
+        return closure_offsets.size();
+    }
 
     InternedString mangleName(const InternedString id) override {
         return pyston::mangleName(id, usage->private_name, usage->scoping->getInternedStrings());
@@ -359,6 +364,10 @@ public:
         if (!allDerefVarsAndInfoCached) {
             allDerefVarsAndInfoCached = true;
 
+            // TODO this could probably be implemented faster
+
+            // Get all the variables that we need to return: any variable from the
+            // passed-in closure that is accessed in this scope or in a child scope.
             StrSet allDerefs = usage->got_from_closure;
             for (InternedString name : usage->passthrough_accesses) {
                 if (allDerefs.find(name) != allDerefs.end()) {
@@ -366,10 +375,13 @@ public:
                 }
             }
 
+            // Call `getDerefInfo` on all of these variables and put the results in
+            // `allDerefVarsAndInfo`
             for (InternedString name : allDerefs) {
                 allDerefVarsAndInfo.push_back({ name, getDerefInfo(name) });
             }
 
+            // Sort in order of `num_parents_from_passed_closure`
             std::sort(allDerefVarsAndInfo.begin(), allDerefVarsAndInfo.end(), derefComparator);
         }
         return allDerefVarsAndInfo;

--- a/src/analysis/scoping_analysis.h
+++ b/src/analysis/scoping_analysis.h
@@ -98,8 +98,8 @@ public:
     virtual DerefInfo getDerefInfo(InternedString name) = 0;
 
     // Gets the DerefInfo for each DEREF variable accessible in the scope.
-    // The returned vector is in SORTED ORDER by the `num_parents_from_passed_closure` field.
-    // This allows the caller to iterate through the vector while also walking up
+    // The returned vector is in SORTED ORDER by the `num_parents_from_passed_closure` field
+    // (ascending). This allows the caller to iterate through the vector while also walking up
     // the closure chain to collect all the DEREF variable values. This is useful, for example,
     // in the implementation of locals().
     //

--- a/src/codegen/ast_interpreter.cpp
+++ b/src/codegen/ast_interpreter.cpp
@@ -228,7 +228,7 @@ void ASTInterpreter::initArguments(int nargs, BoxedClosure* _closure, BoxedGener
     generator = _generator;
 
     if (scope_info->createsClosure())
-        created_closure = createClosure(passed_closure);
+        created_closure = createClosure(passed_closure, scope_info->getClosureSize());
 
     std::vector<Box*, StlCompatAllocator<Box*>> argsArray{ arg1, arg2, arg3 };
     for (int i = 3; i < nargs; ++i)
@@ -354,8 +354,9 @@ void ASTInterpreter::doStore(InternedString name, Value value) {
         setitem(frame_info.boxedLocals, boxString(name.str()), value.o);
     } else {
         sym_table[name] = value.o;
-        if (vst == ScopeInfo::VarScopeType::CLOSURE)
-            setattr(created_closure, name.c_str(), value.o);
+        if (vst == ScopeInfo::VarScopeType::CLOSURE) {
+            created_closure->elts[scope_info->getClosureOffset(name)] = value.o;
+        }
     }
 }
 
@@ -1082,8 +1083,20 @@ Value ASTInterpreter::visit_name(AST_Name* node) {
     switch (node->lookup_type) {
         case ScopeInfo::VarScopeType::GLOBAL:
             return getGlobal(source_info->parent_module, &node->id.str());
-        case ScopeInfo::VarScopeType::DEREF:
-            return getattr(passed_closure, node->id.c_str());
+        case ScopeInfo::VarScopeType::DEREF: {
+            DerefInfo deref_info = scope_info->getDerefInfo(node->id);
+            assert(passed_closure);
+            BoxedClosure* closure = passed_closure;
+            for (int i = 0; i < deref_info.num_parents_from_passed_closure; i++) {
+                closure = closure->parent;
+            }
+            Box* val = closure->elts[deref_info.offset];
+            if (val == NULL) {
+                raiseExcHelper(NameError, "free variable '%s' referenced before assignment in enclosing scope",
+                               node->id.c_str());
+            }
+            return val;
+        }
         case ScopeInfo::VarScopeType::FAST:
         case ScopeInfo::VarScopeType::CLOSURE: {
             SymMap::iterator it = sym_table.find(node->id);

--- a/src/codegen/compvars.cpp
+++ b/src/codegen/compvars.cpp
@@ -1781,15 +1781,17 @@ public:
 
     CompilerVariable* getattr(IREmitter& emitter, const OpInfo& info, ConcreteCompilerVariable* var,
                               const std::string* attr, bool cls_only) override {
+        RELEASE_ASSERT(0, "should not be called\n");
+        /*
         assert(!cls_only);
         llvm::Value* bitcast = emitter.getBuilder()->CreateBitCast(var->getValue(), g.llvm_value_type_ptr);
         return ConcreteCompilerVariable(UNKNOWN, bitcast, true).getattr(emitter, info, attr, cls_only);
+        */
     }
 
     void setattr(IREmitter& emitter, const OpInfo& info, ConcreteCompilerVariable* var, const std::string* attr,
                  CompilerVariable* v) override {
-        llvm::Value* bitcast = emitter.getBuilder()->CreateBitCast(var->getValue(), g.llvm_value_type_ptr);
-        ConcreteCompilerVariable(UNKNOWN, bitcast, true).setattr(emitter, info, attr, v);
+        RELEASE_ASSERT(0, "should not be called\n");
     }
 
     ConcreteCompilerType* getConcreteType() override { return this; }

--- a/src/codegen/runtime_hooks.cpp
+++ b/src/codegen/runtime_hooks.cpp
@@ -216,7 +216,7 @@ void initGlobalFuncs(GlobalState& g) {
     GET(raiseAttributeErrorStr);
     GET(raiseNotIterableError);
     GET(assertNameDefined);
-    GET(assertDerefNameDefined);
+    GET(assertFailDerefNameDefined);
     GET(assertFail);
 
     GET(printFloat);

--- a/src/codegen/runtime_hooks.cpp
+++ b/src/codegen/runtime_hooks.cpp
@@ -216,6 +216,7 @@ void initGlobalFuncs(GlobalState& g) {
     GET(raiseAttributeErrorStr);
     GET(raiseNotIterableError);
     GET(assertNameDefined);
+    GET(assertDerefNameDefined);
     GET(assertFail);
 
     GET(printFloat);

--- a/src/codegen/runtime_hooks.h
+++ b/src/codegen/runtime_hooks.h
@@ -41,7 +41,7 @@ struct GlobalFuncs {
         *exceptionMatches, *yield, *getiterHelper, *hasnext;
 
     llvm::Value* unpackIntoArray, *raiseAttributeError, *raiseAttributeErrorStr, *raiseNotIterableError,
-        *assertNameDefined, *assertFail, *assertDerefNameDefined;
+        *assertNameDefined, *assertFail, *assertFailDerefNameDefined;
     llvm::Value* printFloat, *listAppendInternal, *getSysStdout;
     llvm::Value* runtimeCall0, *runtimeCall1, *runtimeCall2, *runtimeCall3, *runtimeCall, *runtimeCallN;
     llvm::Value* callattr0, *callattr1, *callattr2, *callattr3, *callattr, *callattrN;

--- a/src/codegen/runtime_hooks.h
+++ b/src/codegen/runtime_hooks.h
@@ -41,7 +41,7 @@ struct GlobalFuncs {
         *exceptionMatches, *yield, *getiterHelper, *hasnext;
 
     llvm::Value* unpackIntoArray, *raiseAttributeError, *raiseAttributeErrorStr, *raiseNotIterableError,
-        *assertNameDefined, *assertFail;
+        *assertNameDefined, *assertFail, *assertDerefNameDefined;
     llvm::Value* printFloat, *listAppendInternal, *getSysStdout;
     llvm::Value* runtimeCall0, *runtimeCall1, *runtimeCall2, *runtimeCall3, *runtimeCall, *runtimeCallN;
     llvm::Value* callattr0, *callattr1, *callattr2, *callattr3, *callattr, *callattrN;

--- a/src/runtime/inline/link_forcer.cpp
+++ b/src/runtime/inline/link_forcer.cpp
@@ -98,6 +98,7 @@ void force() {
     FORCE(raiseAttributeErrorStr);
     FORCE(raiseNotIterableError);
     FORCE(assertNameDefined);
+    FORCE(assertDerefNameDefined);
     FORCE(assertFail);
 
     FORCE(printFloat);

--- a/src/runtime/inline/link_forcer.cpp
+++ b/src/runtime/inline/link_forcer.cpp
@@ -98,7 +98,7 @@ void force() {
     FORCE(raiseAttributeErrorStr);
     FORCE(raiseNotIterableError);
     FORCE(assertNameDefined);
-    FORCE(assertDerefNameDefined);
+    FORCE(assertFailDerefNameDefined);
     FORCE(assertFail);
 
     FORCE(printFloat);

--- a/src/runtime/objmodel.cpp
+++ b/src/runtime/objmodel.cpp
@@ -1277,7 +1277,6 @@ Box* getattrInternalGeneric(Box* obj, const std::string& attr, GetattrRewriteArg
         *bind_obj_out = NULL;
     }
 
-    // TODO this should be a custom getattr
     assert(obj->cls != closure_cls);
 
     // Handle descriptor logic here.

--- a/src/runtime/objmodel.cpp
+++ b/src/runtime/objmodel.cpp
@@ -233,10 +233,8 @@ extern "C" void assertNameDefined(bool b, const char* name, BoxedClass* exc_cls,
     }
 }
 
-extern "C" void assertDerefNameDefined(Box* b, const char* name) {
-    if (b == NULL) {
-        raiseExcHelper(NameError, "free variable '%s' referenced before assignment in enclosing scope", name);
-    }
+extern "C" void assertFailDerefNameDefined(const char* name) {
+    raiseExcHelper(NameError, "free variable '%s' referenced before assignment in enclosing scope", name);
 }
 
 extern "C" void raiseAttributeErrorStr(const char* typeName, const char* attr) {

--- a/src/runtime/objmodel.h
+++ b/src/runtime/objmodel.h
@@ -83,9 +83,10 @@ extern "C" Box* importFrom(Box* obj, const std::string* attr);
 extern "C" Box* importStar(Box* from_module, BoxedModule* to_module);
 extern "C" Box** unpackIntoArray(Box* obj, int64_t expected_size);
 extern "C" void assertNameDefined(bool b, const char* name, BoxedClass* exc_cls, bool local_var_msg);
+extern "C" void assertDerefNameDefined(Box* b, const char* name);
 extern "C" void assertFail(BoxedModule* inModule, Box* msg);
 extern "C" bool isSubclass(BoxedClass* child, BoxedClass* parent);
-extern "C" BoxedClosure* createClosure(BoxedClosure* parent_closure);
+extern "C" BoxedClosure* createClosure(BoxedClosure* parent_closure, size_t size);
 
 Box* getiter(Box* o);
 extern "C" Box* getPystonIter(Box* o);

--- a/src/runtime/objmodel.h
+++ b/src/runtime/objmodel.h
@@ -83,7 +83,7 @@ extern "C" Box* importFrom(Box* obj, const std::string* attr);
 extern "C" Box* importStar(Box* from_module, BoxedModule* to_module);
 extern "C" Box** unpackIntoArray(Box* obj, int64_t expected_size);
 extern "C" void assertNameDefined(bool b, const char* name, BoxedClass* exc_cls, bool local_var_msg);
-extern "C" void assertDerefNameDefined(Box* b, const char* name);
+extern "C" void assertFailDerefNameDefined(const char* name);
 extern "C" void assertFail(BoxedModule* inModule, Box* msg);
 extern "C" bool isSubclass(BoxedClass* child, BoxedClass* parent);
 extern "C" BoxedClosure* createClosure(BoxedClosure* parent_closure, size_t size);

--- a/src/runtime/types.cpp
+++ b/src/runtime/types.cpp
@@ -617,6 +617,11 @@ extern "C" void closureGCHandler(GCVisitor* v, Box* b) {
     BoxedClosure* c = (BoxedClosure*)b;
     if (c->parent)
         v->visit(c->parent);
+
+    for (int i = 0; i < c->nelts; i++) {
+        if (c->elts[i])
+            v->visit(c->elts[i]);
+    }
 }
 
 extern "C" {
@@ -830,10 +835,12 @@ extern "C" Box* createSlice(Box* start, Box* stop, Box* step) {
     return rtn;
 }
 
-extern "C" BoxedClosure* createClosure(BoxedClosure* parent_closure) {
+extern "C" BoxedClosure* createClosure(BoxedClosure* parent_closure, size_t n) {
     if (parent_closure)
         assert(parent_closure->cls == closure_cls);
-    return new BoxedClosure(parent_closure);
+    BoxedClosure* closure = new (n) BoxedClosure(parent_closure);
+    assert(closure->cls == closure_cls);
+    return closure;
 }
 
 extern "C" Box* sliceNew(Box* cls, Box* start, Box* stop, Box** args) {
@@ -2002,8 +2009,8 @@ void setupRuntime() {
                                            sizeof(BoxedSet), false, "frozenset");
     capi_getset_cls
         = BoxedHeapClass::create(type_cls, object_cls, NULL, 0, 0, sizeof(BoxedGetsetDescriptor), false, "getset");
-    closure_cls = BoxedHeapClass::create(type_cls, object_cls, &closureGCHandler, offsetof(BoxedClosure, attrs), 0,
-                                         sizeof(BoxedClosure), false, "closure");
+    closure_cls
+        = BoxedHeapClass::create(type_cls, object_cls, &closureGCHandler, 0, 0, sizeof(BoxedClosure), false, "closure");
     property_cls = BoxedHeapClass::create(type_cls, object_cls, &propertyGCHandler, 0, 0, sizeof(BoxedProperty), false,
                                           "property");
     staticmethod_cls = BoxedHeapClass::create(type_cls, object_cls, &staticmethodGCHandler, 0, 0,

--- a/src/runtime/types.h
+++ b/src/runtime/types.h
@@ -618,15 +618,27 @@ public:
     DEFAULT_CLASS_SIMPLE(classmethod_cls);
 };
 
-// TODO is there any particular reason to make this a Box, ie a python-level object?
+// TODO is there any particular reason to make this a Box, i.e. a python-level object?
 class BoxedClosure : public Box {
 public:
-    HCAttrs attrs;
     BoxedClosure* parent;
+    size_t nelts;
+    Box* elts[0];
 
     BoxedClosure(BoxedClosure* parent) : parent(parent) {}
 
-    DEFAULT_CLASS(closure_cls);
+    void* operator new(size_t size, size_t nelts) __attribute__((visibility("default"))) {
+        /*
+        BoxedClosure* rtn
+            = static_cast<BoxedClosure*>(gc_alloc(_PyObject_VAR_SIZE(closure_cls, nelts), gc::GCKind::PYTHON));
+            */
+        BoxedClosure* rtn
+            = static_cast<BoxedClosure*>(gc_alloc(sizeof(BoxedClosure) + nelts * sizeof(Box*), gc::GCKind::PYTHON));
+        rtn->nelts = nelts;
+        rtn->cls = closure_cls;
+        memset((void*)rtn->elts, 0, sizeof(Box*) * nelts);
+        return rtn;
+    }
 };
 
 class BoxedGenerator : public Box {

--- a/test/tests/static_closure_locations.py
+++ b/test/tests/static_closure_locations.py
@@ -1,25 +1,26 @@
-# should_error
-
 # The use of c makes sure a closure gets passed through all 4 functions.
 # The use of a in g makes sure that a is in f's closure.
 # The a in j should refer to the a in h, thus throwing an exception since
 # it is undefined (that is, it should *not* access the a from f even
 # though it access via the closure).
 
-def f():
-    c = 0
-    a = 0
-    def g():
-        print c
-        print a
-        def h():
+try:
+    def f():
+        c = 0
+        a = 0
+        def g():
             print c
-            def j():
+            print a
+            def h():
                 print c
-                print a
+                def j():
+                    print c
+                    print a
 
-            j()
-            a = 1
-        h()
-    g()
-f()
+                j()
+                a = 1
+            h()
+        g()
+    f()
+except NameError as ne:
+    print ne.message

--- a/test/tests/static_closure_locations.py
+++ b/test/tests/static_closure_locations.py
@@ -1,0 +1,25 @@
+# should_error
+
+# The use of c makes sure a closure gets passed through all 4 functions.
+# The use of a in g makes sure that a is in f's closure.
+# The a in j should refer to the a in h, thus throwing an exception since
+# it is undefined (that is, it should *not* access the a from f even
+# though it access via the closure).
+
+def f():
+    c = 0
+    a = 0
+    def g():
+        print c
+        print a
+        def h():
+            print c
+            def j():
+                print c
+                print a
+
+            j()
+            a = 1
+        h()
+    g()
+f()

--- a/tools/tester.py
+++ b/tools/tester.py
@@ -158,6 +158,8 @@ def run_test(fn, check_stats, run_memcheck):
             skip = eval(skip_if)
             if skip:
                 return r + "    (skipped due to 'skip-if: %s')" % skip_if[:30]
+        elif fn.split('.')[0] in TESTS_TO_SKIP:
+                return r + "    (skipped due to command line option)"
         elif l.startswith("# allow-warning:"):
             allow_warnings.append("Warning: " + l.split(':', 1)[1].strip())
         elif l.startswith("# no-collect-stats"):
@@ -386,6 +388,8 @@ parser.add_argument('-a', '--extra-args', default=[], action='append',
                     help="additional arguments to pyston (must be invoked with equal sign: -a=-ARG)")
 parser.add_argument('-t', '--time-limit', type=int, default=TIME_LIMIT,
                     help='set time limit in seconds for each test')
+parser.add_argument('-s', '--skip-tests', type=str, default='',
+                    help='tests to skip (comma-separated)')
 
 parser.add_argument('test_dir')
 parser.add_argument('patterns', nargs='*')
@@ -397,6 +401,7 @@ def main(orig_dir):
     global TIME_LIMIT
     global TEST_DIR
     global FN_JUST_SIZE
+    global TESTS_TO_SKIP
 
     run_memcheck = False
     start = 1
@@ -408,6 +413,7 @@ def main(orig_dir):
     KEEP_GOING = opts.keep_going
     EXTRA_JIT_ARGS += opts.extra_args
     TIME_LIMIT = opts.time_limit
+    TESTS_TO_SKIP = opts.skip_tests.split(',')
 
     TEST_DIR = os.path.join(orig_dir, opts.test_dir)
     patterns = opts.patterns


### PR DESCRIPTION
This needs a lot of cleaning up but I wanted to solicit feedback on the approach first...

Right now we handle closure as normal objects with `HCAttrs`, and we de-reference variables from closures by walking up the closures until we find one with the variable name. This is overly-dynamic to the point of being wrong (see my new `static_closure_locations.py` test case):

```python
# The use of c makes sure a closure gets passed through all 4 functions.
# The use of a in g makes sure that a is in f's closure.
# The a in j should refer to the a in h, thus throwing an exception since
# it is undefined (that is, it should *not* access the a from f even
# though it is accessible via the closure).

def f():
    c = 0 
    a = 0 
    def g():
        print c
        print a
        def h():
            print c
            def j():
                print c
                print a    # should throw a NameError

            j() 
            a = 1 
        h() 
    g() 
f()
```

Since the the set of names is a closure is fixed, in this diff I statically determine the size of the closure and the mapping of names to offsets (letting undefined variables be `NULL`). Then the IR for a closure lookup just consists of some pointer-dereferences with constant offsets. I allocate the array of `Box *`s inside the `BoxedClosure` following @toshok 's lead with tuples in #411.

The offset information is computed statically in the `ScopeInfo`, and for any name you can look up a `DerefInfo`, which tells you exactly how many parent closures you need to walk up and the offset within that closure the desired variable lies. (There are a few other functions which return related information.) Here's some example IR:

```
  %8 = getelementptr inbounds %"class.pyston::BoxedClosure"* %0, i64 0, i32 1, !dbg !7
  %9 = load %"class.pyston::BoxedClosure"** %8, align 8, !dbg !7
  %10 = getelementptr %"class.pyston::BoxedClosure"* %9, i64 0, i32 3, i64 0, !dbg !7
  %11 = load %"class.pyston::Box"** %10, align 8, !dbg !7
  call void (i64, i32, i8*, i32, ...)* @llvm.experimental.patchpoint.void(i64 45780160, i32 95, i8* @assertDerefNameDefined, i32 2, %"class.pyston::Box"* %11, i8* inttoptr (i64 45231744 to i8*), i8* %scratch1.sub, %"struct.pyston::FrameInfo"* %frame_info, i64 45205664,   %"class.pyston::Box"* %7, %"class.pyston::BoxedClosure"* %0, %"class.pyston::Box"* %1), !dbg !7
```

This fixes the test, which is good. I was optimistic about it giving a slight performance boost for closures, but it turned out a lot crappier than I had hoped:

```
              pyston (calibration)                      :    1.0s baseline: 1.0 (+0.0%)
              pyston interp2.py                         :    6.5s baseline: 6.5 (+0.4%)
              pyston raytrace.py                        :    7.1s baseline: 6.8 (+4.5%)
              pyston nbody.py                           :    8.9s baseline: 8.8 (+1.4%)
              pyston fannkuch.py                        :    8.8s baseline: 8.6 (+2.3%)
              pyston chaos.py                           :   21.8s baseline: 20.9 (+4.2%)
              pyston spectral_norm.py                   :   28.0s baseline: 24.9 (+12.3%)
              pyston clos.py                            :    0.7s baseline: 0.7 (+8.8%)
              pyston fasta.py                           :    5.6s baseline: 5.9 (-5.4%)
              pyston pidigits.py                        :    5.4s baseline: 5.3 (+1.3%)
              pyston richards.py                        :    2.0s baseline: 2.0 (-2.5%)
              pyston deltablue.py                       :    2.1s baseline: 2.1 (+0.1%)
              pyston (geomean-6d4e)                     :    5.7s baseline: 5.6 (+2.4%)
```

I can't figure why so many of the benchmarks would be slower, notably `spectral_norm.py`, even though as far as I can tell they don't use closures at all. (If they don't use closures, this diff shouldn't have any effect, right?) Even `clos.py` (a contrived benchmark I wrote just now that uses a lot of closures) is slower. However, I think the slowness is due to the `assertDerefNameDefined` function call, so I'm hoping the speed will improve when I inline it. (The IC under the old method doesn't have a function call like that, just an inline guard.)

Anyway... thoughts?