### PR TITLE
Copy all HAVE_FOO defines from cpython

### DIFF
--- a/from_cpython/Include/pyconfig.h
+++ b/from_cpython/Include/pyconfig.h
@@ -19,8 +19,6 @@
 
 #define _GNU_SOURCE 1
 
-#define HAVE_STDARG_PROTOTYPES
-#define HAVE_LONG_LONG 1
 #define PY_LONG_LONG long long
 #define SIZEOF_VOID_P 8
 #define SIZEOF_SIZE_T 8
@@ -31,116 +29,246 @@
 #define SIZEOF_FLOAT 4
 #define SIZEOF_OFF_T 8
 #define SIZEOF_PTHREAD_T 8
-#define HAVE_COPYSIGN 1
-#define HAVE_ROUND 1
-#define HAVE_HYPOT 1
-#define HAVE_DECL_ISFINITE 1
-#define HAVE_DECL_ISNAN 1
-#define HAVE_ACOSH 1
-#define HAVE_ASINH 1
-#define HAVE_ATANH 1
-#define HAVE_EXPM1 1
 #define Py_USING_UNICODE 1
 #define Py_UNICODE_SIZE 4
-#define HAVE_UINT32_T 1
-#define HAVE_UINT64_T 1
-#define HAVE_UINTPTR_T 1
+#define STDC_HEADERS 1
+#define TIME_WITH_SYS_TIME
+#define PY_FORMAT_LONG_LONG "ll"
+#define PY_FORMAT_SIZE_T "z"
+#define DOUBLE_IS_LITTLE_ENDIAN_IEEE754 1
+#define WITH_THREAD
+
+// Added this for some Pyston modifications:
+#define MAX_PYSTRING_SIZE (PY_SSIZE_T_MAX/2 - (1<<20))
+
+
+// Configured cpython on an ubuntu 14.04 machine, and did
+// `grep '#define HAVE_' | sort':
+#define HAVE_ACOSH 1
+#define HAVE_ADDRINFO 1
+#define HAVE_ALARM 1
+#define HAVE_ALLOCA_H 1
+#define HAVE_ASINH 1
+#define HAVE_ASM_TYPES_H 1
+#define HAVE_ATANH 1
+#define HAVE_BIND_TEXTDOMAIN_CODESET 1
+// #define HAVE_BLUETOOTH_BLUETOOTH_H 1
+#define HAVE_C99_BOOL 1
+#define HAVE_CHOWN 1
+#define HAVE_CHROOT 1
+#define HAVE_CLOCK 1
+#define HAVE_CONFSTR 1
+#define HAVE_COPYSIGN 1
+#define HAVE_CTERMID 1
+#define HAVE_CURSES_H 1
+#define HAVE_CURSES_IS_TERM_RESIZED 1
+#define HAVE_CURSES_RESIZE_TERM 1
+#define HAVE_CURSES_RESIZETERM 1
+#define HAVE_DECL_ISFINITE 1
+#define HAVE_DECL_ISINF 1
+#define HAVE_DECL_ISNAN 1
+#define HAVE_DEVICE_MACROS 1
+#define HAVE_DEV_PTMX 1
+#define HAVE_DIRENT_H 1
+#define HAVE_DLFCN_H 1
+#define HAVE_DLOPEN 1
+#define HAVE_DUP2 1
+#define HAVE_DYNAMIC_LOADING 1
+#define HAVE_EPOLL 1
+#define HAVE_ERF 1
+#define HAVE_ERFC 1
+#define HAVE_ERRNO_H 1
+#define HAVE_EXECV 1
+#define HAVE_EXPM1 1
+#define HAVE_FCHDIR 1
+#define HAVE_FCHMOD 1
+#define HAVE_FCHOWN 1
+#define HAVE_FCNTL_H 1
+#define HAVE_FDATASYNC 1
+#define HAVE_FINITE 1
+#define HAVE_FLOCK 1
+#define HAVE_FORK 1
+// #define HAVE_FORKPTY 1 // pyston change: turned this off for now to avoid -lutil dependency
+#define HAVE_FPATHCONF 1
+#define HAVE_FSEEKO 1
+#define HAVE_FSTATVFS 1
+#define HAVE_FSYNC 1
+#define HAVE_FTELLO 1
+#define HAVE_FTIME 1
+#define HAVE_FTRUNCATE 1
+#define HAVE_GAI_STRERROR 1
+#define HAVE_GAMMA 1
+#define HAVE_GCC_ASM_FOR_X87 1
+#define HAVE_GETADDRINFO 1
+#define HAVE_GETC_UNLOCKED 1
+#define HAVE_GETCWD 1
+#define HAVE_GETGROUPS 1
+#define HAVE_GETHOSTBYNAME_R 1
+#define HAVE_GETHOSTBYNAME_R_6_ARG 1
+#define HAVE_GETITIMER 1
+#define HAVE_GETLOADAVG 1
+#define HAVE_GETLOGIN 1
+#define HAVE_GETNAMEINFO 1
+#define HAVE_GETPAGESIZE 1
+#define HAVE_GETPEERNAME 1
+#define HAVE_GETPGID 1
+#define HAVE_GETPGRP 1
+#define HAVE_GETPID 1
+#define HAVE_GETPRIORITY 1
+#define HAVE_GETPWENT 1
+#define HAVE_GETRESGID 1
+#define HAVE_GETRESUID 1
+#define HAVE_GETSID 1
+#define HAVE_GETSPENT 1
+#define HAVE_GETSPNAM 1
+#define HAVE_GETTIMEOFDAY 1
+#define HAVE_GETWD 1
+#define HAVE_GRP_H 1
+#define HAVE_HSTRERROR 1
+#define HAVE_HYPOT 1
+#define HAVE_INET_ATON 1
+#define HAVE_INET_PTON 1
+#define HAVE_INITGROUPS 1
 #define HAVE_INT32_T 1
 #define HAVE_INT64_T 1
