### PR TITLE
Add PyGC_AddRoot calls any time we assign to a static variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -529,6 +529,7 @@ quick_check:
 	$(MAKE) pyston_dbg
 	$(MAKE) check_format
 	$(MAKE) unittests
+	$(MAKE) ext_pyston ext_python
 	$(PYTHON) $(TOOLS_DIR)/tester.py -R pyston_dbg -j$(TEST_THREADS) -a=-S -k --order-by-mtime $(TESTS_DIR) $(ARGS)
 	$(PYTHON) $(TOOLS_DIR)/tester.py -R pyston_dbg -j$(TEST_THREADS) -a=-S -k --exit-code-only --skip-failing $(TEST_DIR)/cpython $(ARGS)
 

--- a/from_cpython/Modules/_csv.c
+++ b/from_cpython/Modules/_csv.c
@@ -1603,7 +1603,7 @@ init_csv(void)
         return;
 
     /* Add _dialects dictionary */
-    dialects = PyDict_New();
+    dialects = PyGC_AddRoot(PyDict_New());
     if (dialects == NULL)
         return;
     if (PyModule_AddObject(module, "_dialects", dialects))
@@ -1622,7 +1622,7 @@ init_csv(void)
         return;
 
     /* Add the CSV exception object to the module. */
-    error_obj = PyErr_NewException("_csv.Error", NULL, NULL);
+    error_obj = PyGC_AddRoot(PyErr_NewException("_csv.Error", NULL, NULL));
     if (error_obj == NULL)
         return;
     PyModule_AddObject(module, "Error", error_obj);

--- a/from_cpython/Modules/_io/bufferedio.c
+++ b/from_cpython/Modules/_io/bufferedio.c
@@ -730,7 +730,7 @@ _PyIO_trap_eintr(void)
     PyEnvironmentErrorObject *env_err;
 
     if (eintr_int == NULL) {
-        eintr_int = PyLong_FromLong(EINTR);
+        eintr_int = PyGC_AddRoot(PyLong_FromLong(EINTR));
         assert(eintr_int != NULL);
     }
     if (!PyErr_ExceptionMatches(PyExc_EnvironmentError))

--- a/from_cpython/Modules/_ssl.c
+++ b/from_cpython/Modules/_ssl.c
@@ -1777,9 +1777,9 @@ init_ssl(void)
     OpenSSL_add_all_algorithms();
 
     /* Add symbols to module dict */
-    PySSLErrorObject = PyErr_NewException("ssl.SSLError",
+    PySSLErrorObject = PyGC_AddRoot(PyErr_NewException("ssl.SSLError",
                                           PySocketModule.error,
-                                          NULL);
+                                          NULL));
     if (PySSLErrorObject == NULL)
         return;
     if (PyDict_SetItemString(d, "SSLError", PySSLErrorObject) != 0)

--- a/from_cpython/Modules/_struct.c
+++ b/from_cpython/Modules/_struct.c
@@ -2077,7 +2077,7 @@ init_struct(void)
 
     /* Add some symbolic constants to the module */
     if (StructError == NULL) {
-        StructError = PyErr_NewException("struct.error", NULL, NULL);
+        StructError = PyGC_AddRoot(PyErr_NewException("struct.error", NULL, NULL));
         if (StructError == NULL)
             return;
     }

--- a/from_cpython/Modules/binascii.c
+++ b/from_cpython/Modules/binascii.c
@@ -1511,8 +1511,8 @@ initbinascii(void)
     PyDict_SetItemString(d, "__doc__", x);
     Py_XDECREF(x);
 
-    Error = PyErr_NewException("binascii.Error", NULL, NULL);
+    Error = PyGC_AddRoot(PyErr_NewException("binascii.Error", NULL, NULL));
     PyDict_SetItemString(d, "Error", Error);
-    Incomplete = PyErr_NewException("binascii.Incomplete", NULL, NULL);
+    Incomplete = PyGC_AddRoot(PyErr_NewException("binascii.Incomplete", NULL, NULL));
     PyDict_SetItemString(d, "Incomplete", Incomplete);
 }

