### PR TITLE
Add im_class field to BoxedInstanceMethod, implement instancemethodRepr

### DIFF
--- a/src/capi/types.h
+++ b/src/capi/types.h
@@ -150,7 +150,7 @@ public:
         // CPython handles this differently: they create the equivalent of different BoxedMethodDescriptor
         // objects but with different class objects, which define different __get__ and __call__ methods.
         if (self->method->ml_flags & METH_CLASS)
-            return boxInstanceMethod(owner, self);
+            return boxInstanceMethod(owner, self, self->type);
 
         if (self->method->ml_flags & METH_STATIC)
             Py_FatalError("unimplemented");
@@ -160,7 +160,7 @@ public:
         if (inst == None)
             return self;
         else
-            return boxInstanceMethod(inst, self);
+            return boxInstanceMethod(inst, self, self->type);
     }
 
     static Box* __call__(BoxedMethodDescriptor* self, Box* obj, BoxedTuple* varargs, Box** _args);

--- a/src/core/common.h
+++ b/src/core/common.h
@@ -87,4 +87,12 @@ template <typename T1, typename T2> struct hash<pair<T1, T2>> {
 };
 }
 
+namespace std {
+template <typename T1, typename T2, typename T3> struct hash<tuple<T1, T2, T3>> {
+    size_t operator()(const tuple<T1, T2, T3> p) const {
+        return hash<T1>()(std::get<0>(p)) ^ (hash<T2>()(std::get<1>(p)) << 1) ^ (hash<T3>()(std::get<2>(p)) << 2);
+    }
+};
+}
+
 #endif

--- a/src/runtime/descr.cpp
+++ b/src/runtime/descr.cpp
@@ -165,7 +165,7 @@ static Box* classmethodGet(Box* self, Box* obj, Box* type) {
         type = obj->cls;
     }
 
