### PR TITLE
cmake explicitly list all c++ source files

### DIFF
--- a/from_cpython/CMakeLists.txt
+++ b/from_cpython/CMakeLists.txt
@@ -16,85 +16,85 @@ add_custom_target(copy_stdlib ALL DEPENDS ${STDLIB_TARGETS})
 
 # compile specified files in from_cpython/Modules
 file(GLOB_RECURSE STDMODULE_SRCS Modules
-    errnomodule.c
-    shamodule.c
-    sha256module.c
-    sha512module.c
+    _codecsmodule.c
+    _collectionsmodule.c
+    _csv.c
+    _functoolsmodule.c
+    _iomodule.c
     _math.c
+    _randommodule.c
+    _sre.c
+    _ssl.c
+    _struct.c
+    _weakref.c
+    arraymodule.c
+    binascii.c
+    bufferedio.c
+    bytesio.c
+    cache.c
+    connection.c
+    cStringIO.c
+    cursor.c
+    datetimemodule.c
+    errnomodule.c
+    fcntlmodule.c
+    fileio.c
+    getpath.c
+    iobase.c
+    itertoolsmodule.c
     mathmodule.c
     md5.c
     md5module.c
-    _randommodule.c
-    _sre.c
-    operator.c
-    binascii.c
-    pwdmodule.c
-    posixmodule.c
-    _struct.c
-    datetimemodule.c
-    _functoolsmodule.c
-    _collectionsmodule.c
-    itertoolsmodule.c
-    resource.c
-    signalmodule.c
-    selectmodule.c
-    fcntlmodule.c
-    timemodule.c
-    arraymodule.c
-    zlibmodule.c
-    _codecsmodule.c
-    socketmodule.c
-    unicodedata.c
-    _weakref.c
-    cStringIO.c
-    bufferedio.c
-    bytesio.c
-    fileio.c
-    iobase.c
-    _iomodule.c
-    stringio.c
-    textio.c
-    zipimport.c
-    _csv.c
-    _ssl.c
-    getpath.c
-    cache.c
-    connection.c
-    cursor.c
     microprotocols.c
     module.c
+    operator.c
+    posixmodule.c
     prepare_protocol.c
+    pwdmodule.c
+    resource.c
     row.c
+    selectmodule.c
+    sha256module.c
+    sha512module.c
+    shamodule.c
+    signalmodule.c
+    socketmodule.c
     statement.c
+    stringio.c
+    textio.c
+    timemodule.c
+    unicodedata.c
     util.c
+    zipimport.c
+    zlibmodule.c
     )
 
 # compile specified files in from_cpython/Objects
 file(GLOB_RECURSE STDOBJECT_SRCS Objects
-    structseq.c
-    capsule.c
-    stringobject.c
-    exceptions.c
-    unicodeobject.c
-    unicodectype.c
+    bufferobject.c
     bytearrayobject.c
     bytes_methods.c
-    weakrefobject.c
-    memoryobject.c
+    capsule.c
+    exceptions.c
     iterobject.c
-    bufferobject.c
+    memoryobject.c
+    stringobject.c
+    structseq.c
+    unicodectype.c
+    unicodeobject.c
+    weakrefobject.c
     )
 
 # compile specified files in from_cpython/Python
 file(GLOB_RECURSE STDPYTHON_SRCS Python
-    getargs.c
-    pyctype.c
-    formatter_string.c
-    pystrtod.c
     dtoa.c
+    formatter_string.c
     formatter_unicode.c
-    structmember.c
+    getargs.c
     marshal.c
+    pyctype.c
+    pystrtod.c
+    structmember.c
     )
 
 # compile specified files in from_cpython/Python

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,17 +9,6 @@ include_directories(${CMAKE_BINARY_DIR})
 include_directories(${CMAKE_BINARY_DIR}/libunwind/include)
 include_directories(${CMAKE_SOURCE_DIR}/libpypa/src)
 
