### PR TITLE
remove the llvm::StringRef from BoxedString

### DIFF
--- a/src/analysis/scoping_analysis.cpp
+++ b/src/analysis/scoping_analysis.cpp
@@ -59,14 +59,14 @@ bool containsYield(AST* ast) {
 BoxedString* mangleNameBoxedString(BoxedString* id, BoxedString* private_name) {
     assert(id);
     assert(private_name);
-    int len = id->s.size();
-    if (len < 2 || id->s[0] != '_' || id->s[1] != '_')
+    int len = id->size();
+    if (len < 2 || id->s()[0] != '_' || id->s()[1] != '_')
         return id;
 
-    if ((id->s[len - 2] == '_' && id->s[len - 1] == '_') || id->s.find('.') != llvm::StringRef::npos)
+    if ((id->s()[len - 2] == '_' && id->s()[len - 1] == '_') || id->s().find('.') != llvm::StringRef::npos)
         return id;
 
-    const char* p = private_name->s.data();
+    const char* p = private_name->data();
     while (*p == '_') {
         p++;
         len--;
@@ -74,7 +74,7 @@ BoxedString* mangleNameBoxedString(BoxedString* id, BoxedString* private_name) {
     if (*p == '\0')
         return id;
 
-    return static_cast<BoxedString*>(boxStringTwine("_" + (p + id->s)));
+    return static_cast<BoxedString*>(boxStringTwine("_" + (p + id->s())));
 }
 
 static void mangleNameInPlace(InternedString& id, const std::string* private_name,

--- a/src/capi/object.cpp
+++ b/src/capi/object.cpp
@@ -421,9 +421,9 @@ extern "C" PyObject* PyObject_SelfIter(PyObject* obj) noexcept {
 extern "C" int PyObject_GenericSetAttr(PyObject* obj, PyObject* name, PyObject* value) noexcept {
     try {
         if (value == NULL)
-            delattrGeneric(obj, std::string(static_cast<BoxedString*>(name)->s), NULL);
+            delattrGeneric(obj, std::string(static_cast<BoxedString*>(name)->s()), NULL);
         else
-            setattrGeneric(obj, std::string(static_cast<BoxedString*>(name)->s), value, NULL);
+            setattrGeneric(obj, std::string(static_cast<BoxedString*>(name)->s()), value, NULL);
     } catch (ExcInfo e) {
         setCAPIException(e);
         return -1;
@@ -445,9 +445,9 @@ extern "C" int PyObject_SetAttr(PyObject* obj, PyObject* name, PyObject* value) 
 
     try {
         if (value == NULL)
-            delattr(obj, static_cast<BoxedString*>(name)->s.data());
+            delattr(obj, static_cast<BoxedString*>(name)->data());
         else
-            setattr(obj, static_cast<BoxedString*>(name)->s.data(), value);
+            setattr(obj, static_cast<BoxedString*>(name)->data(), value);
     } catch (ExcInfo e) {
         setCAPIException(e);
         return -1;

--- a/src/codegen/ast_interpreter.cpp
+++ b/src/codegen/ast_interpreter.cpp
@@ -1303,7 +1303,7 @@ Box* astInterpretFrom(CompiledFunction* cf, AST_expr* after_expr, AST_stmt* encl
 
     for (const auto& p : frame_state.locals->d) {
         assert(p.first->cls == str_cls);
-        auto& name = static_cast<BoxedString*>(p.first)->s;
+        auto name = static_cast<BoxedString*>(p.first)->s();
         if (name == PASSED_GENERATOR_NAME) {
             interpreter.setGenerator(p.second);
         } else if (name == PASSED_CLOSURE_NAME) {

--- a/src/codegen/irgen/hooks.cpp
+++ b/src/codegen/irgen/hooks.cpp
@@ -456,8 +456,8 @@ Box* compile(Box* source, Box* fn, Box* type, Box** _args) {
     }
     RELEASE_ASSERT(isSubclass(type->cls, str_cls), "");
 
-    llvm::StringRef filename_str = static_cast<BoxedString*>(fn)->s;
-    llvm::StringRef type_str = static_cast<BoxedString*>(type)->s;
+    llvm::StringRef filename_str = static_cast<BoxedString*>(fn)->s();
+    llvm::StringRef type_str = static_cast<BoxedString*>(type)->s();
 
     if (iflags & ~(/*PyCF_MASK | PyCF_MASK_OBSOLETE | PyCF_DONT_IMPLY_DEDENT | */ PyCF_ONLY_AST)) {
         raiseExcHelper(ValueError, "compile(): unrecognised flags");
@@ -473,7 +473,7 @@ Box* compile(Box* source, Box* fn, Box* type, Box** _args) {
         parsed = unboxAst(source);
     } else {
         RELEASE_ASSERT(isSubclass(source->cls, str_cls), "");
-        llvm::StringRef source_str = static_cast<BoxedString*>(source)->s;
+        llvm::StringRef source_str = static_cast<BoxedString*>(source)->s();
 
         if (type_str == "exec") {
             parsed = parseExec(source_str);
@@ -542,7 +542,7 @@ Box* eval(Box* boxedCode, Box* globals, Box* locals) {
 
     CLFunction* cl;
     if (boxedCode->cls == str_cls) {
-        AST_Expression* parsed = parseEval(static_cast<BoxedString*>(boxedCode)->s);
+        AST_Expression* parsed = parseEval(static_cast<BoxedString*>(boxedCode)->s());
         cl = compileEval(parsed, "<string>");
     } else if (boxedCode->cls == code_cls) {
         cl = clfunctionFromCode(boxedCode);
@@ -609,7 +609,7 @@ Box* exec(Box* boxedCode, Box* globals, Box* locals) {
 
     CLFunction* cl;
     if (boxedCode->cls == str_cls) {
-        AST_Suite* parsed = parseExec(static_cast<BoxedString*>(boxedCode)->s);
+        AST_Suite* parsed = parseExec(static_cast<BoxedString*>(boxedCode)->s());
         cl = compileExec(parsed, "<string>");
     } else if (boxedCode->cls == code_cls) {
         cl = clfunctionFromCode(boxedCode);

--- a/src/codegen/pypa-parser.cpp
+++ b/src/codegen/pypa-parser.cpp
@@ -932,7 +932,7 @@ pypa::String pypaEscapeDecoder(const pypa::String& s, const pypa::String& encodi
             BoxedString* str_utf8 = (BoxedString*)PyUnicode_AsUTF8String(str);
             assert(str_utf8->cls == str_cls);
             checkAndThrowCAPIException();
-            return str_utf8->s.str();
+            return str_utf8->s().str();
         }
 
         bool need_encoding = encoding != "utf-8" && encoding != "iso-8859-1";
@@ -943,7 +943,7 @@ pypa::String pypaEscapeDecoder(const pypa::String& s, const pypa::String& encodi
                     throwCAPIException();
                 BoxedString* str = (BoxedString*)PyUnicode_AsEncodedString(u, encoding.c_str(), NULL);
                 assert(str->cls == str_cls);
-                return str->s.str();
+                return str->s().str();
             } else {
                 return s;
             }
@@ -954,12 +954,12 @@ pypa::String pypaEscapeDecoder(const pypa::String& s, const pypa::String& encodi
         if (!decoded)
             throwCAPIException();
         assert(decoded->cls == str_cls);
-        return decoded->s.str();
+        return decoded->s().str();
     } catch (ExcInfo e) {
         error = true;
         BoxedString* error_message = str(e.value);
         if (error_message && error_message->cls == str_cls)
-            return std::string(error_message->s);
+            return std::string(error_message->s());
         return "Encountered an unknown error inside pypaEscapeDecoder";
     }
 }
@@ -1080,7 +1080,7 @@ std::string PystonSourceReader::get_line() {
     if (!line->size())
         is_eof = true;
     ++line_number;
-    return line->s;
+    return line->s();
 }
 
 AST_Module* pypa_parse(char const* file_path) {

--- a/src/core/cfg.cpp
+++ b/src/core/cfg.cpp
@@ -2479,7 +2479,7 @@ CFG* computeCFG(SourceInfo* source, std::vector<AST_stmt*> body) {
         if (source->scoping->areGlobalsFromModule()) {
             Box* module_name = source->parent_module->getattr("__name__", NULL);
             assert(module_name->cls == str_cls);
-            module_assign->value = new AST_Str(static_cast<BoxedString*>(module_name)->s);
+            module_assign->value = new AST_Str(static_cast<BoxedString*>(module_name)->s());
         } else {
             module_assign->value
                 = new AST_Name(source->getInternedStrings().get("__name__"), AST_TYPE::Load, source->ast->lineno);

--- a/src/runtime/builtin_modules/pyston.cpp
+++ b/src/runtime/builtin_modules/pyston.cpp
@@ -30,7 +30,7 @@ static Box* setOption(Box* option, Box* value) {
     int n = ((BoxedInt*)value)->n;
 
 #define CHECK(_s)                                                                                                      \
-    if (option_string->s == STRINGIFY(_s))                                                                             \
+    if (option_string->s() == STRINGIFY(_s))                                                                           \
     _s = n
 
     // :)
@@ -43,7 +43,7 @@ static Box* setOption(Box* option, Box* value) {
     else CHECK(REOPT_THRESHOLD_BASELINE);
     else CHECK(OSR_THRESHOLD_BASELINE);
     else CHECK(SPECULATION_THRESHOLD);
-    else raiseExcHelper(ValueError, "unknown option name '%s", option_string->s.data());
+    else raiseExcHelper(ValueError, "unknown option name '%s", option_string->data());
 
     return None;
 }

--- a/src/runtime/builtin_modules/thread.cpp
+++ b/src/runtime/builtin_modules/thread.cpp
@@ -168,7 +168,7 @@ public:
     }
 
     static Box* setattrPyston(Box* obj, Box* name, Box* val) noexcept {
-        if (isSubclass(name->cls, str_cls) && static_cast<BoxedString*>(name)->s == "__dict__") {
+        if (isSubclass(name->cls, str_cls) && static_cast<BoxedString*>(name)->s() == "__dict__") {
             raiseExcHelper(AttributeError, "'%.50s' object attribute '__dict__' is read-only", Py_TYPE(obj)->tp_name);
         }
 
@@ -189,7 +189,7 @@ public:
 
     static Box* getattro(Box* obj, Box* name) noexcept {
         assert(name->cls == str_cls);
-        llvm::StringRef s = static_cast<BoxedString*>(name)->s;
+        llvm::StringRef s = static_cast<BoxedString*>(name)->s();
 
         Box* tls_obj = getThreadLocalObject(obj);
         if (s == "__dict__")

--- a/src/runtime/capi.cpp
+++ b/src/runtime/capi.cpp
@@ -258,7 +258,7 @@ extern "C" PyObject* PyObject_GetAttr(PyObject* o, PyObject* attr_name) noexcept
 
 extern "C" PyObject* PyObject_GenericGetAttr(PyObject* o, PyObject* name) noexcept {
     try {
-        Box* r = getattrInternalGeneric(o, static_cast<BoxedString*>(name)->s.data(), NULL, false, false, NULL, NULL);
+        Box* r = getattrInternalGeneric(o, static_cast<BoxedString*>(name)->data(), NULL, false, false, NULL, NULL);
         if (!r)
             PyErr_Format(PyExc_AttributeError, "'%.50s' object has no attribute '%.400s'", o->cls->tp_name,
                          PyString_AS_STRING(name));
@@ -868,7 +868,7 @@ extern "C" PyObject* PyImport_Import(PyObject* module_name) noexcept {
     RELEASE_ASSERT(module_name->cls == str_cls, "");
 
     try {
-        std::string _module_name = static_cast<BoxedString*>(module_name)->s;
+        std::string _module_name = static_cast<BoxedString*>(module_name)->s();
         return importModuleLevel(_module_name, None, None, -1);
     } catch (ExcInfo e) {
         fatalOrError(PyExc_NotImplementedError, "unimplemented");

--- a/src/runtime/dict.cpp
+++ b/src/runtime/dict.cpp
@@ -38,10 +38,10 @@ Box* dictRepr(BoxedDict* self) {
 
         BoxedString* k = static_cast<BoxedString*>(repr(p.first));
         BoxedString* v = static_cast<BoxedString*>(repr(p.second));
-        chars.insert(chars.end(), k->s.begin(), k->s.end());
+        chars.insert(chars.end(), k->s().begin(), k->s().end());
         chars.push_back(':');
         chars.push_back(' ');
-        chars.insert(chars.end(), v->s.begin(), v->s.end());
+        chars.insert(chars.end(), v->s().begin(), v->s().end());
     }
     chars.push_back('}');
     return boxString(llvm::StringRef(&chars[0], chars.size()));

--- a/src/runtime/file.cpp
+++ b/src/runtime/file.cpp
@@ -971,7 +971,7 @@ Box* fileNew(BoxedClass* cls, Box* s, Box* m, Box** args) {
         abort(); // unreachable;
     }
 
-    auto file = new BoxedFile(f, fn->s, PyString_AsString(m));
+    auto file = new BoxedFile(f, fn->s(), PyString_AsString(m));
     PyFile_SetBufSize(file, buffering->n);
     return file;
 }
@@ -1110,7 +1110,7 @@ error:
 Box* fileIterNext(BoxedFile* s) {
     Box* rtn = fileReadline1(s);
     assert(!rtn || rtn->cls == str_cls);
-    if (!rtn || ((BoxedString*)rtn)->s.empty())
+    if (!rtn || ((BoxedString*)rtn)->s().empty())
         raiseExcHelper(StopIteration, "");
     return rtn;
 }

--- a/src/runtime/float.cpp
+++ b/src/runtime/float.cpp
@@ -627,7 +627,7 @@ BoxedFloat* _floatNew(Box* a) {
     } else if (isSubclass(a->cls, int_cls)) {
         return new BoxedFloat(static_cast<BoxedInt*>(a)->n);
     } else if (a->cls == str_cls) {
-        const std::string& s = static_cast<BoxedString*>(a)->s;
+        const std::string& s = static_cast<BoxedString*>(a)->s();
         if (s == "nan")
             return new BoxedFloat(NAN);
         if (s == "-nan")

--- a/src/runtime/import.cpp
+++ b/src/runtime/import.cpp
@@ -220,7 +220,7 @@ SearchResult findModule(const std::string& name, const std::string& full_name, B
         BoxedString* p = static_cast<BoxedString*>(_p);
 
         joined_path.clear();
-        llvm::sys::path::append(joined_path, std::string(p->s), name);
+        llvm::sys::path::append(joined_path, std::string(p->s()), name);
         std::string dn(joined_path.str());
 
         llvm::sys::path::append(joined_path, "__init__.py");
@@ -242,14 +242,14 @@ SearchResult findModule(const std::string& name, const std::string& full_name, B
             return SearchResult(std::move(dn), SearchResult::PKG_DIRECTORY);
 
         joined_path.clear();
-        llvm::sys::path::append(joined_path, std::string(p->s), name + ".py");
+        llvm::sys::path::append(joined_path, std::string(p->s()), name + ".py");
         fn = joined_path.str();
 
         if (pathExists(fn))
             return SearchResult(std::move(fn), SearchResult::PY_SOURCE);
 
         joined_path.clear();
-        llvm::sys::path::append(joined_path, p->s, name + ".pyston.so");
+        llvm::sys::path::append(joined_path, p->s(), name + ".pyston.so");
         fn = joined_path.str();
 
         if (pathExists(fn))
@@ -291,7 +291,7 @@ static Box* getParent(Box* globals, int level, std::string& buf) {
         if (len > PATH_MAX) {
             raiseExcHelper(ValueError, "Package name too long");
         }
-        buf += pkgname->s;
+        buf += pkgname->s();
     } else {
         /* __package__ not set, so figure it out and set it */
         BoxedString* modname = static_cast<BoxedString*>(getFromGlobals(globals, name_str));
@@ -305,11 +305,11 @@ static Box* getParent(Box* globals, int level, std::string& buf) {
             if (modname->size() > PATH_MAX) {
                 raiseExcHelper(ValueError, "Module name too long");
             }
-            buf += modname->s;
+            buf += modname->s();
             setGlobal(globals, package_str, modname);
         } else {
             /* Normal module, so work out the package name if any */
-            size_t lastdot = modname->s.rfind('.');
+            size_t lastdot = modname->s().rfind('.');
             if (lastdot == std::string::npos && level > 0) {
                 raiseExcHelper(ValueError, "Attempted relative import in non-package");
             }
@@ -321,7 +321,7 @@ static Box* getParent(Box* globals, int level, std::string& buf) {
                 raiseExcHelper(ValueError, "Module name too long");
             }
 
-            buf = std::string(modname->s, 0, lastdot);
+            buf = std::string(modname->s(), 0, lastdot);
             setGlobal(globals, package_str, boxStringPtr(&buf));
         }
     }
@@ -562,7 +562,7 @@ static void ensureFromlist(Box* module, Box* fromlist, std::string& buf, bool re
         assert(_s->cls == str_cls);
         BoxedString* s = static_cast<BoxedString*>(_s);
 
-        if (s->s[0] == '*') {
+        if (s->s()[0] == '*') {
             // If __all__ contains a '*', just skip it:
             if (recursive)
                 continue;
@@ -574,12 +574,12 @@ static void ensureFromlist(Box* module, Box* fromlist, std::string& buf, bool re
             continue;
         }
 
-        Box* attr = getattrInternal(module, s->s, NULL);
+        Box* attr = getattrInternal(module, s->s(), NULL);
         if (attr != NULL)
             continue;
 
         // Just want to import it and add it to the modules list for now:
-        importSub(s->s, (llvm::Twine(buf) + "." + s->s).str(), module);
+        importSub(s->s(), (llvm::Twine(buf) + "." + s->s()).str(), module);
     }
 }
 
@@ -651,7 +651,7 @@ Box* nullImporterInit(Box* self, Box* _path) {
         raiseExcHelper(TypeError, "must be string, not %s", getTypeName(_path));
 
     BoxedString* path = (BoxedString*)_path;
-    if (path->s.empty())
+    if (path->s().empty())
         raiseExcHelper(ImportError, "empty pathname");
 
     if (isdir(path->data()))
@@ -676,7 +676,7 @@ Box* impFindModule(Box* _name, BoxedList* path) {
     BoxedString* name = static_cast<BoxedString*>(_name);
     BoxedList* path_list = path && path != None ? path : getSysPath();
 
-    SearchResult sr = findModule(name->s, name->s, path_list);
+    SearchResult sr = findModule(name->s(), name->s(), path_list);
     if (sr.type == SearchResult::SEARCH_ERROR)
         raiseExcHelper(ImportError, "%s", name->data());
 
@@ -726,13 +726,13 @@ Box* impLoadModule(Box* _name, Box* _file, Box* _pathname, Box** args) {
 
     if (type->n == SearchResult::PKG_DIRECTORY) {
         RELEASE_ASSERT(suffix->cls == str_cls, "");
-        RELEASE_ASSERT(suffix->s.empty(), "");
-        RELEASE_ASSERT(mode->s.empty(), "");
+        RELEASE_ASSERT(suffix->s().empty(), "");
+        RELEASE_ASSERT(mode->s().empty(), "");
         RELEASE_ASSERT(_file == None, "");
-        return createAndRunModule(name->s, (llvm::Twine(pathname->s) + "/__init__.py").str(), pathname->s);
+        return createAndRunModule(name->s(), (llvm::Twine(pathname->s()) + "/__init__.py").str(), pathname->s());
     } else if (type->n == SearchResult::PY_SOURCE) {
         RELEASE_ASSERT(_file->cls == file_cls, "");
-        return createAndRunModule(name->s, pathname->s);
+        return createAndRunModule(name->s(), pathname->s());
     }
 
     Py_FatalError("unimplemented");
@@ -744,7 +744,7 @@ Box* impLoadSource(Box* _name, Box* _pathname, Box* _file) {
     RELEASE_ASSERT(_name->cls == str_cls, "");
     RELEASE_ASSERT(_pathname->cls == str_cls, "");
 
-    return createAndRunModule(static_cast<BoxedString*>(_name)->s, static_cast<BoxedString*>(_pathname)->s);
+    return createAndRunModule(static_cast<BoxedString*>(_name)->s(), static_cast<BoxedString*>(_pathname)->s());
 }
 
 Box* impLoadDynamic(Box* _name, Box* _pathname, Box* _file) {
@@ -755,16 +755,16 @@ Box* impLoadDynamic(Box* _name, Box* _pathname, Box* _file) {
     BoxedString* name = (BoxedString*)_name;
     BoxedString* pathname = (BoxedString*)_pathname;
 
-    const char* lastdot = strrchr(name->s.data(), '.');
+    const char* lastdot = strrchr(name->s().data(), '.');
 
     const char* shortname;
     if (lastdot == NULL) {
-        shortname = name->s.data();
+        shortname = name->s().data();
     } else {
         shortname = lastdot + 1;
     }
 
-    return importCExtension(name->s, shortname, pathname->s);
+    return importCExtension(name->s(), shortname, pathname->s());
 }
 
 Box* impGetSuffixes() {

--- a/src/runtime/list.cpp
+++ b/src/runtime/list.cpp
@@ -76,7 +76,7 @@ extern "C" Box* listRepr(BoxedList* self) {
 
         assert(r->cls == str_cls);
         BoxedString* s = static_cast<BoxedString*>(r);
-        os << s->s;
+        os << s->s();
     }
     os << ']';
     return boxString(os.str());

--- a/src/runtime/long.cpp
+++ b/src/runtime/long.cpp
@@ -566,7 +566,7 @@ BoxedLong* _longNew(Box* val, Box* _base) {
             raiseExcHelper(TypeError, "long() can't convert non-string with explicit base");
         BoxedString* s = static_cast<BoxedString*>(val);
 
-        rtn = (BoxedLong*)PyLong_FromString(s->s.str().c_str(), NULL, base);
+        rtn = (BoxedLong*)PyLong_FromString(s->data(), NULL, base);
         checkAndThrowCAPIException();
     } else {
         if (isSubclass(val->cls, long_cls)) {
@@ -579,7 +579,7 @@ BoxedLong* _longNew(Box* val, Box* _base) {
         } else if (isSubclass(val->cls, int_cls)) {
             mpz_init_set_si(rtn->n, static_cast<BoxedInt*>(val)->n);
         } else if (val->cls == str_cls) {
-            const std::string& s = static_cast<BoxedString*>(val)->s;
+            const std::string& s = static_cast<BoxedString*>(val)->s();
             int r = mpz_init_set_str(rtn->n, s.c_str(), 10);
             RELEASE_ASSERT(r == 0, "");
         } else if (val->cls == float_cls) {

--- a/src/runtime/set.cpp
+++ b/src/runtime/set.cpp
@@ -106,7 +106,7 @@ static Box* _setRepr(BoxedSet* self, const char* type_name) {
         if (!first) {
             os << ", ";
         }
-        os << static_cast<BoxedString*>(repr(elt))->s;
+        os << static_cast<BoxedString*>(repr(elt))->s();
         first = false;
     }
     os << "])";

--- a/src/runtime/str.cpp
+++ b/src/runtime/str.cpp
@@ -52,7 +52,7 @@ extern "C" PyObject* string_splitlines(PyStringObject* self, PyObject* args) noe
 
 namespace pyston {
 
-BoxedString::BoxedString(const char* s, size_t n) : s(storage(), n), interned_state(SSTATE_NOT_INTERNED) {
+BoxedString::BoxedString(const char* s, size_t n) : interned_state(SSTATE_NOT_INTERNED) {
     RELEASE_ASSERT(n != llvm::StringRef::npos, "");
     if (s) {
         memmove(data(), s, n);
@@ -62,21 +62,20 @@ BoxedString::BoxedString(const char* s, size_t n) : s(storage(), n), interned_st
     }
 }
 
-BoxedString::BoxedString(llvm::StringRef lhs, llvm::StringRef rhs)
-    : s(storage(), lhs.size() + rhs.size()), interned_state(SSTATE_NOT_INTERNED) {
+BoxedString::BoxedString(llvm::StringRef lhs, llvm::StringRef rhs) : interned_state(SSTATE_NOT_INTERNED) {
     RELEASE_ASSERT(lhs.size() + rhs.size() != llvm::StringRef::npos, "");
     memmove(data(), lhs.data(), lhs.size());
     memmove(data() + lhs.size(), rhs.data(), rhs.size());
     data()[lhs.size() + rhs.size()] = 0;
 }
 
-BoxedString::BoxedString(llvm::StringRef s) : s(storage(), s.size()), interned_state(SSTATE_NOT_INTERNED) {
+BoxedString::BoxedString(llvm::StringRef s) : interned_state(SSTATE_NOT_INTERNED) {
     RELEASE_ASSERT(s.size() != llvm::StringRef::npos, "");
     memmove(data(), s.data(), s.size());
     data()[s.size()] = 0;
 }
 
-BoxedString::BoxedString(size_t n, char c) : s(storage(), n), interned_state(SSTATE_NOT_INTERNED) {
+BoxedString::BoxedString(size_t n, char c) : interned_state(SSTATE_NOT_INTERNED) {
     RELEASE_ASSERT(n != llvm::StringRef::npos, "");
     memset(data(), c, n);
     data()[n] = 0;
@@ -84,7 +83,7 @@ BoxedString::BoxedString(size_t n, char c) : s(storage(), n), interned_state(SST
 
 extern "C" char PyString_GetItem(PyObject* op, ssize_t n) noexcept {
     RELEASE_ASSERT(PyString_Check(op), "");
-    return static_cast<const BoxedString*>(op)->s[n];
+    return static_cast<const BoxedString*>(op)->s()[n];
 }
 
 extern "C" PyObject* PyString_FromFormatV(const char* format, va_list vargs) noexcept {
@@ -342,7 +341,7 @@ extern "C" Box* strAdd(BoxedString* lhs, Box* _rhs) {
     }
 
     BoxedString* rhs = static_cast<BoxedString*>(_rhs);
-    return new (lhs->size() + rhs->size()) BoxedString(lhs->s, rhs->s);
+    return new (lhs->size() + rhs->size()) BoxedString(lhs->s(), rhs->s());
 }
 
 static llvm::StringMap<Box*> interned_strings;
@@ -369,7 +368,7 @@ extern "C" void PyString_InternInPlace(PyObject** p) noexcept {
     if (PyString_CHECK_INTERNED(s))
         return;
 
-    auto& entry = interned_strings[s->s];
+    auto& entry = interned_strings[s->s()];
     if (entry)
         *p = entry;
     else {
@@ -1161,7 +1160,7 @@ extern "C" Box* strLt(BoxedString* lhs, Box* rhs) {
         return NotImplemented;
 
     BoxedString* srhs = static_cast<BoxedString*>(rhs);
-    return boxBool(lhs->s < srhs->s);
+    return boxBool(lhs->s() < srhs->s());
 }
 
 extern "C" Box* strLe(BoxedString* lhs, Box* rhs) {
@@ -1171,7 +1170,7 @@ extern "C" Box* strLe(BoxedString* lhs, Box* rhs) {
         return NotImplemented;
 
     BoxedString* srhs = static_cast<BoxedString*>(rhs);
-    return boxBool(lhs->s <= srhs->s);
+    return boxBool(lhs->s() <= srhs->s());
 }
 
 extern "C" Box* strGt(BoxedString* lhs, Box* rhs) {
@@ -1181,7 +1180,7 @@ extern "C" Box* strGt(BoxedString* lhs, Box* rhs) {
         return NotImplemented;
 
     BoxedString* srhs = static_cast<BoxedString*>(rhs);
-    return boxBool(lhs->s > srhs->s);
+    return boxBool(lhs->s() > srhs->s());
 }
 
 extern "C" Box* strGe(BoxedString* lhs, Box* rhs) {
@@ -1191,7 +1190,7 @@ extern "C" Box* strGe(BoxedString* lhs, Box* rhs) {
         return NotImplemented;
 
     BoxedString* srhs = static_cast<BoxedString*>(rhs);
-    return boxBool(lhs->s >= srhs->s);
+    return boxBool(lhs->s() >= srhs->s());
 }
 
 extern "C" Box* strEq(BoxedString* lhs, Box* rhs) {
@@ -1201,7 +1200,7 @@ extern "C" Box* strEq(BoxedString* lhs, Box* rhs) {
         return NotImplemented;
 
     BoxedString* srhs = static_cast<BoxedString*>(rhs);
-    return boxBool(lhs->s == srhs->s);
+    return boxBool(lhs->s() == srhs->s());
 }
 
 extern "C" Box* strNe(BoxedString* lhs, Box* rhs) {
@@ -1211,7 +1210,7 @@ extern "C" Box* strNe(BoxedString* lhs, Box* rhs) {
         return NotImplemented;
 
     BoxedString* srhs = static_cast<BoxedString*>(rhs);
-    return boxBool(lhs->s != srhs->s);
+    return boxBool(lhs->s() != srhs->s());
 }
 
 #define JUST_LEFT 0
@@ -1229,11 +1228,11 @@ static Box* pad(BoxedString* self, Box* width, Box* fillchar, int justType) {
             return self;
         } else {
             // If self isn't a string but a subclass of str, then make a new string to return
-            return boxString(self->s);
+            return boxString(self->s());
         }
     }
 
-    char c = static_cast<BoxedString*>(fillchar)->s[0];
+    char c = static_cast<BoxedString*>(fillchar)->s()[0];
 
     int padLeft, padRight;
     int nNeeded = targetWidth - curWidth;
@@ -1255,7 +1254,7 @@ static Box* pad(BoxedString* self, Box* width, Box* fillchar, int justType) {
     }
 
     // TODO this is probably slow
-    return boxStringTwine(llvm::Twine(std::string(padLeft, c)) + self->s + std::string(padRight, c));
+    return boxStringTwine(llvm::Twine(std::string(padLeft, c)) + self->s() + std::string(padRight, c));
 }
 extern "C" Box* strLjust(BoxedString* lhs, Box* width, Box* fillchar) {
     return pad(lhs, width, fillchar, JUST_LEFT);
@@ -1279,7 +1278,7 @@ extern "C" Box* strStr(BoxedString* self) {
     if (self->cls == str_cls)
         return self;
 
-    return boxString(self->s);
+    return boxString(self->s());
 }
 
 static bool _needs_escaping[256]
@@ -1307,7 +1306,7 @@ extern "C" PyObject* PyString_Repr(PyObject* obj, int smartquotes) noexcept {
 
     std::ostringstream os("");
 
-    llvm::StringRef s(self->s);
+    llvm::StringRef s(self->s());
     char quote = '\'';
     if (smartquotes && s.find('\'', 0) != std::string::npos && s.find('\"', 0) == std::string::npos) {
         quote = '\"';
@@ -1572,7 +1571,7 @@ extern "C" Box* strNew(BoxedClass* cls, Box* obj) {
 
     BoxedString* _rtn = static_cast<BoxedString*>(rtn);
 
-    return new (cls, _rtn->size()) BoxedString(_rtn->s);
+    return new (cls, _rtn->size()) BoxedString(_rtn->s());
 }
 
 extern "C" Box* basestringNew(BoxedClass* cls, Box* args, Box* kwargs) {
@@ -1582,7 +1581,7 @@ extern "C" Box* basestringNew(BoxedClass* cls, Box* args, Box* kwargs) {
 Box* _strSlice(BoxedString* self, i64 start, i64 stop, i64 step, i64 length) {
     assert(isSubclass(self->cls, str_cls));
 
-    llvm::StringRef s = self->s;
+    llvm::StringRef s = self->s();
 
     assert(step != 0);
     if (step > 0) {
@@ -1604,7 +1603,7 @@ Box* _strSlice(BoxedString* self, i64 start, i64 stop, i64 step, i64 length) {
 Box* strIsAlpha(BoxedString* self) {
     assert(isSubclass(self->cls, str_cls));
 
-    llvm::StringRef str(self->s);
+    llvm::StringRef str(self->s());
     if (str.empty())
         return False;
 
@@ -1619,7 +1618,7 @@ Box* strIsAlpha(BoxedString* self) {
 Box* strIsDigit(BoxedString* self) {
     assert(isSubclass(self->cls, str_cls));
 
-    llvm::StringRef str(self->s);
+    llvm::StringRef str(self->s());
     if (str.empty())
         return False;
 
@@ -1634,7 +1633,7 @@ Box* strIsDigit(BoxedString* self) {
 Box* strIsAlnum(BoxedString* self) {
     assert(isSubclass(self->cls, str_cls));
 
-    llvm::StringRef str(self->s);
+    llvm::StringRef str(self->s());
     if (str.empty())
         return False;
 
@@ -1649,7 +1648,7 @@ Box* strIsAlnum(BoxedString* self) {
 Box* strIsLower(BoxedString* self) {
     assert(isSubclass(self->cls, str_cls));
 
-    llvm::StringRef str(self->s);
+    llvm::StringRef str(self->s());
     bool lowered = false;
 
     if (str.empty())
@@ -1671,7 +1670,7 @@ Box* strIsLower(BoxedString* self) {
 Box* strIsUpper(BoxedString* self) {
     assert(isSubclass(self->cls, str_cls));
 
-    llvm::StringRef str(self->s);
+    llvm::StringRef str(self->s());
 
     if (str.empty())
         return False;
@@ -1690,7 +1689,7 @@ Box* strIsUpper(BoxedString* self) {
 Box* strIsSpace(BoxedString* self) {
     assert(isSubclass(self->cls, str_cls));
 
-    llvm::StringRef str(self->s);
+    llvm::StringRef str(self->s());
     if (str.empty())
         return False;
 
@@ -1705,7 +1704,7 @@ Box* strIsSpace(BoxedString* self) {
 Box* strIsTitle(BoxedString* self) {
     assert(isSubclass(self->cls, str_cls));
 
-    llvm::StringRef str(self->s);
+    llvm::StringRef str(self->s());
 
     if (str.empty())
         return False;
@@ -1767,12 +1766,12 @@ Box* strReplace(Box* _self, Box* _old, Box* _new, Box** _args) {
 
     int max_replaces = static_cast<BoxedInt*>(_maxreplace)->n;
     size_t start_pos = 0;
-    std::string s = self->s;
+    std::string s = self->s();
     for (int num_replaced = 0; num_replaced < max_replaces || max_replaces < 0; ++num_replaced) {
-        start_pos = s.find(old->s, start_pos);
+        start_pos = s.find(old->s(), start_pos);
         if (start_pos == std::string::npos)
             break;
-        s.replace(start_pos, old->size(), new_->s);
+        s.replace(start_pos, old->size(), new_->s());
         start_pos += new_->size(); // Handles case where 'to' is a substring of 'from'
     }
     return boxString(s);
@@ -1782,7 +1781,7 @@ Box* strPartition(BoxedString* self, BoxedString* sep) {
     RELEASE_ASSERT(isSubclass(self->cls, str_cls), "");
     RELEASE_ASSERT(isSubclass(sep->cls, str_cls), "");
 
-    size_t found_idx = self->s.find(sep->s);
+    size_t found_idx = self->s().find(sep->s());
     if (found_idx == std::string::npos)
         return BoxedTuple::create({ self, EmptyString, EmptyString });
 
@@ -1796,7 +1795,7 @@ Box* strRpartition(BoxedString* self, BoxedString* sep) {
     RELEASE_ASSERT(isSubclass(self->cls, str_cls), "");
     RELEASE_ASSERT(isSubclass(sep->cls, str_cls), "");
 
-    size_t found_idx = self->s.rfind(sep->s);
+    size_t found_idx = self->s().rfind(sep->s());
     if (found_idx == std::string::npos)
         return BoxedTuple::create({ EmptyString, EmptyString, self });
 
@@ -1819,10 +1818,10 @@ Box* strFormat(BoxedString* self, BoxedTuple* args, BoxedDict* kwargs) {
 
 Box* strStrip(BoxedString* self, Box* chars) {
     assert(isSubclass(self->cls, str_cls));
-    auto str = self->s;
+    auto str = self->s();
 
     if (isSubclass(chars->cls, str_cls)) {
-        auto chars_str = static_cast<BoxedString*>(chars)->s;
+        auto chars_str = static_cast<BoxedString*>(chars)->s();
         return boxStringRef(str.trim(chars_str));
     } else if (chars->cls == none_cls) {
         return boxStringRef(str.trim(" \t\n\r\f\v"));
@@ -1843,10 +1842,10 @@ Box* strStrip(BoxedString* self, Box* chars) {
 
 Box* strLStrip(BoxedString* self, Box* chars) {
     assert(isSubclass(self->cls, str_cls));
-    auto str = self->s;
+    auto str = self->s();
 
     if (isSubclass(chars->cls, str_cls)) {
-        auto chars_str = static_cast<BoxedString*>(chars)->s;
+        auto chars_str = static_cast<BoxedString*>(chars)->s();
         return boxStringRef(str.ltrim(chars_str));
     } else if (chars->cls == none_cls) {
         return boxStringRef(str.ltrim(" \t\n\r\f\v"));
@@ -1867,10 +1866,10 @@ Box* strLStrip(BoxedString* self, Box* chars) {
 
 Box* strRStrip(BoxedString* self, Box* chars) {
     assert(isSubclass(self->cls, str_cls));
-    auto str = self->s;
+    auto str = self->s();
 
     if (isSubclass(chars->cls, str_cls)) {
-        auto chars_str = static_cast<BoxedString*>(chars)->s;
+        auto chars_str = static_cast<BoxedString*>(chars)->s();
         return boxStringRef(str.rtrim(chars_str));
     } else if (chars->cls == none_cls) {
         return boxStringRef(str.rtrim(" \t\n\r\f\v"));
@@ -1892,7 +1891,7 @@ Box* strRStrip(BoxedString* self, Box* chars) {
 Box* strCapitalize(BoxedString* self) {
     assert(isSubclass(self->cls, str_cls));
 
-    std::string s(self->s);
+    std::string s(self->s());
 
     for (auto& i : s) {
         i = std::tolower(i);
@@ -1908,7 +1907,7 @@ Box* strCapitalize(BoxedString* self) {
 Box* strTitle(BoxedString* self) {
     assert(isSubclass(self->cls, str_cls));
 
-    std::string s(self->s);
+    std::string s(self->s());
     bool start_of_word = false;
 
     for (auto& i : s) {
@@ -1938,7 +1937,7 @@ Box* strTranslate(BoxedString* self, BoxedString* table, BoxedString* delete_cha
     if (delete_chars) {
         if (!isSubclass(delete_chars->cls, str_cls))
             raiseExcHelper(TypeError, "expected a character buffer object");
-        delete_set.insert(delete_chars->s.begin(), delete_chars->s.end());
+        delete_set.insert(delete_chars->s().begin(), delete_chars->s().end());
     }
 
     bool have_table = table != None;
@@ -1950,9 +1949,9 @@ Box* strTranslate(BoxedString* self, BoxedString* table, BoxedString* delete_cha
     }
 
     std::string str;
-    for (const char c : self->s) {
+    for (const char c : self->s()) {
         if (!delete_set.count(c))
-            str.append(1, have_table ? table->s[(unsigned char)c] : c);
+            str.append(1, have_table ? table->s()[(unsigned char)c] : c);
     }
     return boxString(str);
 }
@@ -1960,7 +1959,7 @@ Box* strTranslate(BoxedString* self, BoxedString* table, BoxedString* delete_cha
 Box* strLower(BoxedString* self) {
     assert(isSubclass(self->cls, str_cls));
 
-    BoxedString* rtn = static_cast<BoxedString*>(boxString(self->s));
+    BoxedString* rtn = static_cast<BoxedString*>(boxString(self->s()));
     for (int i = 0; i < rtn->size(); i++)
         rtn->data()[i] = std::tolower(rtn->data()[i]);
     return rtn;
@@ -1968,7 +1967,7 @@ Box* strLower(BoxedString* self) {
 
 Box* strUpper(BoxedString* self) {
     assert(isSubclass(self->cls, str_cls));
-    BoxedString* rtn = static_cast<BoxedString*>(boxString(self->s));
+    BoxedString* rtn = static_cast<BoxedString*>(boxString(self->s()));
     for (int i = 0; i < rtn->size(); i++)
         rtn->data()[i] = std::toupper(rtn->data()[i]);
     return rtn;
@@ -1976,7 +1975,7 @@ Box* strUpper(BoxedString* self) {
 
 Box* strSwapcase(BoxedString* self) {
     assert(isSubclass(self->cls, str_cls));
-    BoxedString* rtn = static_cast<BoxedString*>(boxString(self->s));
+    BoxedString* rtn = static_cast<BoxedString*>(boxString(self->s()));
     for (int i = 0; i < rtn->size(); i++) {
         char c = rtn->data()[i];
         if (std::islower(c))
@@ -2002,7 +2001,7 @@ Box* strContains(BoxedString* self, Box* elt) {
 
     BoxedString* sub = static_cast<BoxedString*>(elt);
 
-    size_t found_idx = self->s.find(sub->s);
+    size_t found_idx = self->s().find(sub->s());
     if (found_idx == std::string::npos)
         return False;
     return True;
@@ -2078,7 +2077,7 @@ Box* strStartswith(BoxedString* self, Box* elt, Box* start, Box** _args) {
         return False;
     if (sub->size() > compare_len)
         return False;
-    return boxBool(compareStringRefs(self->s, istart, sub->size(), sub->s) == 0);
+    return boxBool(compareStringRefs(self->s(), istart, sub->size(), sub->s()) == 0);
 }
 
 Box* strEndswith(BoxedString* self, Box* elt, Box* start, Box** _args) {
@@ -2143,7 +2142,7 @@ Box* strEndswith(BoxedString* self, Box* elt, Box* start, Box** _args) {
         return False;
     // XXX: this line is the only difference between startswith and endswith:
     istart += compare_len - sub->size();
-    return boxBool(compareStringRefs(self->s, istart, sub->size(), sub->s) == 0);
+    return boxBool(compareStringRefs(self->s(), istart, sub->size(), sub->s()) == 0);
 }
 
 Box* strDecode(BoxedString* self, Box* encoding, Box* error) {
@@ -2211,7 +2210,7 @@ extern "C" Box* strGetitem(BoxedString* self, Box* slice) {
             raiseExcHelper(IndexError, "string index out of range");
         }
 
-        char c = self->s[n];
+        char c = self->s()[n];
         return boxStringRef(llvm::StringRef(&c, 1));
     } else if (slice->cls == slice_cls) {
         BoxedSlice* sslice = static_cast<BoxedSlice*>(slice);
@@ -2236,7 +2235,7 @@ public:
     BoxedString* s;
     std::string::const_iterator it, end;
 
-    BoxedStringIterator(BoxedString* s) : s(s), it(s->s.begin()), end(s->s.end()) {}
+    BoxedStringIterator(BoxedString* s) : s(s), it(s->s().begin()), end(s->s().end()) {}
 
     DEFAULT_CLASS(str_iterator_cls);
 
@@ -2371,7 +2370,7 @@ extern "C" int _PyString_Resize(PyObject** pv, Py_ssize_t newsize) noexcept {
 
     if (newsize < s->size()) {
         // XXX resize the box (by reallocating) smaller if it makes sense
-        s->s = llvm::StringRef(s->data(), newsize);
+        s->ob_size = newsize;
         s->data()[newsize] = 0;
         return 0;
     }
@@ -2583,7 +2582,7 @@ static int string_print(PyObject* _op, FILE* fp, int flags) noexcept {
         with the GIL released. */
         // Pyston change:
         // c = op->ob_sval[i];
-        c = op->s[i];
+        c = op->s()[i];
         if (c == quote || c == '\\')
             fprintf(fp, "\\%c", c);
         else if (c == '\t')

--- a/src/runtime/super.cpp
+++ b/src/runtime/super.cpp
@@ -64,7 +64,7 @@ Box* superGetattribute(Box* _s, Box* _attr) {
 
     if (!skip) {
         // Looks like __class__ is supposed to be "super", not the class of the the proxied object.
-        skip = (attr->s == class_str);
+        skip = (attr->s() == class_str);
     }
 
     if (!skip) {
@@ -101,7 +101,7 @@ Box* superGetattribute(Box* _s, Box* _attr) {
                 continue;
             res = PyDict_GetItem(dict, name);
 #endif
-            res = tmp->getattr(std::string(attr->s));
+            res = tmp->getattr(std::string(attr->s()));
 
             if (res != NULL) {
 // Pyston change:
@@ -128,7 +128,7 @@ Box* superGetattribute(Box* _s, Box* _attr) {
         }
     }
 
-    Box* r = typeLookup(s->cls, std::string(attr->s), NULL);
+    Box* r = typeLookup(s->cls, std::string(attr->s()), NULL);
     // TODO implement this
     RELEASE_ASSERT(r, "should call the equivalent of objectGetattr here");
     return processDescriptor(r, s, s->cls);

--- a/src/runtime/tuple.cpp
+++ b/src/runtime/tuple.cpp
@@ -215,7 +215,7 @@ Box* tupleRepr(BoxedTuple* t) {
             os << ", ";
 
         BoxedString* elt_repr = static_cast<BoxedString*>(repr(t->elts[i]));
-        os << elt_repr->s;
+        os << elt_repr->s();
     }
     if (n == 1)
         os << ",";
@@ -376,7 +376,7 @@ extern "C" Box* tupleNew(Box* _cls, BoxedTuple* args, BoxedDict* kwargs) {
             auto const seq = *(kwargs->d.begin());
             auto const kw = static_cast<BoxedString*>(seq.first);
 
-            if (kw->s == "sequence")
+            if (kw->s() == "sequence")
                 elements = seq.second;
             else
                 raiseExcHelper(TypeError, "'%s' is an invalid keyword argument for this function", kw->data());

--- a/src/runtime/types.cpp
+++ b/src/runtime/types.cpp
@@ -401,7 +401,7 @@ std::string BoxedModule::name() {
         return "?";
     } else {
         BoxedString* sname = static_cast<BoxedString*>(name);
-        return sname->s;
+        return sname->s();
     }
 }
 
@@ -1038,7 +1038,7 @@ Box* sliceRepr(BoxedSlice* self) {
     BoxedString* start = static_cast<BoxedString*>(repr(self->start));
     BoxedString* stop = static_cast<BoxedString*>(repr(self->stop));
     BoxedString* step = static_cast<BoxedString*>(repr(self->step));
-    return boxStringTwine(llvm::Twine("slice(") + start->s + ", " + stop->s + ", " + step->s + ")");
+    return boxStringTwine(llvm::Twine("slice(") + start->s() + ", " + stop->s() + ", " + step->s() + ")");
 }
 
 extern "C" int PySlice_GetIndices(PySliceObject* r, Py_ssize_t length, Py_ssize_t* start, Py_ssize_t* stop,
@@ -1150,8 +1150,8 @@ Box* typeRepr(BoxedClass* self) {
     Box* m = self->getattr("__module__");
     if (m && m->cls == str_cls) {
         BoxedString* sm = static_cast<BoxedString*>(m);
-        if (sm->s != "__builtin__")
-            os << sm->s << '.';
+        if (sm->s() != "__builtin__")
+            os << sm->s() << '.';
     }
 
     os << self->tp_name;
@@ -1347,7 +1347,7 @@ public:
 
         RELEASE_ASSERT(_key->cls == str_cls, "");
         BoxedString* key = static_cast<BoxedString*>(_key);
-        self->b->setattr(key->s, value, NULL);
+        self->b->setattr(key->s(), value, NULL);
         return None;
     }
 
@@ -1360,10 +1360,10 @@ public:
 
         RELEASE_ASSERT(_key->cls == str_cls, "");
         BoxedString* key = static_cast<BoxedString*>(_key);
-        Box* cur = self->b->getattr(key->s);
+        Box* cur = self->b->getattr(key->s());
         if (cur)
             return cur;
-        self->b->setattr(key->s, value, NULL);
+        self->b->setattr(key->s(), value, NULL);
         return value;
     }
 
@@ -1376,7 +1376,7 @@ public:
 
         RELEASE_ASSERT(_key->cls == str_cls, "");
         BoxedString* key = static_cast<BoxedString*>(_key);
-        Box* r = self->b->getattr(key->s);
+        Box* r = self->b->getattr(key->s());
         if (!r)
             return def;
         return r;
@@ -1391,7 +1391,7 @@ public:
 
         RELEASE_ASSERT(_key->cls == str_cls, "%s", _key->cls->tp_name);
         BoxedString* key = static_cast<BoxedString*>(_key);
-        Box* r = self->b->getattr(key->s);
+        Box* r = self->b->getattr(key->s());
         if (!r)
             raiseExcHelper(KeyError, "'%s'", key->data());
         return r;
@@ -1405,9 +1405,9 @@ public:
 
         RELEASE_ASSERT(_key->cls == str_cls, "");
         BoxedString* key = static_cast<BoxedString*>(_key);
-        Box* r = self->b->getattr(key->s);
+        Box* r = self->b->getattr(key->s());
         if (r) {
-            self->b->delattr(key->s, NULL);
+            self->b->delattr(key->s(), NULL);
             return r;
         } else {
             if (default_)
@@ -1425,8 +1425,8 @@ public:
 
         RELEASE_ASSERT(_key->cls == str_cls, "%s", _key->cls->tp_name);
         BoxedString* key = static_cast<BoxedString*>(_key);
-        if (self->b->getattr(key->s))
-            self->b->delattr(key->s, NULL);
+        if (self->b->getattr(key->s()))
+            self->b->delattr(key->s(), NULL);
         else
             raiseExcHelper(KeyError, "'%s'", key->data());
         return None;
@@ -1450,7 +1450,7 @@ public:
             first = false;
 
             BoxedString* v = attrs->attr_list->attrs[p.second]->reprICAsString();
-            os << p.first().str() << ": " << v->s;
+            os << p.first().str() << ": " << v->s();
         }
         os << "})";
         return boxString(os.str());
@@ -1464,7 +1464,7 @@ public:
 
         RELEASE_ASSERT(_key->cls == str_cls, "");
         BoxedString* key = static_cast<BoxedString*>(_key);
-        Box* r = self->b->getattr(key->s);
+        Box* r = self->b->getattr(key->s());
         return r ? True : False;
     }
 
@@ -1728,7 +1728,7 @@ Box* objectSetattr(Box* obj, Box* attr, Box* value) {
     }
 
     BoxedString* attr_str = static_cast<BoxedString*>(attr);
-    setattrGeneric(obj, attr_str->s, value, NULL);
+    setattrGeneric(obj, attr_str->s(), value, NULL);
     return None;
 }
 


### PR DESCRIPTION
Create it on demand whenever we need it. We can do this since we (i) save the size in `ob_size` and (ii) the char data is at a fixed offset.