### PR TITLE
a few changes which help out GC performance

### DIFF
--- a/src/core/contiguous_map.h
+++ b/src/core/contiguous_map.h
@@ -1,0 +1,109 @@
+// Copyright (c) 2014-2015 Dropbox, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef PYSTON_CORE_CONTIGUOUSMAP_H
+#define PYSTON_CORE_CONTIGUOUSMAP_H
+
+#include <llvm/ADT/DenseMap.h>
+#include <utility>
+#include <vector>
+
+namespace pyston {
+
+template <class TKey, class TVal, class TMap = llvm::DenseMap<TKey, int>> class ContiguousMap {
+    typedef TMap map_type;
+    typedef std::vector<TVal> vec_type;
+
+    map_type map;
+    vec_type vec;
+
+    std::vector<int> free_list;
+
+public:
+    typedef typename map_type::iterator iterator;
+    typedef typename map_type::const_iterator const_iterator;
+    typedef typename std::vector<TVal>::size_type size_type;
+
+    iterator find(TKey key) { return map.find(key); }
+
+    iterator begin() noexcept { return map.begin(); }
+    iterator end() noexcept { return map.end(); }
+
+    const_iterator begin() const noexcept { return map.begin(); }
+    const_iterator end() const noexcept { return map.end(); }
+
+    iterator erase(const_iterator position) {
+        int idx = map[position->first];
+        free_list.push_back(idx);
+        vec[idx] = TVal();
+        map.erase(position->first);
+        return begin(); // this is broken...
+    }
+
+    size_type erase(const TKey& key) {
+        auto it = map.find(key);
+        if (it == end())
+            return 0;
+        int idx = it->second;
+        free_list.push_back(idx);
+        vec[idx] = TVal();
+        map.erase(it);
+        return 1;
+    }
+
+    size_type count(const TKey& key) const { return map.count(key); }
+
+    TVal& operator[](const TKey& key) {
+        auto it = map.find(key);
+        if (it == map.end()) {
+            int idx;
+            if (free_list.size() > 0) {
+                idx = free_list.back();
+                free_list.pop_back();
+            } else {
+                idx = vec.size();
+            }
+            map[key] = idx;
+            vec.push_back(TVal());
+            return vec[idx];
+        } else {
+            return vec[it->second];
+        }
+    }
+
+    TVal& operator[](TKey&& key) {
+        auto it = map.find(key);
+        if (it == map.end()) {
+            int idx;
+            if (free_list.size() > 0) {
+                idx = free_list.back();
+                free_list.pop_back();
+            } else {
+                idx = vec.size();
+            }
+            map[key] = idx;
+            vec.push_back(TVal());
+            return vec[idx];
+        } else {
+            return vec[it->second];
+        }
+    }
+
+    TVal getMapped(int idx) const { return vec[idx]; }
+
+    size_type size() const { return vec.size(); }
+    const vec_type& vector() { return vec; }
+};
+}
+#endif

