### PR TITLE
increase size and number of generic ICs slots (used for getBoxedIterWrapperIfNeeded)

### DIFF
--- a/microbenchmarks/iteration-megamorphic1.py
+++ b/microbenchmarks/iteration-megamorphic1.py
@@ -1,0 +1,26 @@
+class Iterable(object):
+    def __iter__(self):
+        return self
+
+    def __hasnext__(self):
+        False
+
+    def next(self):
+        raise StopIteration()
+
+class IterableSub(Iterable):
+    pass
+
+def do_iter(r):
+    for i in r:
+        pass
+
+
+i1 = Iterable()
+i2 = IterableSub()
+
+f = 0
+while f < 100000:
+    f += 1
+    do_iter(i1)
+    do_iter(i2)

--- a/microbenchmarks/iteration-megamorphic2.py
+++ b/microbenchmarks/iteration-megamorphic2.py
@@ -1,0 +1,26 @@
+class Iterable(object):
+    def __iter__(self):
+        return self
+
+    def __hasnext__(self):
+        False
+
+    def next(self):
+        raise StopIteration()
+
+
+def do_iter(r):
+    for i in r:
+        pass
+
+
+i1 = Iterable()
+
+f = 0
+while f < 100000:
+    class IterableSub(Iterable):
+        pass
+    i2 = IterableSub()
+    f += 1
+    do_iter(i1)
+    do_iter(i2)

--- a/src/codegen/patchpoints.cpp
+++ b/src/codegen/patchpoints.cpp
@@ -299,7 +299,7 @@ PatchpointInfo* PatchpointInfo::create(CompiledFunction* parent_cf, const ICSetu
 }
 
 ICSetupInfo* createGenericIC(TypeRecorder* type_recorder, bool has_return_value, int size) {
-    return ICSetupInfo::initialize(has_return_value, 1, size, ICSetupInfo::Generic, type_recorder);
+    return ICSetupInfo::initialize(has_return_value, 4, size, ICSetupInfo::Generic, type_recorder);
 }
 
 ICSetupInfo* createGetattrIC(TypeRecorder* type_recorder) {


### PR DESCRIPTION
also add some megamorphic microbenchmarks.  The code changes in this commit fix
iteration-megamorphic1.py.  The second rewrite was larger than 128 bytes and didn't fit
in the slot as allocated.  This fixes some of the easiest megamorphic IC's we're seeing
in the django template test.

iteration-megamorphic2.py is harder for us since we get a new class every time. If
we can figure out a way to guard on just the mro (and guarantee that the mro is shared
across all subclasses that don't specify their own), then we should still have 2 slots
used in iteration-megamorphic2.py
