### PR TITLE
[WIP] CMake default / Ubuntu 14.10+ compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ ETAGS := ctags-exuberant -e
 # to disk space concerns.
 FORCE_TRUNK_BINARIES := 0
 
-USE_CMAKE := 0
+USE_CMAKE := 1
 NINJA := ninja
 
 # Put any overrides in here:


### PR DESCRIPTION
In order to support Ubuntu >= 14.10 and other distros we need a configure script which means moving to CMake.

@kmod Are there any remaining issues or missing features that would prevent moving to CMake at this point?

- [ ] update README.md
- [ ] update docs/INSTALLING.md
- [ ] make check use cmake check-pyston
- [ ] ~~include config.h in src/runtime/types.h (find a new home for sizeof asserts)~~ do later
- [x] cmake stop globbing source

Should the instructions be for the Makefile (cmake shim) or using cmake directly? For some of the testing helpers the shim is still necessary.
