### PR TITLE
Speedup analysis by using llvms more cache friendly map/set algorithms

### DIFF
--- a/src/analysis/function_analysis.h
+++ b/src/analysis/function_analysis.h
@@ -16,8 +16,9 @@
 #define PYSTON_ANALYSIS_FUNCTIONANALYSIS_H
 
 #include <memory>
-#include <unordered_map>
-#include <unordered_set>
+
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
 
 #include "core/stringpool.h"
 #include "core/types.h"
@@ -37,10 +38,10 @@ private:
     CFG* cfg;
 
     friend class LivenessBBVisitor;
-    typedef std::unordered_map<CFGBlock*, std::unique_ptr<LivenessBBVisitor>> LivenessCacheMap;
+    typedef llvm::DenseMap<CFGBlock*, std::unique_ptr<LivenessBBVisitor>> LivenessCacheMap;
     LivenessCacheMap liveness_cache;
 
-    std::unordered_map<InternedString, std::unordered_map<CFGBlock*, bool>> result_cache;
+    llvm::DenseMap<InternedString, llvm::DenseMap<CFGBlock*, bool>> result_cache;
 
 public:
     LivenessAnalysis(CFG* cfg);
@@ -58,11 +59,11 @@ public:
         PotentiallyDefined,
         Defined,
     };
-    typedef std::unordered_set<InternedString> RequiredSet;
+    typedef llvm::DenseSet<InternedString> RequiredSet;
 
 private:
-    std::unordered_map<CFGBlock*, std::unordered_map<InternedString, DefinitionLevel>> results;
-    std::unordered_map<CFGBlock*, const RequiredSet> defined_at_end;
+    llvm::DenseMap<CFGBlock*, llvm::DenseMap<InternedString, DefinitionLevel>> results;
+    llvm::DenseMap<CFGBlock*, RequiredSet> defined_at_end;
     ScopeInfo* scope_info;
 
 public:
@@ -73,13 +74,13 @@ public:
 };
 class PhiAnalysis {
 public:
-    typedef std::unordered_set<InternedString> RequiredSet;
+    typedef llvm::DenseSet<InternedString> RequiredSet;
 
     DefinednessAnalysis definedness;
 
 private:
     LivenessAnalysis* liveness;
-    std::unordered_map<CFGBlock*, const RequiredSet> required_phis;
+    llvm::DenseMap<CFGBlock*, RequiredSet> required_phis;
 
 public:
     PhiAnalysis(const ParamNames&, CFG* cfg, LivenessAnalysis* liveness, ScopeInfo* scope_info);


### PR DESCRIPTION
This change does not change our analysis algorithms but instead speeds them up by using llvms containers. This should not change the generated output.
```
for test/integration/django_test.py
us_compiling_analysis_definedness: 130569 --> 29087
us_compiling_analysis_liveness: 132502 --> 102092
us_compiling_analysis_phis: 229944 --> 188633
us_compiling_analysis_types: 214522 --> 36165
```