### PR TITLE
Misc stuff for pycrypto

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,7 +93,7 @@ endif()
 add_subdirectory(${DEPS_DIR}/llvm-trunk ${CMAKE_BINARY_DIR}/llvm EXCLUDE_FROM_ALL)
 set(CMAKE_MODULE_PATH "${CMAKE_BINARY_DIR}/llvm/share/llvm/cmake/")
 include(LLVMConfig)
-llvm_map_components_to_libnames(LLVM_LIBS core mcjit native bitreader ipo irreader debuginfodwarf instrumentation ${INTEL_JIT_EVENTS_LIB})
+llvm_map_components_to_libnames(LLVM_LIBS core mcjit native bitreader bitwriter ipo irreader debuginfodwarf instrumentation ${INTEL_JIT_EVENTS_LIB})
 
 # libunwind
 if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ else
 	LLVM_BIN := $(LLVM_BUILD)/Release/bin
 endif
 
-LLVM_LINK_LIBS := core mcjit native bitreader ipo irreader debuginfodwarf instrumentation
+LLVM_LINK_LIBS := core mcjit native bitreader bitwriter ipo irreader debuginfodwarf instrumentation
 ifneq ($(ENABLE_INTEL_JIT_EVENTS),0)
 LLVM_LINK_LIBS += inteljitevents
 endif

