### PR TITLE
Clean up the BoxedTuple class

### DIFF
--- a/src/runtime/tuple.cpp
+++ b/src/runtime/tuple.cpp
@@ -128,7 +128,7 @@ int BoxedTuple::Resize(BoxedTuple** pv, size_t newsize) noexcept {
 
     if (newsize < t->size()) {
         // XXX resize the box (by reallocating) smaller if it makes sense
-        t->nelts = newsize;
+        t->ob_size = newsize;
         return 0;
     }
 
@@ -436,8 +436,8 @@ extern "C" void tupleIteratorGCHandler(GCVisitor* v, Box* b) {
 
 
 void setupTuple() {
-    tuple_iterator_cls = BoxedHeapClass::create(type_cls, object_cls, &tupleIteratorGCHandler, 0, 0, sizeof(BoxedTuple),
-                                                false, "tuple");
+    tuple_iterator_cls = BoxedHeapClass::create(type_cls, object_cls, &tupleIteratorGCHandler, 0, 0,
+                                                sizeof(BoxedTupleIterator), false, "tuple");
 
     tuple_cls->giveAttr("__new__", new BoxedFunction(boxRTFunction((void*)tupleNew, UNKNOWN, 1, 0, true, true)));
     CLFunction* getitem = createRTFunction(2, 0, 0, 0);

--- a/src/runtime/types.h
+++ b/src/runtime/types.h
@@ -551,8 +551,6 @@ class BoxedTuple : public BoxVar {
 public:
     typedef std::vector<Box*, StlCompatAllocator<Box*>> GCVector;
 
-    Box** elts;
-
     DEFAULT_CLASS_VAR_SIMPLE(tuple_cls, sizeof(Box*));
 
     static BoxedTuple* create(int64_t size) { return new (size) BoxedTuple(size); }
@@ -593,27 +591,25 @@ public:
 
     static int Resize(BoxedTuple** pt, size_t newsize) noexcept;
 
-    Box** begin() const { return &elts[0]; }
-    Box** end() const { return &elts[nelts]; }
+    Box* const* begin() const { return &elts[0]; }
+    Box* const* end() const { return &elts[ob_size]; }
     Box*& operator[](size_t index) { return elts[index]; }
 
-    size_t size() const { return nelts; }
+    size_t size() const { return ob_size; }
 
 private:
-    size_t nelts;
+    BoxedTuple(size_t size) { memset(elts, 0, sizeof(Box*) * size); }
 
-    BoxedTuple(size_t size) : elts(reinterpret_cast<Box**>((char*)this + tuple_cls->tp_basicsize)), nelts(size) {
-        memset(elts, 0, sizeof(Box*) * size);
-    }
-
-    BoxedTuple(std::initializer_list<Box*>& members)
-        : elts(reinterpret_cast<Box**>((char*)this + tuple_cls->tp_basicsize)), nelts(members.size()) {
+    BoxedTuple(std::initializer_list<Box*>& members) {
         // by the time we make it here elts[] is big enough to contain members
         Box** p = &elts[0];
         for (auto b : members) {
             *p++ = b;
         }
     }
+
+public:
+    Box* elts[0];
 };
 
 extern "C" BoxedTuple* EmptyTuple;


### PR DESCRIPTION
(This depends on a few other PRs so just look at the last commit. As far as I know github doesn't have a great way to do PRs that depend on other PRs that live in a fork. :\ )

Since I made BoxedTuple a subclass of BoxVar, there's no need for an `nelts` field, since we can just use `BoxVar::ob_size`. Also, since the elements are stored at a fixed offset, we don't need a `Box** elts`, we can just make it an array `Box* elts[]`.