### PR TITLE
ignore untracked files in the gflags submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,4 @@
 [submodule "test/integration/gflags"]
 	path = test/integration/gflags
 	url = https://github.com/google/python-gflags
+	ignore = untracked


### PR DESCRIPTION
 so that the untracked pyc files don't cause the repo to be marked as dirty