### PR TITLE
Add support for specifying the encoding inside source files.

### DIFF
--- a/from_cpython/Include/fileobject.h
+++ b/from_cpython/Include/fileobject.h
@@ -51,7 +51,7 @@ PyAPI_FUNC(PyObject *) PyFile_FromString(char *, char *) PYSTON_NOEXCEPT;
 PyAPI_FUNC(void) PyFile_SetBufSize(PyObject *, int) PYSTON_NOEXCEPT;
 PyAPI_FUNC(int) PyFile_SetEncoding(PyObject *, const char *) PYSTON_NOEXCEPT;
 PyAPI_FUNC(int) PyFile_SetEncodingAndErrors(PyObject *, const char *, char *errors) PYSTON_NOEXCEPT;
-PyAPI_FUNC(PyObject *) PyFile_FromFile(FILE *, char *, char *,
+PyAPI_FUNC(PyObject *) PyFile_FromFile(FILE *, const char *, const char *,
                                              int (*)(FILE *)) PYSTON_NOEXCEPT;
 PyAPI_FUNC(FILE *) PyFile_AsFile(PyObject *) PYSTON_NOEXCEPT;
 PyAPI_FUNC(void) PyFile_IncUseCount(PyFileObject *) PYSTON_NOEXCEPT;

--- a/src/codegen/parser.cpp
+++ b/src/codegen/parser.cpp
@@ -973,6 +973,7 @@ AST_Module* parse_string(const char* code) {
 
     FILE* f = fopen(tmp.c_str(), "w");
     fwrite(code, 1, size, f);
+    fputc('\n', f);
     fclose(f);
 
     AST_Module* m = parse_file(tmp.c_str());

--- a/src/gc/collector.cpp
+++ b/src/gc/collector.cpp
@@ -136,6 +136,12 @@ void registerPermanentRoot(void* obj, bool allow_duplicates) {
     roots.insert(obj);
 }
 
+void deregisterPermanentRoot(void* obj) {
+    assert(global_heap.getAllocationFromInteriorPointer(obj));
+    ASSERT(roots.count(obj), "");
+    roots.erase(obj);
+}
+
 extern "C" PyObject* PyGC_AddRoot(PyObject* obj) noexcept {
     if (obj) {
         // Allow duplicates from CAPI code since they shouldn't have to know

--- a/src/gc/collector.h
+++ b/src/gc/collector.h
@@ -26,6 +26,8 @@ namespace gc {
 // (Note: this marks the gc allocation itself, not the pointer that points to one.  For that, use
 // a GCRootHandle)
 void registerPermanentRoot(void* root_obj, bool allow_duplicates = false);
+void deregisterPermanentRoot(void* root_obj);
+
 // Register an object that was not allocated through this collector, as a root for this collector.
 // The motivating usecase is statically-allocated PyTypeObject objects, which are full Python objects
 // even if they are not heap allocated.

--- a/src/runtime/file.cpp
+++ b/src/runtime/file.cpp
@@ -1134,7 +1134,7 @@ extern "C" void PyFile_SetFP(PyObject* _f, FILE* fp) noexcept {
     f->f_fp = fp;
 }
 
-extern "C" PyObject* PyFile_FromFile(FILE* fp, char* name, char* mode, int (*close)(FILE*)) noexcept {
+extern "C" PyObject* PyFile_FromFile(FILE* fp, const char* name, const char* mode, int (*close)(FILE*)) noexcept {
     return new BoxedFile(fp, name, mode, close);
 }
 

--- a/test/tests/coding_cp1252.py
+++ b/test/tests/coding_cp1252.py
@@ -1,0 +1,3 @@
+# coding: cp1252
+s = u"€"
+print ord(s), s

--- a/test/tests/coding_koi8.py
+++ b/test/tests/coding_koi8.py
@@ -1,0 +1,7 @@
+# -*- coding: koi8-r -*-
+def test(s):
+    print s, "len:", len(s)
+    for c in s:
+        print hex(ord(c)),
+    print ""
+test(u"Питон".encode("utf8"))


### PR DESCRIPTION
I expect that there are still bugs hiding but at least the pyston tests pass and pyxl helloworld works.

This patch depends on a not yet merged pypa change https://github.com/vinzenz/libpypa/pull/31 so is not yet ready for merging.