### PR TITLE
Stats

### DIFF
--- a/src/codegen/entry.cpp
+++ b/src/codegen/entry.cpp
@@ -362,6 +362,7 @@ static void handle_sigint(int signum) {
     // For now, just call abort(), so that we get a traceback at least.
     fprintf(stderr, "SIGINT!\n");
     joinRuntime();
+    Stats::dump();
     abort();
 }
 

--- a/src/codegen/entry.cpp
+++ b/src/codegen/entry.cpp
@@ -361,6 +361,7 @@ static void handle_sigint(int signum) {
     // TODO: this should set a flag saying a KeyboardInterrupt is pending.
     // For now, just call abort(), so that we get a traceback at least.
     fprintf(stderr, "SIGINT!\n");
+    joinRuntime();
     abort();
 }
 

--- a/src/core/stats.cpp
+++ b/src/core/stats.cpp
@@ -51,7 +51,7 @@ int Stats::getStatId(const std::string& name) {
     return rtn;
 }
 
-void Stats::dump() {
+void Stats::dump(bool includeZeros) {
     if (!Stats::enabled)
         return;
 
@@ -65,7 +65,8 @@ void Stats::dump() {
     std::sort(pairs.begin(), pairs.end());
 
     for (int i = 0; i < pairs.size(); i++) {
-        printf("%s: %ld\n", pairs[i].first.c_str(), (*counts)[pairs[i].second]);
+        if (includeZeros || (*counts)[pairs[i].second] > 0)
+            printf("%s: %ld\n", pairs[i].first.c_str(), (*counts)[pairs[i].second]);
     }
 }
 

--- a/src/core/stats.cpp
+++ b/src/core/stats.cpp
@@ -23,6 +23,7 @@ namespace pyston {
 #if !DISABLE_STATS
 std::vector<long>* Stats::counts;
 std::unordered_map<int, std::string>* Stats::names;
+bool Stats::enabled;
 StatCounter::StatCounter(const std::string& name) : id(Stats::getStatId(name)) {
 }
 
@@ -51,6 +52,9 @@ int Stats::getStatId(const std::string& name) {
 }
 
 void Stats::dump() {
+    if (!Stats::enabled)
+        return;
+
     printf("Stats:\n");
 
     std::vector<std::pair<std::string, int>> pairs;

--- a/src/core/stats.h
+++ b/src/core/stats.h
@@ -32,10 +32,12 @@ struct Stats {
 private:
     static std::vector<long>* counts;
     static std::unordered_map<int, std::string>* names;
+    static bool enabled;
 
 public:
     static int getStatId(const std::string& name);
 
+    static void setEnabled(bool enabled) { Stats::enabled = enabled; }
     static void log(int id, int count = 1) { (*counts)[id] += count; }
 
     static void dump();
@@ -64,6 +66,7 @@ public:
 
 #else
 struct Stats {
+    static void setEnabled(bool enabled) {}
     static void dump() { printf("(Stats disabled)\n"); }
     static void log(int id, int count = 1) {}
     static int getStatId(const std::string& name) { return 0; }

--- a/src/core/stats.h
+++ b/src/core/stats.h
@@ -41,7 +41,7 @@ public:
     static void log(int id, int count = 1) { (*counts)[id] += count; }
 
     static void clear() { std::fill(counts->begin(), counts->end(), 0); }
-    static void dump();
+    static void dump(bool includeZeros = true);
     static void endOfInit();
 };
 

--- a/src/core/stats.h
+++ b/src/core/stats.h
@@ -40,6 +40,7 @@ public:
     static void setEnabled(bool enabled) { Stats::enabled = enabled; }
     static void log(int id, int count = 1) { (*counts)[id] += count; }
 
+    static void clear() { std::fill(counts->begin(), counts->end(), 0); }
     static void dump();
     static void endOfInit();
 };

--- a/src/jit.cpp
+++ b/src/jit.cpp
@@ -95,7 +95,6 @@ static int main(int argc, char** argv) {
 
     int code;
     bool force_repl = false;
-    bool stats = false;
     bool unbuffered = false;
     const char* command = NULL;
 
@@ -123,7 +122,7 @@ static int main(int argc, char** argv) {
         } else if (code == 'j') {
             DUMPJIT = true;
         } else if (code == 's') {
-            stats = true;
+            Stats::setEnabled(true);
         } else if (code == 'S') {
             Py_NoSiteFlag = 1;
         } else if (code == 'u') {
@@ -241,8 +240,7 @@ static int main(int argc, char** argv) {
         } catch (ExcInfo e) {
             int retcode = 1;
             (void)handle_toplevel_exn(e, &retcode);
-            if (stats)
-                Stats::dump();
+            Stats::dump();
             return retcode;
         }
     }
@@ -269,8 +267,7 @@ static int main(int argc, char** argv) {
             int retcode = 1;
             (void)handle_toplevel_exn(e, &retcode);
             if (!force_repl) {
-                if (stats)
-                    Stats::dump();
+                Stats::dump();
                 return retcode;
             }
         }
@@ -320,8 +317,7 @@ static int main(int argc, char** argv) {
             } catch (ExcInfo e) {
                 int retcode = 0xdeadbeef; // should never be seen
                 if (handle_toplevel_exn(e, &retcode)) {
-                    if (stats)
-                        Stats::dump();
+                    Stats::dump();
                     return retcode;
                 }
             }
@@ -340,8 +336,7 @@ static int main(int argc, char** argv) {
     int rtncode = joinRuntime();
     _t.split("finishing up");
 
-    if (stats)
-        Stats::dump();
+    Stats::dump();
 
     return rtncode;
 }

--- a/src/runtime/builtin_modules/pyston.cpp
+++ b/src/runtime/builtin_modules/pyston.cpp
@@ -53,8 +53,11 @@ static Box* clearStats() {
     return None;
 }
 
-static Box* dumpStats() {
-    Stats::dump();
+static Box* dumpStats(Box* includeZeros) {
+    if (includeZeros->cls != bool_cls)
+        raiseExcHelper(TypeError, "includeZeros must be a 'bool' object but received a '%s'",
+                       getTypeName(includeZeros));
+    Stats::dump(((BoxedBool*)includeZeros)->n != 0);
     return None;
 }
 
@@ -67,6 +70,7 @@ void setupPyston() {
     pyston_module->giveAttr("clearStats",
                             new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)clearStats, NONE, 0), "clearStats"));
     pyston_module->giveAttr("dumpStats",
-                            new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)dumpStats, NONE, 0), "dumpStats"));
+                            new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)dumpStats, NONE, 1, 1, false, false),
+                                                             "dumpStats", { False }));
 }
 }

