### PR TITLE
rename member -> member_descriptor

### DIFF
--- a/src/runtime/descr.cpp
+++ b/src/runtime/descr.cpp
@@ -19,7 +19,7 @@
 namespace pyston {
 
 static Box* memberGet(BoxedMemberDescriptor* self, Box* inst, Box* owner) {
-    RELEASE_ASSERT(self->cls == member_cls, "");
+    RELEASE_ASSERT(self->cls == member_descriptor_cls, "");
 
     if (inst == None)
         return self;
@@ -169,8 +169,8 @@ static Box* classmethodGet(Box* self, Box* obj, Box* type) {
 }
 
 void setupDescr() {
-    member_cls->giveAttr("__get__", new BoxedFunction(boxRTFunction((void*)memberGet, UNKNOWN, 3)));
-    member_cls->freeze();
+    member_descriptor_cls->giveAttr("__get__", new BoxedFunction(boxRTFunction((void*)memberGet, UNKNOWN, 3)));
+    member_descriptor_cls->freeze();
 
     property_cls->giveAttr("__init__",
                            new BoxedFunction(boxRTFunction((void*)propertyInit, UNKNOWN, 5, 4, false, false,

--- a/src/runtime/objmodel.cpp
+++ b/src/runtime/objmodel.cpp
@@ -980,7 +980,7 @@ Box* descriptorClsSpecialCases(GetattrRewriteArgs* rewrite_args, BoxedClass* cls
     }
 
     // Special case: member descriptor
-    if (descr->cls == member_cls) {
+    if (descr->cls == member_descriptor_cls) {
         if (rewrite_args)
             r_descr->addAttrGuard(BOX_CLS_OFFSET, (uint64_t)descr->cls);
 
@@ -1026,7 +1026,7 @@ Box* dataDescriptorInstanceSpecialCases(GetattrRewriteArgs* rewrite_args, const 
                                         Box* descr, RewriterVar* r_descr, bool for_call, Box** bind_obj_out,
                                         RewriterVar** r_bind_obj_out) {
     // Special case: data descriptor: member descriptor
-    if (descr->cls == member_cls) {
+    if (descr->cls == member_descriptor_cls) {
         static StatCounter slowpath("slowpath_member_descriptor_get");
         slowpath.log();
 
@@ -1722,7 +1722,7 @@ bool dataDescriptorSetSpecialCases(Box* obj, Box* val, Box* descr, SetattrRewrit
         getset_descr->set(obj, val, getset_descr->closure);
 
         return true;
-    } else if (descr->cls == member_cls) {
+    } else if (descr->cls == member_descriptor_cls) {
         BoxedMemberDescriptor* member_desc = static_cast<BoxedMemberDescriptor*>(descr);
         PyMemberDef member_def;
         memset(&member_def, 0, sizeof(member_def));

--- a/src/runtime/types.cpp
+++ b/src/runtime/types.cpp
@@ -655,7 +655,7 @@ extern "C" void closureGCHandler(GCVisitor* v, Box* b) {
 extern "C" {
 BoxedClass* object_cls, *type_cls, *none_cls, *bool_cls, *int_cls, *float_cls,
     * str_cls = NULL, *function_cls, *instancemethod_cls, *list_cls, *slice_cls, *module_cls, *dict_cls, *tuple_cls,
-      *file_cls, *member_cls, *closure_cls, *generator_cls, *complex_cls, *basestring_cls, *property_cls,
+      *file_cls, *member_descriptor_cls, *closure_cls, *generator_cls, *complex_cls, *basestring_cls, *property_cls,
       *staticmethod_cls, *classmethod_cls, *attrwrapper_cls, *pyston_getset_cls, *capi_getset_cls,
       *builtin_function_or_method_cls, *attrwrapperiter_cls, *set_cls, *frozenset_cls;
 
@@ -2069,8 +2069,8 @@ void setupRuntime() {
 
     module_cls = new BoxedHeapClass(object_cls, &moduleGCHandler, offsetof(BoxedModule, attrs), 0, sizeof(BoxedModule),
                                     false, static_cast<BoxedString*>(boxStrConstant("module")));
-    member_cls = new BoxedHeapClass(object_cls, NULL, 0, 0, sizeof(BoxedMemberDescriptor), false,
-                                    static_cast<BoxedString*>(boxStrConstant("member")));
+    member_descriptor_cls = new BoxedHeapClass(object_cls, NULL, 0, 0, sizeof(BoxedMemberDescriptor), false,
+                                               static_cast<BoxedString*>(boxStrConstant("member_descriptor")));
     capifunc_cls = new BoxedHeapClass(object_cls, NULL, 0, 0, sizeof(BoxedCApiFunction), false,
                                       static_cast<BoxedString*>(boxStrConstant("capifunc")));
     method_cls = new BoxedHeapClass(object_cls, NULL, 0, 0, sizeof(BoxedMethodDescriptor), false,
@@ -2100,7 +2100,7 @@ void setupRuntime() {
     float_cls->tp_mro = BoxedTuple::create({ float_cls, object_cls });
     function_cls->tp_mro = BoxedTuple::create({ function_cls, object_cls });
     builtin_function_or_method_cls->tp_mro = BoxedTuple::create({ builtin_function_or_method_cls, object_cls });
-    member_cls->tp_mro = BoxedTuple::create({ member_cls, object_cls });
+    member_descriptor_cls->tp_mro = BoxedTuple::create({ member_descriptor_cls, object_cls });
     capifunc_cls->tp_mro = BoxedTuple::create({ capifunc_cls, object_cls });
     module_cls->tp_mro = BoxedTuple::create({ module_cls, object_cls });
     method_cls->tp_mro = BoxedTuple::create({ method_cls, object_cls });
@@ -2155,7 +2155,7 @@ void setupRuntime() {
     float_cls->finishInitialization();
     function_cls->finishInitialization();
     builtin_function_or_method_cls->finishInitialization();
-    member_cls->finishInitialization();
+    member_descriptor_cls->finishInitialization();
     module_cls->finishInitialization();
     capifunc_cls->finishInitialization();
     method_cls->finishInitialization();

--- a/src/runtime/types.h
+++ b/src/runtime/types.h
@@ -85,9 +85,9 @@ extern "C" Box* getSysStdout();
 extern "C" {
 extern BoxedClass* object_cls, *type_cls, *bool_cls, *int_cls, *long_cls, *float_cls, *str_cls, *function_cls,
     *none_cls, *instancemethod_cls, *list_cls, *slice_cls, *module_cls, *dict_cls, *tuple_cls, *file_cls,
-    *enumerate_cls, *xrange_cls, *member_cls, *method_cls, *closure_cls, *generator_cls, *complex_cls, *basestring_cls,
-    *property_cls, *staticmethod_cls, *classmethod_cls, *attrwrapper_cls, *pyston_getset_cls, *capi_getset_cls,
-    *builtin_function_or_method_cls, *set_cls, *frozenset_cls, *code_cls;
+    *enumerate_cls, *xrange_cls, *member_descriptor_cls, *method_cls, *closure_cls, *generator_cls, *complex_cls,
+    *basestring_cls, *property_cls, *staticmethod_cls, *classmethod_cls, *attrwrapper_cls, *pyston_getset_cls,
+    *capi_getset_cls, *builtin_function_or_method_cls, *set_cls, *frozenset_cls, *code_cls;
 }
 #define unicode_cls (&PyUnicode_Type)
 #define memoryview_cls (&PyMemoryView_Type)
@@ -732,7 +732,7 @@ public:
     BoxedMemberDescriptor(PyMemberDef* member)
         : type((MemberType)member->type), offset(member->offset), readonly(member->flags & READONLY) {}
 
-    DEFAULT_CLASS_SIMPLE(member_cls);
+    DEFAULT_CLASS_SIMPLE(member_descriptor_cls);
 };
 
 class BoxedGetsetDescriptor : public Box {


### PR DESCRIPTION
This was named wrong and it was getting confusing. On top of that, its `tp_name` was wrong.