### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -859,7 +859,7 @@ pyston_profile: $(PROFILE_OBJS) $(LLVM_PROFILE_DEPS)
 	$(VERB) $(CXX) $(PROFILE_OBJS) $(LDFLAGS_PROFILE) -o $@
 
 cmake_check:
-	@clang --version >/dev/null || (echo "clang not available"; false)
+	@$(CLANG_EXE) --version >/dev/null || (echo "clang not available"; false)
 	@cmake --version >/dev/null || (echo "cmake not available"; false)
 	@ninja --version >/dev/null || (echo "ninja not available"; false)
 


### PR DESCRIPTION
"@clang" is not installed globally according to the previous instructions. use $(CLANG_EXE) instead.
"cmake_check" is used in "make pyston_gcc", which is in one of the steps of "make check".
@clang will trigger an error interrupting "make check"