### PR TITLE
Fewer StopIteration exceptions

### DIFF
--- a/src/capi/types.h
+++ b/src/capi/types.h
@@ -139,7 +139,7 @@ public:
         if (flags == PyWrapperFlag_KEYWORDS) {
             wrapperfunc_kwds wk = (wrapperfunc_kwds)wrapper;
             rtn = (*wk)(self->obj, args, self->descr->wrapped, kwds);
-        } else if (flags == 0) {
+        } else if (flags == PyWrapperFlag_PYSTON || flags == 0) {
             rtn = (*wrapper)(self->obj, args, self->descr->wrapped);
         } else {
             RELEASE_ASSERT(0, "%d", flags);

--- a/src/runtime/types.cpp
+++ b/src/runtime/types.cpp
@@ -2587,7 +2587,7 @@ void setupRuntime() {
 }
 
 BoxedModule* createModule(const std::string& name, const char* fn, const char* doc) {
-    assert(!fn || strlen(fn) && "probably wanted to set the fn to <stdin>?");
+    assert((!fn || strlen(fn)) && "probably wanted to set the fn to <stdin>?");
 
     BoxedDict* d = getSysModulesDict();
     Box* b_name = boxStringPtr(&name);

--- a/src/runtime/types.cpp
+++ b/src/runtime/types.cpp
@@ -2058,6 +2058,8 @@ inline void initUserAttrs(Box* obj, BoxedClass* cls) {
     }
 }
 
+extern "C" void PyCallIter_AddHasNext();
+
 extern "C" PyObject* PyObject_Init(PyObject* op, PyTypeObject* tp) noexcept {
     assert(op);
     assert(tp);
@@ -2512,6 +2514,7 @@ void setupRuntime() {
 
     PyType_Ready(&PyByteArrayIter_Type);
     PyType_Ready(&PyCapsule_Type);
+    PyCallIter_AddHasNext();
     PyType_Ready(&PyCallIter_Type);
     PyType_Ready(&PyCObject_Type);
 

--- a/src/runtime/types.h
+++ b/src/runtime/types.h
@@ -834,6 +834,7 @@ public:
     bool entryExited;
     bool running;
     Box* returnValue;
+    bool iterated_from__hasnext__;
     ExcInfo exception;
 
     struct Context* context, *returnContext;


### PR DESCRIPTION
convert both generators and PyCallIter (used for the sre match iteration code, amongst other places) to use `__hasnext__`-style iteration.  This reduces the number of exceptions thrown by django, and trims about 3s off the django integration test (using pyston_dbg).

the gcc warning fix and `fact()` change were to get make check to succeed for me.