### PR TITLE
Add support for weakref.proxy

### DIFF
--- a/from_cpython/Objects/weakrefobject.c
+++ b/from_cpython/Objects/weakrefobject.c
@@ -35,7 +35,9 @@ new_weakref(PyObject *ob, PyObject *callback)
 {
     PyWeakReference *result;
 
-    result = PyObject_GC_New(PyWeakReference, &_PyWeakref_RefType);
+    // Pyston change: We can't use PyObject_GC_New because it will conservatively scan the memory.
+    // result = PyObject_GC_New(PyWeakReference, &_PyWeakref_RefType);
+    result = (PyWeakReference*)_PyWeakref_RefType.tp_alloc(&_PyWeakref_RefType, 0);
     if (result) {
         init_weakref(result, ob, callback);
         PyObject_GC_Track(result);
@@ -706,9 +708,8 @@ _PyWeakref_ProxyType = {
     0,                                  /* tp_hash */
     0,                                  /* tp_call */
     proxy_str,                          /* tp_str */
-    // Pyston change:
-    0, //proxy_getattr,                      /* tp_getattro */
-    0, //(setattrofunc)proxy_setattr,        /* tp_setattro */
+    proxy_getattr,                      /* tp_getattro */
+    (setattrofunc)proxy_setattr,        /* tp_setattro */
     0,                                  /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC
     | Py_TPFLAGS_CHECKTYPES,            /* tp_flags */
@@ -744,9 +745,8 @@ _PyWeakref_CallableProxyType = {
     0,                                  /* tp_hash */
     proxy_call,                         /* tp_call */
     proxy_str,                          /* tp_str */
-    // Pyston change:
-    0, //proxy_getattr,                      /* tp_getattro */
-    0, //(setattrofunc)proxy_setattr,        /* tp_setattro */
+    proxy_getattr,                      /* tp_getattro */
+    (setattrofunc)proxy_setattr,        /* tp_setattro */
     0,                                  /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC
     | Py_TPFLAGS_CHECKTYPES,            /* tp_flags */

--- a/test/tests/weakref_proxy.py
+++ b/test/tests/weakref_proxy.py
@@ -1,0 +1,39 @@
+import weakref
+import gc
+
+class C(object):
+    def foo(self):
+        print "inside foo()"
+
+def fact(n):
+    if n <= 1:
+        return n
+    return n * fact(n-1)
+
+def getWR():
+    c = C()
+    wr = weakref.proxy(c)
+    wr.attr = "test attr"
+    print wr.attr, c.attr
+    wr.foo()
+    del c
+    return wr
+
+wr = getWR()
+fact(100) # try to clear some memory
+gc.collect()
+
+try:
+    wr.foo()
+except ReferenceError as e:
+    print e
+
+try:
+    print wr.attr
+except ReferenceError as e:
+    print e
+
+try:
+    wr.attr = "val2"
+except ReferenceError as e:
+    print e


### PR DESCRIPTION
I had to change ```new_weakref``` to use ```tp_alloc``` instead of ```PyObject_GC_New```
in order to create a weak ref because ```PyObject_GC_New``` allocated memory is scanned
conservatively.
```tp_alloc``` points to ```PystonType_GenericAlloc``` and is of PYTHON type.

@toshok Maybe you could also take a look at it and check if this makes sense.