--- a/from_cpython/Modules/datetimemodule.c
+++ b/from_cpython/Modules/datetimemodule.c
@@ -3936,7 +3936,7 @@ datetime_strptime(PyObject *cls, PyObject *args)
         return NULL;
 
     if (module == NULL &&
-        (module = PyImport_ImportModuleNoBlock("_strptime")) == NULL)
+        (module = PyGC_AddRoot(PyImport_ImportModuleNoBlock("_strptime"))) == NULL)
         return NULL;
 
     /* _strptime._strptime returns a two-element tuple.  The first

--- a/from_cpython/Modules/posixmodule.c
+++ b/from_cpython/Modules/posixmodule.c
@@ -4935,7 +4935,7 @@ _PyPopen(char *cmdstring, int mode, int n, int bufsize)
      */
     if (!_PyPopenProcs)
     {
-        _PyPopenProcs = PyDict_New();
+        _PyPopenProcs = PyGC_AddRoot(PyDict_New());
     }
 
     if (_PyPopenProcs)
@@ -5682,7 +5682,7 @@ _PyPopen(char *cmdstring, int mode, int n)
       * and variable number of files involved.
       */
      if (!_PyPopenProcs) {
-         _PyPopenProcs = PyDict_New();
+         _PyPopenProcs = PyGC_AddRoot(PyDict_New());
      }
 
      if (_PyPopenProcs) {
@@ -6105,7 +6105,7 @@ wait_helper(pid_t pid, int status, struct rusage *ru)
         PyObject *m = PyImport_ImportModuleNoBlock("resource");
         if (m == NULL)
             return NULL;
-        struct_rusage = PyObject_GetAttrString(m, "struct_rusage");
+        struct_rusage = PyGC_AddRoot(PyObject_GetAttrString(m, "struct_rusage"));
         Py_DECREF(m);
         if (struct_rusage == NULL)
             return NULL;

--- a/from_cpython/Modules/resource.c
+++ b/from_cpython/Modules/resource.c
@@ -254,8 +254,8 @@ initresource(void)
 
     /* Add some symbolic constants to the module */
     if (ResourceError == NULL) {
-        ResourceError = PyErr_NewException("resource.error",
-                                           NULL, NULL);
+        ResourceError = PyGC_AddRoot(PyErr_NewException("resource.error",
+                                           NULL, NULL));
     }
     Py_INCREF(ResourceError);
     PyModule_AddObject(m, "error", ResourceError);

--- a/from_cpython/Modules/selectmodule.c
+++ b/from_cpython/Modules/selectmodule.c
@@ -1807,7 +1807,7 @@ initselect(void)
     if (m == NULL)
         return;
 
-    SelectError = PyErr_NewException("select.error", NULL, NULL);
+    SelectError = PyGC_AddRoot(PyErr_NewException("select.error", NULL, NULL));
     Py_INCREF(SelectError);
     PyModule_AddObject(m, "error", SelectError);
 

--- a/from_cpython/Modules/signalmodule.c
+++ b/from_cpython/Modules/signalmodule.c
@@ -587,11 +587,11 @@ initsignal(void)
     /* Add some symbolic constants to the module */
     d = PyModule_GetDict(m);
 
-    x = DefaultHandler = PyLong_FromVoidPtr((void *)SIG_DFL);
+    x = DefaultHandler = PyGC_AddRoot(PyLong_FromVoidPtr((void *)SIG_DFL));
     if (!x || PyDict_SetItemString(d, "SIG_DFL", x) < 0)
         goto finally;
 
-    x = IgnoreHandler = PyLong_FromVoidPtr((void *)SIG_IGN);
+    x = IgnoreHandler = PyGC_AddRoot(PyLong_FromVoidPtr((void *)SIG_IGN));
     if (!x || PyDict_SetItemString(d, "SIG_IGN", x) < 0)
         goto finally;
 
@@ -600,7 +600,7 @@ initsignal(void)
         goto finally;
     Py_DECREF(x);
 
-    x = IntHandler = PyDict_GetItemString(d, "default_int_handler");
+    x = IntHandler = PyGC_AddRoot(PyDict_GetItemString(d, "default_int_handler"));
     if (!x)
         goto finally;
     Py_INCREF(IntHandler);
@@ -834,8 +834,8 @@ initsignal(void)
 #endif
 
 #if defined (HAVE_SETITIMER) || defined (HAVE_GETITIMER)
-    ItimerError = PyErr_NewException("signal.ItimerError",
-     PyExc_IOError, NULL);
+    ItimerError = PyGC_AddRoot(PyErr_NewException("signal.ItimerError",
+     PyExc_IOError, NULL));
     if (ItimerError != NULL)
     PyDict_SetItemString(d, "ItimerError", ItimerError);
 #endif

--- a/from_cpython/Modules/socketmodule.c
+++ b/from_cpython/Modules/socketmodule.c
@@ -4588,27 +4588,27 @@ init_socket(void)
     if (m == NULL)
         return;
 
-    socket_error = PyErr_NewException("socket.error",
-                                      PyExc_IOError, NULL);
+    socket_error = PyGC_AddRoot(PyErr_NewException("socket.error",
+                                      PyExc_IOError, NULL));
     if (socket_error == NULL)
         return;
     PySocketModuleAPI.error = socket_error;
     Py_INCREF(socket_error);
     PyModule_AddObject(m, "error", socket_error);
-    socket_herror = PyErr_NewException("socket.herror",
-                                       socket_error, NULL);
+    socket_herror = PyGC_AddRoot(PyErr_NewException("socket.herror",
+                                       socket_error, NULL));
     if (socket_herror == NULL)
         return;
     Py_INCREF(socket_herror);
     PyModule_AddObject(m, "herror", socket_herror);
-    socket_gaierror = PyErr_NewException("socket.gaierror", socket_error,
-        NULL);
+    socket_gaierror = PyGC_AddRoot(PyErr_NewException("socket.gaierror", socket_error,
+        NULL));
     if (socket_gaierror == NULL)
         return;
     Py_INCREF(socket_gaierror);
     PyModule_AddObject(m, "gaierror", socket_gaierror);
-    socket_timeout = PyErr_NewException("socket.timeout",
-                                        socket_error, NULL);
+    socket_timeout = PyGC_AddRoot(PyErr_NewException("socket.timeout",
+                                        socket_error, NULL));
     if (socket_timeout == NULL)
         return;
     Py_INCREF(socket_timeout);

--- a/from_cpython/Modules/threadmodule.c
+++ b/from_cpython/Modules/threadmodule.c
@@ -911,7 +911,7 @@ initthread(void)
 
     /* Add a symbolic constant */
     d = PyModule_GetDict(m);
-    ThreadError = PyErr_NewException("thread.error", NULL, NULL);
+    ThreadError = PyGC_AddRoot(PyErr_NewException("thread.error", NULL, NULL));
     PyDict_SetItemString(d, "error", ThreadError);
     Locktype.tp_doc = lock_doc;
     if (PyType_Ready(&Locktype) < 0)
@@ -925,7 +925,7 @@ initthread(void)
 
     nb_threads = 0;
 
-    str_dict = PyString_InternFromString("__dict__");
+    str_dict = PyGC_AddRoot(PyString_InternFromString("__dict__"));
     if (str_dict == NULL)
         return;
 

--- a/from_cpython/Modules/timemodule.c
+++ b/from_cpython/Modules/timemodule.c
@@ -864,7 +864,7 @@ inittime(void)
     */
     Py_XDECREF(moddict);
     /* Squirrel away the module's dictionary for the y2k check */
-    moddict = PyModule_GetDict(m);
+    moddict = PyGC_AddRoot(PyModule_GetDict(m));
     Py_INCREF(moddict);
 
     /* Set, or reset, module variables like time.timezone */

--- a/from_cpython/Modules/zipimport.c
+++ b/from_cpython/Modules/zipimport.c
@@ -1246,8 +1246,8 @@ initzipimport(void)
     if (mod == NULL)
         return;
 
-    ZipImportError = PyErr_NewException("zipimport.ZipImportError",
-                                        PyExc_ImportError, NULL);
+    ZipImportError = PyGC_AddRoot(PyErr_NewException("zipimport.ZipImportError",
+                                        PyExc_ImportError, NULL));
     if (ZipImportError == NULL)
         return;
 
@@ -1261,7 +1261,7 @@ initzipimport(void)
                            (PyObject *)&ZipImporter_Type) < 0)
         return;
 
-    zip_directory_cache = PyDict_New();
+    zip_directory_cache = PyGC_AddRoot(PyDict_New());
     if (zip_directory_cache == NULL)
         return;
     Py_INCREF(zip_directory_cache);

--- a/from_cpython/Modules/zlibmodule.c
+++ b/from_cpython/Modules/zlibmodule.c
@@ -1066,7 +1066,7 @@ PyInit_zlib(void)
     if (m == NULL)
         return;
 
-    ZlibError = PyErr_NewException("zlib.error", NULL, NULL);
+    ZlibError = PyGC_AddRoot(PyErr_NewException("zlib.error", NULL, NULL));
     if (ZlibError != NULL) {
         Py_INCREF(ZlibError);
         PyModule_AddObject(m, "error", ZlibError);


### PR DESCRIPTION
It seems like there's only one potentially bad one (zip_directory_cache),
and the rest are more or less benign (most of the occurrences are added
to the module as well as attributes), but it's probably good practice.