### PR TITLE
Misc stuff

### DIFF
--- a/from_cpython/Objects/stringobject.c
+++ b/from_cpython/Objects/stringobject.c
@@ -364,3 +364,31 @@ PyObject *string_join(PyStringObject *self, PyObject *orig)
     Py_DECREF(seq);
     return res;
 }
+
+PyObject* string__format__(PyObject* self, PyObject* args)
+{
+    PyObject *format_spec;
+    PyObject *result = NULL;
+    PyObject *tmp = NULL;
+
+    /* If 2.x, convert format_spec to the same type as value */
+    /* This is to allow things like u''.format('') */
+    if (!PyArg_ParseTuple(args, "O:__format__", &format_spec))
+        goto done;
+    if (!(PyString_Check(format_spec) || PyUnicode_Check(format_spec))) {
+        PyErr_Format(PyExc_TypeError, "__format__ arg must be str "
+                     "or unicode, not %s", Py_TYPE(format_spec)->tp_name);
+        goto done;
+    }
+    tmp = PyObject_Str(format_spec);
+    if (tmp == NULL)
+        goto done;
+    format_spec = tmp;
+
+    result = _PyBytes_FormatAdvanced(self,
+                                     PyString_AS_STRING(format_spec),
+                                     PyString_GET_SIZE(format_spec));
+done:
+    Py_XDECREF(tmp);
+    return result;
+}

--- a/src/capi/abstract.cpp
+++ b/src/capi/abstract.cpp
@@ -1879,6 +1879,9 @@ extern "C" PyObject* PyNumber_Long(PyObject* o) noexcept {
     if (o->cls == float_cls)
         return PyLong_FromDouble(PyFloat_AsDouble(o));
 
+    if (o->cls == int_cls)
+        return PyLong_FromLong(((BoxedInt*)o)->n);
+
     fatalOrError(PyExc_NotImplementedError, "unimplemented");
     return nullptr;
 }

--- a/src/capi/modsupport.cpp
+++ b/src/capi/modsupport.cpp
@@ -184,6 +184,13 @@ static PyObject* do_mkvalue(const char** p_format, va_list* p_va, int flags) noe
                 }
                 return v;
             }
+#ifdef HAVE_LONG_LONG
+            case 'L':
+                return PyLong_FromLongLong((PY_LONG_LONG)va_arg(*p_va, PY_LONG_LONG));
+
+            case 'K':
+                return PyLong_FromUnsignedLongLong((PY_LONG_LONG)va_arg(*p_va, unsigned PY_LONG_LONG));
+#endif
 #ifdef Py_USING_UNICODE
             case 'u': {
                 PyObject* v;

--- a/src/capi/typeobject.h
+++ b/src/capi/typeobject.h
@@ -32,6 +32,7 @@ void commonClassSetup(BoxedClass* cls);
 // We could probably unify things more but that's for later.
 PyTypeObject* best_base(PyObject* bases) noexcept;
 PyObject* mro_external(PyObject* self) noexcept;
+int type_set_bases(PyTypeObject* type, PyObject* value, void* context) noexcept;
 }
 
 #endif