-file(GLOB ANALYSIS_SRCS analysis/*.cpp)
-file(GLOB ASM_WRITING_SRCS asm_writing/*.cpp)
-file(GLOB CAPI_SRCS capi/*.c capi/*.cpp)
-file(GLOB CODEGEN_IRGEN_SRCS codegen/irgen/*.cpp)
-file(GLOB CODEGEN_OPT_SRCS codegen/opt/*.cpp)
-file(GLOB CODEGEN_SRCS codegen/*.cpp)
-file(GLOB CORE_SRCS core/*.cpp)
-file(GLOB GC_SRCS gc/*.cpp)
-file(GLOB RUNTIME_BUILTIN_MODULES_SRCS runtime/builtin_modules/*.cpp)
-file(GLOB RUNTIME_SRCS runtime/*.cpp runtime/*.S)
-
 if(ENABLE_GPERFTOOLS)
   set(OPTIONAL_SRCS ${OPTIONAL_SRCS} codegen/profiling/pprof.cpp)
 endif()
@@ -28,7 +17,94 @@ if(ENABLE_OPROFILE)
   set(OPTIONAL_SRCS codegen/profiling/oprofile.cpp)
 endif()
 
-add_library(PYSTON_OBJECTS OBJECT codegen/profiling/profiling.cpp ${ANALYSIS_SRCS} ${ASM_WRITING_SRCS} ${CAPI_SRCS} ${CODEGEN_SRCS} ${CODEGEN_IRGEN_SRCS} ${CODEGEN_OPT_SRCS} ${CORE_SRCS} ${GC_SRCS} ${RUNTIME_BUILTIN_MODULES_SRCS} ${RUNTIME_SRCS} ${OPTIONAL_SRCS})
+add_library(PYSTON_OBJECTS OBJECT ${OPTIONAL_SRCS}
+		analysis/function_analysis.cpp
+		analysis/scoping_analysis.cpp
+		analysis/type_analysis.cpp
+		asm_writing/assembler.cpp
+		asm_writing/icinfo.cpp
+		asm_writing/mc_writer.cpp
+		asm_writing/rewriter.cpp
+		capi/abstract.cpp
+		capi/codecs.cpp
+		capi/descrobject.cpp
+		capi/errors.cpp
+		capi/float.cpp
+		capi/modsupport.cpp
+		capi/object.cpp
+		capi/typeobject.cpp
+		codegen/ast_interpreter.cpp
+		codegen/codegen.cpp
+		codegen/compvars.cpp
+		codegen/entry.cpp
+		codegen/gcbuilder.cpp
+		codegen/irgen.cpp
+		codegen/irgen/future.cpp
+		codegen/irgen/hooks.cpp
+		codegen/irgen/irgenerator.cpp
+		codegen/irgen/util.cpp
+		codegen/memmgr.cpp
+		codegen/opt/aa.cpp
+		codegen/opt/boxing_passes.cpp
+		codegen/opt/const_classes.cpp
+		codegen/opt/dead_allocs.cpp
+		codegen/opt/escape_analysis.cpp
+		codegen/opt/inliner.cpp
+		codegen/opt/mallocs_nonnull.cpp
+		codegen/opt/util.cpp
+		codegen/parser.cpp
+		codegen/patchpoints.cpp
+		codegen/profiling/dumprof.cpp
+		codegen/profiling/profiling.cpp
+		codegen/pypa-parser.cpp
+		codegen/runtime_hooks.cpp
+		codegen/serialize_ast.cpp
+		codegen/stackmaps.cpp
+		codegen/type_recording.cpp
+		codegen/unwinding.cpp
+		core/ast.cpp
+		core/cfg.cpp
+		core/options.cpp
+		core/stats.cpp
+		core/threading.cpp
+		core/util.cpp
+		gc/collector.cpp
+		gc/gc_alloc.cpp
+		gc/heap.cpp
+		runtime/bool.cpp
+		runtime/builtin_modules/builtins.cpp
+		runtime/builtin_modules/gc.cpp
+		runtime/builtin_modules/pyston.cpp
+		runtime/builtin_modules/sys.cpp
+		runtime/builtin_modules/thread.cpp
+		runtime/capi.cpp
+		runtime/classobj.cpp
+		runtime/code.cpp
+		runtime/complex.cpp
+		runtime/ctxswitching.S
+		runtime/descr.cpp
+		runtime/dict.cpp
+		runtime/file.cpp
+		runtime/float.cpp
+		runtime/generator.cpp
+		runtime/ics.cpp
+		runtime/import.cpp
+		runtime/int.cpp
+		runtime/iterators.cpp
+		runtime/iterobject.cpp
+		runtime/list.cpp
+		runtime/long.cpp
+		runtime/objmodel.cpp
+		runtime/set.cpp
+		runtime/stacktrace.cpp
+		runtime/str.cpp
+		runtime/super.cpp
+		runtime/traceback.cpp
+		runtime/tuple.cpp
+		runtime/types.cpp
+		runtime/util.cpp
+		)
+
 add_dependencies(PYSTON_OBJECTS libunwind pypa ${LLVM_LIBS})
 
 add_library(PYSTON_MAIN_OBJECT OBJECT jit.cpp)

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -10,7 +10,6 @@ add_custom_target(unittests)
 macro(add_unittest unittest)
   add_executable(${unittest}_unittest EXCLUDE_FROM_ALL ${unittest}.cpp $<TARGET_OBJECTS:PYSTON_OBJECTS> $<TARGET_OBJECTS:FROM_CPYTHON>)
   target_link_libraries(${unittest}_unittest stdlib sqlite3 gmp ssl crypto readline pypa double-conversion unwind gtest gtest_main ${LLVM_LIBS} ${LIBLZMA_LIBRARIES})
-  add_dependencies(${unittest}_unittest gtest gtest_main)
   add_dependencies(unittests ${unittest}_unittest)
 endmacro()
 

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -5,7 +5,6 @@ llvm_map_components_to_libnames(LLVM_LIBS_EXTRA BitWriter)
 
 add_executable(publicize publicize.cpp)
 target_link_libraries(publicize curses dl pthread ${LLVM_LIBS} ${LLVM_LIBS_EXTRA}) 
-add_dependencies(publicize ${LLVM_LIBS_EXTRA})
 
 include_directories(${CMAKE_SOURCE_DIR}/src)
 add_executable(astprint EXCLUDE_FROM_ALL astprint.cpp $<TARGET_OBJECTS:PYSTON_OBJECTS> $<TARGET_OBJECTS:FROM_CPYTHON>)


### PR DESCRIPTION
This is done so that cmake knows when a source file has been added or removed, otherwise cmake would have to be manually rerun.