### PR TITLE
Add a pycrypto integration test

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "lz4"]
 	path = lz4
 	url = git://github.com/Cyan4973/lz4.git
+[submodule "test/integration/pycrypto"]
+	path = test/integration/pycrypto
+	url = https://github.com/dlitz/pycrypto.git

--- a/from_cpython/Include/longobject.h
+++ b/from_cpython/Include/longobject.h
@@ -138,6 +138,15 @@ PyAPI_FUNC(PyObject *) _PyLong_FormatAdvanced(PyObject *obj,
 					      char *format_spec,
 					      Py_ssize_t format_spec_len) PYSTON_NOEXCEPT;
 
+// Pyston change: Pyston specific API
+#define Py_HAVE_LONG_MPZ_API 1
+/* _PyLongMPZ: alias for mpz_src, used to not have to pull in the GMP header. */
+typedef void* _PyLongMPZ;
+/* _PyLong_AsMPZ: Sets the supplied initialized GMP mpz to the value of the supplied long object. */
+PyAPI_FUNC(void) _PyLong_AsMPZ(PyObject *, _PyLongMPZ) PYSTON_NOEXCEPT;
+/* _PyLong_FromMPZ: Creates a python long object from the supplied GMP mpz value. */
+PyAPI_FUNC(PyObject *) _PyLong_FromMPZ(const _PyLongMPZ) PYSTON_NOEXCEPT;
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/codegen/irgen/hooks.cpp
+++ b/src/codegen/irgen/hooks.cpp
@@ -552,7 +552,7 @@ void CompiledFunction::speculationFailed() {
 
     this->times_speculation_failed++;
 
-    if (this->times_speculation_failed >= 4) {
+    if (this->times_speculation_failed == 4) {
         // printf("Killing %p because it failed too many speculations\n", this);
 
         CLFunction* cl = this->clfunc;

--- a/src/runtime/classobj.cpp
+++ b/src/runtime/classobj.cpp
@@ -511,6 +511,26 @@ static PyObject* instance_index(PyObject* self) noexcept {
     return res;
 }
 
+Box* instanceEq(Box* _inst, Box* other) {
+    RELEASE_ASSERT(_inst->cls == instance_cls, "");
+    BoxedInstance* inst = static_cast<BoxedInstance*>(_inst);
+
+    Box* func = _instanceGetattribute(inst, boxStrConstant("__eq__"), false);
+    if (!func)
+        return NotImplemented;
+    return runtimeCall(func, ArgPassSpec(1), other, NULL, NULL, NULL, NULL);
+}
+
+Box* instanceNe(Box* _inst, Box* other) {
+    RELEASE_ASSERT(_inst->cls == instance_cls, "");
+    BoxedInstance* inst = static_cast<BoxedInstance*>(_inst);
+
+    Box* func = _instanceGetattribute(inst, boxStrConstant("__ne__"), false);
+    if (!func)
+        return NotImplemented;
+    return runtimeCall(func, ArgPassSpec(1), other, NULL, NULL, NULL, NULL);
+}
+
 Box* instanceCall(Box* _inst, Box* _args, Box* _kwargs) {
     assert(_inst->cls == instance_cls);
     BoxedInstance* inst = static_cast<BoxedInstance*>(_inst);
@@ -560,6 +580,8 @@ void setupClassobj() {
     instance_cls->giveAttr("__hash__", new BoxedFunction(boxRTFunction((void*)instanceHash, UNKNOWN, 1)));
     instance_cls->giveAttr("__call__",
                            new BoxedFunction(boxRTFunction((void*)instanceCall, UNKNOWN, 1, 0, true, true)));
+    instance_cls->giveAttr("__eq__", new BoxedFunction(boxRTFunction((void*)instanceEq, UNKNOWN, 2)));
+    instance_cls->giveAttr("__ne__", new BoxedFunction(boxRTFunction((void*)instanceNe, UNKNOWN, 2)));
 
     instance_cls->freeze();
     instance_cls->tp_getattro = instance_getattro;

--- a/src/runtime/long.cpp
+++ b/src/runtime/long.cpp
@@ -452,6 +452,17 @@ extern "C" PyObject* _PyLong_FromByteArray(const unsigned char* bytes, size_t n,
     return rtn;
 }
 
+extern "C" void _PyLong_AsMPZ(PyObject* obj, _PyLongMPZ num) noexcept {
+    RELEASE_ASSERT(obj->cls == long_cls, "needs a long argument");
+    mpz_set((mpz_ptr)num, ((BoxedLong*)obj)->n);
+}
+
+extern "C" PyObject* _PyLong_FromMPZ(const _PyLongMPZ num) noexcept {
+    BoxedLong* r = new BoxedLong();
+    mpz_init_set(r->n, (mpz_srcptr)num);
+    return r;
+}
+
 extern "C" Box* createLong(const std::string* s) {
     BoxedLong* rtn = new BoxedLong();
     int r = mpz_init_set_str(rtn->n, s->c_str(), 10);

--- a/src/runtime/types.cpp
+++ b/src/runtime/types.cpp
@@ -2242,6 +2242,7 @@ void setupRuntime() {
     function_cls->giveAttr("func_code", new (pyston_getset_cls) BoxedGetsetDescriptor(functionCode, NULL, NULL));
     function_cls->giveAttr("func_defaults",
                            new (pyston_getset_cls) BoxedGetsetDescriptor(functionDefaults, NULL, NULL));
+    function_cls->giveAttr("func_name", function_cls->getattr("__name__"));
     function_cls->freeze();
 
     builtin_function_or_method_cls->giveAttr(

--- a/test/integration/pycrypto_0001-fastmath-Add-support-for-Pyston.patch
+++ b/test/integration/pycrypto_0001-fastmath-Add-support-for-Pyston.patch
@@ -1,0 +1,59 @@
+From 7303cd6db08b41a513bbd45aad0676a47eb3820a Mon Sep 17 00:00:00 2001
+From: Marius Wachtler <undingen@gmail.com>
+Date: Tue, 28 Apr 2015 11:49:32 +0200
+Subject: [PATCH] fastmath: Add support for Pyston
+
+---
+ src/_fastmath.c | 21 +++++++++++++++++++++
+ 1 file changed, 21 insertions(+)
+
+diff --git a/src/_fastmath.c b/src/_fastmath.c
+index e369f5a..c4cf2aa 100644
+--- a/src/_fastmath.c
++++ b/src/_fastmath.c
+@@ -29,7 +29,14 @@
+ #include "pycrypto_common.h"
+ #include <stdio.h>
+ #include <string.h>
++
++#ifdef Py_HAVE_LONG_MPZ_API
++#ifndef HAVE_LIBGMP
++#error Pyston only supports GMP.
++#endif
++#else
+ #include <longintrepr.h>				/* for conversions */
++#endif
+ #if HAVE_LIBGMP
+ # include <gmp.h>
+ #elif HAVE_LIBMPIR
+@@ -60,6 +67,19 @@
+ static unsigned int sieve_base[10000];
+ static int rabinMillerTest (mpz_t n, int rounds, PyObject *randfunc);
+ 
++#ifdef Py_HAVE_LONG_MPZ_API
++static void
++longObjToMPZ (mpz_t m, PyLongObject * p)
++{
++    _PyLong_AsMPZ ((PyObject*)p, m);
++}
++
++static PyObject *
++mpzToLongObj (mpz_t m)
++{
++    return _PyLong_FromMPZ (m);
++}
++#else
+ static void
+ longObjToMPZ (mpz_t m, PyLongObject * p)
+ {
+@@ -113,6 +133,7 @@ mpzToLongObj (mpz_t m)
+ 	mpz_clear (temp);
+ 	return (PyObject *) l;
+ }
++#endif
+ 
+ typedef struct
+ {
+-- 
+2.1.0
+

--- a/test/integration/pycrypto_test.py
+++ b/test/integration/pycrypto_test.py
@@ -1,0 +1,58 @@
+import subprocess, sys, os, shutil, StringIO
+
+pycrypto_dir = os.path.dirname(os.path.abspath(__file__)) + "/pycrypto"
+os.chdir(pycrypto_dir)
+
+for d in ("build", "install"):
+    if os.path.exists(d):
+         print "Removing the existing", d, "directory"
+         shutil.rmtree(d)
+
+devnull = open(os.devnull, "w")
+
+
+print "-- Patching pycrypto"
+patches = ["../pycrypto_0001-fastmath-Add-support-for-Pyston.patch"]
+for patch in patches:
+    out = StringIO.StringIO()
+    try:
+        cmd = ["patch", "-p1", "--forward", "-i", patch]
+        subprocess.check_output(cmd, stderr=subprocess.STDOUT)
+    except subprocess.CalledProcessError as e:
+        print e.output
+        if "Reversed (or previously applied) patch detected!  Skipping patch" not in e.output:
+            raise e
+
+print "-- Building pycrypto" 
+subprocess.check_call([sys.executable, "setup.py", "build"], stdout=devnull)
+
+print "-- Installing pycrypto" 
+subprocess.check_call([sys.executable, "setup.py", "install", "--prefix=install"], stdout=devnull)
+
+print "-- Testing pycrypto"
+sys.path.append("install/site-packages")
+
+test_string = "test string".ljust(16)
+
+from Crypto.Hash import SHA256, MD5
+assert SHA256.new(test_string).hexdigest() == "edce3184097ede907d91c4069c55104785a3a989b9706e5919202d6f5fe2d814"
+assert MD5.new(test_string).hexdigest() == "e135865bb047e78e1827b0cf83696725"
+
+from Crypto.Cipher import AES
+aes1 = AES.new("pwd1__0123456789")
+aes2 = AES.new("pwd2__0123456789")
+enc_data = aes1.encrypt(test_string)
+enc_data2 = aes2.encrypt(test_string)
+assert enc_data != enc_data2
+assert aes1.decrypt(enc_data) == test_string
+assert aes2.decrypt(enc_data2) == test_string
+
+from Crypto.PublicKey import RSA
+from Crypto import Random
+key = RSA.generate(1024, Random.new().read)
+public_key = key.publickey()
+enc_data = public_key.encrypt(test_string, 32)
+assert enc_data != test_string
+assert key.decrypt(enc_data) == test_string
+
+print "-- Tests finished"

--- a/test/tests/functions.py
+++ b/test/tests/functions.py
@@ -12,4 +12,10 @@ def g():
 print type(f).__call__(f)
 print type(f).__call__(g)
 
+print f.__name__, f.func_name
+f.__name__ = "New name"
+print f.__name__, f.func_name
+f.func_name = "f"
+print f.__name__, f.func_name
+
 print bool(f)

--- a/test/tests/oldstyle_classes.py
+++ b/test/tests/oldstyle_classes.py
@@ -55,6 +55,14 @@ class E():
             print "f", a
         return f
 
+    def __eq__(self, other):
+        print "eq"
+        return self.n == other.n
+
+    def __ne__(self, other):
+        print "ne"
+        return self.n != other.n
+
 e = E(1)
 print e
 print e.n
@@ -63,6 +71,8 @@ print e[1]
 print e[1:2]
 print len(e)
 print e()("test")
+print e == E(1)
+print e != E(1)
 
 def str2():
     return "str2"
@@ -82,6 +92,8 @@ class F:
 
 print bool(F(0))
 print bool(F(1))
+print F(0) == F(0)
+print F(0) != F(0)
 
 f = F(0)
 try:


### PR DESCRIPTION
Adds:
- pycrypto integration test
- pyston specific CAPI extension for converting between a python longs and GMP
- old style classes support for ```__eq__``` and ```__ne__```
- cancel OSR if number of live syms exceeds 225

With this changes all pycrypto tests succeed
