### PR TITLE
Add pycurl as an 'extra' test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ addons:
     - ninja-build
     - python-dev
     - texlive-extra-utils
+    - libcurl4-openssl-dev
 
 before_install:
   - if [ "$CC" = "clang" ]; then export CC="clang-3.5" CXX="clang++-3.5"; fi
@@ -53,6 +54,7 @@ script:
   - ninja -j4 pyston
   - ccache -s
   - PYSTON_RUN_ARGS=G ninja check-pyston
+  - PYSTON_RUN_ARGS=G python $TRAVIS_BUILD_DIR/tools/tester.py -R ./pyston -a=-S -k -t180 --exit-code-only $TRAVIS_BUILD_DIR/test/extra
 
 os:
   - linux

--- a/Makefile
+++ b/Makefile
@@ -962,6 +962,7 @@ $1: nosearch_$1
 $1: $(TESTS_DIR)/nosearch_$1 ;
 $1: $(TEST_DIR)/cpython/nosearch_$1 ;
 $1: $(TEST_DIR)/integration/nosearch_$1 ;
+$1: $(TEST_DIR)/extra/nosearch_$1 ;
 $1: ./microbenchmarks/nosearch_$1 ;
 $1: ./minibenchmarks/nosearch_$1 ;
 $1: ./benchmarks/nosearch_$1 ;

--- a/src/jit.cpp
+++ b/src/jit.cpp
@@ -376,6 +376,11 @@ static int main(int argc, char** argv) {
             if (fn != NULL) {
                 llvm::SmallString<128> path;
 
+                if (!llvm::sys::fs::exists(fn)) {
+                    fprintf(stderr, "[Errno 2] No such file or directory: '%s'\n", fn);
+                    return 2;
+                }
+
                 if (!llvm::sys::path::is_absolute(fn)) {
                     char cwd_buf[1026];
                     char* cwd = getcwd(cwd_buf, sizeof(cwd_buf));
@@ -387,6 +392,7 @@ static int main(int argc, char** argv) {
                 llvm::sys::path::remove_filename(path);
                 char* real_path
                     = realpath(path.str().str().c_str(), NULL); // inefficient way of null-terminating the string
+                ASSERT(real_path, "%s %s", path.str().str().c_str(), strerror(errno));
                 prependToSysPath(real_path);
                 free(real_path);
 

--- a/test/extra/pycurl_test.py
+++ b/test/extra/pycurl_test.py
@@ -1,0 +1,37 @@
+# pycurl depends on libcurl
+
+import os
+import sys
+import subprocess
+import shutil
+
+p = subprocess.Popen(["which", "curl-config"], stdout=open("/dev/null", 'w'))
+if p.wait() != 0:
+    print >>sys.stderr, "curl-config not available; try 'sudo apt-get install libcurl4-openssl-dev'"
+    sys.exit(1)
+
+VIRTUALENV_SCRIPT = os.path.dirname(__file__) + "/../integration/virtualenv/virtualenv.py"
+
+if os.path.exists("pycurl_test_env"):
+    print "Removing the existing 'pycurl_test_env/' directory"
+    subprocess.check_call(["rm", "-rf", "pycurl_test_env"])
+    # shutil follows symlinks to directories, and deletes whatever those contain.
+    # shutil.rmtree("pycurl_test_env")
+
+args = [sys.executable, VIRTUALENV_SCRIPT, "-p", sys.executable, "pycurl_test_env"]
+print "Running", args
+subprocess.check_call(args)
+
+sh_script = """
+set -e
+. pycurl_test_env/bin/activate
+set -ux
+pip install pycurl==7.19.5.1
+python -c 'import pycurl; print "pycurl imports"'
+""".strip()
+
+# print sh_script
+subprocess.check_call(["sh", "-c", sh_script])
+
+print
+print "PASSED"


### PR DESCRIPTION
I don't feel like it's worth adding libcurl to our dependencies
just so that we can test pycurl.  Let's try adding it as a
Travis-CI-only test; I'm slightly worried that that will confuse people,
but I think we're already pretty used to travis-ci being a more
comprehensive test suite.