### PR TITLE
basic implementation of `exec code in dict`

### DIFF
--- a/src/codegen/ast_interpreter.cpp
+++ b/src/codegen/ast_interpreter.cpp
@@ -888,12 +888,12 @@ Value ASTInterpreter::visit_print(AST_Print* node) {
 }
 
 Value ASTInterpreter::visit_exec(AST_Exec* node) {
-    RELEASE_ASSERT(!node->globals, "do not support exec with globals or locals yet");
-    assert(!node->locals);
-
     // TODO implement the locals and globals arguments
     Box* code = visit_expr(node->body).o;
-    exec(code);
+    Box* globals = node->globals == NULL ? NULL : visit_expr(node->globals).o;
+    Box* locals = node->locals == NULL ? NULL : visit_expr(node->locals).o;
+
+    exec(code, globals, locals);
 
     return Value();
 }

--- a/src/codegen/irgen/hooks.cpp
+++ b/src/codegen/irgen/hooks.cpp
@@ -379,8 +379,17 @@ Box* eval(Box* boxedCode) {
     return evalOrExec<AST_Expression>(parsedExpr, body, module, boxedLocals);
 }
 
-Box* exec(Box* boxedCode) {
-    Box* boxedLocals = fastLocalsToBoxedLocals();
+Box* exec(Box* boxedCode, Box* globals, Box* locals) {
+    // TODO boxedCode is allowed to be a tuple
+    // TODO need to handle passing in globals
+    if (locals == NULL) {
+        locals = globals;
+    }
+
+    if (locals == NULL) {
+        locals = fastLocalsToBoxedLocals();
+    }
+
     BoxedModule* module = getCurrentModule();
 
     // TODO same issues as in `eval`
@@ -390,7 +399,7 @@ Box* exec(Box* boxedCode) {
     AST_Suite* parsedSuite = new AST_Suite(std::move(parsedModule->interned_strings));
     parsedSuite->body = parsedModule->body;
 
-    return evalOrExec<AST_Suite>(parsedSuite, parsedSuite->body, module, boxedLocals);
+    return evalOrExec<AST_Suite>(parsedSuite, parsedSuite->body, module, locals);
 }
 
 // If a function version keeps failing its speculations, kill it (remove it

--- a/src/codegen/irgen/hooks.h
+++ b/src/codegen/irgen/hooks.h
@@ -37,7 +37,7 @@ void compileAndRunModule(AST_Module* m, BoxedModule* bm);
 // will we always want to generate unique function names? (ie will this function always be reasonable?)
 CompiledFunction* cfForMachineFunctionName(const std::string&);
 
-extern "C" Box* exec(Box* boxedCode);
+extern "C" Box* exec(Box* boxedCode, Box* globals, Box* locals);
 extern "C" Box* eval(Box* boxedCode);
 }
 

--- a/test/tests/exec_in_basic_test.py
+++ b/test/tests/exec_in_basic_test.py
@@ -1,0 +1,9 @@
+d = {}
+exec "a = 5" in d
+print d['a']
+
+def f():
+    d2 = {}
+    exec "b = 6" in d2
+    print d2['b']
+f()


### PR DESCRIPTION
This lets you do `exec code in dict`, sort of

It doesn't pass in the globals, but it should still work a lot of the time (as long as there's no global variable reference from within a function in the exec, and if there is nothing explicitly declared `global`)