--- a/src/runtime/capi.cpp
+++ b/src/runtime/capi.cpp
@@ -461,8 +461,14 @@ extern "C" int PySequence_SetItem(PyObject* o, Py_ssize_t i, PyObject* v) noexce
 }
 
 extern "C" int PySequence_DelItem(PyObject* o, Py_ssize_t i) noexcept {
-    fatalOrError(PyExc_NotImplementedError, "unimplemented");
-    return -1;
+    try {
+        // Not sure if this is really the same:
+        delitem(o, boxInt(i));
+        return 0;
+    } catch (ExcInfo e) {
+        setCAPIException(e);
+        return -1;
+    }
 }
 
 extern "C" int PySequence_SetSlice(PyObject* o, Py_ssize_t i1, Py_ssize_t i2, PyObject* v) noexcept {

--- a/src/runtime/int.cpp
+++ b/src/runtime/int.cpp
@@ -196,11 +196,11 @@ extern "C" PyObject* PyInt_FromString(const char* s, char** pend, int base) noex
         s++;
     errno = 0;
     if (base == 0 && s[0] == '0') {
-        x = (long)strtoul(s, &end, base);
+        x = (long)PyOS_strtoul(const_cast<char*>(s), &end, base);
         if (x < 0)
             return PyLong_FromString(s, pend, base);
     } else
-        x = strtol(s, &end, base);
+        x = PyOS_strtol(const_cast<char*>(s), &end, base);
     if (end == s || !isalnum(Py_CHARMASK(end[-1])))
         goto bad;
     while (*end && isspace(Py_CHARMASK(*end)))

--- a/src/runtime/objmodel.cpp
+++ b/src/runtime/objmodel.cpp
@@ -4165,7 +4165,7 @@ Box* typeNew(Box* _cls, Box* arg1, Box* arg2, Box** _args) {
         return rtn;
     }
 
-    RELEASE_ASSERT(arg3->cls == dict_cls, "%s", getTypeName(arg3));
+    RELEASE_ASSERT(PyDict_Check(arg3), "%s", getTypeName(arg3));
     BoxedDict* attr_dict = static_cast<BoxedDict*>(arg3);
 
     RELEASE_ASSERT(arg2->cls == tuple_cls, "");

--- a/src/runtime/str.cpp
+++ b/src/runtime/str.cpp
@@ -44,6 +44,7 @@ extern "C" PyObject* string_index(PyStringObject* self, PyObject* args) noexcept
 extern "C" PyObject* string_rindex(PyStringObject* self, PyObject* args) noexcept;
 extern "C" PyObject* string_rfind(PyStringObject* self, PyObject* args) noexcept;
 extern "C" PyObject* string_splitlines(PyStringObject* self, PyObject* args) noexcept;
+extern "C" PyObject* string__format__(PyObject* self, PyObject* args) noexcept;
 
 // from cpython's stringobject.c:
 #define LEFTSTRIP 0
@@ -2653,6 +2654,7 @@ static PyMethodDef string_methods[] = {
     { "expandtabs", (PyCFunction)string_expandtabs, METH_VARARGS, NULL },
     { "splitlines", (PyCFunction)string_splitlines, METH_VARARGS, NULL },
     { "zfill", (PyCFunction)string_zfill, METH_VARARGS, NULL },
+    { "__format__", (PyCFunction)string__format__, METH_VARARGS, NULL },
 };
 
 void setupStr() {

--- a/src/runtime/types.cpp
+++ b/src/runtime/types.cpp
@@ -2082,8 +2082,11 @@ static Box* typeBases(Box* b, void*) {
     return type->tp_bases;
 }
 
-static void typeSetBases(Box* b, Box* v, void*) {
-    Py_FatalError("unimplemented");
+static void typeSetBases(Box* b, Box* v, void* c) {
+    RELEASE_ASSERT(isSubclass(b->cls, type_cls), "");
+    BoxedClass* type = static_cast<BoxedClass*>(b);
+    if (type_set_bases(type, v, c) == -1)
+        throwCAPIException();
 }
 
 // cls should be obj->cls.

--- a/src/runtime/types.cpp
+++ b/src/runtime/types.cpp
@@ -1542,6 +1542,22 @@ public:
         return rtn;
     }
 
+    static Box* clear(Box* _self) {
+        RELEASE_ASSERT(_self->cls == attrwrapper_cls, "");
+        AttrWrapper* self = static_cast<AttrWrapper*>(_self);
+
+        HCAttrs* attrs = self->b->getHCAttrsPtr();
+        RELEASE_ASSERT(attrs->hcls->type == HiddenClass::NORMAL || attrs->hcls->type == HiddenClass::SINGLETON, "");
+
+        while (true) {
+            const auto& attrMap = attrs->hcls->getStrAttrOffsets();
+            if (attrMap.size() == 0)
+                break;
+            self->b->delattr(attrMap.begin()->first(), NULL);
+        }
+        return None;
+    }
+
     static Box* len(Box* _self) {
         RELEASE_ASSERT(_self->cls == attrwrapper_cls, "");
         AttrWrapper* self = static_cast<AttrWrapper*>(_self);
@@ -2539,6 +2555,7 @@ void setupRuntime() {
                               new BoxedFunction(boxRTFunction((void*)AttrWrapper::itervalues, UNKNOWN, 1)));
     attrwrapper_cls->giveAttr("iteritems", new BoxedFunction(boxRTFunction((void*)AttrWrapper::iteritems, UNKNOWN, 1)));
     attrwrapper_cls->giveAttr("copy", new BoxedFunction(boxRTFunction((void*)AttrWrapper::copy, UNKNOWN, 1)));
+    attrwrapper_cls->giveAttr("clear", new BoxedFunction(boxRTFunction((void*)AttrWrapper::clear, NONE, 1)));
     attrwrapper_cls->giveAttr("__len__", new BoxedFunction(boxRTFunction((void*)AttrWrapper::len, BOXED_INT, 1)));
     attrwrapper_cls->giveAttr("__iter__", new BoxedFunction(boxRTFunction((void*)AttrWrapper::iter, UNKNOWN, 1)));
     attrwrapper_cls->giveAttr("update",

--- a/test/tests/dict_setting.py
+++ b/test/tests/dict_setting.py
@@ -38,3 +38,12 @@ p()
 c1.__dict__ = d = {}
 d['i'] = 5
 p()
+
+class C(object):
+    def foo(self):
+        return 0
+c = C()
+c.attr = "test"
+c.__dict__.clear()
+print hasattr(c, "attr")
+print hasattr(c, "foo")

--- a/test/tests/intmethods.py
+++ b/test/tests/intmethods.py
@@ -67,6 +67,7 @@ print type(int(L()))
 
 print int(u'123')
 print int("9223372036854775808", 0)
+print int("0b101", 2), int("0b101", 0)
 print 1 << 63, 1 << 64, -1 << 63, -1 << 64, 2 << 63
 print type(1 << 63), type(1 << 64), type(-1 << 63), type(-1 << 64), type(2 << 63)
 

--- a/test/tests/mutable_bases.py
+++ b/test/tests/mutable_bases.py
@@ -1,0 +1,170 @@
+class A(object):
+    def foo(self):
+        print "foo"
+
+class B(object):
+    def bar(self):
+        print "bar"
+
+class C(object):
+    def baz(self):
+        print "baz"
+
+class D(C):
+    pass
+print D.__bases__ == (C,)
+print hasattr(D, "bar")
+try:
+    D.__bases__ += (A, B, C)
+except Exception as e:
+    print e # duplicate base class C
+D.__bases__ += (A, B)
+print D.__bases__ == (C, A, B, C)
+print D.__base__ == (C)
+D().foo(), D().bar(), D().baz()
+D.__bases__ = (C,)
+print D.__bases__ == (C,)
+print hasattr(D, "foo"), hasattr(D, "bar"), hasattr(D, "baz")
+D().baz()
+
+# inheritance circle:
+try:
+    C.__bases__ = (D,)
+except TypeError as e:
+    print e
+
+class Slots(object):
+    __slots__ = ["a", "b", "c"]
+    def __init__(self):
+        self.a = 1
+        self.b = 2
+        self.c = 3
+try:
+    Slots.__bases__ = (A,)
+except TypeError:
+    print "cought TypeError exception" # pyston and cpython throw a different exception
+
+# This tests are copied from CPython an can be removed when we support running test/cpython/test_descr.py
+class CPythonTests(object):
+    def assertEqual(self, x, y):
+        assert x == y
+    def fail(self, msg):
+        print "Error", msg
+
+    def test_mutable_bases(self):
+        # Testing mutable bases...
+
+        # stuff that should work:
+        class C(object):
+            pass
+        class C2(object):
+            def __getattribute__(self, attr):
+                if attr == 'a':
+                    return 2
+                else:
+                    return super(C2, self).__getattribute__(attr)
+            def meth(self):
+                return 1
+        class D(C):
+            pass
+        class E(D):
+            pass
+        d = D()
+        e = E()
+        D.__bases__ = (C,)
+        D.__bases__ = (C2,)
+        self.assertEqual(d.meth(), 1)
+        self.assertEqual(e.meth(), 1)
+        self.assertEqual(d.a, 2)
+        self.assertEqual(e.a, 2)
+        self.assertEqual(C2.__subclasses__(), [D])
+
+        try:
+            del D.__bases__
+        except (TypeError, AttributeError):
+            pass
+        else:
+            self.fail("shouldn't be able to delete .__bases__")
+
+        try:
+            D.__bases__ = ()
+        except TypeError, msg:
+            if str(msg) == "a new-style class can't have only classic bases":
+                self.fail("wrong error message for .__bases__ = ()")
+        else:
+            self.fail("shouldn't be able to set .__bases__ to ()")
+
+        try:
+            D.__bases__ = (D,)
+        except TypeError:
+            pass
+        else:
+            # actually, we'll have crashed by here...
+            self.fail("shouldn't be able to create inheritance cycles")
+
+        try:
+            D.__bases__ = (C, C)
+        except TypeError:
+            pass
+        else:
+            self.fail("didn't detect repeated base classes")
+
+        try:
+            D.__bases__ = (E,)
+        except TypeError:
+            pass
+        else:
+            self.fail("shouldn't be able to create inheritance cycles")
+
+        # let's throw a classic class into the mix:
+        class Classic:
+            def meth2(self):
+                return 3
+
+        D.__bases__ = (C, Classic)
+
+        self.assertEqual(d.meth2(), 3)
+        self.assertEqual(e.meth2(), 3)
+        try:
+            d.a
+        except AttributeError:
+            pass
+        else:
+            self.fail("attribute should have vanished")
+
+        try:
+            D.__bases__ = (Classic,)
+        except TypeError:
+            pass
+        else:
+            self.fail("new-style class must have a new-style base")
+
+    def test_mutable_bases_catch_mro_conflict(self):
+        # Testing mutable bases catch mro conflict...
+        class A(object):
+            pass
+
+        class B(object):
+            pass
+
+        class C(A, B):
+            pass
+
+        class D(A, B):
+            pass
+
+        class E(C, D):
+            pass
+
+        try:
+            C.__bases__ = (B, A)
+        except TypeError:
+            pass
+        else:
+            self.fail("didn't catch MRO conflict")
+
+tests = CPythonTests()
+tests.test_mutable_bases()
+tests.test_mutable_bases_catch_mro_conflict()
+print
+print "Finished"

--- a/test/tests/str_functions.py
+++ b/test/tests/str_functions.py
@@ -168,3 +168,8 @@ it = iter("hello world")
 print list(it)
 
 print "'{0}' '{1}'".format("Hello " * 3, "Hello " * -3)
+
+class C(object):
+    def __str__(self):
+        return "my class"
+print "{0}".format(C())


### PR DESCRIPTION
- Allow changing ```class.__bases__```:
I copied the implementation from cpython but I'm not sure if the ```same_slots_added``` method is correct for pyston.  I'm not sure if I have to also check for additional things.
It looks like we are stricter than cpython (```tp_basicsize``` will more often have a different size) and support less sublassing.

- Add ```attrwrapper.clear()```:
My implementation looks very ugly, is there a cleaner way to clear the attributes?