-    return new BoxedInstanceMethod(type, cm->cm_callable);
+    return new BoxedInstanceMethod(type, cm->cm_callable, type);
 }
 
 void setupDescr() {

--- a/src/runtime/dict.cpp
+++ b/src/runtime/dict.cpp
@@ -667,7 +667,7 @@ void setupDict() {
     dict_cls->giveAttr("popitem", new BoxedFunction(boxRTFunction((void*)dictPopitem, BOXED_TUPLE, 1)));
 
     auto* fromkeys_func = new BoxedFunction(boxRTFunction((void*)dictFromkeys, DICT, 3, 1, false, false), { None });
-    dict_cls->giveAttr("fromkeys", boxInstanceMethod(dict_cls, fromkeys_func));
+    dict_cls->giveAttr("fromkeys", boxInstanceMethod(dict_cls, fromkeys_func, dict_cls));
 
     dict_cls->giveAttr("viewkeys", new BoxedFunction(boxRTFunction((void*)dictViewKeys, UNKNOWN, 1)));
     dict_cls->giveAttr("viewvalues", new BoxedFunction(boxRTFunction((void*)dictViewValues, UNKNOWN, 1)));

--- a/src/runtime/types.cpp
+++ b/src/runtime/types.cpp
@@ -715,15 +715,15 @@ extern "C" Box* createUserClass(const std::string* name, Box* _bases, Box* _attr
     }
 }
 
-extern "C" Box* boxInstanceMethod(Box* obj, Box* func) {
+extern "C" Box* boxInstanceMethod(Box* obj, Box* func, Box* type) {
     static StatCounter num_ims("num_instancemethods");
     num_ims.log();
 
-    return new BoxedInstanceMethod(obj, func);
+    return new BoxedInstanceMethod(obj, func, type);
 }
 
-extern "C" Box* boxUnboundInstanceMethod(Box* func) {
-    return new BoxedInstanceMethod(NULL, func);
+extern "C" Box* boxUnboundInstanceMethod(Box* func, Box* type) {
+    return new BoxedInstanceMethod(NULL, func, type);
 }
 
 extern "C" BoxedString* noneRepr(Box* v) {
@@ -773,8 +773,8 @@ static Box* functionGet(BoxedFunction* self, Box* inst, Box* owner) {
     RELEASE_ASSERT(self->cls == function_cls, "");
 
     if (inst == None)
-        return boxUnboundInstanceMethod(self);
-    return boxInstanceMethod(inst, self);
+        inst = NULL;
+    return new BoxedInstanceMethod(inst, self, owner);
 }
 
 static Box* functionCall(BoxedFunction* self, Box* args, Box* kwargs) {
@@ -919,9 +919,11 @@ Box* instancemethodGet(BoxedInstanceMethod* self, Box* obj, Box* type) {
         return self;
     }
 
-    // TODO subclass test
+    if (!PyObject_IsSubclass(type, self->im_class)) {
+        return self;
+    }
 
-    return new BoxedInstanceMethod(obj, self->func);
+    return new BoxedInstanceMethod(obj, self->func, self->im_class);
 }
 
 Box* instancemethodNew(BoxedClass* cls, Box* func, Box* self, Box** args) {
@@ -938,14 +940,49 @@ Box* instancemethodNew(BoxedClass* cls, Box* func, Box* self, Box** args) {
         return NULL;
     }
 
-    return new BoxedInstanceMethod(self, func);
+    return new BoxedInstanceMethod(self, func, classObj);
 }
 
-Box* instancemethodRepr(BoxedInstanceMethod* self) {
-    if (self->obj)
-        return boxStrConstant("<bound instancemethod object>");
-    else
-        return boxStrConstant("<unbound instancemethod object>");
+// Modified from cpython, Objects/object.c, instancemethod_repr
+static Box* instancemethodRepr(Box* b) {
+    assert(isSubclass(b->cls, instancemethod_cls));
+    BoxedInstanceMethod* a = static_cast<BoxedInstanceMethod*>(b);
+    Box* self = a->obj;
+    Box* func = a->func;
+    Box* klass = a->im_class;
+    Box* funcname = NULL, * klassname = NULL, * result = NULL;
+    const char* sfuncname = "?", * sklassname = "?";
+
+    funcname = getattrInternal(func, "__name__", NULL);
+    if (funcname != NULL) {
+        if (!PyString_Check(funcname)) {
+            funcname = NULL;
+        } else
+            sfuncname = PyString_AS_STRING(funcname);
+    }
+
+    if (klass == NULL) {
+        klassname = NULL;
+    } else {
+        klassname = getattrInternal(klass, "__name__", NULL);
+        if (klassname != NULL) {
+            if (!PyString_Check(klassname)) {
+                klassname = NULL;
+            } else {
+                sklassname = PyString_AS_STRING(klassname);
+            }
+        }
+    }
+
+    if (self == NULL)
+        result = PyString_FromFormat("<unbound method %s.%s>", sklassname, sfuncname);
+    else {
+        // This was a CPython comment: /* XXX Shouldn't use repr() here! */
+        Box* selfrepr = repr(self);
+        assert(PyString_Check(selfrepr));
+        result = PyString_FromFormat("<bound method %s.%s of %s>", sklassname, sfuncname, PyString_AS_STRING(selfrepr));
+    }
+    return result;
 }
 
 Box* instancemethodEq(BoxedInstanceMethod* self, Box* rhs) {
@@ -2203,9 +2240,10 @@ void setupRuntime() {
     object_cls->giveAttr("__init__", new BoxedFunction(boxRTFunction((void*)objectInit, UNKNOWN, 1, 0, true, false)));
     object_cls->giveAttr("__repr__", new BoxedFunction(boxRTFunction((void*)objectRepr, UNKNOWN, 1, 0, false, false)));
     object_cls->giveAttr("__str__", new BoxedFunction(boxRTFunction((void*)objectStr, UNKNOWN, 1, 0, false, false)));
-    object_cls->giveAttr(
-        "__subclasshook__",
-        boxInstanceMethod(object_cls, new BoxedFunction(boxRTFunction((void*)objectSubclasshook, UNKNOWN, 2))));
+    object_cls->giveAttr("__subclasshook__",
+                         boxInstanceMethod(object_cls,
+                                           new BoxedFunction(boxRTFunction((void*)objectSubclasshook, UNKNOWN, 2)),
+                                           object_cls));
     // __setattr__ was already set to a WrapperDescriptor; it'd be nice to set this to a faster BoxedFunction
     // object_cls->setattr("__setattr__", new BoxedFunction(boxRTFunction((void*)objectSetattr, UNKNOWN, 3)), NULL);
     // but unfortunately that will set tp_setattro to slot_tp_setattro on object_cls and all already-made subclasses!
@@ -2316,6 +2354,9 @@ void setupRuntime() {
         "im_self", new BoxedMemberDescriptor(BoxedMemberDescriptor::OBJECT, offsetof(BoxedInstanceMethod, obj)));
     instancemethod_cls->giveAttr("__self__", instancemethod_cls->getattr("im_self"));
     instancemethod_cls->freeze();
+
+    instancemethod_cls->giveAttr("im_class", new BoxedMemberDescriptor(BoxedMemberDescriptor::OBJECT,
+                                                                       offsetof(BoxedInstanceMethod, im_class), true));
 
     slice_cls->giveAttr("__new__",
                         new BoxedFunction(boxRTFunction((void*)sliceNew, UNKNOWN, 4, 2, false, false), { NULL, None }));

--- a/src/runtime/types.h
+++ b/src/runtime/types.h
@@ -107,8 +107,8 @@ extern "C" Box* boxBool(bool);
 extern "C" Box* boxInt(i64);
 extern "C" i64 unboxInt(Box*);
 extern "C" Box* boxFloat(double d);
-extern "C" Box* boxInstanceMethod(Box* obj, Box* func);
-extern "C" Box* boxUnboundInstanceMethod(Box* func);
+extern "C" Box* boxInstanceMethod(Box* obj, Box* func, Box* type);
+extern "C" Box* boxUnboundInstanceMethod(Box* func, Box* type);
 
 extern "C" Box* boxStringPtr(const std::string* s);
 Box* boxString(const std::string& s);
@@ -470,10 +470,10 @@ public:
     Box** in_weakreflist;
 
     // obj is NULL for unbound instancemethod
-    Box* obj, *func;
+    Box* obj, *func, *im_class;
 
-    BoxedInstanceMethod(Box* obj, Box* func) __attribute__((visibility("default")))
-    : in_weakreflist(NULL), obj(obj), func(func) {}
+    BoxedInstanceMethod(Box* obj, Box* func, Box* im_class) __attribute__((visibility("default")))
+    : in_weakreflist(NULL), obj(obj), func(func), im_class(im_class) {}
 
     DEFAULT_CLASS_SIMPLE(instancemethod_cls);
 };

--- a/test/tests/function_instancemethod.py
+++ b/test/tests/function_instancemethod.py
@@ -117,3 +117,13 @@ print type(bound_instancemethod)
 unbound_instancemethod = C.l
 unbound_instancemethod(c2)
 print type(unbound_instancemethod)
+
+### Test instancemethod repr
+print 'test instancemethod repr'
+class C(object):
+    def f(self):
+        pass
+    def __repr__(self):
+        return '(alpacas are cool)'
+print repr(C.f)
+print repr(C().f)

--- a/test/tests/instance_methods.py
+++ b/test/tests/instance_methods.py
@@ -2,6 +2,38 @@ class C(object):
     def foo(self):
         pass
 
+    def __repr__(self):
+        return 'some C obj'
+
 print type(C.foo)
 print type(C.foo.im_func), type(C.foo.__func__)
 print type(C.foo.im_self), type(C.foo.__self__)
+print type(C.foo.im_class)
+print repr(C.foo)
+
+print type(C().foo)
+print type(C().foo.im_func), type(C().foo.__func__)
+print type(C().foo.im_self), type(C().foo.__self__)
+print type(C().foo.im_class)
+print repr(C().foo)
+
+# old-style classes
+
+class C:
+    def foo(self):
+        pass
+
+    def __repr__(self):
+        return 'some old-style C obj'
+
+print type(C.foo)
+print type(C.foo.im_func), type(C.foo.__func__)
+print type(C.foo.im_self), type(C.foo.__self__)
+print type(C.foo.im_class)
+print repr(C.foo)
+
+print type(C().foo)
+print type(C().foo.im_func), type(C().foo.__func__)
+print type(C().foo.im_self), type(C().foo.__self__)
+print type(C().foo.im_class)
+print repr(C().foo)


### PR DESCRIPTION
Add the `im_class` field to `BoxedInstanceMethod` and implement `repr`.

There were a lot of places to insert it, hopefully I didn't screw up. It's kind of tricky: for example you can't assume it's a `BoxedClass`. One occasion where it wouldn't be a `BoxedClass` is if you were using old-style classes:

```
>>> class C:
...     def f(self): pass
... 
>>> C.f.im_class
<class __main__.C at 0x7fa97d41e258>
>>> type(C.f.im_class)
<type 'classobj'>
```

I also had to add support for the new field for the `InstanceMethodType` in codegen.