-#define HAVE_EPOLL 1
-#define HAVE_POLL 1
-#define HAVE_SELECT 1
-#define HAVE_ALARM 1
-#define HAVE_SYMLINK 1
-#define HAVE_ADDRINFO 1
-#define HAVE_SOCKADDR_STORAGE 1
-#define HAVE_SOCKETPAIR 1
-#define HAVE_GETPEERNAME 1
-#define HAVE_STRFTIME 1
-#define HAVE_TIMES 1
-#define HAVE_STRUCT_TM_TM_ZONE 1
+#define HAVE_INTTYPES_H 1
+#define HAVE_KILL 1
+#define HAVE_KILLPG 1
+#define HAVE_LANGINFO_H 1
+#define HAVE_LCHOWN 1
+#define HAVE_LGAMMA 1
+#define HAVE_LIBDL 1
+#define HAVE_LIBINTL_H 1
+#define HAVE_LIBREADLINE 1
+#define HAVE_LINK 1
+#define HAVE_LINUX_NETLINK_H 1
+#define HAVE_LINUX_TIPC_H 1
+#define HAVE_LOG1P 1
+#define HAVE_LONG_DOUBLE 1
+#define HAVE_LONG_LONG 1
+#define HAVE_LSTAT 1
+#define HAVE_MAKEDEV 1
+#define HAVE_MEMMOVE 1
+#define HAVE_MEMORY_H 1
+#define HAVE_MKFIFO 1
+#define HAVE_MKNOD 1
 #define HAVE_MKTIME 1
+#define HAVE_MMAP 1
+#define HAVE_MREMAP 1
+#define HAVE_NCURSES_H 1
+#define HAVE_NETPACKET_PACKET_H 1
+#define HAVE_NICE 1
+// #define HAVE_OPENPTY 1 // pyston change: turned this off for now to avoid -lutil dependency
+#define HAVE_PATHCONF 1
+#define HAVE_PAUSE 1
+#define HAVE_POLL 1
+#define HAVE_POLL_H 1
 #define HAVE_PROTOTYPES 1
-#define STDC_HEADERS 1
+#define HAVE_PTHREAD_ATFORK 1
+#define HAVE_PTHREAD_H 1
+#define HAVE_PTHREAD_SIGMASK 1
+#define HAVE_PTY_H 1
+#define HAVE_PUTENV 1
+#define HAVE_READLINK 1
+#define HAVE_REALPATH 1
+#define HAVE_RL_CALLBACK 1
+#define HAVE_RL_CATCH_SIGNAL 1
+#define HAVE_RL_COMPLETION_APPEND_CHARACTER 1
+#define HAVE_RL_COMPLETION_DISPLAY_MATCHES_HOOK 1
+#define HAVE_RL_COMPLETION_MATCHES 1
+#define HAVE_RL_COMPLETION_SUPPRESS_APPEND 1
+#define HAVE_RL_PRE_INPUT_HOOK 1
+#define HAVE_ROUND 1
+#define HAVE_SELECT 1
 #define HAVE_SEM_GETVALUE 1
 #define HAVE_SEM_OPEN 1
 #define HAVE_SEM_TIMEDWAIT 1
 #define HAVE_SEM_UNLINK 1
