### PR TITLE
turn on ConstructorInitializerAllOnOneLineOrOnePerLine

### DIFF
--- a/src/.clang-format
+++ b/src/.clang-format
@@ -9,6 +9,7 @@ AllowShortIfStatementsOnASingleLine: false
 BreakBeforeBraces: Attach
 BreakConstructorInitializersBeforeComma: false
 ColumnLimit: 120
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
 IndentCaseLabels: true
 IndentWidth: 4
 Language: Cpp

--- a/src/analysis/scoping_analysis.cpp
+++ b/src/analysis/scoping_analysis.cpp
@@ -244,8 +244,13 @@ struct ScopingAnalysis::ScopeNameUsage {
     bool child_free;
 
     ScopeNameUsage(AST* node, ScopeNameUsage* parent, ScopingAnalysis* scoping)
-        : node(node), parent(parent), scoping(scoping), nameForcingNodeImportStar(NULL), nameForcingNodeBareExec(NULL),
-          free(false), child_free(false) {
+        : node(node),
+          parent(parent),
+          scoping(scoping),
+          nameForcingNodeImportStar(NULL),
+          nameForcingNodeBareExec(NULL),
+          free(false),
+          child_free(false) {
         if (node->type == AST_TYPE::ClassDef) {
             AST_ClassDef* classdef = ast_cast<AST_ClassDef>(node);
 
@@ -303,7 +308,11 @@ private:
 public:
     ScopeInfoBase(ScopeInfo* parent, ScopingAnalysis::ScopeNameUsage* usage, AST* ast, bool usesNameLookup,
                   bool globals_from_module)
-        : parent(parent), usage(usage), ast(ast), usesNameLookup_(usesNameLookup), allDerefVarsAndInfoCached(false),
+        : parent(parent),
+          usage(usage),
+          ast(ast),
+          usesNameLookup_(usesNameLookup),
+          allDerefVarsAndInfoCached(false),
           globals_from_module(globals_from_module) {
         assert(usage);
         assert(ast);

--- a/src/analysis/type_analysis.cpp
+++ b/src/analysis/type_analysis.cpp
@@ -98,8 +98,12 @@ private:
     BasicBlockTypePropagator(CFGBlock* block, TypeMap& initial, ExprTypeMap& expr_types,
                              TypeSpeculations& type_speculations, TypeAnalysis::SpeculationLevel speculation,
                              ScopeInfo* scope_info)
-        : block(block), sym_table(initial), expr_types(expr_types), type_speculations(type_speculations),
-          speculation(speculation), scope_info(scope_info) {}
+        : block(block),
+          sym_table(initial),
+          expr_types(expr_types),
+          type_speculations(type_speculations),
+          speculation(speculation),
+          scope_info(scope_info) {}
 
     void run() {
         for (int i = 0; i < block->body.size(); i++) {
@@ -661,7 +665,9 @@ private:
 
     PropagatingTypeAnalysis(const AllTypeMap& starting_types, const ExprTypeMap& expr_types,
                             TypeSpeculations& type_speculations, SpeculationLevel speculation)
-        : starting_types(starting_types), expr_types(expr_types), type_speculations(type_speculations),
+        : starting_types(starting_types),
+          expr_types(expr_types),
+          type_speculations(type_speculations),
           speculation(speculation) {}
 
 public:

--- a/src/asm_writing/icinfo.cpp
+++ b/src/asm_writing/icinfo.cpp
@@ -182,10 +182,20 @@ ICSlotInfo* ICInfo::pickEntryForRewrite(const char* debug_name) {
 ICInfo::ICInfo(void* start_addr, void* slowpath_rtn_addr, void* continue_addr, StackInfo stack_info, int num_slots,
                int slot_size, llvm::CallingConv::ID calling_conv, const std::unordered_set<int>& live_outs,
                assembler::GenericRegister return_register, TypeRecorder* type_recorder)
-    : next_slot_to_try(0), stack_info(stack_info), num_slots(num_slots), slot_size(slot_size),
-      calling_conv(calling_conv), live_outs(live_outs.begin(), live_outs.end()), return_register(return_register),
-      type_recorder(type_recorder), retry_in(0), retry_backoff(1), times_rewritten(0), start_addr(start_addr),
-      slowpath_rtn_addr(slowpath_rtn_addr), continue_addr(continue_addr) {
+    : next_slot_to_try(0),
+      stack_info(stack_info),
+      num_slots(num_slots),
+      slot_size(slot_size),
+      calling_conv(calling_conv),
+      live_outs(live_outs.begin(), live_outs.end()),
+      return_register(return_register),
+      type_recorder(type_recorder),
+      retry_in(0),
+      retry_backoff(1),
+      times_rewritten(0),
+      start_addr(start_addr),
+      slowpath_rtn_addr(slowpath_rtn_addr),
+      continue_addr(continue_addr) {
     for (int i = 0; i < num_slots; i++) {
         slots.push_back(ICSlotInfo(this, i));
     }

--- a/src/asm_writing/rewriter.cpp
+++ b/src/asm_writing/rewriter.cpp
@@ -1379,8 +1379,13 @@ TypeRecorder* Rewriter::getTypeRecorder() {
 }
 
 Rewriter::Rewriter(ICSlotRewrite* rewrite, int num_args, const std::vector<int>& live_outs)
-    : rewrite(rewrite), assembler(rewrite->getAssembler()), return_location(rewrite->returnRegister()),
-      added_changing_action(false), marked_inside_ic(false), last_guard_action(-1), done_guarding(false) {
+    : rewrite(rewrite),
+      assembler(rewrite->getAssembler()),
+      return_location(rewrite->returnRegister()),
+      added_changing_action(false),
+      marked_inside_ic(false),
+      last_guard_action(-1),
+      done_guarding(false) {
     initPhaseCollecting();
 
 #ifndef NDEBUG

--- a/src/codegen/ast_interpreter.cpp
+++ b/src/codegen/ast_interpreter.cpp
@@ -223,9 +223,18 @@ void ASTInterpreter::gcVisit(GCVisitor* visitor) {
 }
 
 ASTInterpreter::ASTInterpreter(CompiledFunction* compiled_function)
-    : compiled_func(compiled_function), source_info(compiled_function->clfunc->source.get()), scope_info(0), phis(NULL),
-      current_block(0), current_inst(0), last_exception(NULL, NULL, NULL), passed_closure(0), created_closure(0),
-      generator(0), edgecount(0), frame_info(ExcInfo(NULL, NULL, NULL)) {
+    : compiled_func(compiled_function),
+      source_info(compiled_function->clfunc->source.get()),
+      scope_info(0),
+      phis(NULL),
+      current_block(0),
+      current_inst(0),
+      last_exception(NULL, NULL, NULL),
+      passed_closure(0),
+      created_closure(0),
+      generator(0),
+      edgecount(0),
+      frame_info(ExcInfo(NULL, NULL, NULL)) {
 
     CLFunction* f = compiled_function->clfunc;
     if (!source_info->cfg)

--- a/src/codegen/irgen/irgenerator.cpp
+++ b/src/codegen/irgen/irgenerator.cpp
@@ -45,8 +45,16 @@ extern "C" void dumpLLVM(llvm::Value* v) {
 IRGenState::IRGenState(CompiledFunction* cf, SourceInfo* source_info, std::unique_ptr<LivenessAnalysis> liveness,
                        std::unique_ptr<PhiAnalysis> phis, ParamNames* param_names, GCBuilder* gc,
                        llvm::MDNode* func_dbg_info)
-    : cf(cf), source_info(source_info), liveness(std::move(liveness)), phis(std::move(phis)), param_names(param_names),
-      gc(gc), func_dbg_info(func_dbg_info), scratch_space(NULL), frame_info(NULL), frame_info_arg(NULL),
+    : cf(cf),
+      source_info(source_info),
+      liveness(std::move(liveness)),
+      phis(std::move(phis)),
+      param_names(param_names),
+      gc(gc),
+      func_dbg_info(func_dbg_info),
+      scratch_space(NULL),
+      frame_info(NULL),
+      frame_info_arg(NULL),
       scratch_size(0) {
     assert(cf->func);
     assert(!cf->clfunc); // in this case don't need to pass in sourceinfo
@@ -437,8 +445,13 @@ private:
 public:
     IRGeneratorImpl(IRGenState* irstate, std::unordered_map<CFGBlock*, llvm::BasicBlock*>& entry_blocks,
                     CFGBlock* myblock, TypeAnalysis* types)
-        : irstate(irstate), curblock(entry_blocks[myblock]), emitter(irstate, curblock, this),
-          entry_blocks(entry_blocks), myblock(myblock), types(types), state(RUNNING) {}
+        : irstate(irstate),
+          curblock(entry_blocks[myblock]),
+          emitter(irstate, curblock, this),
+          entry_blocks(entry_blocks),
+          myblock(myblock),
+          types(types),
+          state(RUNNING) {}
 
     ~IRGeneratorImpl() { delete emitter.getBuilder(); }
 

--- a/src/codegen/patchpoints.h
+++ b/src/codegen/patchpoints.h
@@ -56,7 +56,10 @@ private:
     unsigned int id;
 
     PatchpointInfo(CompiledFunction* parent_cf, const ICSetupInfo* icinfo, int num_ic_stackmap_args)
-        : parent_cf(parent_cf), icinfo(icinfo), num_ic_stackmap_args(num_ic_stackmap_args), num_frame_stackmap_args(-1),
+        : parent_cf(parent_cf),
+          icinfo(icinfo),
+          num_ic_stackmap_args(num_ic_stackmap_args),
+          num_frame_stackmap_args(-1),
           id(0) {}
 
 
@@ -115,7 +118,10 @@ public:
 
 private:
     ICSetupInfo(ICType type, int num_slots, int slot_size, bool has_return_value, TypeRecorder* type_recorder)
-        : type(type), num_slots(num_slots), slot_size(slot_size), has_return_value(has_return_value),
+        : type(type),
+          num_slots(num_slots),
+          slot_size(slot_size),
+          has_return_value(has_return_value),
           type_recorder(type_recorder) {}
 
 public:

--- a/src/core/ast.h
+++ b/src/core/ast.h
@@ -707,7 +707,9 @@ public:
     virtual void* accept_expr(ExprVisitor* v);
 
     AST_Name(InternedString id, AST_TYPE::AST_TYPE ctx_type, int lineno, int col_offset = 0)
-        : AST_expr(AST_TYPE::Name, lineno, col_offset), ctx_type(ctx_type), id(id),
+        : AST_expr(AST_TYPE::Name, lineno, col_offset),
+          ctx_type(ctx_type),
+          id(id),
           lookup_type(ScopeInfo::VarScopeType::UNKNOWN) {}
 
     static const AST_TYPE::AST_TYPE TYPE = AST_TYPE::Name;

--- a/src/core/cfg.cpp
+++ b/src/core/cfg.cpp
@@ -147,8 +147,12 @@ private:
 
         ContInfo(CFGBlock* continue_dest, CFGBlock* break_dest, CFGBlock* return_dest, bool say_why,
                  InternedString why_name)
-            : continue_dest(continue_dest), break_dest(break_dest), return_dest(return_dest), say_why(say_why),
-              did_why(0), why_name(why_name) {}
+            : continue_dest(continue_dest),
+              break_dest(break_dest),
+              return_dest(return_dest),
+              say_why(say_why),
+              did_why(0),
+              why_name(why_name) {}
     };
 
     struct ExcBlockInfo {
@@ -179,7 +183,10 @@ private:
 public:
     CFGVisitor(SourceInfo* source, AST_TYPE::AST_TYPE root_type, FutureFlags future_flags,
                ScopingAnalysis* scoping_analysis, CFG* cfg)
-        : source(source), root_type(root_type), future_flags(future_flags), cfg(cfg),
+        : source(source),
+          root_type(root_type),
+          future_flags(future_flags),
+          cfg(cfg),
           scoping_analysis(scoping_analysis) {
         curblock = cfg->addBlock();
         curblock->info = "entry";

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -200,8 +200,16 @@ public:
 
     CompiledFunction(llvm::Function* func, FunctionSpecialization* spec, bool is_interpreted, void* code,
                      EffortLevel effort, const OSREntryDescriptor* entry_descriptor)
-        : clfunc(NULL), func(func), spec(spec), entry_descriptor(entry_descriptor), is_interpreted(is_interpreted),
-          code(code), effort(effort), times_called(0), times_speculation_failed(0), location_map(nullptr) {
+        : clfunc(NULL),
+          func(func),
+          spec(spec),
+          entry_descriptor(entry_descriptor),
+          is_interpreted(is_interpreted),
+          code(code),
+          effort(effort),
+          times_called(0),
+          times_speculation_failed(0),
+          location_map(nullptr) {
         assert((spec != NULL) + (entry_descriptor != NULL) == 1);
     }
 
@@ -288,13 +296,23 @@ public:
 
     CLFunction(int num_args, int num_defaults, bool takes_varargs, bool takes_kwargs,
                std::unique_ptr<SourceInfo> source)
-        : num_args(num_args), num_defaults(num_defaults), takes_varargs(takes_varargs), takes_kwargs(takes_kwargs),
-          source(std::move(source)), param_names(this->source->ast), always_use_version(NULL) {
+        : num_args(num_args),
+          num_defaults(num_defaults),
+          takes_varargs(takes_varargs),
+          takes_kwargs(takes_kwargs),
+          source(std::move(source)),
+          param_names(this->source->ast),
+          always_use_version(NULL) {
         assert(num_args >= num_defaults);
     }
     CLFunction(int num_args, int num_defaults, bool takes_varargs, bool takes_kwargs, const ParamNames& param_names)
-        : num_args(num_args), num_defaults(num_defaults), takes_varargs(takes_varargs), takes_kwargs(takes_kwargs),
-          source(nullptr), param_names(param_names), always_use_version(NULL) {
+        : num_args(num_args),
+          num_defaults(num_defaults),
+          takes_varargs(takes_varargs),
+          takes_kwargs(takes_kwargs),
+          source(nullptr),
+          param_names(param_names),
+          always_use_version(NULL) {
         assert(num_args >= num_defaults);
     }
 

--- a/src/runtime/generator.cpp
+++ b/src/runtime/generator.cpp
@@ -224,8 +224,17 @@ extern "C" BoxedGenerator* createGenerator(BoxedFunctionBase* function, Box* arg
 
 
 extern "C" BoxedGenerator::BoxedGenerator(BoxedFunctionBase* function, Box* arg1, Box* arg2, Box* arg3, Box** args)
-    : function(function), arg1(arg1), arg2(arg2), arg3(arg3), args(nullptr), entryExited(false), running(false),
-      returnValue(nullptr), exception(nullptr, nullptr, nullptr), context(nullptr), returnContext(nullptr) {
+    : function(function),
+      arg1(arg1),
+      arg2(arg2),
+      arg3(arg3),
+      args(nullptr),
+      entryExited(false),
+      running(false),
+      returnValue(nullptr),
+      exception(nullptr, nullptr, nullptr),
+      context(nullptr),
+      returnContext(nullptr) {
 
     int numArgs = function->f->num_args;
     if (numArgs > 3) {

--- a/src/runtime/objmodel.cpp
+++ b/src/runtime/objmodel.cpp
@@ -318,8 +318,13 @@ void BoxedClass::freeze() {
 
 BoxedClass::BoxedClass(BoxedClass* base, gcvisit_func gc_visit, int attrs_offset, int weaklist_offset,
                        int instance_size, bool is_user_defined)
-    : attrs(HiddenClass::makeSingleton()), gc_visit(gc_visit), simple_destructor(NULL), attrs_offset(attrs_offset),
-      is_constant(false), is_user_defined(is_user_defined), is_pyston_class(true) {
+    : attrs(HiddenClass::makeSingleton()),
+      gc_visit(gc_visit),
+      simple_destructor(NULL),
+      attrs_offset(attrs_offset),
+      is_constant(false),
+      is_user_defined(is_user_defined),
+      is_pyston_class(true) {
 
     // Zero out the CPython tp_* slots:
     memset(&tp_name, 0, (char*)(&tp_version_tag + 1) - (char*)(&tp_name));
@@ -400,7 +405,8 @@ void BoxedClass::finishInitialization() {
 
 BoxedHeapClass::BoxedHeapClass(BoxedClass* base, gcvisit_func gc_visit, int attrs_offset, int weaklist_offset,
                                int instance_size, bool is_user_defined, BoxedString* name)
-    : BoxedClass(base, gc_visit, attrs_offset, weaklist_offset, instance_size, is_user_defined), ht_name(name),
+    : BoxedClass(base, gc_visit, attrs_offset, weaklist_offset, instance_size, is_user_defined),
+      ht_name(name),
       ht_slots(NULL) {
 
     tp_as_number = &as_number;

--- a/src/runtime/rewrite_args.h
+++ b/src/runtime/rewrite_args.h
@@ -30,7 +30,11 @@ struct GetattrRewriteArgs {
     bool obj_hcls_guarded;
 
     GetattrRewriteArgs(Rewriter* rewriter, RewriterVar* obj, Location destination)
-        : rewriter(rewriter), obj(obj), destination(destination), out_success(false), out_rtn(NULL),
+        : rewriter(rewriter),
+          obj(obj),
+          destination(destination),
+          out_success(false),
+          out_rtn(NULL),
           obj_hcls_guarded(false) {}
 };
 
@@ -78,8 +82,17 @@ struct CallRewriteArgs {
     RewriterVar* out_rtn;
 
     CallRewriteArgs(Rewriter* rewriter, RewriterVar* obj, Location destination)
-        : rewriter(rewriter), obj(obj), arg1(NULL), arg2(NULL), arg3(NULL), args(NULL), func_guarded(false),
-          args_guarded(false), destination(destination), out_success(false), out_rtn(NULL) {}
+        : rewriter(rewriter),
+          obj(obj),
+          arg1(NULL),
+          arg2(NULL),
+          arg3(NULL),
+          args(NULL),
+          func_guarded(false),
+          args_guarded(false),
+          destination(destination),
+          out_success(false),
+          out_rtn(NULL) {}
 };
 
 struct BinopRewriteArgs {

--- a/src/runtime/types.cpp
+++ b/src/runtime/types.cpp
@@ -287,8 +287,15 @@ Box* Box::nextIC() {
 std::string builtinStr("__builtin__");
 
 extern "C" BoxedFunctionBase::BoxedFunctionBase(CLFunction* f)
-    : in_weakreflist(NULL), f(f), closure(NULL), isGenerator(false), ndefaults(0), defaults(NULL), modname(NULL),
-      name(NULL), doc(NULL) {
+    : in_weakreflist(NULL),
+      f(f),
+      closure(NULL),
+      isGenerator(false),
+      ndefaults(0),
+      defaults(NULL),
+      modname(NULL),
+      name(NULL),
+      doc(NULL) {
     if (f->source) {
         this->modname = PyDict_GetItemString(getGlobalsDict(), "__name__");
         this->doc = f->source->getDocString();
@@ -302,8 +309,15 @@ extern "C" BoxedFunctionBase::BoxedFunctionBase(CLFunction* f)
 
 extern "C" BoxedFunctionBase::BoxedFunctionBase(CLFunction* f, std::initializer_list<Box*> defaults,
                                                 BoxedClosure* closure, bool isGenerator)
-    : in_weakreflist(NULL), f(f), closure(closure), isGenerator(isGenerator), ndefaults(0), defaults(NULL),
-      modname(NULL), name(NULL), doc(NULL) {
+    : in_weakreflist(NULL),
+      f(f),
+      closure(closure),
+      isGenerator(isGenerator),
+      ndefaults(0),
+      defaults(NULL),
+      modname(NULL),
+      name(NULL),
+      doc(NULL) {
     if (defaults.size()) {
         // make sure to initialize defaults first, since the GC behavior is triggered by ndefaults,
         // and a GC can happen within this constructor:


### PR DESCRIPTION
The really long constructor initializer lists are pretty hard to read. This turns on the ConstructorInitializerAllOnOneLineOrOnePerLine option, which puts them one-per-line.

I realize that format style changes can be contentious :P so feel free to ignore if you disagree.