### PR TITLE
Make our pyc handling more robust

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,7 +220,7 @@ add_test(NAME pyston_defaults COMMAND ${PYTHON_EXE} ${CMAKE_SOURCE_DIR}/tools/te
 add_test(NAME pyston_defaults_cpython_tests COMMAND ${PYTHON_EXE} ${CMAKE_SOURCE_DIR}/tools/tester.py -R ./pyston -j${TEST_THREADS} -a=-S -k --exit-code-only --skip-failing -t30 ${CMAKE_SOURCE_DIR}/test/cpython)
 add_test(NAME pyston_defaults_integration_tests COMMAND ${PYTHON_EXE} ${CMAKE_SOURCE_DIR}/tools/tester.py -R ./pyston -j${TEST_THREADS} -a=-S -k --exit-code-only --skip-failing -t300 ${CMAKE_SOURCE_DIR}/test/integration)
 add_test(NAME pyston_max_compilation_tier COMMAND ${PYTHON_EXE} ${CMAKE_SOURCE_DIR}/tools/tester.py -R ./pyston -j${TEST_THREADS} -a=-O -a=-S -k ${CMAKE_SOURCE_DIR}/test/tests)
-add_test(NAME pyston_old_parser COMMAND ${PYTHON_EXE} ${CMAKE_SOURCE_DIR}/tools/tester.py -a=-x -R ./pyston -j1 -a=-n -a=-S -k ${CMAKE_SOURCE_DIR}/test/tests)
+add_test(NAME pyston_old_parser COMMAND ${PYTHON_EXE} ${CMAKE_SOURCE_DIR}/tools/tester.py -a=-x -R ./pyston -j${TEST_THREADS} -a=-n -a=-S -k ${CMAKE_SOURCE_DIR}/test/tests)
 
 # format
 file(GLOB_RECURSE FORMAT_FILES ${CMAKE_SOURCE_DIR}/src/*.h ${CMAKE_SOURCE_DIR}/src/*.cpp)

--- a/src/codegen/serialize_ast.h
+++ b/src/codegen/serialize_ast.h
@@ -15,11 +15,13 @@
 #ifndef PYSTON_CODEGEN_SERIALIZEAST_H
 #define PYSTON_CODEGEN_SERIALIZEAST_H
 
+#include <cstdint>
 #include <cstdio>
+#include <utility>
 
 namespace pyston {
 class AST_Module;
-unsigned long serializeAST(AST_Module* module, FILE* file);
+std::pair<unsigned long, uint8_t> serializeAST(AST_Module* module, FILE* file);
 }
 
 #endif // PYSTON_CODEGEN_SERIALIZEAST_H

--- a/src/gc/collector.cpp
+++ b/src/gc/collector.cpp
@@ -351,6 +351,17 @@ void disableGC() {
 
 static int ncollections = 0;
 static bool should_not_reenter_gc = false;
+
+void startGCUnexpectedRegion() {
+    RELEASE_ASSERT(!should_not_reenter_gc, "");
+    should_not_reenter_gc = true;
+}
+
+void endGCUnexpectedRegion() {
+    RELEASE_ASSERT(should_not_reenter_gc, "");
+    should_not_reenter_gc = false;
+}
+
 void runCollection() {
     static StatCounter sc("gc_collections");
     sc.log();

--- a/src/gc/collector.h
+++ b/src/gc/collector.h
@@ -61,6 +61,12 @@ void enableGC();
 // These are mostly for debugging:
 bool isValidGCObject(void* p);
 bool isNonheapRoot(void* p);
+
+// Debugging/validation helpers: if a GC should not happen in certain sections (ex during unwinding),
+// use these functions to mark that.  This is different from disableGC/enableGC, since it causes an
+// assert rather than delaying of the next GC.
+void startGCUnexpectedRegion();
+void endGCUnexpectedRegion();
 }
 }
 

--- a/src/runtime/import.cpp
+++ b/src/runtime/import.cpp
@@ -43,6 +43,7 @@ Box* createAndRunModule(const std::string& name, const std::string& fn) {
     BoxedModule* module = createModule(name, fn.c_str());
 
     AST_Module* ast = caching_parse_file(fn.c_str());
+    assert(ast);
     try {
         compileAndRunModule(ast, module);
     } catch (ExcInfo e) {
@@ -67,6 +68,7 @@ static Box* createAndRunModule(const std::string& name, const std::string& fn, c
     module->setattr(path_str, path_list, NULL);
 
     AST_Module* ast = caching_parse_file(fn.c_str());
+    assert(ast);
     try {
         compileAndRunModule(ast, module);
     } catch (ExcInfo e) {

--- a/test/tests/pyc_import_target.py
+++ b/test/tests/pyc_import_target.py
@@ -1,0 +1,3 @@
+"""
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum
+"""

--- a/test/tests/pyc_stress_test.py
+++ b/test/tests/pyc_stress_test.py
@@ -1,0 +1,44 @@
+# skip-if: '-x' in EXTRA_JIT_ARGS
+# - too slow
+
+# Note: CPython doesn't pass this test
+
+import os
+import sys
+import multiprocessing
+
+def worker():
+    global done
+
+    for i in xrange(1000):
+        del sys.modules["pyc_import_target"]
+        import pyc_import_target
+
+    done = True
+
+import pyc_import_target
+path = os.path.join(os.path.dirname(__file__), "pyc_import_target.pyc")
+assert os.path.exists(path)
+
+TEST_THREADS = 3
+
+l = []
+for i in xrange(TEST_THREADS):
+    p = multiprocessing.Process(target=worker)
+    p.start()
+    l.append(p)
+
+idx = 0
+while l:
+    p = l.pop()
+    while p.is_alive():
+        for i in xrange(100):
+            if os.path.exists(path):
+                os.remove(path)
+        for i in xrange(100):
+            if os.path.exists(path):
+                with open(path, "rw+") as f:
+                    f.write(chr(i) * 100)
+                    f.truncate(200)
+    p.join()
+    assert p.exitcode == 0, p.exitcode


### PR DESCRIPTION
and add a pyc "stress test".

I think these issues are the source of our sporadic ci failures;
it makes sense based on where things fail (usually in the parser), and
because it's stateful (if you already have pycs generated you don't
run into the issue) and because it only happens in multithreaded mode.

changes:
- read the entire file at once, then do checks
- add a simple xor checksum in addition to the expected length