-
-#define TIME_WITH_SYS_TIME
-#define HAVE_GETTIMEOFDAY 1
-
-#define PY_FORMAT_LONG_LONG "ll"
-#define PY_FORMAT_SIZE_T "z"
-
-#define DOUBLE_IS_LITTLE_ENDIAN_IEEE754 1
-
-#define WITH_THREAD
-
-// Copied from a CPython ./configure run on a Linux machine:
-// TODO copy these more systematically
-#define HAVE_WAIT3 1
-#define HAVE_WAIT4 1
-#define HAVE_WAITPID 1
-
-#define HAVE_ALLOCA_H 1
-#define HAVE_ASM_TYPES_H 1
-#define HAVE_CLOCK 1
-#define HAVE_CURSES_H 1
-#define HAVE_DIRENT_H 1
-#define HAVE_DLFCN_H 1
-#define HAVE_ERRNO_H 1
-#define HAVE_FCNTL_H 1
-#define HAVE_FTIME 1
-#define HAVE_FTRUNCATE 1
-#define HAVE_GRP_H 1
-#define HAVE_INTTYPES_H 1
-#define HAVE_LANGINFO_H 1
-#define HAVE_LIBINTL_H 1
-#define HAVE_LIBUTIL_H 1
-#define HAVE_LINUX_NETLINK_H 1
-#define HAVE_LINUX_TIPC_H 1
-#define HAVE_MEMORY_H 1
-#define HAVE_NCURSES_H 1
-#define HAVE_NETPACKET_PACKET_H 1
-#define HAVE_POLL_H 1
-#define HAVE_PTHREAD_H 1
-#define HAVE_PTY_H 1
-#define HAVE_READLINK 1
+#define HAVE_SETEGID 1
+#define HAVE_SETEUID 1
+#define HAVE_SETGID 1
+#define HAVE_SETGROUPS 1
+#define HAVE_SETITIMER 1
+#define HAVE_SETLOCALE 1
+#define HAVE_SETPGID 1
+#define HAVE_SETPGRP 1
+#define HAVE_SETREGID 1
+#define HAVE_SETRESGID 1
+#define HAVE_SETRESUID 1
+#define HAVE_SETREUID 1
+#define HAVE_SETSID 1
+#define HAVE_SETUID 1
 #define HAVE_SETVBUF 1
 #define HAVE_SHADOW_H 1
+#define HAVE_SIGACTION 1
+#define HAVE_SIGINTERRUPT 1
 #define HAVE_SIGNAL_H 1
+#define HAVE_SIGRELSE 1
+#define HAVE_SNPRINTF 1
+#define HAVE_SOCKADDR_STORAGE 1
+#define HAVE_SOCKETPAIR 1
 #define HAVE_SPAWN_H 1
+#define HAVE_SSIZE_T 1
+#define HAVE_STAT_TV_NSEC 1
+#define HAVE_STATVFS 1
+#define HAVE_ST_BLOCKS 1
+#define HAVE_STDARG_PROTOTYPES 1
 #define HAVE_STDINT_H 1
 #define HAVE_STDLIB_H 1
-#define HAVE_STRINGS_H 1
+#define HAVE_STRDUP 1
+#define HAVE_STRFTIME 1
 #define HAVE_STRING_H 1
+#define HAVE_STRINGS_H 1
 #define HAVE_STROPTS_H 1
-#define HAVE_SYSEXITS_H 1
+#define HAVE_STRUCT_STAT_ST_BLKSIZE 1
+#define HAVE_STRUCT_STAT_ST_BLOCKS 1
+#define HAVE_STRUCT_STAT_ST_RDEV 1
+#define HAVE_STRUCT_TM_TM_ZONE 1
+#define HAVE_SYMLINK 1
+#define HAVE_SYSCONF 1
 #define HAVE_SYS_EPOLL_H 1
+#define HAVE_SYSEXITS_H 1
 #define HAVE_SYS_FILE_H 1
 #define HAVE_SYS_PARAM_H 1
 #define HAVE_SYS_POLL_H 1
 #define HAVE_SYS_RESOURCE_H 1
 #define HAVE_SYS_SELECT_H 1
 #define HAVE_SYS_SOCKET_H 1
-#define HAVE_SYS_STATVFS_H 1
 #define HAVE_SYS_STAT_H 1
+#define HAVE_SYS_STATVFS_H 1
+#define HAVE_SYS_TIME_H 1
 #define HAVE_SYS_TIMES_H 1
 #define HAVE_SYS_TYPES_H 1
 #define HAVE_SYS_UN_H 1
 #define HAVE_SYS_UTSNAME_H 1
 #define HAVE_SYS_WAIT_H 1
