### PR TITLE
Rewrite calls into BoxedMethodDescriptors

### DIFF
--- a/microbenchmarks/re_perf.py
+++ b/microbenchmarks/re_perf.py
@@ -1,0 +1,8 @@
+names = ["%s.py" for i in xrange(100)]
+import re
+regex = re.compile(".*.py")
+print type(regex)
+for i in xrange(50000):
+    for n in names:
+        regex.match(n)
+    # fnmatch.filter(names, "*.py")

--- a/src/asm_writing/rewriter.cpp
+++ b/src/asm_writing/rewriter.cpp
@@ -542,6 +542,16 @@ RewriterVar* Rewriter::call(bool can_call_into_python, void* func_addr, Rewriter
     return call(can_call_into_python, func_addr, args, args_xmm);
 }
 
+RewriterVar* Rewriter::call(bool can_call_into_python, void* func_addr, RewriterVar* arg0, RewriterVar* arg1,
+                            RewriterVar* arg2) {
+    RewriterVar::SmallVector args;
+    RewriterVar::SmallVector args_xmm;
+    args.push_back(arg0);
+    args.push_back(arg1);
+    args.push_back(arg2);
+    return call(can_call_into_python, func_addr, args, args_xmm);
+}
+
 static const Location caller_save_registers[]{
     assembler::RAX,   assembler::RCX,   assembler::RDX,   assembler::RSI,   assembler::RDI,
     assembler::R8,    assembler::R9,    assembler::R10,   assembler::R11,   assembler::XMM0,

--- a/src/asm_writing/rewriter.h
+++ b/src/asm_writing/rewriter.h
@@ -459,6 +459,8 @@ public:
     RewriterVar* call(bool can_call_into_python, void* func_addr);
     RewriterVar* call(bool can_call_into_python, void* func_addr, RewriterVar* arg0);
     RewriterVar* call(bool can_call_into_python, void* func_addr, RewriterVar* arg0, RewriterVar* arg1);
+    RewriterVar* call(bool can_call_into_python, void* func_addr, RewriterVar* arg0, RewriterVar* arg1,
+                      RewriterVar* arg2);
     RewriterVar* add(RewriterVar* a, int64_t b, Location dest);
     RewriterVar* allocate(int n);
     RewriterVar* allocateAndCopy(RewriterVar* array, int n);

--- a/src/runtime/types.h
+++ b/src/runtime/types.h
@@ -510,6 +510,24 @@ public:
         memmove(&rtn->elts[0], elts, sizeof(Box*) * nelts);
         return rtn;
     }
+    static BoxedTuple* create1(Box* elt0) {
+        BoxedTuple* rtn = new (1) BoxedTuple(1);
+        rtn->elts[0] = elt0;
+        return rtn;
+    }
+    static BoxedTuple* create2(Box* elt0, Box* elt1) {
+        BoxedTuple* rtn = new (2) BoxedTuple(2);
+        rtn->elts[0] = elt0;
+        rtn->elts[1] = elt1;
+        return rtn;
+    }
+    static BoxedTuple* create3(Box* elt0, Box* elt1, Box* elt2) {
+        BoxedTuple* rtn = new (3) BoxedTuple(3);
+        rtn->elts[0] = elt0;
+        rtn->elts[1] = elt1;
+        rtn->elts[2] = elt2;
+        return rtn;
+    }
     static BoxedTuple* create(std::initializer_list<Box*> members) { return new (members.size()) BoxedTuple(members); }
 
     static BoxedTuple* create(int64_t size, BoxedClass* cls) { return new (cls, size) BoxedTuple(size); }

--- a/test/tests/capi_method_ics.py
+++ b/test/tests/capi_method_ics.py
@@ -1,0 +1,8 @@
+# statcheck: noninit_count("slowpath_runtimecall") <= 10
+# statcheck: noninit_count("slowpath_callattr") <= 10
+# statcheck: noninit_count("slowpath_callfunc") <= 10
+# run_args: -n
+
+import math
+for i in xrange(10000):
+    math.copysign(1, -1)


### PR DESCRIPTION
This involves
- special-casing their `__get__`
- adding some ability to rewrite calls to functions that take *args