--- a/src/gc/collector.cpp
+++ b/src/gc/collector.cpp
@@ -191,6 +191,9 @@ bool GCVisitor::isValid(void* p) {
 }
 
 void GCVisitor::visit(void* p) {
+    if (!p)
+        return;
+
     if (isNonheapRoot(p)) {
         return;
     } else {

--- a/src/gc/collector.cpp
+++ b/src/gc/collector.cpp
@@ -150,6 +150,7 @@ static std::unordered_set<void*> nonheap_roots;
 // typically all have lower addresses than the heap roots, so this can serve as a cheap
 // way to verify it's not a nonheap root (the full check requires a hashtable lookup).
 static void* max_nonheap_root = 0;
+static void* min_nonheap_root = (void*)~0;
 void registerNonheapRootObject(void* obj) {
     // I suppose that things could work fine even if this were true, but why would it happen?
     assert(global_heap.getAllocationFromInteriorPointer(obj) == NULL);
@@ -158,10 +159,13 @@ void registerNonheapRootObject(void* obj) {
     nonheap_roots.insert(obj);
 
     max_nonheap_root = std::max(obj, max_nonheap_root);
+    min_nonheap_root = std::min(obj, min_nonheap_root);
 }
 
 bool isNonheapRoot(void* p) {
-    return p <= max_nonheap_root && nonheap_roots.count(p) != 0;
+    if (p > max_nonheap_root || p < min_nonheap_root)
+        return false;
+    return nonheap_roots.count(p) != 0;
 }
 
 bool isValidGCObject(void* p) {

--- a/src/gc/collector.cpp
+++ b/src/gc/collector.cpp
@@ -259,7 +259,7 @@ void markPhase() {
     }
 
     for (auto h : *getRootHandles()) {
-        visitor.visitPotential(h->value);
+        visitor.visit(h->value);
     }
 
     // if (VERBOSITY()) printf("Found %d roots\n", stack.size());

--- a/src/runtime/dict.cpp
+++ b/src/runtime/dict.cpp
@@ -67,6 +67,7 @@ Box* dictCopy(BoxedDict* self) {
 Box* dictItems(BoxedDict* self) {
     BoxedList* rtn = new BoxedList();
 
+    rtn->ensure(self->d.size());
     for (const auto& p : self->d) {
         BoxedTuple::GCVector elts;
         elts.push_back(p.first);
@@ -80,6 +81,7 @@ Box* dictItems(BoxedDict* self) {
 
 Box* dictValues(BoxedDict* self) {
     BoxedList* rtn = new BoxedList();
+    rtn->ensure(self->d.size());
     for (const auto& p : self->d) {
         listAppendInternal(rtn, p.second);
     }
@@ -90,6 +92,7 @@ Box* dictKeys(BoxedDict* self) {
     RELEASE_ASSERT(isSubclass(self->cls, dict_cls), "");
 
     BoxedList* rtn = new BoxedList();
+    rtn->ensure(self->d.size());
     for (const auto& p : self->d) {
         listAppendInternal(rtn, p.first);
     }

--- a/src/runtime/objmodel.cpp
+++ b/src/runtime/objmodel.cpp
@@ -474,7 +474,7 @@ HiddenClass* HiddenClass::getOrMakeChild(const std::string& attr) {
 
     auto it = children.find(attr);
     if (it != children.end())
-        return it->second;
+        return children.getMapped(it->second);
 
     static StatCounter num_hclses("num_hidden_classes");
     num_hclses.log();

--- a/src/runtime/traceback.cpp
+++ b/src/runtime/traceback.cpp
@@ -96,6 +96,7 @@ Box* BoxedTraceback::getLines(Box* b) {
 
     if (!tb->py_lines) {
         BoxedList* lines = new BoxedList();
+        lines->ensure(tb->lines.size());
         for (auto line : tb->lines) {
             auto l = new BoxedTuple({ boxString(line->file), boxString(line->func), boxInt(line->line) });
             listAppendInternal(lines, l);


### PR DESCRIPTION
A few changes (mostly dealing with scanning) that help GC perf.

```
              pyston (calibration)                      :    1.0s baseline: 1.0 (-0.4%)
              pyston django_migrate.py                  :    5.9s baseline: 10.7 (-45.1%)
              pyston interp2.py                         :    6.0s baseline: 5.9 (+1.5%)
              pyston raytrace.py                        :    6.7s baseline: 6.8 (-1.1%)
              pyston nbody.py                           :    8.9s baseline: 9.3 (-4.0%)
              pyston fannkuch.py                        :    8.1s baseline: 8.0 (+0.8%)
              pyston chaos.py                           :   21.3s baseline: 20.5 (+4.2%)
              pyston fasta.py                           :    6.0s baseline: 5.6 (+8.2%)
              pyston pidigits.py                        :    5.4s baseline: 5.5 (-0.6%)
              pyston richards.py                        :    2.0s baseline: 2.0 (-0.9%)
              pyston deltablue.py                       :    2.1s baseline: 2.1 (+0.8%)
              pyston (geomean-8999)                     :    5.9s baseline: 6.2 (-5.0%)
```