### PR TITLE
Reduce memory by not caching analysis passes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -779,11 +779,16 @@ endef
 PASS_SRCS := codegen/opt/aa.cpp
 PASS_OBJS := $(PASS_SRCS:.cpp=.standalone.o)
 
+ifneq ($(USE_CMAKE),1)
 $(call make_compile_config,,$(CXXFLAGS_DBG))
 $(call make_compile_config,.release,$(CXXFLAGS_RELEASE))
 $(call make_compile_config,.grwl,$(CXXFLAGS_RELEASE) -DTHREADING_USE_GRWL=1 -DTHREADING_USE_GIL=0 -UBINARY_SUFFIX -DBINARY_SUFFIX=_grwl)
 $(call make_compile_config,.grwl_dbg,$(CXXFLAGS_DBG) -DTHREADING_USE_GRWL=1 -DTHREADING_USE_GIL=0 -UBINARY_SUFFIX -DBINARY_SUFFIX=_grwl_dbg -UBINARY_STRIPPED_SUFFIX -DBINARY_STRIPPED_SUFFIX=)
 $(call make_compile_config,.nosync,$(CXXFLAGS_RELEASE) -DTHREADING_USE_GRWL=0 -DTHREADING_USE_GIL=0 -UBINARY_SUFFIX -DBINARY_SUFFIX=_nosync)
+else
+%.o: %.cpp $(CMAKE_SETUP_DBG)
+	$(NINJA) -C $(HOME)/pyston-build-dbg src/CMakeFiles/PYSTON_OBJECTS.dir/$(patsubst src/%.o,%.cpp.o,$@) $(NINJAFLAGS)
+endif
 
 $(UNITTEST_SRCS:.cpp=.o): CXXFLAGS += -isystem $(GTEST_DIR)/include
 

--- a/src/analysis/function_analysis.h
+++ b/src/analysis/function_analysis.h
@@ -45,6 +45,7 @@ private:
 
 public:
     LivenessAnalysis(CFG* cfg);
+    ~LivenessAnalysis();
 
     // we don't keep track of node->parent_block relationships, so you have to pass both:
     bool isKill(AST_Name* node, CFGBlock* parent_block);
@@ -105,9 +106,9 @@ public:
     bool isPotentiallyUndefinedAt(InternedString name, CFGBlock* block);
 };
 
-LivenessAnalysis* computeLivenessInfo(CFG*);
-PhiAnalysis* computeRequiredPhis(const ParamNames&, CFG*, LivenessAnalysis*, ScopeInfo* scope_info);
-PhiAnalysis* computeRequiredPhis(const OSREntryDescriptor*, LivenessAnalysis*, ScopeInfo* scope_info);
+std::unique_ptr<LivenessAnalysis> computeLivenessInfo(CFG*);
+std::unique_ptr<PhiAnalysis> computeRequiredPhis(const ParamNames&, CFG*, LivenessAnalysis*, ScopeInfo* scope_info);
+std::unique_ptr<PhiAnalysis> computeRequiredPhis(const OSREntryDescriptor*, LivenessAnalysis*, ScopeInfo* scope_info);
 }
 
 #endif

--- a/src/codegen/ast_interpreter.cpp
+++ b/src/codegen/ast_interpreter.cpp
@@ -83,7 +83,6 @@ private:
     Value doBinOp(Box* left, Box* right, int op, BinExpType exp_type);
     void doStore(AST_expr* node, Value value);
     void doStore(InternedString name, Value value);
-    void eraseDeadSymbols();
 
     Value visit_assert(AST_Assert* node);
     Value visit_assign(AST_Assign* node);
@@ -321,31 +320,6 @@ Value ASTInterpreter::execute(ASTInterpreter& interpreter, CFGBlock* start_block
     return v;
 }
 
