### PR TITLE
put back in the Timer-based stats I removed in the stats-timer branch…

### DIFF
--- a/src/codegen/parser.cpp
+++ b/src/codegen/parser.cpp
@@ -983,6 +983,7 @@ AST_Module* parse_string(const char* code) {
 
 AST_Module* parse_file(const char* fn) {
     STAT_TIMER(t0, "us_timer_cpyton_parsing");
+    Timer _t("parsing");
 
     if (ENABLE_PYPA_PARSER) {
         AST_Module* rtn = pypa_parse(fn);
@@ -1002,6 +1003,10 @@ AST_Module* parse_file(const char* fn) {
     assert(code == 0);
 
     assert(rtn->type == AST_TYPE::Module);
+
+    long us = _t.end();
+    static StatCounter us_parsing("us_parsing");
+    us_parsing.log(us);
 
     return ast_cast<AST_Module>(rtn);
 }
@@ -1068,6 +1073,9 @@ static ParseResult _reparse(const char* fn, const std::string& cache_fn, AST_Mod
 // on the startup time (40ms -> 10ms).
 AST_Module* caching_parse_file(const char* fn) {
     STAT_TIMER(t0, "us_timer_caching_parse_file");
+    static StatCounter us_parsing("us_parsing");
+    Timer _t("parsing");
+    _t.setExitCallback([](uint64_t t) { us_parsing.log(t); });
 
     int code;
     std::string cache_fn = std::string(fn) + "c";

--- a/src/core/stats.cpp
+++ b/src/core/stats.cpp
@@ -22,6 +22,7 @@
 namespace pyston {
 
 #if !DISABLE_STATS
+#if STAT_TIMERS
 extern "C" const char* getStatTimerNameById(int id) {
     return Stats::getStatName(id).c_str();
 }
@@ -116,6 +117,7 @@ StatTimer* StatTimer::swapStack(StatTimer* s, uint64_t at_time) {
     }
     return prev_stack;
 }
+#endif
 
 std::vector<uint64_t>* Stats::counts;
 std::unordered_map<int, std::string>* Stats::names;

--- a/src/gc/collector.cpp
+++ b/src/gc/collector.cpp
@@ -346,6 +346,8 @@ void runCollection() {
     if (VERBOSITY("gc") >= 2)
         printf("Collection #%d\n", ncollections);
 
+    Timer _t("collecting", /*min_usec=*/10000);
+
     markPhase();
     std::list<Box*, StlCompatAllocator<Box*>> weakly_referenced;
     sweepPhase(weakly_referenced);
@@ -368,6 +370,10 @@ void runCollection() {
 
     if (VERBOSITY("gc") >= 2)
         printf("Collection #%d done\n\n", ncollections);
+
+    long us = _t.end();
+    static StatCounter sc_us("gc_collections_us");
+    sc_us.log(us);
 
     // dumpHeapStatistics();
 }

--- a/src/jit.cpp
+++ b/src/jit.cpp
@@ -369,7 +369,7 @@ static int main(int argc, char** argv) {
         uint64_t main_time_duration = main_time.end(&main_time_ended_at);
         static StatCounter mt("ticks_in_main");
         mt.log(main_time_duration);
-        _stt0.pause(main_time_ended_at);
+        STAT_TIMER_NAME(t0).pause(main_time_ended_at);
     }
     Stats::dump(true);
 

--- a/src/runtime/generator.cpp
+++ b/src/runtime/generator.cpp
@@ -111,7 +111,7 @@ void generatorEntry(BoxedGenerator* g) {
         g->entryExited = true;
         threading::popGenerator();
 
-#if !DISABLE_STATS
+#if STAT_TIMERS
         g->timer_time = getCPUTicks(); // store off the timer that our caller (in g->returnContext) will resume at
         STAT_TIMER_NAME(t0).pause(g->timer_time);
 #endif
@@ -139,7 +139,7 @@ Box* generatorSend(Box* s, Box* v) {
     self->returnValue = v;
     self->running = true;
 
-#if !DISABLE_STATS
+#if STAT_TIMERS
     // store off the time that the generator will use to initialize its toplevel timer
     self->timer_time = getCPUTicks();
     StatTimer* current_timers = StatTimer::swapStack(self->statTimers, self->timer_time);
@@ -147,7 +147,7 @@ Box* generatorSend(Box* s, Box* v) {
 
     swapContext(&self->returnContext, self->context, (intptr_t)self);
 
-#if !DISABLE_STATS
+#if STAT_TIMERS
     // if the generator exited we use the time that generatorEntry stored in self->timer_time (the same time it paused
     // its timer at).
     self->statTimers = StatTimer::swapStack(current_timers, self->entryExited ? self->timer_time : getCPUTicks());

--- a/src/runtime/objmodel.cpp
+++ b/src/runtime/objmodel.cpp
@@ -2735,7 +2735,7 @@ static StatCounter slowpath_callfunc_slowpath("slowpath_callfunc_slowpath");
 Box* callFunc(BoxedFunctionBase* func, CallRewriteArgs* rewrite_args, ArgPassSpec argspec, Box* arg1, Box* arg2,
               Box* arg3, Box** args, const std::vector<const std::string*>* keyword_names) {
 
-#if !DISABLE_STATS
+#if STAT_TIMERS
     StatTimer::assertActive();
 #endif
     /*

--- a/src/runtime/types.h
+++ b/src/runtime/types.h
@@ -873,7 +873,7 @@ public:
     struct Context* context, *returnContext;
     void* stack_begin;
 
-#if !DISABLE_STATS
+#if STAT_TIMERS
     StatTimer* statTimers;
     uint64_t timer_time;
 #endif


### PR DESCRIPTION
…, and allow stat timers to be disabled separately from the rest of the stats (disable them by default.)