### PR TITLE
use llvm::StringRef instead of std::string typeNew

### DIFF
--- a/src/capi/typeobject.cpp
+++ b/src/capi/typeobject.cpp
@@ -1482,7 +1482,7 @@ static slotdef slotdefs[]
         SQSLOT("__contains__", sq_contains, slot_sq_contains, wrap_objobjproc, "x.__contains__(y) <==> y in x"),
         SQSLOT("__iadd__", sq_inplace_concat, NULL, wrap_binaryfunc, "x.__iadd__(y) <==> x+=y"),
         SQSLOT("__imul__", sq_inplace_repeat, NULL, wrap_indexargfunc, "x.__imul__(y) <==> x*=y"),
-        { NULL, 0, NULL, NULL, NULL, 0 } };
+        { "", 0, NULL, NULL, "", 0 } };
 
 static void init_slotdefs() noexcept {
     static bool initialized = false;
@@ -1491,21 +1491,21 @@ static void init_slotdefs() noexcept {
 
     for (int i = 0; i < sizeof(slotdefs) / sizeof(slotdefs[0]); i++) {
         if (i > 0) {
-            if (!slotdefs[i].name)
+            if (!slotdefs[i].name.size())
                 continue;
 
 #ifndef NDEBUG
             if (slotdefs[i - 1].offset > slotdefs[i].offset) {
-                printf("slotdef for %s in the wrong place\n", slotdefs[i - 1].name);
+                printf("slotdef for %s in the wrong place\n", slotdefs[i - 1].name.data());
                 for (int j = i; j < sizeof(slotdefs) / sizeof(slotdefs[0]); j++) {
                     if (slotdefs[i - 1].offset <= slotdefs[j].offset) {
-                        printf("Should go before %s\n", slotdefs[j].name);
+                        printf("Should go before %s\n", slotdefs[j].name.data());
                         break;
                     }
                 }
             }
 #endif
-            ASSERT(slotdefs[i].offset >= slotdefs[i - 1].offset, "%d %s", i, slotdefs[i - 1].name);
+            ASSERT(slotdefs[i].offset >= slotdefs[i - 1].offset, "%d %s", i, slotdefs[i - 1].name.data());
             // CPython interns the name here
         }
     }
@@ -1534,7 +1534,7 @@ static void** resolve_slotdups(PyTypeObject* type, const std::string& name) noex
         /* Collect all slotdefs that match name into ptrs. */
         pname = name;
         pp = ptrs;
-        for (p = slotdefs; p->name; p++) {
+        for (p = slotdefs; p->name.size() != 0; p++) {
             if (p->name == name)
                 *pp++ = p;
         }
@@ -1556,7 +1556,7 @@ static void** resolve_slotdups(PyTypeObject* type, const std::string& name) noex
 }
 
 static const slotdef* update_one_slot(BoxedClass* type, const slotdef* p) noexcept {
-    assert(p->name);
+    assert(p->name.size() != 0);
 
     PyObject* descr;
     BoxedWrapperDescriptor* d;
@@ -1646,7 +1646,7 @@ static int update_slots_callback(PyTypeObject* type, void* data) noexcept {
 static int update_subclasses(PyTypeObject* type, PyObject* name, update_callback callback, void* data) noexcept;
 static int recurse_down_subclasses(PyTypeObject* type, PyObject* name, update_callback callback, void* data) noexcept;
 
-bool update_slot(BoxedClass* type, const std::string& attr) noexcept {
+bool update_slot(BoxedClass* type, llvm::StringRef attr) noexcept {
     slotdef* ptrs[MAX_EQUIV];
     slotdef* p;
     slotdef** pp;
@@ -1661,7 +1661,7 @@ bool update_slot(BoxedClass* type, const std::string& attr) noexcept {
 
     init_slotdefs();
     pp = ptrs;
-    for (p = slotdefs; p->name; p++) {
+    for (p = slotdefs; p->name.size() != 0; p++) {
         /* XXX assume name is interned! */
         if (p->name == attr)
             *pp++ = p;
@@ -1688,7 +1688,7 @@ void fixup_slot_dispatchers(BoxedClass* self) noexcept {
     init_slotdefs();
 
     const slotdef* p = slotdefs;
-    while (p->name)
+    while (p->name.size() != 0)
         p = update_one_slot(self, p);
 }
 
@@ -2666,7 +2666,7 @@ static void update_all_slots(PyTypeObject* type) noexcept {
     slotdef* p;
 
     init_slotdefs();
-    for (p = slotdefs; p->name; p++) {
+    for (p = slotdefs; p->name.size() > 0; p++) {
         /* update_slot returns int but can't actually fail */
         update_slot(type, p->name);
     }

--- a/src/capi/typeobject.h
+++ b/src/capi/typeobject.h
@@ -20,7 +20,7 @@
 namespace pyston {
 
 // Returns if a slot was updated
-bool update_slot(BoxedClass* self, const std::string& attr) noexcept;
+bool update_slot(BoxedClass* self, llvm::StringRef attr) noexcept;
 
 void add_operators(BoxedClass* self) noexcept;
 void fixup_slot_dispatchers(BoxedClass* self) noexcept;

--- a/src/capi/types.h
+++ b/src/capi/types.h
@@ -25,11 +25,11 @@ typedef PyObject* (*wrapperfunc)(PyObject* self, PyObject* args, void* wrapped);
 typedef PyObject* (*wrapperfunc_kwds)(PyObject* self, PyObject* args, void* wrapped, PyObject* kwds);
 
 struct wrapper_def {
-    const char* name;
+    const llvm::StringRef name;
     int offset;
     void* function;      // "generic" handler that gets put in the tp_* slot which proxies to the python version
     wrapperfunc wrapper; // "wrapper" that ends up getting called by the Python-visible WrapperDescr
-    const char* doc;
+    const llvm::StringRef doc;
     int flags;
     // exists in CPython: PyObject *name_strobj
 };


### PR DESCRIPTION
found this while adding more timers and figured it was small enough to just fix instead of creating a trello card for it.

turns out we're converting from const char* to std::string (including the malloc/free) for num_slots * num_typeNew_calls.