--- a/from_cpython/Lib/platform.py
+++ b/from_cpython/Lib/platform.py
@@ -155,6 +155,10 @@ def libc_ver(executable=sys.executable,lib='',version='',
         The file is read and scanned in chunks of chunksize bytes.
 
     """
+    # Pyston change: hard code pyston executable libc version
+    if executable == sys.executable:
+        return ("glibc", "2.6")
+
     if hasattr(os.path, 'realpath'):
         # Python 2.2 introduced os.path.realpath(); it is used
         # here to work around problems with Cygwin not being

--- a/src/codegen/entry.cpp
+++ b/src/codegen/entry.cpp
@@ -281,7 +281,7 @@ public:
 
         // Generate a hash for the module
         HashOStream hash_stream;
-        M->print(hash_stream, 0);
+        llvm::WriteBitcodeToFile(M, hash_stream);
         hash_before_codegen = hash_stream.getHash();
 
         llvm::SmallString<128> cache_file = cache_dir;

--- a/src/runtime/builtin_modules/builtins.cpp
+++ b/src/runtime/builtin_modules/builtins.cpp
@@ -750,6 +750,12 @@ Box* divmod(Box* lhs, Box* rhs) {
     return binopInternal(lhs, rhs, AST_TYPE::DivMod, false, NULL);
 }
 
+Box* powFunc(Box* x, Box* y, Box* z) {
+    Box* rtn = PyNumber_Power(x, y, z);
+    checkAndThrowCAPIException();
+    return rtn;
+}
+
 Box* execfile(Box* _fn) {
     // The "globals" and "locals" arguments aren't implemented for now
     if (!isSubclass(_fn->cls, str_cls)) {
@@ -1082,6 +1088,8 @@ void setupBuiltins() {
     Box* hasattr_obj = new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)hasattr, BOXED_BOOL, 2), "hasattr");
     builtins_module->giveAttr("hasattr", hasattr_obj);
 
+    builtins_module->giveAttr("pow", new BoxedBuiltinFunctionOrMethod(
+                                         boxRTFunction((void*)powFunc, UNKNOWN, 3, 1, false, false), "pow", { None }));
 
     Box* isinstance_obj
         = new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)isinstance_func, BOXED_BOOL, 2), "isinstance");

--- a/src/runtime/capi.cpp
+++ b/src/runtime/capi.cpp
@@ -38,9 +38,9 @@ namespace pyston {
 
 BoxedClass* method_cls;
 
-extern "C" bool _PyIndex_Check(PyObject* op) noexcept {
-    // TODO this is wrong (the CPython version checks for things that can be coerced to a number):
-    return PyInt_Check(op);
+extern "C" bool _PyIndex_Check(PyObject* obj) noexcept {
+    return (Py_TYPE(obj)->tp_as_number != NULL && PyType_HasFeature(Py_TYPE(obj), Py_TPFLAGS_HAVE_INDEX)
+            && Py_TYPE(obj)->tp_as_number->nb_index != NULL);
 }
 
 extern "C" bool _PyObject_CheckBuffer(PyObject* obj) noexcept {

--- a/src/runtime/import.cpp
+++ b/src/runtime/import.cpp
@@ -589,7 +589,9 @@ extern "C" PyObject* PyImport_ImportModule(const char* name) noexcept {
     try {
         // TODO: check if this has the same behaviour as the cpython implementation
         std::string str = name;
-        return import(0, None, &str);
+        BoxedList* silly_list = new BoxedList();
+        listAppendInternal(silly_list, boxString("__doc__"));
+        return import(0, silly_list, &str);
     } catch (ExcInfo e) {
         setCAPIException(e);
         return NULL;

--- a/src/runtime/inline/xrange.cpp
+++ b/src/runtime/inline/xrange.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "core/types.h"
+#include "runtime/capi.h"
 #include "runtime/objmodel.h"
 #include "runtime/types.h"
 
@@ -134,25 +135,22 @@ Box* xrange(Box* cls, Box* start, Box* stop, Box** args) {
     Box* step = args[0];
 
     if (stop == NULL) {
-        RELEASE_ASSERT(isSubclass(start->cls, int_cls), "%s", getTypeName(start));
-
-        i64 istop = static_cast<BoxedInt*>(start)->n;
+        i64 istop = PyLong_AsLong(start);
+        checkAndThrowCAPIException();
         return new BoxedXrange(0, istop, 1);
     } else if (step == NULL) {
-        RELEASE_ASSERT(isSubclass(start->cls, int_cls), "%s", getTypeName(start));
-        RELEASE_ASSERT(isSubclass(stop->cls, int_cls), "%s", getTypeName(stop));
-
-        i64 istart = static_cast<BoxedInt*>(start)->n;
-        i64 istop = static_cast<BoxedInt*>(stop)->n;
+        i64 istart = PyLong_AsLong(start);
+        checkAndThrowCAPIException();
+        i64 istop = PyLong_AsLong(stop);
+        checkAndThrowCAPIException();
         return new BoxedXrange(istart, istop, 1);
     } else {
-        RELEASE_ASSERT(isSubclass(start->cls, int_cls), "%s", getTypeName(start));
-        RELEASE_ASSERT(isSubclass(stop->cls, int_cls), "%s", getTypeName(stop));
-        RELEASE_ASSERT(isSubclass(step->cls, int_cls), "%s", getTypeName(step));
-
-        i64 istart = static_cast<BoxedInt*>(start)->n;
-        i64 istop = static_cast<BoxedInt*>(stop)->n;
-        i64 istep = static_cast<BoxedInt*>(step)->n;
+        i64 istart = PyLong_AsLong(start);
+        checkAndThrowCAPIException();
+        i64 istop = PyLong_AsLong(stop);
+        checkAndThrowCAPIException();
+        i64 istep = PyLong_AsLong(step);
+        checkAndThrowCAPIException();
         RELEASE_ASSERT(istep != 0, "step can't be 0");
         return new BoxedXrange(istart, istop, istep);
     }

--- a/src/runtime/long.h
+++ b/src/runtime/long.h
@@ -47,7 +47,7 @@ Box* longAdd(BoxedLong* lhs, Box* rhs);
 Box* longSub(BoxedLong* lhs, Box* rhs);
 Box* longMul(BoxedLong* lhs, Box* rhs);
 Box* longDiv(BoxedLong* lhs, Box* rhs);
-Box* longPow(BoxedLong* lhs, Box* rhs);
+Box* longPow(BoxedLong* lhs, Box* rhs, Box* mod = None);
 Box* longLshift(BoxedLong* lhs, Box* rhs);
 Box* longRshift(BoxedLong* lhs, Box* rhs);
 

--- a/src/runtime/objmodel.cpp
+++ b/src/runtime/objmodel.cpp
@@ -326,6 +326,7 @@ BoxedClass::BoxedClass(BoxedClass* base, gcvisit_func gc_visit, int attrs_offset
     tp_flags |= Py_TPFLAGS_HAVE_GC;
     tp_flags |= Py_TPFLAGS_HAVE_WEAKREFS;
     tp_flags |= Py_TPFLAGS_HAVE_RICHCOMPARE;
+    tp_flags |= Py_TPFLAGS_HAVE_INDEX;
 
     if (base && (base->tp_flags & Py_TPFLAGS_HAVE_NEWBUFFER))
         tp_flags |= Py_TPFLAGS_HAVE_NEWBUFFER;

--- a/src/runtime/str.cpp
+++ b/src/runtime/str.cpp
@@ -2240,9 +2240,10 @@ Box* strEncode(BoxedString* self, Box* encoding, Box* error) {
 extern "C" Box* strGetitem(BoxedString* self, Box* slice) {
     assert(isSubclass(self->cls, str_cls));
 
-    if (isSubclass(slice->cls, int_cls)) {
-        BoxedInt* islice = static_cast<BoxedInt*>(slice);
-        int64_t n = islice->n;
+    if (PyIndex_Check(slice)) {
+        Py_ssize_t n = PyNumber_AsSsize_t(slice, PyExc_IndexError);
+        if (n == -1 && PyErr_Occurred())
+            throwCAPIException();
         int size = self->size();
         if (n < 0)
             n = size + n;

--- a/test/tests/builtins.py
+++ b/test/tests/builtins.py
@@ -40,6 +40,8 @@ print isinstance(1, int)
 print isinstance(1, (float, int))
 print isinstance(1, (float, (), (int, 3), 4))
 
+print pow(11, 42)
+print pow(11, 42, 75)
 print divmod(5, 2)
 print divmod(5L, -2)
 try:

--- a/test/tests/gcj_2014_2_d.py
+++ b/test/tests/gcj_2014_2_d.py
@@ -1,6 +1,3 @@
-# expected: fail
-# - long % int
-
 import sys
 
 P = 1000000007

--- a/test/tests/index_meth.py
+++ b/test/tests/index_meth.py
@@ -1,0 +1,14 @@
+class Index(object):
+    def __init__(self, i):
+        self.i = i
+
+    def __index__(self):
+        print "called __index__"
+        return self.i
+
+s = "String"
+l = [1, 2, "List"]
+t = (1, 2, "Tuple")
+print s[Index(2L)]
+print l[Index(2L)]
+print t[Index(2L)]

--- a/test/tests/intmethods.py
+++ b/test/tests/intmethods.py
@@ -13,6 +13,9 @@ for i in xrange(1, 12):
 print 1 ** 0
 print 0 ** 0
 print -1 ** 0
+print (11).__pow__(5, 50)
+print (11).__pow__(32, 50)
+print (11).__index__()
 
 for i in (-10, 10, 0, -15):
     print i, i.__hex__(), i.__oct__()

--- a/test/tests/list.py
+++ b/test/tests/list.py
@@ -4,6 +4,7 @@ print l * 5
 l[0] = 1
 print l
 print l[2]
+print l[2L]
 
 l = range(5)
 while l:

--- a/test/tests/long.py
+++ b/test/tests/long.py
@@ -13,6 +13,7 @@ def test(a, b):
     print a - b, b - a, a.__sub__(b), b.__sub__(a)
     print a * b, b * a, a.__mul__(b), b.__mul__(a)
     print a / b, b / a, a.__div__(b), b.__div__(a)
+    print a % b, b % a, a.__mod__(b), b.__mod__(a)
     print repr(a), repr(b), a < b, a > b, a <= b, a >= b, a == b, a != b
     if not isinstance(a, float) and not isinstance(b, float):
         print a ^ b, a | b, a & b
@@ -55,10 +56,15 @@ print ~(-10L)
 print -(1L)
 print 1L**2L
 print 1L**2
+print (11L).__pow__(32, 50L)
+print (11L).__index__()
 
 print long("100", 16)
 print long("100", 10)
 print long("100", 26)
+print long("0x100", 16), long("0100", 8), long("0b100", 2)
+print long("0x100", 0), long("0100", 0), long("0b100", 0)
+print long("0b100", 16), long("0b100L", 0), long("-0b100L", 0)
 print long(-1.1)
 print long(1.9)
 print long(-1.9)

--- a/test/tests/tuples.py
+++ b/test/tests/tuples.py
@@ -133,6 +133,7 @@ except TypeError, e:
 t = (1, "2")
 print t[0]
 print t[1]
+print t[1L]
 
 t = (1, 2, 'a', 'b', 'c')
 print t[::-1]

--- a/test/tests/xrange.py
+++ b/test/tests/xrange.py
@@ -15,3 +15,6 @@ for i in xrange(10, -10, -3):
 
 for i in xrange(0):
     print i
+
+for i in xrange(10L, 15L, 1L):
+    print i


### PR DESCRIPTION
Add ```pow()```, ```long.__mod__```, ```__index__```, slice and xrange long arg support,
support for 3arg pow, long("0xBB", 16) and long("0xBBL", 0)

Support for ```__eq__``` method overwriting for old style classes is still missing, but when that's in place we fail only 2 out of 1820 pycrypto tests.