### PR TITLE
Float pow

### DIFF
--- a/from_cpython/Objects/floatobject.c
+++ b/from_cpython/Objects/floatobject.c
@@ -820,7 +820,8 @@ float_floor_div(PyObject *v, PyObject *w)
    x is not an infinity or nan. */
 #define DOUBLE_IS_ODD_INTEGER(x) (fmod(fabs(x), 2.0) == 1.0)
 
-static PyObject *
+// pyston change: make not static
+PyObject *
 float_pow(PyObject *v, PyObject *w, PyObject *z)
 {
     double iv, iw, ix;

--- a/src/runtime/float.cpp
+++ b/src/runtime/float.cpp
@@ -31,6 +31,7 @@ extern "C" PyObject* float_as_integer_ratio(PyObject* v, PyObject* unused) noexc
 extern "C" PyObject* float_is_integer(PyObject* v) noexcept;
 extern "C" PyObject* float__format__(PyObject* v) noexcept;
 extern "C" PyObject* float_pow(PyObject* v, PyObject* w, PyObject* z) noexcept;
+extern "C" int float_pow_unboxed(double iv, double iw, double* res) noexcept;
 
 namespace pyston {
 
@@ -446,8 +447,13 @@ extern "C" Box* floatPowInt(BoxedFloat* lhs, BoxedInt* rhs, Box* mod = None) {
 }
 
 extern "C" double pow_float_float(double lhs, double rhs) {
-    // TODO inline this without the boxing
-    return unboxFloat(floatPowFloat(static_cast<BoxedFloat*>(boxFloat(lhs)), static_cast<BoxedFloat*>(boxFloat(rhs))));
+    double res;
+    int err = float_pow_unboxed(lhs, rhs, &res);
+    if (err) {
+        throwCAPIException();
+    } else {
+        return res;
+    }
 }
 
 extern "C" Box* floatMulFloat(BoxedFloat* lhs, BoxedFloat* rhs) {

--- a/src/runtime/int.cpp
+++ b/src/runtime/int.cpp
@@ -30,6 +30,8 @@
 #include "runtime/types.h"
 #include "runtime/util.h"
 
+extern "C" PyObject* float_pow(PyObject* v, PyObject* w, PyObject* z) noexcept;
+
 namespace pyston {
 
 extern "C" long PyInt_GetMax() noexcept {

--- a/test/tests/float.py
+++ b/test/tests/float.py
@@ -65,3 +65,12 @@ print (0.5).as_integer_ratio()
 print (0.5).is_integer()
 print (1.0).is_integer()
 print 1.0.__hash__(), 1.1.__hash__(), -1.1.__hash__()
+
+print 1.0 ** (10 ** 100)
+print (-1.0) ** (10 ** 100)
+print (-1.0) ** (10 ** 100 + 1)
+print 0.0 ** 0.0
+try:
+    0.0 ** (-1.0)
+except ZeroDivisionError as e:
+    print e.message


### PR DESCRIPTION
fix float.pow, which is wrong

The actual float.pow covers a bunch of special cases that the c++ stdlib `pow` doesn't cover (e.g. `1.0 ** large_number` is always 1.0), and there are exceptions to throw and stuff. So just use `float_pow` from `floatobject.c`.

I refactored `float_pow` in floatobject.c in order to add an unboxed version `float_pow_unboxed`, which I call directly in the implementation of `float_pow_pow` (our specialization of pow to unboxed floats).
