### PR TITLE
fix the remaining subclass checks for list comparisons <, <=, >, >=

### DIFF
--- a/src/runtime/list.cpp
+++ b/src/runtime/list.cpp
@@ -961,7 +961,7 @@ Box* listNe(BoxedList* self, Box* rhs) {
 }
 
 Box* listLt(BoxedList* self, Box* rhs) {
-    if (rhs->cls != list_cls) {
+    if (!isSubclass(rhs->cls, list_cls)) {
         return NotImplemented;
     }
 
@@ -971,7 +971,7 @@ Box* listLt(BoxedList* self, Box* rhs) {
 }
 
 Box* listLe(BoxedList* self, Box* rhs) {
-    if (rhs->cls != list_cls) {
+    if (!isSubclass(rhs->cls, list_cls)) {
         return NotImplemented;
     }
 
@@ -981,7 +981,7 @@ Box* listLe(BoxedList* self, Box* rhs) {
 }
 
 Box* listGt(BoxedList* self, Box* rhs) {
-    if (rhs->cls != list_cls) {
+    if (!isSubclass(rhs->cls, list_cls)) {
         return NotImplemented;
     }
 
@@ -991,7 +991,7 @@ Box* listGt(BoxedList* self, Box* rhs) {
 }
 
 Box* listGe(BoxedList* self, Box* rhs) {
-    if (rhs->cls != list_cls) {
+    if (!isSubclass(rhs->cls, list_cls)) {
         return NotImplemented;
     }
 

--- a/test/tests/list_subclassing.py
+++ b/test/tests/list_subclassing.py
@@ -13,5 +13,26 @@ print len(MyList.__new__(MyList))
 l[:] = l[:]
 print l
 
-print [1,2,3] == MyList((1,2,3))
-print [1,2,3] != MyList((1,2,3))
+print [1,2,3] == MyList((1,2,3,4))
+print [1,2,3] != MyList((1,2,3,4))
+
+print [1,2,3,4] > MyList((1,2,3))
+print [1,2,3,4] < MyList((1,2,3))
+
+print [1,2,3] > MyList((1,2,3,4))
+print [1,2,3] < MyList((1,2,3,4))
+
+print [1,2,3] >= MyList((1,2,3))
+print [1,2,3] <= MyList((1,2,3))
+
+print MyList((1,2,3)) == MyList((1,2,3,4))
+print MyList((1,2,3)) != MyList((1,2,3,4))
+
+print MyList((1,2,3,4)) > MyList((1,2,3))
+print MyList((1,2,3,4)) < MyList((1,2,3))
+
+print MyList((1,2,3)) > MyList((1,2,3,4))
+print MyList((1,2,3)) < MyList((1,2,3,4))
+
+print MyList((1,2,3)) >= MyList((1,2,3))
+print MyList((1,2,3)) <= MyList((1,2,3))


### PR DESCRIPTION
basically the same as 5209849, but for the other comparisons.  also add `subclass op subclass` comparison tests so that we ensure pyston doesn't rewrite the op to the reverse and succeed due to one of them being `list_cls`.