-void ASTInterpreter::eraseDeadSymbols() {
-    if (source_info->liveness == NULL)
-        source_info->liveness = computeLivenessInfo(source_info->cfg);
-
-    if (this->phis == NULL) {
-        PhiAnalysis*& phis = source_info->phis[/* entry_descriptor = */ NULL];
-        if (!phis)
-            phis = computeRequiredPhis(compiled_func->clfunc->param_names, source_info->cfg, source_info->liveness,
-                                       scope_info);
-        this->phis = phis;
-    }
-
-    std::vector<InternedString> dead_symbols;
-    for (auto& it : sym_table) {
-        if (!source_info->liveness->isLiveAtEnd(it.first, current_block)) {
-            dead_symbols.push_back(it.first);
-        } else if (phis->isRequiredAfter(it.first, current_block)) {
-            assert(scope_info->getScopeTypeOfName(it.first) != ScopeInfo::VarScopeType::GLOBAL);
-        } else {
-        }
-    }
-    for (auto&& dead : dead_symbols)
-        sym_table.erase(dead);
-}
-
 Value ASTInterpreter::doBinOp(Box* left, Box* right, int op, BinExpType exp_type) {
     if (op == AST_TYPE::Div && (source_info->parent_module->future_flags & FF_DIVISION)) {
         op = AST_TYPE::TrueDiv;
@@ -463,7 +437,26 @@ Value ASTInterpreter::visit_jump(AST_Jump* node) {
     if (ENABLE_OSR && backedge && (globals->cls == module_cls)) {
         bool can_osr = !FORCE_INTERPRETER && (globals->cls == module_cls);
         if (can_osr && edgecount++ == OSR_THRESHOLD_INTERPRETER) {
-            eraseDeadSymbols();
+            static StatCounter ast_osrs("num_ast_osrs");
+            ast_osrs.log();
+
+            // TODO: we will immediately want the liveness info again in the jit, we should pass
+            // it through.
+            std::unique_ptr<LivenessAnalysis> liveness = computeLivenessInfo(source_info->cfg);
+            std::unique_ptr<PhiAnalysis> phis
+                = computeRequiredPhis(compiled_func->clfunc->param_names, source_info->cfg, liveness.get(), scope_info);
+
+            std::vector<InternedString> dead_symbols;
+            for (auto& it : sym_table) {
+                if (!liveness->isLiveAtEnd(it.first, current_block)) {
+                    dead_symbols.push_back(it.first);
+                } else if (phis->isRequiredAfter(it.first, current_block)) {
+                    assert(scope_info->getScopeTypeOfName(it.first) != ScopeInfo::VarScopeType::GLOBAL);
+                } else {
+                }
+            }
+            for (auto&& dead : dead_symbols)
+                sym_table.erase(dead);
 
             const OSREntryDescriptor* found_entry = nullptr;
             for (auto& p : compiled_func->clfunc->osr_versions) {
@@ -479,7 +472,7 @@ Value ASTInterpreter::visit_jump(AST_Jump* node) {
 
             for (auto& name : phis->definedness.getDefinedNamesAtEnd(current_block)) {
                 auto it = sym_table.find(name);
-                if (!source_info->liveness->isLiveAtEnd(name, current_block))
+                if (!liveness->isLiveAtEnd(name, current_block))
                     continue;
 
                 if (phis->isPotentiallyUndefinedAfter(name, current_block)) {
@@ -495,10 +488,14 @@ Value ASTInterpreter::visit_jump(AST_Jump* node) {
                 }
             }
 
+            // Manually free these here, since we might not return from this scope for a long time.
+            liveness.reset(nullptr);
+            phis.reset(nullptr);
+
             // LLVM has a limit on the number of operands a machine instruction can have (~255),
             // in order to not hit the limit with the patchpoints cancel OSR when we have a high number of symbols.
             if (sorted_symbol_table.size() > 225) {
-                static StatCounter times_osr_cancel("num_osr_cancel_to_many_syms");
+                static StatCounter times_osr_cancel("num_osr_cancel_too_many_syms");
                 times_osr_cancel.log();
                 next_block = node->target;
                 return Value();

--- a/src/codegen/codegen.cpp
+++ b/src/codegen/codegen.cpp
@@ -35,8 +35,7 @@ namespace pyston {
 DS_DEFINE_RWLOCK(codegen_rwlock);
 
 SourceInfo::SourceInfo(BoxedModule* m, ScopingAnalysis* scoping, AST* ast, std::vector<AST_stmt*> body, std::string fn)
-    : parent_module(m), scoping(scoping), ast(ast), cfg(NULL), liveness(NULL), fn(std::move(fn)),
-      body(std::move(body)) {
+    : parent_module(m), scoping(scoping), ast(ast), cfg(NULL), fn(std::move(fn)), body(std::move(body)) {
     assert(this->fn.size());
 
     switch (ast->type) {

--- a/src/codegen/irgen/hooks.cpp
+++ b/src/codegen/irgen/hooks.cpp
@@ -228,19 +228,6 @@ CompiledFunction* compileFunction(CLFunction* f, FunctionSpecialization* spec, E
         source->cfg = computeCFG(source, source->body);
     }
 
-    if (effort != EffortLevel::INTERPRETED) {
-        if (source->liveness == NULL)
-            source->liveness = computeLivenessInfo(source->cfg);
-
-        PhiAnalysis*& phis = source->phis[entry_descriptor];
-        if (!phis) {
-            if (entry_descriptor)
-                phis = computeRequiredPhis(entry_descriptor, source->liveness, source->getScopeInfo());
-            else
-                phis = computeRequiredPhis(f->param_names, source->cfg, source->liveness, source->getScopeInfo());
-        }
-    }
-
 
 
     CompiledFunction* cf = 0;

--- a/src/codegen/irgen/irgenerator.h
+++ b/src/codegen/irgen/irgenerator.h
@@ -56,7 +56,8 @@ class IRGenState {
 private:
     CompiledFunction* cf;
     SourceInfo* source_info;
-    PhiAnalysis* phis;
+    std::unique_ptr<LivenessAnalysis> liveness;
+    std::unique_ptr<PhiAnalysis> phis;
     ParamNames* param_names;
     GCBuilder* gc;
     llvm::MDNode* func_dbg_info;
@@ -69,13 +70,9 @@ private:
 
 
 public:
-    IRGenState(CompiledFunction* cf, SourceInfo* source_info, PhiAnalysis* phis, ParamNames* param_names, GCBuilder* gc,
-               llvm::MDNode* func_dbg_info)
-        : cf(cf), source_info(source_info), phis(phis), param_names(param_names), gc(gc), func_dbg_info(func_dbg_info),
-          scratch_space(NULL), frame_info(NULL), frame_info_arg(NULL), scratch_size(0) {
-        assert(cf->func);
-        assert(!cf->clfunc); // in this case don't need to pass in sourceinfo
-    }
+    IRGenState(CompiledFunction* cf, SourceInfo* source_info, std::unique_ptr<LivenessAnalysis> liveness,
+               std::unique_ptr<PhiAnalysis> phis, ParamNames* param_names, GCBuilder* gc, llvm::MDNode* func_dbg_info);
+    ~IRGenState();
 
     CompiledFunction* getCurFunction() { return cf; }
 
@@ -93,7 +90,8 @@ public:
 
     SourceInfo* getSourceInfo() { return source_info; }
 
-    PhiAnalysis* getPhis() { return phis; }
+    LivenessAnalysis* getLiveness() { return liveness.get(); }
+    PhiAnalysis* getPhis() { return phis.get(); }
 
     ScopeInfo* getScopeInfo();
     ScopeInfo* getScopeInfoForNode(AST* node);

--- a/src/core/stats.cpp
+++ b/src/core/stats.cpp
@@ -17,6 +17,7 @@
 #include <algorithm>
 
 #include "core/thread_utils.h"
+#include "gc/heap.h"
 
 namespace pyston {
 
@@ -55,7 +56,11 @@ void Stats::dump(bool includeZeros) {
     if (!Stats::enabled)
         return;
 
-    printf("Stats:\n");
+    fprintf(stderr, "Stats:\n");
+
+    gc::dumpHeapStatistics(0);
+
+    fprintf(stderr, "Counters:\n");
 
     std::vector<std::pair<std::string, int>> pairs;
     for (const auto& p : *names) {
@@ -66,8 +71,10 @@ void Stats::dump(bool includeZeros) {
 
     for (int i = 0; i < pairs.size(); i++) {
         if (includeZeros || (*counts)[pairs[i].second] > 0)
-            printf("%s: %ld\n", pairs[i].first.c_str(), (*counts)[pairs[i].second]);
+            fprintf(stderr, "%s: %ld\n", pairs[i].first.c_str(), (*counts)[pairs[i].second]);
     }
+
+    fprintf(stderr, "(End of stats)\n");
 }
 
 void Stats::endOfInit() {

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -243,8 +243,6 @@ public:
     ScopingAnalysis* scoping;
     AST* ast;
     CFG* cfg;
-    LivenessAnalysis* liveness;
-    std::unordered_map<const OSREntryDescriptor*, PhiAnalysis*> phis;
     bool is_generator;
     std::string fn; // equivalent of code.co_filename
 

--- a/src/gc/heap.h
+++ b/src/gc/heap.h
@@ -22,6 +22,7 @@
 
 #include "core/common.h"
 #include "core/threading.h"
+#include "core/types.h"
 
 namespace pyston {
 
@@ -535,13 +536,13 @@ public:
         huge_arena.freeUnmarked(weakly_referenced);
     }
 
-    void dumpHeapStatistics();
+    void dumpHeapStatistics(int level);
 
     friend void markPhase();
 };
 
 extern Heap global_heap;
-void dumpHeapStatistics();
+void dumpHeapStatistics(int level);
 
 } // namespace gc
 } // namespace pyston

--- a/src/runtime/stacktrace.cpp
+++ b/src/runtime/stacktrace.cpp
@@ -160,28 +160,31 @@ extern "C" void abort() {
     // In case displaying the traceback recursively calls abort:
     static bool recursive = false;
 
-    // If traceback_cls is NULL, then we somehow died early on, and won't be able to display a traceback.
-    if (!recursive && traceback_cls) {
+    if (!recursive) {
         recursive = true;
-
+        Stats::dump();
         fprintf(stderr, "Someone called abort!\n");
 
-        // If we call abort(), things may be seriously wrong.  Set an alarm() to
-        // try to handle cases that we would just hang.
-        // (Ex if we abort() from a static constructor, and _printStackTrace uses
-        // that object, _printStackTrace will hang waiting for the first construction
-        // to finish.)
-        alarm(1);
-        try {
-            _printStacktrace();
-        } catch (ExcInfo) {
-            fprintf(stderr, "error printing stack trace during abort()");
-        }
+        // If traceback_cls is NULL, then we somehow died early on, and won't be able to display a traceback.
+        if (traceback_cls) {
 
-        // Cancel the alarm.
-        // This is helpful for when running in a debugger, since otherwise the debugger will catch the
-        // abort and let you investigate, but the alarm will still come back to kill the program.
-        alarm(0);
+            // If we call abort(), things may be seriously wrong.  Set an alarm() to
+            // try to handle cases that we would just hang.
+            // (Ex if we abort() from a static constructor, and _printStackTrace uses
+            // that object, _printStackTrace will hang waiting for the first construction
+            // to finish.)
+            alarm(1);
+            try {
+                _printStacktrace();
+            } catch (ExcInfo) {
+                fprintf(stderr, "error printing stack trace during abort()");
+            }
+
+            // Cancel the alarm.
+            // This is helpful for when running in a debugger, since otherwise the debugger will catch the
+            // abort and let you investigate, but the alarm will still come back to kill the program.
+            alarm(0);
+        }
     }
 
     if (PAUSE_AT_ABORT) {

--- a/test/tests/package_test.py
+++ b/test/tests/package_test.py
@@ -1,7 +1,7 @@
 import os
 
 import test_package
-print 1, test_package.__name__, os.path.normpath(test_package.__file__)
+print 1, test_package.__name__, os.path.normpath(test_package.__file__).replace(".pyc", ".py")
 
 import test_package.intrapackage_import
 import test_package.absolute_import

--- a/test/tests/test_package/absolute_import.py
+++ b/test/tests/test_package/absolute_import.py
@@ -1,4 +1,4 @@
 import os
 import import_target
 
-print 3, import_target.__name__, os.path.normpath(import_target.__file__)
+print 3, import_target.__name__, os.path.normpath(import_target.__file__).replace(".pyc", ".py")

--- a/test/tests/test_package/absolute_import_with_future.py
+++ b/test/tests/test_package/absolute_import_with_future.py
@@ -2,4 +2,4 @@ from __future__ import absolute_import
 import os
 import import_target
 
-print 4, import_target.__name__, os.path.normpath(import_target.__file__)
+print 4, import_target.__name__, os.path.normpath(import_target.__file__).replace(".pyc", ".py")

--- a/test/tests/test_package/intrapackage_import.py
+++ b/test/tests/test_package/intrapackage_import.py
@@ -1,3 +1,3 @@
 import os
 from . import import_target
-print 2, import_target.__name__, os.path.normpath(import_target.__file__)
+print 2, import_target.__name__, os.path.normpath(import_target.__file__).replace(".pyc", ".py")


### PR DESCRIPTION
This eliminates 20% of the memory used by "import pip".  We will probably want to cache them again eventually, but it seems like they're reused pretty rarely so I'm hopeful we won't see too much of a perf impact for now.