### PR TITLE
WIP: add "shapes" for BoxedClass

### DIFF
--- a/from_cpython/CMakeLists.txt
+++ b/from_cpython/CMakeLists.txt
@@ -112,12 +112,15 @@ file(GLOB_RECURSE STDPARSER_SRCS Parser
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-missing-field-initializers -Wno-tautological-compare -Wno-type-limits -Wno-unused-result -Wno-strict-aliasing")
 add_library(FROM_CPYTHON OBJECT ${STDMODULE_SRCS} ${STDOBJECT_SRCS} ${STDPYTHON_SRCS} ${STDPARSER_SRCS})
 
+file(GLOB HEADER_DEPS Include/*.h)
+
 add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/lib_pyston/_multiprocessing.pyston.so ${CMAKE_BINARY_DIR}/lib_pyston/pyexpat.pyston.so
                    COMMAND ${CMAKE_BINARY_DIR}/pyston setup.py build --build-lib ${CMAKE_BINARY_DIR}/lib_pyston
                    DEPENDS
                        pyston
                        copy_stdlib
                        copy_libpyston
+		       ${HEADER_DEPS}
                        Modules/_multiprocessing/multiprocessing.c
                        Modules/_multiprocessing/semaphore.c
                        Modules/_multiprocessing/socket_connection.c

--- a/from_cpython/Include/object.h
+++ b/from_cpython/Include/object.h
@@ -454,6 +454,14 @@ struct _typeobject {
 
     void* _hcls;
     void* _hcattrs;
+    struct {
+        // we store the sha256 hash in here
+        uint64_t t0;
+        uint64_t t1;
+        uint64_t t2;
+        uint64_t t3;
+    } _local_shape;
+    void* _total_shape;
     char _ics[32];
     void* _gcvisit_func;
     void* _dtor;

--- a/src/capi/typeobject.cpp
+++ b/src/capi/typeobject.cpp
@@ -2936,7 +2936,7 @@ extern "C" void PyType_Modified(PyTypeObject* type) noexcept {
 
     // Pyston change: invalidate the things we cache on types.
     type->total_shape = NULL;
-    type->computeTotalShape();
+    Shape::computeTotalShape(type);
 
     raw = type->tp_subclasses;
     if (raw != NULL) {

--- a/src/codegen/entry.cpp
+++ b/src/codegen/entry.cpp
@@ -42,6 +42,7 @@
 #include "codegen/memmgr.h"
 #include "codegen/profiling/profiling.h"
 #include "codegen/stackmaps.h"
+#include "core/hash.h"
 #include "core/options.h"
 #include "core/types.h"
 #include "core/util.h"
@@ -206,38 +207,6 @@ public:
 
 class PystonObjectCache : public llvm::ObjectCache {
 private:
-    // Stream which calculates the SHA256 hash of the data writen to.
-    class HashOStream : public llvm::raw_ostream {
-        EVP_MD_CTX* md_ctx;
-
-        void write_impl(const char* ptr, size_t size) override { EVP_DigestUpdate(md_ctx, ptr, size); }
-        uint64_t current_pos() const override { return 0; }
-
-    public:
-        HashOStream() {
-            md_ctx = EVP_MD_CTX_create();
-            RELEASE_ASSERT(md_ctx, "");
-            int ret = EVP_DigestInit_ex(md_ctx, EVP_sha256(), NULL);
-            RELEASE_ASSERT(ret == 1, "");
-        }
-        ~HashOStream() { EVP_MD_CTX_destroy(md_ctx); }
-
-        std::string getHash() {
-            flush();
-            unsigned char md_value[EVP_MAX_MD_SIZE];
-            unsigned int md_len = 0;
-            int ret = EVP_DigestFinal_ex(md_ctx, md_value, &md_len);
-            RELEASE_ASSERT(ret == 1, "");
-
-            std::string str;
-            str.reserve(md_len * 2 + 1);
-            llvm::raw_string_ostream stream(str);
-            for (int i = 0; i < md_len; ++i)
-                stream.write_hex(md_value[i]);
-            return stream.str();
-        }
-    };
-
     llvm::SmallString<128> cache_dir;
     std::string module_identifier;
     std::string hash_before_codegen;
@@ -282,7 +251,7 @@ public:
         module_identifier = M->getModuleIdentifier();
 
         // Generate a hash for the module
-        HashOStream hash_stream;
+        SHA256OStream hash_stream;
         llvm::WriteBitcodeToFile(M, hash_stream);
         hash_before_codegen = hash_stream.getHash();
 

--- a/src/codegen/patchpoints.cpp
+++ b/src/codegen/patchpoints.cpp
@@ -299,7 +299,7 @@ PatchpointInfo* PatchpointInfo::create(CompiledFunction* parent_cf, const ICSetu
 }
 
 ICSetupInfo* createGenericIC(TypeRecorder* type_recorder, bool has_return_value, int size) {
-    return ICSetupInfo::initialize(has_return_value, 1, size, ICSetupInfo::Generic, type_recorder);
+    return ICSetupInfo::initialize(has_return_value, 4, size, ICSetupInfo::Generic, type_recorder);
 }
 
 ICSetupInfo* createGetattrIC(TypeRecorder* type_recorder) {

--- a/src/core/hash.h
+++ b/src/core/hash.h
@@ -1,0 +1,74 @@
+// Copyright (c) 2014-2015 Dropbox, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef PYSTON_CORE_HASH_H
+#define PYSTON_CORE_HASH_H
+
+#include <iostream>
+#include <openssl/evp.h>
+#include <string>
+
+#include "llvm/Support/raw_ostream.h"
+
+namespace pyston {
+
+// Stream which calculates the SHA256 hash of the data written to it.
+class SHA256OStream : public llvm::raw_ostream {
+    EVP_MD_CTX* md_ctx;
+
+    void write_impl(const char* ptr, size_t size) override { EVP_DigestUpdate(md_ctx, ptr, size); }
+    uint64_t current_pos() const override { return 0; }
+
+public:
+    SHA256OStream() {
+        md_ctx = EVP_MD_CTX_create();
+        RELEASE_ASSERT(md_ctx, "");
+        int ret = EVP_DigestInit_ex(md_ctx, EVP_sha256(), NULL);
+        RELEASE_ASSERT(ret == 1, "");
+    }
+    ~SHA256OStream() { EVP_MD_CTX_destroy(md_ctx); }
+
+    std::string getHash() {
+        flush();
+        unsigned char md_value[EVP_MAX_MD_SIZE];
+        unsigned int md_len = 0;
+        int ret = EVP_DigestFinal_ex(md_ctx, md_value, &md_len);
+        RELEASE_ASSERT(ret == 1, "");
+
+        std::string str;
+        str.reserve(md_len * 2 + 1);
+        llvm::raw_string_ostream stream(str);
+        for (int i = 0; i < md_len; ++i)
+            stream.write_hex(md_value[i]);
+        return stream.str();
+    }
+
+    void getHash(uint64_t* hash_output) {
+        flush();
+        unsigned char md_value[EVP_MAX_MD_SIZE];
+        unsigned int md_len = 0;
+        int ret = EVP_DigestFinal_ex(md_ctx, md_value, &md_len);
+        RELEASE_ASSERT(ret == 1, "");
+        RELEASE_ASSERT(md_len = 32, "");
+
+        uint64_t* p = reinterpret_cast<uint64_t*>(&md_value[0]);
+        hash_output[0] = p[0];
+        hash_output[1] = p[1];
+        hash_output[2] = p[2];
+        hash_output[3] = p[3];
+    }
+};
+}
+
+#endif

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -391,6 +391,7 @@ enum class GCKind : uint8_t {
     UNTRACKED = 4,
     HIDDEN_CLASS = 5,
     CONSERVATIVE_PYTHON = 6,
+    SHAPE = 7
 };
 
 extern "C" void* gc_alloc(size_t nbytes, GCKind kind);

--- a/src/gc/collector.cpp
+++ b/src/gc/collector.cpp
@@ -332,6 +332,9 @@ void markPhase() {
         } else if (kind_id == GCKind::HIDDEN_CLASS) {
             HiddenClass* hcls = reinterpret_cast<HiddenClass*>(p);
             hcls->gc_visit(&visitor);
+        } else if (kind_id == GCKind::SHAPE) {
+            Shape* shape = reinterpret_cast<Shape*>(p);
+            shape->gc_visit(&visitor);
         } else {
             RELEASE_ASSERT(0, "Unhandled kind: %d", (int)kind_id);
         }

--- a/src/gc/heap.cpp
+++ b/src/gc/heap.cpp
@@ -212,7 +212,7 @@ struct HeapStatistics {
     int num_hcls_by_attrs[HCLS_ATTRS_STAT_MAX + 1];
     int num_hcls_by_attrs_exceed;
 
-    TypeStats python, conservative, conservative_python, untracked, hcls, precise;
+    TypeStats python, conservative, conservative_python, untracked, hcls, precise, shape;
     TypeStats total;
 
     HeapStatistics(bool collect_cls_stats, bool collect_hcls_stats)
@@ -277,6 +277,9 @@ void addStatistic(HeapStatistics* stats, GCAllocation* al, int nbytes) {
             else
                 stats->num_hcls_by_attrs_exceed++;
         }
+    } else if (al->kind_id == GCKind::SHAPE) {
+        stats->shape.nallocs++;
+        stats->shape.nbytes += nbytes;
     } else if (al->kind_id == GCKind::PRECISE) {
         stats->precise.nallocs++;
         stats->precise.nbytes += nbytes;
@@ -306,6 +309,7 @@ void Heap::dumpHeapStatistics(int level) {
     stats.conservative_python.print("conservative_python");
     stats.untracked.print("untracked");
     stats.hcls.print("hcls");
+    stats.shape.print("shape");
     stats.precise.print("precise");
 
     if (collect_cls_stats) {

--- a/src/gc/heap.h
+++ b/src/gc/heap.h
@@ -159,8 +159,8 @@ constexpr uintptr_t HUGE_ARENA_START = 0x3270000000L;
 // bitmap for objects of a given size (constant for the block)
 //
 static const size_t sizes[] = {
-    16,  32,  48,  64,  80,  96,  112, 128, 160, 192,
-    224, 256, 320, 384, 448, 512, 640, 768, 896, 1024 //, 1280, 1536, 1792, 2048, 2560, 3072, 3584, // 4096,
+    16,  32,  48,  64,  80,  96,  112, 128, 160,  192,  224,
+    256, 320, 384, 448, 512, 640, 768, 896, 1024, 1280, // 1536, 1792, 2048, 2560, 3072, 3584, // 4096,
 };
 static constexpr size_t NUM_BUCKETS = sizeof(sizes) / sizeof(sizes[0]);
 

--- a/src/runtime/builtin_modules/pyston.cpp
+++ b/src/runtime/builtin_modules/pyston.cpp
@@ -62,12 +62,8 @@ static Box* dumpStats(Box* includeZeros) {
 }
 
 static Box* dumpTotalShape(Box* cls) {
-    if (!isSubclass(cls->cls, type_cls))
-        raiseExcHelper(TypeError, "cls must be a 'type' object but received a '%s'", getTypeName(cls));
-
-    auto _cls = static_cast<BoxedClass*>(cls);
-    _cls->computeTotalShape();
-    fprintf(stderr, "TotalShape(%p)\n", _cls->total_shape);
+    Shape* s = Shape::computeTotalShape(cls);
+    fprintf(stderr, "TotalShape(%p)\n", s);
     return None;
 }
 

--- a/src/runtime/builtin_modules/pyston.cpp
+++ b/src/runtime/builtin_modules/pyston.cpp
@@ -61,6 +61,16 @@ static Box* dumpStats(Box* includeZeros) {
     return None;
 }
 
+static Box* dumpTotalShape(Box* cls) {
+    if (!isSubclass(cls->cls, type_cls))
+        raiseExcHelper(TypeError, "cls must be a 'type' object but received a '%s'", getTypeName(cls));
+
+    auto _cls = static_cast<BoxedClass*>(cls);
+    _cls->computeTotalShape();
+    fprintf(stderr, "TotalShape(%p)\n", _cls->total_shape);
+    return None;
+}
+
 void setupPyston() {
     pyston_module = createModule("__pyston__");
 
@@ -72,5 +82,9 @@ void setupPyston() {
     pyston_module->giveAttr("dumpStats",
                             new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)dumpStats, NONE, 1, 1, false, false),
                                                              "dumpStats", { False }));
+
+    pyston_module->giveAttr("dumpTotalShape",
+                            new BoxedBuiltinFunctionOrMethod(
+                                boxRTFunction((void*)dumpTotalShape, NONE, 1, 0, false, false), "dumpTotalShape"));
 }
 }

--- a/src/runtime/objmodel.cpp
+++ b/src/runtime/objmodel.cpp
@@ -34,6 +34,7 @@
 #include "codegen/type_recording.h"
 #include "codegen/unwinding.h"
 #include "core/ast.h"
+#include "core/hash.h"
 #include "core/options.h"
 #include "core/stats.h"
 #include "core/types.h"
@@ -53,6 +54,7 @@
 #include "runtime/util.h"
 
 #define BOX_CLS_OFFSET ((char*)&(((Box*)0x01)->cls) - (char*)0x1)
+#define CLS_TOTAL_SHAPE_OFFSET ((char*)&(((BoxedClass*)0x01)->total_shape) - (char*)0x1)
 #define HCATTRS_HCLS_OFFSET ((char*)&(((HCAttrs*)0x01)->hcls) - (char*)0x1)
 #define HCATTRS_ATTRS_OFFSET ((char*)&(((HCAttrs*)0x01)->attr_list) - (char*)0x1)
 #define ATTRLIST_ATTRS_OFFSET ((char*)&(((HCAttrs::AttrList*)0x01)->attrs) - (char*)0x1)
@@ -300,6 +302,9 @@ extern "C" Box** unpackIntoArray(Box* obj, int64_t expected_size) {
     return &elts[0];
 }
 
+Shape* Shape::root_shape = new Shape(NULL);
+
+
 void BoxedClass::freeze() {
     assert(!is_constant);
     assert(tp_name); // otherwise debugging will be very hard
@@ -317,6 +322,8 @@ void BoxedClass::freeze() {
 BoxedClass::BoxedClass(BoxedClass* base, gcvisit_func gc_visit, int attrs_offset, int weaklist_offset,
                        int instance_size, bool is_user_defined)
     : attrs(HiddenClass::makeSingleton()),
+      local_shape(LocalShape::uninitialized()),
+      total_shape(NULL),
       gc_visit(gc_visit),
       simple_destructor(NULL),
       attrs_offset(attrs_offset),
@@ -399,6 +406,54 @@ void BoxedClass::finishInitialization() {
     this->tp_dict = this->getAttrWrapper();
 
     commonClassSetup(this);
+}
+
+LocalShape BoxedClass::computeLocalShape() {
+    if (local_shape.isUninitialized()) {
+        std::vector<std::pair<llvm::StringRef, int>> attrs;
+
+        // iterate over all class attributes, storing the pairs of name, offset into attrs
+        auto hcls = getHCAttrsPtr()->hcls;
+        llvm::StringMap<int>::const_iterator it;
+        for (it = hcls->getStrAttrOffsets().begin(); it != hcls->getStrAttrOffsets().end(); it++) {
+            attrs.emplace_back(it->first(), it->second);
+        }
+        // sort the vector to hopefully give a deterministic ordering
+        std::sort(attrs.begin(), attrs.end(), [](std::pair<llvm::StringRef, int> a, std::pair<llvm::StringRef, int> b) {
+            return a.second < b.second;
+        });
+
+        // compute a hash of all attribute names
+        SHA256OStream hash_stream;
+        for (auto& s : attrs) {
+            hash_stream << s.first;
+        }
+        uint64_t lshape[4];
+        hash_stream.getHash(lshape);
+        local_shape = LocalShape(lshape[0], lshape[1], lshape[2], lshape[3]);
+    }
+
+    return local_shape;
+}
+
+Shape* BoxedClass::computeTotalShape() {
+    if (total_shape)
+        return total_shape;
+
+    Shape* shape = Shape::root_shape;
+    auto mro = static_cast<BoxedTuple*>(this->tp_mro);
+
+    assert(this == mro->elts[0]);
+
+    for (int i = mro->ob_size - 1; i >= 0; i--) {
+        BoxedClass* b = static_cast<BoxedClass*>(mro->elts[i]);
+
+        LocalShape b_shape = computeLocalShape();
+        b->total_shape = shape->getOrMakeChild(b_shape);
+        shape = b->total_shape;
+    }
+
+    return total_shape;
 }
 
 BoxedHeapClass::BoxedHeapClass(BoxedClass* base, gcvisit_func gc_visit, int attrs_offset, int weaklist_offset,
@@ -915,43 +970,57 @@ Box* typeLookup(BoxedClass* cls, llvm::StringRef attr, GetattrRewriteArgs* rewri
     if (rewrite_args) {
         assert(!rewrite_args->out_success);
 
-        RewriterVar* obj_saved = rewrite_args->obj;
+        // Guard on the total shape of the class.
+        // from here we can assume that the index into the mro + the offset into the object remain the same.
+        Shape* total_shape = cls->computeTotalShape();
+        rewrite_args->obj->addAttrGuard(CLS_TOTAL_SHAPE_OFFSET, (intptr_t)total_shape);
 
-        auto _mro = cls->tp_mro;
-        assert(_mro->cls == tuple_cls);
-        BoxedTuple* mro = static_cast<BoxedTuple*>(_mro);
+        auto mro = static_cast<BoxedTuple*>(cls->tp_mro);
+        assert(mro->cls == tuple_cls);
 
-        // Guarding approach:
-        // Guard on the value of the tp_mro slot, which should be a tuple and thus be
-        // immutable.  Then we don't have to figure out the guards to emit that check
-        // the individual mro entries.
-        // We can probably move this guard to after we call getattr() on the given cls.
-        //
-        // TODO this can fail if we replace the mro with another mro that lives in the same
-        // address.
-        obj_saved->addAttrGuard(offsetof(BoxedClass, tp_mro), (intptr_t)mro);
+        int index = 0;
 
-        for (auto base : *mro) {
-            rewrite_args->out_success = false;
-            if (base == cls) {
-                // Small optimization: don't have to load the class again since it was given to us in
-                // a register.
-                assert(rewrite_args->obj == obj_saved);
-            } else {
-                rewrite_args->obj = rewrite_args->rewriter->loadConst((intptr_t)base, Location::any());
-            }
-            val = base->getattr(attr, rewrite_args);
-            assert(rewrite_args->out_success);
-            if (val)
+        // we always succeed here, we just might return NULL;
+        rewrite_args->out_success = true;
+
+        for (auto mc : *mro) {
+            BoxedClass* mro_cls = static_cast<BoxedClass*>(mc);
+
+            auto mro_cls_hcattrs = mro_cls->getHCAttrsPtr();
+            auto mro_cls_hcls = mro_cls_hcattrs->hcls;
+
+            int offset = mro_cls_hcls->getOffset(attr);
+
+            // this shouldn't be necessary since if a hidden class
+            // changes, we should also change the shapes of everything
+            // below it in its inheritance hierarchy.
+            if (mro_cls_hcls->type == HiddenClass::SINGLETON)
+                mro_cls_hcls->addDependence(rewrite_args->rewriter);
+
+            if (offset != -1) {
+                val = mro_cls_hcattrs->attr_list->attrs[offset];
+
+                // this encodes _mro_cls = rewrite_args->obj->tp_mro->elts[index]
+                RewriterVar* _mro = rewrite_args->obj->getAttr(offsetof(BoxedClass, tp_mro));
+                RewriterVar* _mro_cls = _mro->getAttr(offsetof(BoxedTuple, elts) + index * sizeof(Box*));
+
+                RewriterVar* r_attrs
+                    = _mro_cls->getAttr(mro_cls->cls->attrs_offset + HCATTRS_ATTRS_OFFSET, Location::any());
+                rewrite_args->out_rtn
+                    = r_attrs->getAttr(offset * sizeof(Box*) + ATTRLIST_ATTRS_OFFSET, Location::any());
+
                 return val;
+            }
+
+            index++;
         }
 
         return NULL;
     } else {
         assert(cls->tp_mro);
         assert(cls->tp_mro->cls == tuple_cls);
-        for (auto b : *static_cast<BoxedTuple*>(cls->tp_mro)) {
-            val = b->getattr(attr, NULL);
+        for (auto mc : *static_cast<BoxedTuple*>(cls->tp_mro)) {
+            val = mc->getattr(attr, NULL);
             if (val)
                 return val;
         }
@@ -4111,12 +4180,15 @@ extern "C" Box* createBoxedIterWrapperIfNeeded(Box* o) {
         if (!rewrite_args.out_success) {
             rewriter.reset(NULL);
         } else if (r) {
-            rewrite_args.out_rtn->addGuard((uint64_t)r);
+            // guard that r is non-null, don't guard on the specific value
+            rewrite_args.out_rtn->addGuardNotEq((uint64_t)0);
             if (rewrite_args.out_success) {
                 rewriter->commitReturning(r_o);
                 return o;
             }
         } else if (!r) {
+            // guard that r null
+            // rewrite_args.out_rtn->addGuard((uint64_t)0);
             RewriterVar* var = rewriter.get()->call(true, (void*)createBoxedIterWrapper, rewriter->getArg(0));
             if (rewrite_args.out_success) {
                 rewriter->commitReturning(var);

--- a/src/runtime/objmodel.cpp
+++ b/src/runtime/objmodel.cpp
@@ -302,7 +302,7 @@ extern "C" Box** unpackIntoArray(Box* obj, int64_t expected_size) {
     return &elts[0];
 }
 
-Shape* Shape::root_shape = new Shape(NULL);
+Shape* Shape::root_shape;
 
 
 void BoxedClass::freeze() {

--- a/src/runtime/types.cpp
+++ b/src/runtime/types.cpp
@@ -490,6 +490,8 @@ extern "C" void typeGCHandler(GCVisitor* v, Box* b) {
         v->visit(cls->tp_bases);
     if (cls->tp_subclasses)
         v->visit(cls->tp_subclasses);
+    if (cls->total_shape)
+        v->visit(cls->total_shape);
 
     if (cls->tp_flags & Py_TPFLAGS_HEAPTYPE) {
         BoxedHeapClass* hcls = static_cast<BoxedHeapClass*>(cls);
@@ -2301,6 +2303,9 @@ void setupRuntime() {
     gc::registerPermanentRoot(root_hcls);
     HiddenClass::dict_backed = HiddenClass::makeDictBacked();
     gc::registerPermanentRoot(HiddenClass::dict_backed);
+
+    Shape::root_shape = Shape::makeRoot();
+    gc::registerPermanentRoot(Shape::root_shape);
 
     // Disable the GC while we do some manual initialization of the object hierarchy:
     gc::disableGC();

--- a/src/runtime/types.h
+++ b/src/runtime/types.h
@@ -36,6 +36,7 @@ struct LocalShape {
     uint64_t t3;
 
     LocalShape(uint64_t t0, uint64_t t1, uint64_t t2, uint64_t t3) : t0(t0), t1(t1), t2(t2), t3(t3) {}
+    LocalShape(Box* b) : t0((uintptr_t)b), t1((uintptr_t)b), t2((uintptr_t)b), t3((uintptr_t)b) {}
 
     bool isUninitialized() const { return t0 == 0 && t1 == 0 && t2 == 0 && t3 == 0; }
 
@@ -177,7 +178,9 @@ public:
     ContiguousMap<LocalShape, Shape*, llvm::DenseMap<LocalShape, int>> children;
     Shape* parent;
 
-    static uint64_t computeLocalShape(BoxedClass* cls);
+    static LocalShape computeLocalShape(Box* b);
+    static Shape* computeTotalShape(Box* b);
+
 
     Shape* getOrMakeChild(LocalShape child_local_shape) {
         auto it = children.find(child_local_shape);
@@ -275,9 +278,6 @@ public:
     bool hasGenericGetattr() { return tp_getattr == NULL; }
 
     void freeze();
-
-    LocalShape computeLocalShape();
-    Shape* computeTotalShape();
 
 protected:
     // These functions are not meant for external callers and will mostly just be called

--- a/src/runtime/types.h
+++ b/src/runtime/types.h
@@ -29,6 +29,34 @@
 #include "gc/gc_alloc.h"
 
 namespace pyston {
+struct LocalShape {
+    uint64_t t0;
+    uint64_t t1;
+    uint64_t t2;
+    uint64_t t3;
+
+    LocalShape(uint64_t t0, uint64_t t1, uint64_t t2, uint64_t t3) : t0(t0), t1(t1), t2(t2), t3(t3) {}
+
+    bool isUninitialized() const { return t0 == 0 && t1 == 0 && t2 == 0 && t3 == 0; }
+
+    static LocalShape uninitialized() { return LocalShape(0, 0, 0, 0); }
+};
+}
+
+namespace llvm {
+template <> struct DenseMapInfo<pyston::LocalShape> {
+    static inline pyston::LocalShape getEmptyKey() { return pyston::LocalShape::uninitialized(); }
+    static inline pyston::LocalShape getTombstoneKey() { return pyston::LocalShape(-1, -1, -1, -1); }
+    static unsigned getHashValue(const pyston::LocalShape& localVal) {
+        return (unsigned)localVal.t0 ^ localVal.t1 ^ localVal.t2 ^ localVal.t3;
+    }
+    static bool isEqual(const pyston::LocalShape& s1, const pyston::LocalShape& s2) {
+        return (s1.t0 == s2.t0 && s1.t1 == s2.t1 && s1.t2 == s2.t2 && s1.t3 == s2.t3);
+    }
+};
+}
+
+namespace pyston {
 
 extern bool IN_SHUTDOWN;
 
@@ -142,6 +170,45 @@ extern "C" void printFloat(double d);
 Box* objectStr(Box*);
 Box* objectRepr(Box*);
 
+class Shape : public GCAllocated<gc::GCKind::SHAPE> {
+public:
+    static Shape* root_shape;
+
+    ContiguousMap<LocalShape, Shape*, llvm::DenseMap<LocalShape, int>> children;
+    Shape* parent;
+
+    static uint64_t computeLocalShape(BoxedClass* cls);
+
+    Shape* getOrMakeChild(LocalShape child_local_shape) {
+        auto it = children.find(child_local_shape);
+        if (it != children.end())
+            return children.getMapped(it->second);
+
+        Shape* rtn = new Shape(this);
+
+        this->children[child_local_shape] = rtn;
+        return rtn;
+    }
+
+    static Shape* makeRoot() {
+#ifndef NDEBUG
+        static bool made = false;
+        assert(!made);
+        made = true;
+#endif
+        return new Shape(NULL);
+    }
+
+    void gc_visit(GCVisitor* visitor) {
+        visitor->visit(parent);
+        visitor->visitRange((void* const*)&children.vector()[0], (void* const*)&children.vector()[children.size()]);
+    }
+
+    ~Shape() {}
+
+private:
+    Shape(Shape* parent) : parent(parent) {}
+};
 
 class BoxedClass : public BoxVar {
 public:
@@ -151,6 +218,9 @@ public:
     PyTypeObject_BODY;
 
     HCAttrs attrs;
+
+    LocalShape local_shape;
+    Shape* total_shape;
 
     // TODO: these don't actually get deallocated right now
     std::unique_ptr<CallattrIC> hasnext_ic, next_ic, repr_ic;
@@ -205,6 +275,9 @@ public:
     bool hasGenericGetattr() { return tp_getattr == NULL; }
 
     void freeze();
+
+    LocalShape computeLocalShape();
+    Shape* computeTotalShape();
 
 protected:
     // These functions are not meant for external callers and will mostly just be called
@@ -262,6 +335,8 @@ static_assert(offsetof(pyston::BoxedClass, cls) == offsetof(struct _typeobject, 
 static_assert(offsetof(pyston::BoxedClass, tp_name) == offsetof(struct _typeobject, tp_name), "");
 static_assert(offsetof(pyston::BoxedClass, attrs) == offsetof(struct _typeobject, _hcls), "");
 static_assert(offsetof(pyston::BoxedClass, gc_visit) == offsetof(struct _typeobject, _gcvisit_func), "");
+static_assert(offsetof(pyston::BoxedClass, local_shape) == offsetof(struct _typeobject, _local_shape), "");
+static_assert(offsetof(pyston::BoxedClass, total_shape) == offsetof(struct _typeobject, _total_shape), "");
 static_assert(sizeof(pyston::BoxedClass) == sizeof(struct _typeobject), "");
 
 static_assert(offsetof(pyston::BoxedHeapClass, as_number) == offsetof(PyHeapTypeObject, as_number), "");
@@ -589,6 +664,7 @@ public:
 
     Box* const* begin() const { return &elts[0]; }
     Box* const* end() const { return &elts[ob_size]; }
+
     Box*& operator[](size_t index) { return elts[index]; }
 
     size_t size() const { return ob_size; }


### PR DESCRIPTION
in order to make typeLookup not emit assembly for a given IC slot specialized to
a specific class's mro we need something that is shared between classes.

That something is a 'shape'.  Each class computes its own "local shape", which is
just the sha256 of its attribute names (in ascending order of slot offset).  This
local shape, combined with a parent's total shape, gives a subclass's total shape.

This is similar to the way hidden classes work, but with shapes we want a single
identifier (the sha256 hash) that describes multiple attributes, as opposed to a
separate hidden class for each attribute.

Once we've computed this total shape for a class, we can cache in the IC the index
of the class which has this attribute.  We also should know at this point what the
offset of the actual attribute within this class is.