### PR TITLE
list __eq__ and __ne__ work for rhs's that are list subclasses

### DIFF
--- a/src/runtime/list.cpp
+++ b/src/runtime/list.cpp
@@ -941,7 +941,7 @@ Box* _listCmp(BoxedList* lhs, BoxedList* rhs, AST_TYPE::AST_TYPE op_type) {
 }
 
 Box* listEq(BoxedList* self, Box* rhs) {
-    if (rhs->cls != list_cls) {
+    if (!isSubclass(rhs->cls, list_cls)) {
         return NotImplemented;
     }
 
@@ -951,7 +951,7 @@ Box* listEq(BoxedList* self, Box* rhs) {
 }
 
 Box* listNe(BoxedList* self, Box* rhs) {
-    if (rhs->cls != list_cls) {
+    if (!isSubclass(rhs->cls, list_cls)) {
         return NotImplemented;
     }
 

--- a/test/tests/list_subclassing.py
+++ b/test/tests/list_subclassing.py
@@ -12,3 +12,6 @@ print l
 print len(MyList.__new__(MyList))
 l[:] = l[:]
 print l
+
+print [1,2,3] == MyList((1,2,3))
+print [1,2,3] != MyList((1,2,3))


### PR DESCRIPTION
splitting out the smaller self-contained bits of the django-fixes PR/branch.  `==` and `!=` both handle list subclasses.