-#define HAVE_TERMIOS_H 1
+#define HAVE_TCGETPGRP 1
+#define HAVE_TCSETPGRP 1
+#define HAVE_TEMPNAM 1
 #define HAVE_TERM_H 1
+#define HAVE_TERMIOS_H 1
+#define HAVE_TGAMMA 1
+#define HAVE_TIMEGM 1
+#define HAVE_TIMES 1
+#define HAVE_TMPFILE 1
+#define HAVE_TMPNAM 1
+#define HAVE_TMPNAM_R 1
+#define HAVE_TM_ZONE 1
+#define HAVE_TRUNCATE 1
+#define HAVE_UINT32_T 1
+#define HAVE_UINT64_T 1
+#define HAVE_UINTPTR_T 1
+#define HAVE_UNAME 1
 #define HAVE_UNISTD_H 1
+#define HAVE_UNSETENV 1
 #define HAVE_UTIME_H 1
+#define HAVE_UTIMES 1
+#define HAVE_WAIT3 1
+#define HAVE_WAIT4 1
+#define HAVE_WAITPID 1
 #define HAVE_WCHAR_H 1
+#define HAVE_WCSCOLL 1
 #define HAVE_WORKING_TZSET 1
-#define HAVE_PUTENV 1
-#define HAVE_LSTAT 1
-
-// Added this for some Pyston modifications:
-#define MAX_PYSTRING_SIZE (PY_SSIZE_T_MAX/2 - (1<<20))
+#define HAVE_ZLIB_COPY 1
 
 #endif /*Py_PYCONFIG_H*/

--- a/from_cpython/Include/pymath.h
+++ b/from_cpython/Include/pymath.h
@@ -2,6 +2,10 @@
 
 #ifndef Py_PYMATH_H
 #define Py_PYMATH_H
+// Pyston change: most other files include this:
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #include "pyconfig.h" /* include for defines */
 
@@ -189,6 +193,11 @@ PyAPI_FUNC(void) _Py_set_387controlword(unsigned short) PYSTON_NOEXCEPT;
 #define Py_OVERFLOWED(X) ((X) != 0.0 && (errno == ERANGE ||    \
                      (X) == Py_HUGE_VAL || \
                      (X) == -Py_HUGE_VAL))
+#endif
+
+// Pyston change: most other files include this:
+#ifdef __cplusplus
+}
 #endif
 
 #endif /* Py_PYMATH_H */

--- a/from_cpython/Include/pyport.h
+++ b/from_cpython/Include/pyport.h
@@ -34,6 +34,12 @@ typedef ssize_t         Py_ssize_t;
 
 // Pyston change: the rest of these have just been copied from CPython's pyport.h, in an arbitrary order:
 
+#if defined(__GNUC__) && __GNUC__ >= 3
+#define Py_ALIGNED(x) __attribute__((aligned(x)))
+#else
+#define Py_ALIGNED(x)
+#endif
+
 #if defined(_MSC_VER)
 #if defined(PY_LOCAL_AGGRESSIVE)
 /* enable more aggressive optimization for visual studio */

--- a/src/runtime/capi.cpp
+++ b/src/runtime/capi.cpp
@@ -1406,6 +1406,23 @@ extern "C" void PyObject_GC_Del(void* op) noexcept {
     PyObject_FREE(op);
 }
 
+#ifdef HAVE_GCC_ASM_FOR_X87
+
+/* inline assembly for getting and setting the 387 FPU control word on
+   gcc/x86 */
+
+extern "C" unsigned short _Py_get_387controlword(void) noexcept {
+    unsigned short cw;
+    __asm__ __volatile__("fnstcw %0" : "=m"(cw));
+    return cw;
+}
+
+extern "C" void _Py_set_387controlword(unsigned short cw) noexcept {
+    __asm__ __volatile__("fldcw %0" : : "m"(cw));
+}
+
+#endif
+
 extern "C" void _Py_FatalError(const char* fmt, const char* function, const char* message) {
     fprintf(stderr, fmt, function, message);
     fflush(stderr); /* it helps in Windows debug build */


### PR DESCRIPTION
Previously we were only copying them when we noticed they were needed,
but we've been spending a fair bit of time hunting down issues that
are caused by a missing HAVE_ define.

So instead, bulk-copy the ones that the CPython configure script determined.
I bet we'll start running into some that were available on my 14.04
machine but won't be on other configurations; I'm hoping that an extra
define is easier to debug than a missing one (build error vs run error),
making this the better approach.