--- a/src/runtime/builtin_modules/pyston.cpp
+++ b/src/runtime/builtin_modules/pyston.cpp
@@ -48,10 +48,25 @@ static Box* setOption(Box* option, Box* value) {
     return None;
 }
 
+static Box* clearStats() {
+    Stats::clear();
+    return None;
+}
+
+static Box* dumpStats() {
+    Stats::dump();
+    return None;
+}
+
 void setupPyston() {
     pyston_module = createModule("__pyston__", "__builtin__");
 
     pyston_module->giveAttr("setOption",
                             new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)setOption, UNKNOWN, 2), "setOption"));
+
+    pyston_module->giveAttr("clearStats",
+                            new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)clearStats, NONE, 0), "clearStats"));
+    pyston_module->giveAttr("dumpStats",
+                            new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)dumpStats, NONE, 0), "dumpStats"));
 }
 }


### PR DESCRIPTION
Adds some useful features for stats collection:

1. outputs the stats even if you Ctrl-C
2. adds Stats::clear(), which just resets the counters to 0 (without removing their names)
3. Stats::dump() now takes a bool argument, if `true` (the default) we output the 0's, otherwise we don't.
3. exposes `__pyston__.dumpStats`/`__pyston__.clearStats` so we can call them from python code

also snuck in a joinRuntime call in the SIGINT handling, so we dump the perf maps when exiting that way as well.