### PR TITLE
add versions of llvm's DenseMap/DenseSet which take allocator functors

### DIFF
--- a/from_cpython/Include/dictobject.h
+++ b/from_cpython/Include/dictobject.h
@@ -94,7 +94,7 @@ struct _dictobject {
 #endif
 typedef struct {
     PyObject_HEAD;
-    char _filler[SIZEOF_UNORDEREDMAP];
+    char _filler[24];
 } PyDictObject;
 
 // Pyston change: these are no longer static objects:

--- a/microbenchmarks/type_creation.py
+++ b/microbenchmarks/type_creation.py
@@ -1,0 +1,6 @@
+
+i = 0
+while i < 100000:
+    class Foo:
+        pass
+    i += 1

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -64,6 +64,7 @@ add_library(PYSTON_OBJECTS OBJECT ${OPTIONAL_SRCS}
 		core/ast.cpp
 		core/cfg.cpp
 		core/options.cpp
+		core/SmallVector.cpp
 		core/stats.cpp
 		core/stringpool.cpp
 		core/threading.cpp

--- a/src/codegen/ast_interpreter.cpp
+++ b/src/codegen/ast_interpreter.cpp
@@ -31,6 +31,7 @@
 #include "core/cfg.h"
 #include "core/common.h"
 #include "core/contiguous_map.h"
+#include "core/SmallVector.h"
 #include "core/stats.h"
 #include "core/thread_utils.h"
 #include "core/util.h"
@@ -878,7 +879,7 @@ Value ASTInterpreter::visit_makeClass(AST_MakeClass* mkclass) {
         basesTuple->elts[base_idx++] = visit_expr(b).o;
     }
 
-    std::vector<Box*, StlCompatAllocator<Box*>> decorators;
+    SmallVector<Box*, StlCompatAllocator<Box*>, 8> decorators;
     for (AST_expr* d : node->decorator_list)
         decorators.push_back(visit_expr(d).o);
 

--- a/src/core/DenseMap.h
+++ b/src/core/DenseMap.h
@@ -92,7 +92,7 @@ public:
 
         // If the capacity of the array is huge, and the # elements used is small,
         // shrink the array.
-        if (getNumEntries() * 4 < getNumBuckets() && getNumBuckets() > 64) {
+        if (getNumEntries() * 4 < getNumBuckets() && getNumBuckets() > 32) {
             shrink_and_clear();
             return;
         }
@@ -554,7 +554,7 @@ public:
         unsigned OldNumBuckets = NumBuckets;
         BucketT* OldBuckets = Buckets;
 
-        allocateBuckets(std::max<unsigned>(64, static_cast<unsigned>(llvm::NextPowerOf2(AtLeast - 1))));
+        allocateBuckets(std::max<unsigned>(32, static_cast<unsigned>(llvm::NextPowerOf2(AtLeast - 1))));
         assert(Buckets);
         if (!OldBuckets) {
             this->BaseT::initEmpty();
@@ -574,7 +574,7 @@ public:
         // Reduce the number of buckets.
         unsigned NewNumBuckets = 0;
         if (OldNumEntries)
-            NewNumBuckets = std::max(64, 1 << (llvm::Log2_32_Ceil(OldNumEntries) + 1));
+            NewNumBuckets = std::max(32, 1 << (llvm::Log2_32_Ceil(OldNumEntries) + 1));
         if (NewNumBuckets == NumBuckets) {
             this->BaseT::initEmpty();
             return;
@@ -757,7 +757,7 @@ public:
 
     void grow(unsigned AtLeast) {
         if (AtLeast >= InlineBuckets)
-            AtLeast = std::max<unsigned>(64, llvm::NextPowerOf2(AtLeast - 1));
+            AtLeast = std::max<unsigned>(32, llvm::NextPowerOf2(AtLeast - 1));
 
         if (Small) {
             if (AtLeast < InlineBuckets)
@@ -813,8 +813,8 @@ public:
         unsigned NewNumBuckets = 0;
         if (OldSize) {
             NewNumBuckets = 1 << (llvm::Log2_32_Ceil(OldSize) + 1);
-            if (NewNumBuckets > InlineBuckets && NewNumBuckets < 64u)
-                NewNumBuckets = 64;
+            if (NewNumBuckets > InlineBuckets && NewNumBuckets < 32u)
+                NewNumBuckets = 32;
         }
         if ((Small && NewNumBuckets <= InlineBuckets) || (!Small && NewNumBuckets == getLargeRep()->NumBuckets)) {
             this->BaseT::initEmpty();

--- a/src/core/DenseMap.h
+++ b/src/core/DenseMap.h
@@ -1,0 +1,936 @@
+//===- llvm/ADT/DenseMap.h - Dense probed hash table ------------*- C++ -*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the DenseMap class.
+//
+//===----------------------------------------------------------------------===//
+
+// Pyston changes Copyright (c) 2014-2015 Dropbox, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef PYSTON_CORE_DENSEMAP_H
+#define PYSTON_CORE_DENSEMAP_H
+
+#include <algorithm>
+#include <cassert>
+#include <climits>
+#include <cstddef>
+#include <cstring>
+#include <iterator>
+#include <llvm/ADT/DenseMapInfo.h>
+#include <llvm/Support/AlignOf.h>
+#include <llvm/Support/Compiler.h>
+#include <llvm/Support/MathExtras.h>
+#include <llvm/Support/PointerLikeTypeTraits.h>
+#include <llvm/Support/type_traits.h>
+#include <new>
+#include <utility>
+
+namespace pyston {
+
+namespace detail {
+// We extend a pair to allow users to override the bucket type with their own
+// implementation without requiring two members.
+template <typename KeyT, typename ValueT> struct DenseMapPair : public std::pair<KeyT, ValueT> {
+    KeyT& getFirst() { return std::pair<KeyT, ValueT>::first; }
+    const KeyT& getFirst() const { return std::pair<KeyT, ValueT>::first; }
+    ValueT& getSecond() { return std::pair<KeyT, ValueT>::second; }
+    const ValueT& getSecond() const { return std::pair<KeyT, ValueT>::second; }
+};
+}
+
+template <typename KeyT, typename ValueT, typename KeyInfoT = llvm::DenseMapInfo<KeyT>,
+          typename Bucket = detail::DenseMapPair<KeyT, ValueT>, bool IsConst = false>
+class DenseMapIterator;
+
+template <typename DerivedT, typename KeyT, typename ValueT, typename KeyInfoT, typename BucketT> class DenseMapBase {
+public:
+    typedef unsigned size_type;
+    typedef KeyT key_type;
+    typedef ValueT mapped_type;
+    typedef BucketT value_type;
+
+    typedef DenseMapIterator<KeyT, ValueT, KeyInfoT, BucketT> iterator;
+    typedef DenseMapIterator<KeyT, ValueT, KeyInfoT, BucketT, true> const_iterator;
+    inline iterator begin() {
+        // When the map is empty, avoid the overhead of AdvancePastEmptyBuckets().
+        return empty() ? end() : iterator(getBuckets(), getBucketsEnd());
+    }
+    inline iterator end() { return iterator(getBucketsEnd(), getBucketsEnd(), true); }
+    inline const_iterator begin() const { return empty() ? end() : const_iterator(getBuckets(), getBucketsEnd()); }
+    inline const_iterator end() const { return const_iterator(getBucketsEnd(), getBucketsEnd(), true); }
+
+    bool LLVM_ATTRIBUTE_UNUSED_RESULT empty() const { return getNumEntries() == 0; }
+    unsigned size() const { return getNumEntries(); }
+
+    /// Grow the densemap so that it has at least Size buckets. Does not shrink
+    void resize(size_type Size) {
+        if (Size > getNumBuckets())
+            grow(Size);
+    }
+
+    void clear() {
+        if (getNumEntries() == 0 && getNumTombstones() == 0)
+            return;
+
+        // If the capacity of the array is huge, and the # elements used is small,
+        // shrink the array.
+        if (getNumEntries() * 4 < getNumBuckets() && getNumBuckets() > 64) {
+            shrink_and_clear();
+            return;
+        }
+
+        const KeyT EmptyKey = getEmptyKey(), TombstoneKey = getTombstoneKey();
+        for (BucketT* P = getBuckets(), * E = getBucketsEnd(); P != E; ++P) {
+            if (!KeyInfoT::isEqual(P->getFirst(), EmptyKey)) {
+                if (!KeyInfoT::isEqual(P->getFirst(), TombstoneKey)) {
+                    P->getSecond().~ValueT();
+                    decrementNumEntries();
+                }
+                P->getFirst() = EmptyKey;
+            }
+        }
+        assert(getNumEntries() == 0 && "Node count imbalance!");
+        setNumTombstones(0);
+    }
+
+    /// Return 1 if the specified key is in the map, 0 otherwise.
+    size_type count(const KeyT& Val) const {
+        const BucketT* TheBucket;
+        return LookupBucketFor(Val, TheBucket) ? 1 : 0;
+    }
+
+    iterator find(const KeyT& Val) {
+        BucketT* TheBucket;
+        if (LookupBucketFor(Val, TheBucket))
+            return iterator(TheBucket, getBucketsEnd(), true);
+        return end();
+    }
+    const_iterator find(const KeyT& Val) const {
+        const BucketT* TheBucket;
+        if (LookupBucketFor(Val, TheBucket))
+            return const_iterator(TheBucket, getBucketsEnd(), true);
+        return end();
+    }
+
+    /// Alternate version of find() which allows a different, and possibly
+    /// less expensive, key type.
+    /// The DenseMapInfo is responsible for supplying methods
+    /// getHashValue(LookupKeyT) and isEqual(LookupKeyT, KeyT) for each key
+    /// type used.
+    template <class LookupKeyT> iterator find_as(const LookupKeyT& Val) {
+        BucketT* TheBucket;
+        if (LookupBucketFor(Val, TheBucket))
+            return iterator(TheBucket, getBucketsEnd(), true);
+        return end();
+    }
+    template <class LookupKeyT> const_iterator find_as(const LookupKeyT& Val) const {
+        const BucketT* TheBucket;
+        if (LookupBucketFor(Val, TheBucket))
+            return const_iterator(TheBucket, getBucketsEnd(), true);
+        return end();
+    }
+
+    /// lookup - Return the entry for the specified key, or a default
+    /// constructed value if no such entry exists.
+    ValueT lookup(const KeyT& Val) const {
+        const BucketT* TheBucket;
+        if (LookupBucketFor(Val, TheBucket))
+            return TheBucket->getSecond();
+        return ValueT();
+    }
+
+    // Inserts key,value pair into the map if the key isn't already in the map.
+    // If the key is already in the map, it returns false and doesn't update the
+    // value.
+    std::pair<iterator, bool> insert(const std::pair<KeyT, ValueT>& KV) {
+        BucketT* TheBucket;
+        if (LookupBucketFor(KV.first, TheBucket))
+            return std::make_pair(iterator(TheBucket, getBucketsEnd(), true), false); // Already in map.
+
+        // Otherwise, insert the new element.
+        TheBucket = InsertIntoBucket(KV.first, KV.second, TheBucket);
+        return std::make_pair(iterator(TheBucket, getBucketsEnd(), true), true);
+    }
+
+    // Inserts key,value pair into the map if the key isn't already in the map.
+    // If the key is already in the map, it returns false and doesn't update the
+    // value.
+    std::pair<iterator, bool> insert(std::pair<KeyT, ValueT>&& KV) {
+        BucketT* TheBucket;
+        if (LookupBucketFor(KV.first, TheBucket))
+            return std::make_pair(iterator(TheBucket, getBucketsEnd(), true), false); // Already in map.
+
+        // Otherwise, insert the new element.
+        TheBucket = InsertIntoBucket(std::move(KV.first), std::move(KV.second), TheBucket);
+        return std::make_pair(iterator(TheBucket, getBucketsEnd(), true), true);
+    }
+
+    /// insert - Range insertion of pairs.
+    template <typename InputIt> void insert(InputIt I, InputIt E) {
+        for (; I != E; ++I)
+            insert(*I);
+    }
+
+
+    bool erase(const KeyT& Val) {
+        BucketT* TheBucket;
+        if (!LookupBucketFor(Val, TheBucket))
+            return false; // not in map.
+
+        TheBucket->getSecond().~ValueT();
+        TheBucket->getFirst() = getTombstoneKey();
+        decrementNumEntries();
+        incrementNumTombstones();
+        return true;
+    }
+    void erase(iterator I) {
+        BucketT* TheBucket = &*I;
+        TheBucket->getSecond().~ValueT();
+        TheBucket->getFirst() = getTombstoneKey();
+        decrementNumEntries();
+        incrementNumTombstones();
+    }
+
+    value_type& FindAndConstruct(const KeyT& Key) {
+        BucketT* TheBucket;
+        if (LookupBucketFor(Key, TheBucket))
+            return *TheBucket;
+
+        return *InsertIntoBucket(Key, ValueT(), TheBucket);
+    }
+
+    ValueT& operator[](const KeyT& Key) { return FindAndConstruct(Key).second; }
+
+    value_type& FindAndConstruct(KeyT&& Key) {
+        BucketT* TheBucket;
+        if (LookupBucketFor(Key, TheBucket))
+            return *TheBucket;
+
+        return *InsertIntoBucket(std::move(Key), ValueT(), TheBucket);
+    }
+
+    ValueT& operator[](KeyT&& Key) { return FindAndConstruct(std::move(Key)).second; }
+
+    /// isPointerIntoBucketsArray - Return true if the specified pointer points
+    /// somewhere into the DenseMap's array of buckets (i.e. either to a key or
+    /// value in the DenseMap).
+    bool isPointerIntoBucketsArray(const void* Ptr) const { return Ptr >= getBuckets() && Ptr < getBucketsEnd(); }
+
+    /// getPointerIntoBucketsArray() - Return an opaque pointer into the buckets
+    /// array.  In conjunction with the previous method, this can be used to
+    /// determine whether an insertion caused the DenseMap to reallocate.
+    const void* getPointerIntoBucketsArray() const { return getBuckets(); }
+
+protected:
+    DenseMapBase() {}
+
+    void destroyAll() {
+        if (getNumBuckets() == 0) // Nothing to do.
+            return;
+
+        const KeyT EmptyKey = getEmptyKey(), TombstoneKey = getTombstoneKey();
+        for (BucketT* P = getBuckets(), * E = getBucketsEnd(); P != E; ++P) {
+            if (!KeyInfoT::isEqual(P->getFirst(), EmptyKey) && !KeyInfoT::isEqual(P->getFirst(), TombstoneKey))
+                P->getSecond().~ValueT();
+            P->getFirst().~KeyT();
+        }
+
+#ifndef NDEBUG
+        memset((void*)getBuckets(), 0x5a, sizeof(BucketT) * getNumBuckets());
+#endif
+    }
+
+    void initEmpty() {
+        setNumEntries(0);
+        setNumTombstones(0);
+
+        assert((getNumBuckets() & (getNumBuckets() - 1)) == 0 && "# initial buckets must be a power of two!");
+        const KeyT EmptyKey = getEmptyKey();
+        for (BucketT* B = getBuckets(), * E = getBucketsEnd(); B != E; ++B)
+            new (&B->getFirst()) KeyT(EmptyKey);
+    }
+
+    void moveFromOldBuckets(BucketT* OldBucketsBegin, BucketT* OldBucketsEnd) {
+        initEmpty();
+
+        // Insert all the old elements.
+        const KeyT EmptyKey = getEmptyKey();
+        const KeyT TombstoneKey = getTombstoneKey();
+        for (BucketT* B = OldBucketsBegin, * E = OldBucketsEnd; B != E; ++B) {
+            if (!KeyInfoT::isEqual(B->getFirst(), EmptyKey) && !KeyInfoT::isEqual(B->getFirst(), TombstoneKey)) {
+                // Insert the key/value into the new table.
+                BucketT* DestBucket;
+                bool FoundVal = LookupBucketFor(B->getFirst(), DestBucket);
+                (void)FoundVal; // silence warning.
+                assert(!FoundVal && "Key already in new map?");
+                DestBucket->getFirst() = std::move(B->getFirst());
+                new (&DestBucket->getSecond()) ValueT(std::move(B->getSecond()));
+                incrementNumEntries();
+
+                // Free the value.
+                B->getSecond().~ValueT();
+            }
+            B->getFirst().~KeyT();
+        }
+
+#ifndef NDEBUG
+        if (OldBucketsBegin != OldBucketsEnd)
+            memset((void*)OldBucketsBegin, 0x5a, sizeof(BucketT) * (OldBucketsEnd - OldBucketsBegin));
+#endif
+    }
+
+    template <typename OtherBaseT>
+    void copyFrom(const DenseMapBase<OtherBaseT, KeyT, ValueT, KeyInfoT, BucketT>& other) {
+        assert(&other != this);
+        assert(getNumBuckets() == other.getNumBuckets());
+
+        setNumEntries(other.getNumEntries());
+        setNumTombstones(other.getNumTombstones());
+
+        if (llvm::isPodLike<KeyT>::value && llvm::isPodLike<ValueT>::value)
+            memcpy(getBuckets(), other.getBuckets(), getNumBuckets() * sizeof(BucketT));
+        else
+            for (size_t i = 0; i < getNumBuckets(); ++i) {
+                new (&getBuckets()[i].getFirst()) KeyT(other.getBuckets()[i].getFirst());
+                if (!KeyInfoT::isEqual(getBuckets()[i].getFirst(), getEmptyKey())
+                    && !KeyInfoT::isEqual(getBuckets()[i].getFirst(), getTombstoneKey()))
+                    new (&getBuckets()[i].getSecond()) ValueT(other.getBuckets()[i].getSecond());
+            }
+    }
+
+    void swap(DenseMapBase& RHS) {
+        std::swap(getNumEntries(), RHS.getNumEntries());
+        std::swap(getNumTombstones(), RHS.getNumTombstones());
+    }
+
+    static unsigned getHashValue(const KeyT& Val) { return KeyInfoT::getHashValue(Val); }
+    template <typename LookupKeyT> static unsigned getHashValue(const LookupKeyT& Val) {
+        return KeyInfoT::getHashValue(Val);
+    }
+    static const KeyT getEmptyKey() { return KeyInfoT::getEmptyKey(); }
+    static const KeyT getTombstoneKey() { return KeyInfoT::getTombstoneKey(); }
+
+private:
+    unsigned getNumEntries() const { return static_cast<const DerivedT*>(this)->getNumEntries(); }
+    void setNumEntries(unsigned Num) { static_cast<DerivedT*>(this)->setNumEntries(Num); }
+    void incrementNumEntries() { setNumEntries(getNumEntries() + 1); }
+    void decrementNumEntries() { setNumEntries(getNumEntries() - 1); }
+    unsigned getNumTombstones() const { return static_cast<const DerivedT*>(this)->getNumTombstones(); }
+    void setNumTombstones(unsigned Num) { static_cast<DerivedT*>(this)->setNumTombstones(Num); }
+    void incrementNumTombstones() { setNumTombstones(getNumTombstones() + 1); }
+    void decrementNumTombstones() { setNumTombstones(getNumTombstones() - 1); }
+    const BucketT* getBuckets() const { return static_cast<const DerivedT*>(this)->getBuckets(); }
+    BucketT* getBuckets() { return static_cast<DerivedT*>(this)->getBuckets(); }
+    unsigned getNumBuckets() const { return static_cast<const DerivedT*>(this)->getNumBuckets(); }
+    BucketT* getBucketsEnd() { return getBuckets() + getNumBuckets(); }
+    const BucketT* getBucketsEnd() const { return getBuckets() + getNumBuckets(); }
+
+    void grow(unsigned AtLeast) { static_cast<DerivedT*>(this)->grow(AtLeast); }
+
+    void shrink_and_clear() { static_cast<DerivedT*>(this)->shrink_and_clear(); }
+
+
+    BucketT* InsertIntoBucket(const KeyT& Key, const ValueT& Value, BucketT* TheBucket) {
+        TheBucket = InsertIntoBucketImpl(Key, TheBucket);
+
+        TheBucket->getFirst() = Key;
+        new (&TheBucket->getSecond()) ValueT(Value);
+        return TheBucket;
+    }
+
+    BucketT* InsertIntoBucket(const KeyT& Key, ValueT&& Value, BucketT* TheBucket) {
+        TheBucket = InsertIntoBucketImpl(Key, TheBucket);
+
+        TheBucket->getFirst() = Key;
+        new (&TheBucket->getSecond()) ValueT(std::move(Value));
+        return TheBucket;
+    }
+
+    BucketT* InsertIntoBucket(KeyT&& Key, ValueT&& Value, BucketT* TheBucket) {
+        TheBucket = InsertIntoBucketImpl(Key, TheBucket);
+
+        TheBucket->getFirst() = std::move(Key);
+        new (&TheBucket->getSecond()) ValueT(std::move(Value));
+        return TheBucket;
+    }
+
+    BucketT* InsertIntoBucketImpl(const KeyT& Key, BucketT* TheBucket) {
+        // If the load of the hash table is more than 3/4, or if fewer than 1/8 of
+        // the buckets are empty (meaning that many are filled with tombstones),
+        // grow the table.
+        //
+        // The later case is tricky.  For example, if we had one empty bucket with
+        // tons of tombstones, failing lookups (e.g. for insertion) would have to
+        // probe almost the entire table until it found the empty bucket.  If the
+        // table completely filled with tombstones, no lookup would ever succeed,
+        // causing infinite loops in lookup.
+        unsigned NewNumEntries = getNumEntries() + 1;
+        unsigned NumBuckets = getNumBuckets();
+        if (LLVM_UNLIKELY(NewNumEntries * 4 >= NumBuckets * 3)) {
+            this->grow(NumBuckets * 2);
+            LookupBucketFor(Key, TheBucket);
+            NumBuckets = getNumBuckets();
+        } else if (LLVM_UNLIKELY(NumBuckets - (NewNumEntries + getNumTombstones()) <= NumBuckets / 8)) {
+            this->grow(NumBuckets);
+            LookupBucketFor(Key, TheBucket);
+        }
+        assert(TheBucket);
+
+        // Only update the state after we've grown our bucket space appropriately
+        // so that when growing buckets we have self-consistent entry count.
+        incrementNumEntries();
+
+        // If we are writing over a tombstone, remember this.
+        const KeyT EmptyKey = getEmptyKey();
+        if (!KeyInfoT::isEqual(TheBucket->getFirst(), EmptyKey))
+            decrementNumTombstones();
+
+        return TheBucket;
+    }
+
+    /// LookupBucketFor - Lookup the appropriate bucket for Val, returning it in
+    /// FoundBucket.  If the bucket contains the key and a value, this returns
+    /// true, otherwise it returns a bucket with an empty marker or tombstone and
+    /// returns false.
+    template <typename LookupKeyT> bool LookupBucketFor(const LookupKeyT& Val, const BucketT*& FoundBucket) const {
+        const BucketT* BucketsPtr = getBuckets();
+        const unsigned NumBuckets = getNumBuckets();
+
+        if (NumBuckets == 0) {
+            FoundBucket = nullptr;
+            return false;
+        }
+
+        // FoundTombstone - Keep track of whether we find a tombstone while probing.
+        const BucketT* FoundTombstone = nullptr;
+        const KeyT EmptyKey = getEmptyKey();
+        const KeyT TombstoneKey = getTombstoneKey();
+        assert(!KeyInfoT::isEqual(Val, EmptyKey) && !KeyInfoT::isEqual(Val, TombstoneKey)
+               && "Empty/Tombstone value shouldn't be inserted into map!");
+
+        unsigned BucketNo = getHashValue(Val) & (NumBuckets - 1);
+        unsigned ProbeAmt = 1;
+        while (1) {
+            const BucketT* ThisBucket = BucketsPtr + BucketNo;
+            // Found Val's bucket?  If so, return it.
+            if (LLVM_LIKELY(KeyInfoT::isEqual(Val, ThisBucket->getFirst()))) {
+                FoundBucket = ThisBucket;
+                return true;
+            }
+
+            // If we found an empty bucket, the key doesn't exist in the set.
+            // Insert it and return the default value.
+            if (LLVM_LIKELY(KeyInfoT::isEqual(ThisBucket->getFirst(), EmptyKey))) {
+                // If we've already seen a tombstone while probing, fill it in instead
+                // of the empty bucket we eventually probed to.
+                FoundBucket = FoundTombstone ? FoundTombstone : ThisBucket;
+                return false;
+            }
+
+            // If this is a tombstone, remember it.  If Val ends up not in the map, we
+            // prefer to return it than something that would require more probing.
+            if (KeyInfoT::isEqual(ThisBucket->getFirst(), TombstoneKey) && !FoundTombstone)
+                FoundTombstone = ThisBucket; // Remember the first tombstone found.
+
+            // Otherwise, it's a hash collision or a tombstone, continue quadratic
+            // probing.
+            BucketNo += ProbeAmt++;
+            BucketNo &= (NumBuckets - 1);
+        }
+    }
+
+    template <typename LookupKeyT> bool LookupBucketFor(const LookupKeyT& Val, BucketT*& FoundBucket) {
+        const BucketT* ConstFoundBucket;
+        bool Result = const_cast<const DenseMapBase*>(this)->LookupBucketFor(Val, ConstFoundBucket);
+        FoundBucket = const_cast<BucketT*>(ConstFoundBucket);
+        return Result;
+    }
+
+public:
+    /// Return the approximate size (in bytes) of the actual map.
+    /// This is just the raw memory used by DenseMap.
+    /// If entries are pointers to objects, the size of the referenced objects
+    /// are not included.
+    size_t getMemorySize() const { return getNumBuckets() * sizeof(BucketT); }
+};
+
+template <typename KeyT, typename ValueT, typename KeyInfoT = llvm::DenseMapInfo<KeyT>,
+          typename BucketT = detail::DenseMapPair<KeyT, ValueT>, typename AllocT = std::allocator<BucketT>>
+class DenseMap
+    : public DenseMapBase<DenseMap<KeyT, ValueT, KeyInfoT, BucketT, AllocT>, KeyT, ValueT, KeyInfoT, BucketT> {
+    // Lift some types from the dependent base class into this class for
+    // simplicity of referring to them.
+    typedef DenseMapBase<DenseMap, KeyT, ValueT, KeyInfoT, BucketT> BaseT;
+    friend class DenseMapBase<DenseMap, KeyT, ValueT, KeyInfoT, BucketT>;
+
+    BucketT* Buckets;
+    unsigned NumEntries;
+    unsigned NumTombstones;
+    unsigned NumBuckets;
+
+public:
+    explicit DenseMap(unsigned NumInitBuckets = 0) { init(NumInitBuckets); }
+
+    DenseMap(const DenseMap& other) : BaseT() {
+        init(0);
+        copyFrom(other);
+    }
+
+    DenseMap(DenseMap&& other) : BaseT() {
+        init(0);
+        swap(other);
+    }
+
+    template <typename InputIt> DenseMap(const InputIt& I, const InputIt& E) {
+        init(NextPowerOf2(std::distance(I, E)));
+        this->insert(I, E);
+    }
+
+    ~DenseMap() {
+        this->destroyAll();
+        AllocT().deallocate(Buckets, NumBuckets);
+    }
+
+    void swap(DenseMap& RHS) {
+        std::swap(Buckets, RHS.Buckets);
+        std::swap(NumEntries, RHS.NumEntries);
+        std::swap(NumTombstones, RHS.NumTombstones);
+        std::swap(NumBuckets, RHS.NumBuckets);
+    }
+
+    DenseMap& operator=(const DenseMap& other) {
+        if (&other != this)
+            copyFrom(other);
+        return *this;
+    }
+
+    DenseMap& operator=(DenseMap&& other) {
+        this->destroyAll();
+        AllocT().deallocate(Buckets, NumBuckets);
+        init(0);
+        swap(other);
+        return *this;
+    }
+
+    void copyFrom(const DenseMap& other) {
+        this->destroyAll();
+        AllocT().deallocate(Buckets, NumBuckets);
+        if (allocateBuckets(other.NumBuckets)) {
+            this->BaseT::copyFrom(other);
+        } else {
+            NumEntries = 0;
+            NumTombstones = 0;
+        }
+    }
+
+    void init(unsigned InitBuckets) {
+        if (allocateBuckets(InitBuckets)) {
+            this->BaseT::initEmpty();
+        } else {
+            NumEntries = 0;
+            NumTombstones = 0;
+        }
+    }
+
+    void grow(unsigned AtLeast) {
+        unsigned OldNumBuckets = NumBuckets;
+        BucketT* OldBuckets = Buckets;
+
+        allocateBuckets(std::max<unsigned>(64, static_cast<unsigned>(llvm::NextPowerOf2(AtLeast - 1))));
+        assert(Buckets);
+        if (!OldBuckets) {
+            this->BaseT::initEmpty();
+            return;
+        }
+
+        this->moveFromOldBuckets(OldBuckets, OldBuckets + OldNumBuckets);
+
+        // Free the old table.
+        AllocT().deallocate(OldBuckets, OldNumBuckets);
+    }
+
+    void shrink_and_clear() {
+        unsigned OldNumEntries = NumEntries;
+        this->destroyAll();
+
+        // Reduce the number of buckets.
+        unsigned NewNumBuckets = 0;
+        if (OldNumEntries)
+            NewNumBuckets = std::max(64, 1 << (llvm::Log2_32_Ceil(OldNumEntries) + 1));
+        if (NewNumBuckets == NumBuckets) {
+            this->BaseT::initEmpty();
+            return;
+        }
+
+        AllocT().deallocate(Buckets, NumBuckets);
+        init(NewNumBuckets);
+    }
+
+private:
+    unsigned getNumEntries() const { return NumEntries; }
+    void setNumEntries(unsigned Num) { NumEntries = Num; }
+
+    unsigned getNumTombstones() const { return NumTombstones; }
+    void setNumTombstones(unsigned Num) { NumTombstones = Num; }
+
+    BucketT* getBuckets() const { return Buckets; }
+
+    unsigned getNumBuckets() const { return NumBuckets; }
+
+    bool allocateBuckets(unsigned Num) {
+        NumBuckets = Num;
+        if (NumBuckets == 0) {
+            Buckets = nullptr;
+            return false;
+        }
+
+        Buckets = static_cast<BucketT*>(AllocT().allocate(NumBuckets));
+        return true;
+    }
+};
+
+template <typename KeyT, typename ValueT, unsigned InlineBuckets = 4, typename KeyInfoT = llvm::DenseMapInfo<KeyT>,
+          typename BucketT = detail::DenseMapPair<KeyT, ValueT>, typename AllocT = std::allocator<BucketT>>
+class SmallDenseMap : public DenseMapBase<SmallDenseMap<KeyT, ValueT, InlineBuckets, KeyInfoT, BucketT>, KeyT, ValueT,
+                                          KeyInfoT, BucketT> {
+    // Lift some types from the dependent base class into this class for
+    // simplicity of referring to them.
+    typedef DenseMapBase<SmallDenseMap, KeyT, ValueT, KeyInfoT, BucketT> BaseT;
+    friend class DenseMapBase<SmallDenseMap, KeyT, ValueT, KeyInfoT, BucketT>;
+
+    unsigned Small : 1;
+    unsigned NumEntries : 31;
+    unsigned NumTombstones;
+
+    struct LargeRep {
+        BucketT* Buckets;
+        unsigned NumBuckets;
+    };
+
+    /// A "union" of an inline bucket array and the struct representing
+    /// a large bucket. This union will be discriminated by the 'Small' bit.
+    llvm::AlignedCharArrayUnion<BucketT[InlineBuckets], LargeRep> storage;
+
+public:
+    explicit SmallDenseMap(unsigned NumInitBuckets = 0) { init(NumInitBuckets); }
+
+    SmallDenseMap(const SmallDenseMap& other) : BaseT() {
+        init(0);
+        copyFrom(other);
+    }
+
+    SmallDenseMap(SmallDenseMap&& other) : BaseT() {
+        init(0);
+        swap(other);
+    }
+
+    template <typename InputIt> SmallDenseMap(const InputIt& I, const InputIt& E) {
+        init(NextPowerOf2(std::distance(I, E)));
+        this->insert(I, E);
+    }
+
+    ~SmallDenseMap() {
+        this->destroyAll();
+        deallocateBuckets();
+    }
+
+    void swap(SmallDenseMap& RHS) {
+        unsigned TmpNumEntries = RHS.NumEntries;
+        RHS.NumEntries = NumEntries;
+        NumEntries = TmpNumEntries;
+        std::swap(NumTombstones, RHS.NumTombstones);
+
+        const KeyT EmptyKey = this->getEmptyKey();
+        const KeyT TombstoneKey = this->getTombstoneKey();
+        if (Small && RHS.Small) {
+            // If we're swapping inline bucket arrays, we have to cope with some of
+            // the tricky bits of DenseMap's storage system: the buckets are not
+            // fully initialized. Thus we swap every key, but we may have
+            // a one-directional move of the value.
+            for (unsigned i = 0, e = InlineBuckets; i != e; ++i) {
+                BucketT* LHSB = &getInlineBuckets()[i], * RHSB = &RHS.getInlineBuckets()[i];
+                bool hasLHSValue = (!KeyInfoT::isEqual(LHSB->getFirst(), EmptyKey)
+                                    && !KeyInfoT::isEqual(LHSB->getFirst(), TombstoneKey));
+                bool hasRHSValue = (!KeyInfoT::isEqual(RHSB->getFirst(), EmptyKey)
+                                    && !KeyInfoT::isEqual(RHSB->getFirst(), TombstoneKey));
+                if (hasLHSValue && hasRHSValue) {
+                    // Swap together if we can...
+                    std::swap(*LHSB, *RHSB);
+                    continue;
+                }
+                // Swap separately and handle any assymetry.
+                std::swap(LHSB->getFirst(), RHSB->getFirst());
+                if (hasLHSValue) {
+                    new (&RHSB->getSecond()) ValueT(std::move(LHSB->getSecond()));
+                    LHSB->getSecond().~ValueT();
+                } else if (hasRHSValue) {
+                    new (&LHSB->getSecond()) ValueT(std::move(RHSB->getSecond()));
+                    RHSB->getSecond().~ValueT();
+                }
+            }
+            return;
+        }
+        if (!Small && !RHS.Small) {
+            std::swap(getLargeRep()->Buckets, RHS.getLargeRep()->Buckets);
+            std::swap(getLargeRep()->NumBuckets, RHS.getLargeRep()->NumBuckets);
+            return;
+        }
+
+        SmallDenseMap& SmallSide = Small ? *this : RHS;
+        SmallDenseMap& LargeSide = Small ? RHS : *this;
+
+        // First stash the large side's rep and move the small side across.
+        LargeRep TmpRep = std::move(*LargeSide.getLargeRep());
+        LargeSide.getLargeRep()->~LargeRep();
+        LargeSide.Small = true;
+        // This is similar to the standard move-from-old-buckets, but the bucket
+        // count hasn't actually rotated in this case. So we have to carefully
+        // move construct the keys and values into their new locations, but there
+        // is no need to re-hash things.
+        for (unsigned i = 0, e = InlineBuckets; i != e; ++i) {
+            BucketT* NewB = &LargeSide.getInlineBuckets()[i], * OldB = &SmallSide.getInlineBuckets()[i];
+            new (&NewB->getFirst()) KeyT(std::move(OldB->getFirst()));
+            OldB->getFirst().~KeyT();
+            if (!KeyInfoT::isEqual(NewB->getFirst(), EmptyKey) && !KeyInfoT::isEqual(NewB->getFirst(), TombstoneKey)) {
+                new (&NewB->getSecond()) ValueT(std::move(OldB->getSecond()));
+                OldB->getSecond().~ValueT();
+            }
+        }
+
+        // The hard part of moving the small buckets across is done, just move
+        // the TmpRep into its new home.
+        SmallSide.Small = false;
+        new (SmallSide.getLargeRep()) LargeRep(std::move(TmpRep));
+    }
+
+    SmallDenseMap& operator=(const SmallDenseMap& other) {
+        if (&other != this)
+            copyFrom(other);
+        return *this;
+    }
+
+    SmallDenseMap& operator=(SmallDenseMap&& other) {
+        this->destroyAll();
+        deallocateBuckets();
+        init(0);
+        swap(other);
+        return *this;
+    }
+
+    void copyFrom(const SmallDenseMap& other) {
+        this->destroyAll();
+        deallocateBuckets();
+        Small = true;
+        if (other.getNumBuckets() > InlineBuckets) {
+            Small = false;
+            new (getLargeRep()) LargeRep(allocateBuckets(other.getNumBuckets()));
+        }
+        this->BaseT::copyFrom(other);
+    }
+
+    void init(unsigned InitBuckets) {
+        Small = true;
+        if (InitBuckets > InlineBuckets) {
+            Small = false;
+            new (getLargeRep()) LargeRep(allocateBuckets(InitBuckets));
+        }
+        this->BaseT::initEmpty();
+    }
+
+    void grow(unsigned AtLeast) {
+        if (AtLeast >= InlineBuckets)
+            AtLeast = std::max<unsigned>(64, llvm::NextPowerOf2(AtLeast - 1));
+
+        if (Small) {
+            if (AtLeast < InlineBuckets)
+                return; // Nothing to do.
+
+            // First move the inline buckets into a temporary storage.
+            llvm::AlignedCharArrayUnion<BucketT[InlineBuckets]> TmpStorage;
+            BucketT* TmpBegin = reinterpret_cast<BucketT*>(TmpStorage.buffer);
+            BucketT* TmpEnd = TmpBegin;
+
+            // Loop over the buckets, moving non-empty, non-tombstones into the
+            // temporary storage. Have the loop move the TmpEnd forward as it goes.
+            const KeyT EmptyKey = this->getEmptyKey();
+            const KeyT TombstoneKey = this->getTombstoneKey();
+            for (BucketT* P = getBuckets(), * E = P + InlineBuckets; P != E; ++P) {
+                if (!KeyInfoT::isEqual(P->getFirst(), EmptyKey) && !KeyInfoT::isEqual(P->getFirst(), TombstoneKey)) {
+                    assert(size_t(TmpEnd - TmpBegin) < InlineBuckets && "Too many inline buckets!");
+                    new (&TmpEnd->getFirst()) KeyT(std::move(P->getFirst()));
+                    new (&TmpEnd->getSecond()) ValueT(std::move(P->getSecond()));
+                    ++TmpEnd;
+                    P->getSecond().~ValueT();
+                }
+                P->getFirst().~KeyT();
+            }
+
+            // Now make this map use the large rep, and move all the entries back
+            // into it.
+            Small = false;
+            new (getLargeRep()) LargeRep(allocateBuckets(AtLeast));
+            this->moveFromOldBuckets(TmpBegin, TmpEnd);
+            return;
+        }
+
+        LargeRep OldRep = std::move(*getLargeRep());
+        getLargeRep()->~LargeRep();
+        if (AtLeast <= InlineBuckets) {
+            Small = true;
+        } else {
+            new (getLargeRep()) LargeRep(allocateBuckets(AtLeast));
+        }
+
+        this->moveFromOldBuckets(OldRep.Buckets, OldRep.Buckets + OldRep.NumBuckets);
+
+        // Free the old table.
+        AllocT().deallocate(OldRep.Buckets, OldRep.NumBuckets);
+    }
+
+    void shrink_and_clear() {
+        unsigned OldSize = this->size();
+        this->destroyAll();
+
+        // Reduce the number of buckets.
+        unsigned NewNumBuckets = 0;
+        if (OldSize) {
+            NewNumBuckets = 1 << (llvm::Log2_32_Ceil(OldSize) + 1);
+            if (NewNumBuckets > InlineBuckets && NewNumBuckets < 64u)
+                NewNumBuckets = 64;
+        }
+        if ((Small && NewNumBuckets <= InlineBuckets) || (!Small && NewNumBuckets == getLargeRep()->NumBuckets)) {
+            this->BaseT::initEmpty();
+            return;
+        }
+
+        deallocateBuckets();
+        init(NewNumBuckets);
+    }
+
+private:
+    unsigned getNumEntries() const { return NumEntries; }
+    void setNumEntries(unsigned Num) {
+        assert(Num < INT_MAX && "Cannot support more than INT_MAX entries");
+        NumEntries = Num;
+    }
+
+    unsigned getNumTombstones() const { return NumTombstones; }
+    void setNumTombstones(unsigned Num) { NumTombstones = Num; }
+
+    const BucketT* getInlineBuckets() const {
+        assert(Small);
+        // Note that this cast does not violate aliasing rules as we assert that
+        // the memory's dynamic type is the small, inline bucket buffer, and the
+        // 'storage.buffer' static type is 'char *'.
+        return reinterpret_cast<const BucketT*>(storage.buffer);
+    }
+    BucketT* getInlineBuckets() {
+        return const_cast<BucketT*>(const_cast<const SmallDenseMap*>(this)->getInlineBuckets());
+    }
+    const LargeRep* getLargeRep() const {
+        assert(!Small);
+        // Note, same rule about aliasing as with getInlineBuckets.
+        return reinterpret_cast<const LargeRep*>(storage.buffer);
+    }
+    LargeRep* getLargeRep() { return const_cast<LargeRep*>(const_cast<const SmallDenseMap*>(this)->getLargeRep()); }
+
+    const BucketT* getBuckets() const { return Small ? getInlineBuckets() : getLargeRep()->Buckets; }
+    BucketT* getBuckets() { return const_cast<BucketT*>(const_cast<const SmallDenseMap*>(this)->getBuckets()); }
+    unsigned getNumBuckets() const { return Small ? InlineBuckets : getLargeRep()->NumBuckets; }
+
+    void deallocateBuckets() {
+        if (Small)
+            return;
+
+        AllocT().deallocate(getLargeRep()->Buckets, getLargeRep()->NumBuckets);
+        getLargeRep()->~LargeRep();
+    }
+
+    LargeRep allocateBuckets(unsigned Num) {
+        assert(Num > InlineBuckets && "Must allocate more buckets than are inline");
+        LargeRep Rep = { static_cast<BucketT*>(AllocT().allocate(Num)), Num };
+        return Rep;
+    }
+};
+
+template <typename KeyT, typename ValueT, typename KeyInfoT, typename Bucket, bool IsConst> class DenseMapIterator {
+    typedef DenseMapIterator<KeyT, ValueT, KeyInfoT, Bucket, true> ConstIterator;
+    friend class DenseMapIterator<KeyT, ValueT, KeyInfoT, Bucket, true>;
+
+public:
+    typedef ptrdiff_t difference_type;
+    typedef typename std::conditional<IsConst, const Bucket, Bucket>::type value_type;
+    typedef value_type* pointer;
+    typedef value_type& reference;
+    typedef std::forward_iterator_tag iterator_category;
+
+private:
+    pointer Ptr, End;
+
+public:
+    DenseMapIterator() : Ptr(nullptr), End(nullptr) {}
+
+    DenseMapIterator(pointer Pos, pointer E, bool NoAdvance = false) : Ptr(Pos), End(E) {
+        if (!NoAdvance)
+            AdvancePastEmptyBuckets();
+    }
+
+    // If IsConst is true this is a converting constructor from iterator to
+    // const_iterator and the default copy constructor is used.
+    // Otherwise this is a copy constructor for iterator.
+    DenseMapIterator(const DenseMapIterator<KeyT, ValueT, KeyInfoT, Bucket, false>& I) : Ptr(I.Ptr), End(I.End) {}
+
+    reference operator*() const { return *Ptr; }
+    pointer operator->() const { return Ptr; }
+
+    bool operator==(const ConstIterator& RHS) const { return Ptr == RHS.operator->(); }
+    bool operator!=(const ConstIterator& RHS) const { return Ptr != RHS.operator->(); }
+
+    inline DenseMapIterator& operator++() { // Preincrement
+        ++Ptr;
+        AdvancePastEmptyBuckets();
+        return *this;
+    }
+    DenseMapIterator operator++(int) { // Postincrement
+        DenseMapIterator tmp = *this;
+        ++*this;
+        return tmp;
+    }
+
+private:
+    void AdvancePastEmptyBuckets() {
+        const KeyT Empty = KeyInfoT::getEmptyKey();
+        const KeyT Tombstone = KeyInfoT::getTombstoneKey();
+
+        while (Ptr != End
+               && (KeyInfoT::isEqual(Ptr->getFirst(), Empty) || KeyInfoT::isEqual(Ptr->getFirst(), Tombstone)))
+            ++Ptr;
+    }
+};
+
+template <typename KeyT, typename ValueT, typename KeyInfoT>
+static inline size_t capacity_in_bytes(const DenseMap<KeyT, ValueT, KeyInfoT>& X) {
+    return X.getMemorySize();
+}
+
+} // end namespace llvm
+
+#endif

--- a/src/core/DenseSet.h
+++ b/src/core/DenseSet.h
@@ -1,0 +1,171 @@
+//===- llvm/ADT/DenseSet.h - Dense probed hash table ------------*- C++ -*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the DenseSet class.
+//
+//===----------------------------------------------------------------------===//
+
+// Pyston changes Copyright (c) 2014-2015 Dropbox, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef PYSTON_CORE_DENSESET_H
+#define PYSTON_CORE_DENSESET_H
+
+#include "core/DenseMap.h"
+
+namespace pyston {
+
+namespace detail {
+struct DenseSetEmpty {};
+
+// Use the empty base class trick so we can create a DenseMap where the buckets
+// contain only a single item.
+template <typename KeyT> class DenseSetPair : public DenseSetEmpty {
+    KeyT key;
+
+public:
+    KeyT& getFirst() { return key; }
+    const KeyT& getFirst() const { return key; }
+    DenseSetEmpty& getSecond() { return *this; }
+    const DenseSetEmpty& getSecond() const { return *this; }
+};
+}
+
+/// DenseSet - This implements a dense probed hash-table based set.
+template <typename ValueT, typename ValueInfoT = llvm::DenseMapInfo<ValueT>,
+          typename AllocT = detail::DenseSetPair<ValueT>>
+class DenseSet {
+    typedef DenseMap<ValueT, detail::DenseSetEmpty, ValueInfoT, detail::DenseSetPair<ValueT>, AllocT> MapTy;
+    static_assert(sizeof(typename MapTy::value_type) == sizeof(ValueT), "DenseMap buckets unexpectedly large!");
+    MapTy TheMap;
+
+public:
+    typedef ValueT key_type;
+    typedef ValueT value_type;
+    typedef unsigned size_type;
+
+    explicit DenseSet(unsigned NumInitBuckets = 0) : TheMap(NumInitBuckets) {}
+
+    bool empty() const { return TheMap.empty(); }
+    size_type size() const { return TheMap.size(); }
+    size_t getMemorySize() const { return TheMap.getMemorySize(); }
+
+    /// Grow the DenseSet so that it has at least Size buckets. Will not shrink
+    /// the Size of the set.
+    void resize(size_t Size) { TheMap.resize(Size); }
+
+    void clear() { TheMap.clear(); }
+
+    /// Return 1 if the specified key is in the set, 0 otherwise.
+    size_type count(const ValueT& V) const { return TheMap.count(V); }
+
+    bool erase(const ValueT& V) { return TheMap.erase(V); }
+
+    void swap(DenseSet& RHS) { TheMap.swap(RHS.TheMap); }
+
+    // Iterators.
+
+    class Iterator {
+        typename MapTy::iterator I;
+        friend class DenseSet;
+
+    public:
+        typedef typename MapTy::iterator::difference_type difference_type;
+        typedef ValueT value_type;
+        typedef value_type* pointer;
+        typedef value_type& reference;
+        typedef std::forward_iterator_tag iterator_category;
+
+        Iterator(const typename MapTy::iterator& i) : I(i) {}
+
+        ValueT& operator*() { return I->getFirst(); }
+        ValueT* operator->() { return &I->getFirst(); }
+
+        Iterator& operator++() {
+            ++I;
+            return *this;
+        }
+        bool operator==(const Iterator& X) const { return I == X.I; }
+        bool operator!=(const Iterator& X) const { return I != X.I; }
+    };
+
+    class ConstIterator {
+        typename MapTy::const_iterator I;
+        friend class DenseSet;
+
+    public:
+        typedef typename MapTy::const_iterator::difference_type difference_type;
+        typedef ValueT value_type;
+        typedef value_type* pointer;
+        typedef value_type& reference;
+        typedef std::forward_iterator_tag iterator_category;
+
+        ConstIterator(const typename MapTy::const_iterator& i) : I(i) {}
+
+        const ValueT& operator*() { return I->getFirst(); }
+        const ValueT* operator->() { return &I->getFirst(); }
+
+        ConstIterator& operator++() {
+            ++I;
+            return *this;
+        }
+        bool operator==(const ConstIterator& X) const { return I == X.I; }
+        bool operator!=(const ConstIterator& X) const { return I != X.I; }
+    };
+
+    typedef Iterator iterator;
+    typedef ConstIterator const_iterator;
+
+    iterator begin() { return Iterator(TheMap.begin()); }
+    iterator end() { return Iterator(TheMap.end()); }
+
+    const_iterator begin() const { return ConstIterator(TheMap.begin()); }
+    const_iterator end() const { return ConstIterator(TheMap.end()); }
+
+    iterator find(const ValueT& V) { return Iterator(TheMap.find(V)); }
+
+    /// Alternative version of find() which allows a different, and possibly less
+    /// expensive, key type.
+    /// The DenseMapInfo is responsible for supplying methods
+    /// getHashValue(LookupKeyT) and isEqual(LookupKeyT, KeyT) for each key type
+    /// used.
+    template <class LookupKeyT> iterator find_as(const LookupKeyT& Val) { return Iterator(TheMap.find_as(Val)); }
+    template <class LookupKeyT> const_iterator find_as(const LookupKeyT& Val) const {
+        return ConstIterator(TheMap.find_as(Val));
+    }
+
+    void erase(Iterator I) { return TheMap.erase(I.I); }
+    void erase(ConstIterator CI) { return TheMap.erase(CI.I); }
+
+    std::pair<iterator, bool> insert(const ValueT& V) {
+        detail::DenseSetEmpty Empty;
+        return TheMap.insert(std::make_pair(V, Empty));
+    }
+
+    // Range insertion of values.
+    template <typename InputIt> void insert(InputIt I, InputIt E) {
+        for (; I != E; ++I)
+            insert(*I);
+    }
+};
+
+} // end namespace llvm
+
+#endif

--- a/src/core/SmallVector.cpp
+++ b/src/core/SmallVector.cpp
@@ -11,6 +11,20 @@
 //
 //===----------------------------------------------------------------------===//
 
+// Pyston changes Copyright (c) 2014-2015 Dropbox, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "core/SmallVector.h"
 
 using namespace pyston;

--- a/src/core/SmallVector.cpp
+++ b/src/core/SmallVector.cpp
@@ -1,0 +1,40 @@
+//===- llvm/ADT/SmallVector.cpp - 'Normally small' vectors ----------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements the SmallVector class.
+//
+//===----------------------------------------------------------------------===//
+
+#include "core/SmallVector.h"
+
+using namespace pyston;
+
+/// grow_pod - This is an implementation of the grow() method which only works
+/// on POD-like datatypes and is out of line to reduce code duplication.
+void SmallVectorBase::grow_pod(void* FirstEl, size_t MinSizeInBytes, size_t TSize) {
+    size_t CurSizeBytes = size_in_bytes();
+    size_t NewCapacityInBytes = 2 * capacity_in_bytes() + TSize; // Always grow.
+    if (NewCapacityInBytes < MinSizeInBytes)
+        NewCapacityInBytes = MinSizeInBytes;
+
+    void* NewElts;
+    if (BeginX == FirstEl) {
+        NewElts = malloc(NewCapacityInBytes);
+
+        // Copy the elements over.  No need to run dtors on PODs.
+        memcpy(NewElts, this->BeginX, CurSizeBytes);
+    } else {
+        // If this wasn't grown from the inline copy, grow the allocated space.
+        NewElts = realloc(this->BeginX, NewCapacityInBytes);
+    }
+
+    this->EndX = (char*)NewElts + CurSizeBytes;
+    this->BeginX = NewElts;
+    this->CapacityX = (char*)this->BeginX + NewCapacityInBytes;
+}

--- a/src/core/SmallVector.h
+++ b/src/core/SmallVector.h
@@ -28,11 +28,6 @@
 #ifndef PYSTON_CORE_SMALLVECTOR_H
 #define PYSTON_CORE_SMALLVECTOR_H
 
-#include "llvm/ADT/iterator_range.h"
-#include "llvm/Support/AlignOf.h"
-#include "llvm/Support/Compiler.h"
-#include "llvm/Support/MathExtras.h"
-#include "llvm/Support/type_traits.h"
 #include <algorithm>
 #include <cassert>
 #include <cstddef>
@@ -40,6 +35,12 @@
 #include <cstring>
 #include <iterator>
 #include <memory>
+
+#include "llvm/ADT/iterator_range.h"
+#include "llvm/Support/AlignOf.h"
+#include "llvm/Support/Compiler.h"
+#include "llvm/Support/MathExtras.h"
+#include "llvm/Support/type_traits.h"
 
 namespace pyston {
 

--- a/src/core/SmallVector.h
+++ b/src/core/SmallVector.h
@@ -1,0 +1,900 @@
+//===- llvm/ADT/SmallVector.h - 'Normally small' vectors --------*- C++ -*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the SmallVector class.
+//
+//===----------------------------------------------------------------------===//
+
+// Pyston changes Copyright (c) 2014-2015 Dropbox, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef PYSTON_CORE_SMALLVECTOR_H
+#define PYSTON_CORE_SMALLVECTOR_H
+
+#include "llvm/ADT/iterator_range.h"
+#include "llvm/Support/AlignOf.h"
+#include "llvm/Support/Compiler.h"
+#include "llvm/Support/MathExtras.h"
+#include "llvm/Support/type_traits.h"
+#include <algorithm>
+#include <cassert>
+#include <cstddef>
+#include <cstdlib>
+#include <cstring>
+#include <iterator>
+#include <memory>
+
+namespace pyston {
+
+/// This is all the non-templated stuff common to all SmallVectors.
+class SmallVectorBase {
+protected:
+    void* BeginX, *EndX, *CapacityX;
+
+protected:
+    SmallVectorBase(void* FirstEl, size_t Size) : BeginX(FirstEl), EndX(FirstEl), CapacityX((char*)FirstEl + Size) {}
+
+    /// This is an implementation of the grow() method which only works
+    /// on POD-like data types and is out of line to reduce code duplication.
+    void grow_pod(void* FirstEl, size_t MinSizeInBytes, size_t TSize);
+
+public:
+    /// This returns size()*sizeof(T).
+    size_t size_in_bytes() const { return size_t((char*)EndX - (char*)BeginX); }
+
+    /// capacity_in_bytes - This returns capacity()*sizeof(T).
+    size_t capacity_in_bytes() const { return size_t((char*)CapacityX - (char*)BeginX); }
+
+    bool LLVM_ATTRIBUTE_UNUSED_RESULT empty() const { return BeginX == EndX; }
+};
+
+template <typename T, unsigned N> struct SmallVectorStorage;
+
+/// This is the part of SmallVectorTemplateBase which does not depend on whether
+/// the type T is a POD. The extra dummy template argument is used by ArrayRef
+/// to avoid unnecessarily requiring T to be complete.
+template <typename T, typename = void> class SmallVectorTemplateCommon : public SmallVectorBase {
+private:
+    template <typename, unsigned> friend struct SmallVectorStorage;
+
+    // Allocate raw space for N elements of type T.  If T has a ctor or dtor, we
+    // don't want it to be automatically run, so we need to represent the space as
+    // something else.  Use an array of char of sufficient alignment.
+    typedef llvm::AlignedCharArrayUnion<T> U;
+    U FirstEl;
+    // Space after 'FirstEl' is clobbered, do not add any instance vars after it.
+
+protected:
+    SmallVectorTemplateCommon(size_t Size) : SmallVectorBase(&FirstEl, Size) {}
+
+    void grow_pod(size_t MinSizeInBytes, size_t TSize) { SmallVectorBase::grow_pod(&FirstEl, MinSizeInBytes, TSize); }
+
+    /// Return true if this is a smallvector which has not had dynamic
+    /// memory allocated for it.
+    bool isSmall() const { return BeginX == static_cast<const void*>(&FirstEl); }
+
+    /// Put this vector in a state of being small.
+    void resetToSmall() { BeginX = EndX = CapacityX = &FirstEl; }
+
+    void setEnd(T* P) { this->EndX = P; }
+
+public:
+    typedef size_t size_type;
+    typedef ptrdiff_t difference_type;
+    typedef T value_type;
+    typedef T* iterator;
+    typedef const T* const_iterator;
+
+    typedef std::reverse_iterator<const_iterator> const_reverse_iterator;
+    typedef std::reverse_iterator<iterator> reverse_iterator;
+
+    typedef T& reference;
+    typedef const T& const_reference;
+    typedef T* pointer;
+    typedef const T* const_pointer;
+
+    // forward iterator creation methods.
+    iterator begin() { return (iterator) this->BeginX; }
+    const_iterator begin() const { return (const_iterator) this->BeginX; }
+    iterator end() { return (iterator) this->EndX; }
+    const_iterator end() const { return (const_iterator) this->EndX; }
+
+protected:
+    iterator capacity_ptr() { return (iterator) this->CapacityX; }
+    const_iterator capacity_ptr() const { return (const_iterator) this->CapacityX; }
+
+public:
+    // reverse iterator creation methods.
+    reverse_iterator rbegin() { return reverse_iterator(end()); }
+    const_reverse_iterator rbegin() const { return const_reverse_iterator(end()); }
+    reverse_iterator rend() { return reverse_iterator(begin()); }
+    const_reverse_iterator rend() const { return const_reverse_iterator(begin()); }
+
+    size_type size() const { return end() - begin(); }
+    size_type max_size() const { return size_type(-1) / sizeof(T); }
+
+    /// Return the total number of elements in the currently allocated buffer.
+    size_t capacity() const { return capacity_ptr() - begin(); }
+
+    /// Return a pointer to the vector's buffer, even if empty().
+    pointer data() { return pointer(begin()); }
+    /// Return a pointer to the vector's buffer, even if empty().
+    const_pointer data() const { return const_pointer(begin()); }
+
+    reference operator[](size_type idx) {
+        assert(idx < size());
+        return begin()[idx];
+    }
+    const_reference operator[](size_type idx) const {
+        assert(idx < size());
+        return begin()[idx];
+    }
+
+    reference front() {
+        assert(!empty());
+        return begin()[0];
+    }
+    const_reference front() const {
+        assert(!empty());
+        return begin()[0];
+    }
+
+    reference back() {
+        assert(!empty());
+        return end()[-1];
+    }
+    const_reference back() const {
+        assert(!empty());
+        return end()[-1];
+    }
+};
+
+/// SmallVectorTemplateBase<llvm::isPodLike = false> - This is where we put method
+/// implementations that are designed to work with non-POD-like T's.
+template <typename T, typename AllocT, bool llvm::isPodLike>
+class SmallVectorTemplateBase : public SmallVectorTemplateCommon<T> {
+protected:
+    SmallVectorTemplateBase(size_t Size) : SmallVectorTemplateCommon<T>(Size) {}
+
+    static void destroy_range(T* S, T* E) {
+        while (S != E) {
+            --E;
+            E->~T();
+        }
+    }
+
+    /// Use move-assignment to move the range [I, E) onto the
+    /// objects starting with "Dest".  This is just <memory>'s
+    /// std::move, but not all stdlibs actually provide that.
+    template <typename It1, typename It2> static It2 move(It1 I, It1 E, It2 Dest) {
+        for (; I != E; ++I, ++Dest)
+            *Dest = ::std::move(*I);
+        return Dest;
+    }
+
+    /// Use move-assignment to move the range
+    /// [I, E) onto the objects ending at "Dest", moving objects
+    /// in reverse order.  This is just <algorithm>'s
+    /// std::move_backward, but not all stdlibs actually provide that.
+    template <typename It1, typename It2> static It2 move_backward(It1 I, It1 E, It2 Dest) {
+        while (I != E)
+            *--Dest = ::std::move(*--E);
+        return Dest;
+    }
+
+    /// Move the range [I, E) into the uninitialized memory starting with "Dest",
+    /// constructing elements as needed.
+    template <typename It1, typename It2> static void uninitialized_move(It1 I, It1 E, It2 Dest) {
+        for (; I != E; ++I, ++Dest)
+            ::new ((void*)&*Dest) T(::std::move(*I));
+    }
+
+    /// Copy the range [I, E) onto the uninitialized memory starting with "Dest",
+    /// constructing elements as needed.
+    template <typename It1, typename It2> static void uninitialized_copy(It1 I, It1 E, It2 Dest) {
+        std::uninitialized_copy(I, E, Dest);
+    }
+
+    /// Grow the allocated memory (without initializing new elements), doubling
+    /// the size of the allocated memory. Guarantees space for at least one more
+    /// element, or MinSize more elements if specified.
+    void grow(size_t MinSize = 0);
+
+public:
+    void push_back(const T& Elt) {
+        if (LLVM_UNLIKELY(this->EndX >= this->CapacityX))
+            this->grow();
+        ::new ((void*)this->end()) T(Elt);
+        this->setEnd(this->end() + 1);
+    }
+
+    void push_back(T&& Elt) {
+        if (LLVM_UNLIKELY(this->EndX >= this->CapacityX))
+            this->grow();
+        ::new ((void*)this->end()) T(::std::move(Elt));
+        this->setEnd(this->end() + 1);
+    }
+
+    void pop_back() {
+        this->setEnd(this->end() - 1);
+        this->end()->~T();
+    }
+};
+
+// Define this out-of-line to dissuade the C++ compiler from inlining it.
+template <typename T, typename AllocT, bool isPodLike>
+void SmallVectorTemplateBase<T, AllocT, isPodLike>::grow(size_t MinSize) {
+    size_t CurCapacity = this->capacity();
+    size_t CurSize = this->size();
+    // Always grow, even from zero.
+    size_t NewCapacity = size_t(llvm::NextPowerOf2(CurCapacity + 2));
+    if (NewCapacity < MinSize)
+        NewCapacity = MinSize;
+    T* NewElts = static_cast<T*>(AllocT().allocate(NewCapacity));
+
+    // Move the elements over.
+    this->uninitialized_move(this->begin(), this->end(), NewElts);
+
+    // Destroy the original elements.
+    destroy_range(this->begin(), this->end());
+
+    // If this wasn't grown from the inline copy, deallocate the old space.
+    if (!this->isSmall())
+        AllocT().deallocate(this->begin(), CurCapacity);
+
+    this->setEnd(NewElts + CurSize);
+    this->BeginX = NewElts;
+    this->CapacityX = this->begin() + NewCapacity;
+}
+
+
+/// SmallVectorTemplateBase<llvm::isPodLike = true> - This is where we put method
+/// implementations that are designed to work with POD-like T's.
+template <typename T, typename AllocT>
+class SmallVectorTemplateBase<T, AllocT, true> : public SmallVectorTemplateCommon<T> {
+protected:
+    SmallVectorTemplateBase(size_t Size) : SmallVectorTemplateCommon<T>(Size) {}
+
+    // No need to do a destroy loop for POD's.
+    static void destroy_range(T*, T*) {}
+
+    /// Use move-assignment to move the range [I, E) onto the
+    /// objects starting with "Dest".  For PODs, this is just memcpy.
+    template <typename It1, typename It2> static It2 move(It1 I, It1 E, It2 Dest) { return ::std::copy(I, E, Dest); }
+
+    /// Use move-assignment to move the range [I, E) onto the objects ending at
+    /// "Dest", moving objects in reverse order.
+    template <typename It1, typename It2> static It2 move_backward(It1 I, It1 E, It2 Dest) {
+        return ::std::copy_backward(I, E, Dest);
+    }
+
+    /// Move the range [I, E) onto the uninitialized memory
+    /// starting with "Dest", constructing elements into it as needed.
+    template <typename It1, typename It2> static void uninitialized_move(It1 I, It1 E, It2 Dest) {
+        // Just do a copy.
+        uninitialized_copy(I, E, Dest);
+    }
+
+    /// Copy the range [I, E) onto the uninitialized memory
+    /// starting with "Dest", constructing elements into it as needed.
+    template <typename It1, typename It2> static void uninitialized_copy(It1 I, It1 E, It2 Dest) {
+        // Arbitrary iterator types; just use the basic implementation.
+        std::uninitialized_copy(I, E, Dest);
+    }
+
+    /// Copy the range [I, E) onto the uninitialized memory
+    /// starting with "Dest", constructing elements into it as needed.
+    template <typename T1, typename T2>
+    static void uninitialized_copy(
+        T1* I, T1* E, T2* Dest,
+        typename std::enable_if<std::is_same<typename std::remove_const<T1>::type, T2>::value>::type* = nullptr) {
+        // Use memcpy for PODs iterated by pointers (which includes SmallVector
+        // iterators): std::uninitialized_copy optimizes to memmove, but we can
+        // use memcpy here.
+        memcpy(Dest, I, (E - I) * sizeof(T));
+    }
+
+    /// Double the size of the allocated memory, guaranteeing space for at
+    /// least one more element or MinSize if specified.
+    void grow(size_t MinSize = 0) { this->grow_pod(MinSize * sizeof(T), sizeof(T)); }
+
+public:
+    void push_back(const T& Elt) {
+        if (LLVM_UNLIKELY(this->EndX >= this->CapacityX))
+            this->grow();
+        memcpy(this->end(), &Elt, sizeof(T));
+        this->setEnd(this->end() + 1);
+    }
+
+    void pop_back() { this->setEnd(this->end() - 1); }
+};
+
+
+/// This class consists of common code factored out of the SmallVector class to
+/// reduce code duplication based on the SmallVector 'N' template parameter.
+template <typename T, typename AllocT>
+class SmallVectorImpl : public SmallVectorTemplateBase<T, AllocT, llvm::isPodLike<T>::value> {
+    typedef SmallVectorTemplateBase<T, AllocT, llvm::isPodLike<T>::value> SuperClass;
+
+    SmallVectorImpl(const SmallVectorImpl&) = delete;
+
+public:
+    typedef typename SuperClass::iterator iterator;
+    typedef typename SuperClass::size_type size_type;
+
+protected:
+    // Default ctor - Initialize to empty.
+    explicit SmallVectorImpl(unsigned N)
+        : SmallVectorTemplateBase<T, AllocT, llvm::isPodLike<T>::value>(N * sizeof(T)) {}
+
+public:
+    ~SmallVectorImpl() {
+        // Destroy the constructed elements in the vector.
+        this->destroy_range(this->begin(), this->end());
+
+        // If this wasn't grown from the inline copy, deallocate the old space.
+        if (!this->isSmall())
+            free(this->begin());
+    }
+
+
+    void clear() {
+        this->destroy_range(this->begin(), this->end());
+        this->EndX = this->BeginX;
+    }
+
+    void resize(size_type N) {
+        if (N < this->size()) {
+            this->destroy_range(this->begin() + N, this->end());
+            this->setEnd(this->begin() + N);
+        } else if (N > this->size()) {
+            if (this->capacity() < N)
+                this->grow(N);
+            for (auto I = this->end(), E = this->begin() + N; I != E; ++I)
+                new (&*I) T();
+            this->setEnd(this->begin() + N);
+        }
+    }
+
+    void resize(size_type N, const T& NV) {
+        if (N < this->size()) {
+            this->destroy_range(this->begin() + N, this->end());
+            this->setEnd(this->begin() + N);
+        } else if (N > this->size()) {
+            if (this->capacity() < N)
+                this->grow(N);
+            std::uninitialized_fill(this->end(), this->begin() + N, NV);
+            this->setEnd(this->begin() + N);
+        }
+    }
+
+    void reserve(size_type N) {
+        if (this->capacity() < N)
+            this->grow(N);
+    }
+
+    T LLVM_ATTRIBUTE_UNUSED_RESULT pop_back_val() {
+        T Result = ::std::move(this->back());
+        this->pop_back();
+        return Result;
+    }
+
+    void swap(SmallVectorImpl& RHS);
+
+    /// Add the specified range to the end of the SmallVector.
+    template <typename in_iter> void append(in_iter in_start, in_iter in_end) {
+        size_type NumInputs = std::distance(in_start, in_end);
+        // Grow allocated space if needed.
+        if (NumInputs > size_type(this->capacity_ptr() - this->end()))
+            this->grow(this->size() + NumInputs);
+
+        // Copy the new elements over.
+        this->uninitialized_copy(in_start, in_end, this->end());
+        this->setEnd(this->end() + NumInputs);
+    }
+
+    /// Add the specified range to the end of the SmallVector.
+    void append(size_type NumInputs, const T& Elt) {
+        // Grow allocated space if needed.
+        if (NumInputs > size_type(this->capacity_ptr() - this->end()))
+            this->grow(this->size() + NumInputs);
+
+        // Copy the new elements over.
+        std::uninitialized_fill_n(this->end(), NumInputs, Elt);
+        this->setEnd(this->end() + NumInputs);
+    }
+
+    void assign(size_type NumElts, const T& Elt) {
+        clear();
+        if (this->capacity() < NumElts)
+            this->grow(NumElts);
+        this->setEnd(this->begin() + NumElts);
+        std::uninitialized_fill(this->begin(), this->end(), Elt);
+    }
+
+    iterator erase(iterator I) {
+        assert(I >= this->begin() && "Iterator to erase is out of bounds.");
+        assert(I < this->end() && "Erasing at past-the-end iterator.");
+
+        iterator N = I;
+        // Shift all elts down one.
+        this->move(I + 1, this->end(), I);
+        // Drop the last elt.
+        this->pop_back();
+        return (N);
+    }
+
+    iterator erase(iterator S, iterator E) {
+        assert(S >= this->begin() && "Range to erase is out of bounds.");
+        assert(S <= E && "Trying to erase invalid range.");
+        assert(E <= this->end() && "Trying to erase past the end.");
+
+        iterator N = S;
+        // Shift all elts down.
+        iterator I = this->move(E, this->end(), S);
+        // Drop the last elts.
+        this->destroy_range(I, this->end());
+        this->setEnd(I);
+        return (N);
+    }
+
+    iterator insert(iterator I, T&& Elt) {
+        if (I == this->end()) { // Important special case for empty vector.
+            this->push_back(::std::move(Elt));
+            return this->end() - 1;
+        }
+
+        assert(I >= this->begin() && "Insertion iterator is out of bounds.");
+        assert(I <= this->end() && "Inserting past the end of the vector.");
+
+        if (this->EndX >= this->CapacityX) {
+            size_t EltNo = I - this->begin();
+            this->grow();
+            I = this->begin() + EltNo;
+        }
+
+        ::new ((void*)this->end()) T(::std::move(this->back()));
+        // Push everything else over.
+        this->move_backward(I, this->end() - 1, this->end());
+        this->setEnd(this->end() + 1);
+
+        // If we just moved the element we're inserting, be sure to update
+        // the reference.
+        T* EltPtr = &Elt;
+        if (I <= EltPtr && EltPtr < this->EndX)
+            ++EltPtr;
+
+        *I = ::std::move(*EltPtr);
+        return I;
+    }
+
+    iterator insert(iterator I, const T& Elt) {
+        if (I == this->end()) { // Important special case for empty vector.
+            this->push_back(Elt);
+            return this->end() - 1;
+        }
+
+        assert(I >= this->begin() && "Insertion iterator is out of bounds.");
+        assert(I <= this->end() && "Inserting past the end of the vector.");
+
+        if (this->EndX >= this->CapacityX) {
+            size_t EltNo = I - this->begin();
+            this->grow();
+            I = this->begin() + EltNo;
+        }
+        ::new ((void*)this->end()) T(std::move(this->back()));
+        // Push everything else over.
+        this->move_backward(I, this->end() - 1, this->end());
+        this->setEnd(this->end() + 1);
+
+        // If we just moved the element we're inserting, be sure to update
+        // the reference.
+        const T* EltPtr = &Elt;
+        if (I <= EltPtr && EltPtr < this->EndX)
+            ++EltPtr;
+
+        *I = *EltPtr;
+        return I;
+    }
+
+    iterator insert(iterator I, size_type NumToInsert, const T& Elt) {
+        // Convert iterator to elt# to avoid invalidating iterator when we reserve()
+        size_t InsertElt = I - this->begin();
+
+        if (I == this->end()) { // Important special case for empty vector.
+            append(NumToInsert, Elt);
+            return this->begin() + InsertElt;
+        }
+
+        assert(I >= this->begin() && "Insertion iterator is out of bounds.");
+        assert(I <= this->end() && "Inserting past the end of the vector.");
+
+        // Ensure there is enough space.
+        reserve(this->size() + NumToInsert);
+
+        // Uninvalidate the iterator.
+        I = this->begin() + InsertElt;
+
+        // If there are more elements between the insertion point and the end of the
+        // range than there are being inserted, we can use a simple approach to
+        // insertion.  Since we already reserved space, we know that this won't
+        // reallocate the vector.
+        if (size_t(this->end() - I) >= NumToInsert) {
+            T* OldEnd = this->end();
+            append(std::move_iterator<iterator>(this->end() - NumToInsert), std::move_iterator<iterator>(this->end()));
+
+            // Copy the existing elements that get replaced.
+            this->move_backward(I, OldEnd - NumToInsert, OldEnd);
+
+            std::fill_n(I, NumToInsert, Elt);
+            return I;
+        }
+
+        // Otherwise, we're inserting more elements than exist already, and we're
+        // not inserting at the end.
+
+        // Move over the elements that we're about to overwrite.
+        T* OldEnd = this->end();
+        this->setEnd(this->end() + NumToInsert);
+        size_t NumOverwritten = OldEnd - I;
+        this->uninitialized_move(I, OldEnd, this->end() - NumOverwritten);
+
+        // Replace the overwritten part.
+        std::fill_n(I, NumOverwritten, Elt);
+
+        // Insert the non-overwritten middle part.
+        std::uninitialized_fill_n(OldEnd, NumToInsert - NumOverwritten, Elt);
+        return I;
+    }
+
+    template <typename ItTy> iterator insert(iterator I, ItTy From, ItTy To) {
+        // Convert iterator to elt# to avoid invalidating iterator when we reserve()
+        size_t InsertElt = I - this->begin();
+
+        if (I == this->end()) { // Important special case for empty vector.
+            append(From, To);
+            return this->begin() + InsertElt;
+        }
+
+        assert(I >= this->begin() && "Insertion iterator is out of bounds.");
+        assert(I <= this->end() && "Inserting past the end of the vector.");
+
+        size_t NumToInsert = std::distance(From, To);
+
+        // Ensure there is enough space.
+        reserve(this->size() + NumToInsert);
+
+        // Uninvalidate the iterator.
+        I = this->begin() + InsertElt;
+
+        // If there are more elements between the insertion point and the end of the
+        // range than there are being inserted, we can use a simple approach to
+        // insertion.  Since we already reserved space, we know that this won't
+        // reallocate the vector.
+        if (size_t(this->end() - I) >= NumToInsert) {
+            T* OldEnd = this->end();
+            append(std::move_iterator<iterator>(this->end() - NumToInsert), std::move_iterator<iterator>(this->end()));
+
+            // Copy the existing elements that get replaced.
+            this->move_backward(I, OldEnd - NumToInsert, OldEnd);
+
+            std::copy(From, To, I);
+            return I;
+        }
+
+        // Otherwise, we're inserting more elements than exist already, and we're
+        // not inserting at the end.
+
+        // Move over the elements that we're about to overwrite.
+        T* OldEnd = this->end();
+        this->setEnd(this->end() + NumToInsert);
+        size_t NumOverwritten = OldEnd - I;
+        this->uninitialized_move(I, OldEnd, this->end() - NumOverwritten);
+
+        // Replace the overwritten part.
+        for (T* J = I; NumOverwritten > 0; --NumOverwritten) {
+            *J = *From;
+            ++J;
+            ++From;
+        }
+
+        // Insert the non-overwritten middle part.
+        this->uninitialized_copy(From, To, OldEnd);
+        return I;
+    }
+
+    template <typename... ArgTypes> void emplace_back(ArgTypes&&... Args) {
+        if (LLVM_UNLIKELY(this->EndX >= this->CapacityX))
+            this->grow();
+        ::new ((void*)this->end()) T(std::forward<ArgTypes>(Args)...);
+        this->setEnd(this->end() + 1);
+    }
+
+    SmallVectorImpl& operator=(const SmallVectorImpl& RHS);
+
+    SmallVectorImpl& operator=(SmallVectorImpl&& RHS);
+
+    bool operator==(const SmallVectorImpl& RHS) const {
+        if (this->size() != RHS.size())
+            return false;
+        return std::equal(this->begin(), this->end(), RHS.begin());
+    }
+    bool operator!=(const SmallVectorImpl& RHS) const { return !(*this == RHS); }
+
+    bool operator<(const SmallVectorImpl& RHS) const {
+        return std::lexicographical_compare(this->begin(), this->end(), RHS.begin(), RHS.end());
+    }
+
+    /// Set the array size to \p N, which the current array must have enough
+    /// capacity for.
+    ///
+    /// This does not construct or destroy any elements in the vector.
+    ///
+    /// Clients can use this in conjunction with capacity() to write past the end
+    /// of the buffer when they know that more elements are available, and only
+    /// update the size later. This avoids the cost of value initializing elements
+    /// which will only be overwritten.
+    void set_size(size_type N) {
+        assert(N <= this->capacity());
+        this->setEnd(this->begin() + N);
+    }
+};
+
+
+template <typename T, typename AllocT> void SmallVectorImpl<T, AllocT>::swap(SmallVectorImpl<T, AllocT>& RHS) {
+    if (this == &RHS)
+        return;
+
+    // We can only avoid copying elements if neither vector is small.
+    if (!this->isSmall() && !RHS.isSmall()) {
+        std::swap(this->BeginX, RHS.BeginX);
+        std::swap(this->EndX, RHS.EndX);
+        std::swap(this->CapacityX, RHS.CapacityX);
+        return;
+    }
+    if (RHS.size() > this->capacity())
+        this->grow(RHS.size());
+    if (this->size() > RHS.capacity())
+        RHS.grow(this->size());
+
+    // Swap the shared elements.
+    size_t NumShared = this->size();
+    if (NumShared > RHS.size())
+        NumShared = RHS.size();
+    for (size_type i = 0; i != NumShared; ++i)
+        std::swap((*this)[i], RHS[i]);
+
+    // Copy over the extra elts.
+    if (this->size() > RHS.size()) {
+        size_t EltDiff = this->size() - RHS.size();
+        this->uninitialized_copy(this->begin() + NumShared, this->end(), RHS.end());
+        RHS.setEnd(RHS.end() + EltDiff);
+        this->destroy_range(this->begin() + NumShared, this->end());
+        this->setEnd(this->begin() + NumShared);
+    } else if (RHS.size() > this->size()) {
+        size_t EltDiff = RHS.size() - this->size();
+        this->uninitialized_copy(RHS.begin() + NumShared, RHS.end(), this->end());
+        this->setEnd(this->end() + EltDiff);
+        this->destroy_range(RHS.begin() + NumShared, RHS.end());
+        RHS.setEnd(RHS.begin() + NumShared);
+    }
+}
+
+template <typename T, typename AllocT>
+SmallVectorImpl<T, AllocT>& SmallVectorImpl<T, AllocT>::operator=(const SmallVectorImpl<T, AllocT>& RHS) {
+    // Avoid self-assignment.
+    if (this == &RHS)
+        return *this;
+
+    // If we already have sufficient space, assign the common elements, then
+    // destroy any excess.
+    size_t RHSSize = RHS.size();
+    size_t CurSize = this->size();
+    if (CurSize >= RHSSize) {
+        // Assign common elements.
+        iterator NewEnd;
+        if (RHSSize)
+            NewEnd = std::copy(RHS.begin(), RHS.begin() + RHSSize, this->begin());
+        else
+            NewEnd = this->begin();
+
+        // Destroy excess elements.
+        this->destroy_range(NewEnd, this->end());
+
+        // Trim.
+        this->setEnd(NewEnd);
+        return *this;
+    }
+
+    // If we have to grow to have enough elements, destroy the current elements.
+    // This allows us to avoid copying them during the grow.
+    // FIXME: don't do this if they're efficiently moveable.
+    if (this->capacity() < RHSSize) {
+        // Destroy current elements.
+        this->destroy_range(this->begin(), this->end());
+        this->setEnd(this->begin());
+        CurSize = 0;
+        this->grow(RHSSize);
+    } else if (CurSize) {
+        // Otherwise, use assignment for the already-constructed elements.
+        std::copy(RHS.begin(), RHS.begin() + CurSize, this->begin());
+    }
+
+    // Copy construct the new elements in place.
+    this->uninitialized_copy(RHS.begin() + CurSize, RHS.end(), this->begin() + CurSize);
+
+    // Set end.
+    this->setEnd(this->begin() + RHSSize);
+    return *this;
+}
+
+template <typename T, typename AllocT>
+SmallVectorImpl<T, AllocT>& SmallVectorImpl<T, AllocT>::operator=(SmallVectorImpl<T, AllocT>&& RHS) {
+    // Avoid self-assignment.
+    if (this == &RHS)
+        return *this;
+
+    // If the RHS isn't small, clear this vector and then steal its buffer.
+    if (!RHS.isSmall()) {
+        this->destroy_range(this->begin(), this->end());
+        if (!this->isSmall())
+            free(this->begin());
+        this->BeginX = RHS.BeginX;
+        this->EndX = RHS.EndX;
+        this->CapacityX = RHS.CapacityX;
+        RHS.resetToSmall();
+        return *this;
+    }
+
+    // If we already have sufficient space, assign the common elements, then
+    // destroy any excess.
+    size_t RHSSize = RHS.size();
+    size_t CurSize = this->size();
+    if (CurSize >= RHSSize) {
+        // Assign common elements.
+        iterator NewEnd = this->begin();
+        if (RHSSize)
+            NewEnd = this->move(RHS.begin(), RHS.end(), NewEnd);
+
+        // Destroy excess elements and trim the bounds.
+        this->destroy_range(NewEnd, this->end());
+        this->setEnd(NewEnd);
+
+        // Clear the RHS.
+        RHS.clear();
+
+        return *this;
+    }
+
+    // If we have to grow to have enough elements, destroy the current elements.
+    // This allows us to avoid copying them during the grow.
+    // FIXME: this may not actually make any sense if we can efficiently move
+    // elements.
+    if (this->capacity() < RHSSize) {
+        // Destroy current elements.
+        this->destroy_range(this->begin(), this->end());
+        this->setEnd(this->begin());
+        CurSize = 0;
+        this->grow(RHSSize);
+    } else if (CurSize) {
+        // Otherwise, use assignment for the already-constructed elements.
+        this->move(RHS.begin(), RHS.begin() + CurSize, this->begin());
+    }
+
+    // Move-construct the new elements in place.
+    this->uninitialized_move(RHS.begin() + CurSize, RHS.end(), this->begin() + CurSize);
+
+    // Set end.
+    this->setEnd(this->begin() + RHSSize);
+
+    RHS.clear();
+    return *this;
+}
+
+/// Storage for the SmallVector elements which aren't contained in
+/// SmallVectorTemplateCommon. There are 'N-1' elements here. The remaining '1'
+/// element is in the base class. This is specialized for the N=1 and N=0 cases
+/// to avoid allocating unnecessary storage.
+template <typename T, unsigned N> struct SmallVectorStorage {
+    typename SmallVectorTemplateCommon<T>::U InlineElts[N - 1];
+};
+template <typename T> struct SmallVectorStorage<T, 1> {};
+template <typename T> struct SmallVectorStorage<T, 0> {};
+
+/// This is a 'vector' (really, a variable-sized array), optimized
+/// for the case when the array is small.  It contains some number of elements
+/// in-place, which allows it to avoid heap allocation when the actual number of
+/// elements is below that threshold.  This allows normal "small" cases to be
+/// fast without losing generality for large inputs.
+///
+/// Note that this does not attempt to be exception safe.
+///
+template <typename T, typename AllocT, unsigned N> class SmallVector : public SmallVectorImpl<T, AllocT> {
+    /// Inline space for elements which aren't stored in the base class.
+    SmallVectorStorage<T, N> Storage;
+
+public:
+    SmallVector() : SmallVectorImpl<T, AllocT>(N) {}
+
+    explicit SmallVector(size_t Size, const T& Value = T()) : SmallVectorImpl<T, AllocT>(N) {
+        this->assign(Size, Value);
+    }
+
+    template <typename ItTy> SmallVector(ItTy S, ItTy E) : SmallVectorImpl<T, AllocT>(N) { this->append(S, E); }
+
+    template <typename RangeTy>
+    explicit SmallVector(const llvm::iterator_range<RangeTy> R)
+        : SmallVectorImpl<T, AllocT>(N) {
+        this->append(R.begin(), R.end());
+    }
+
+    SmallVector(const SmallVector& RHS) : SmallVectorImpl<T, AllocT>(N) {
+        if (!RHS.empty())
+            SmallVectorImpl<T, AllocT>::operator=(RHS);
+    }
+
+    const SmallVector& operator=(const SmallVector& RHS) {
+        SmallVectorImpl<T, AllocT>::operator=(RHS);
+        return *this;
+    }
+
+    SmallVector(SmallVector&& RHS) : SmallVectorImpl<T, AllocT>(N) {
+        if (!RHS.empty())
+            SmallVectorImpl<T, AllocT>::operator=(::std::move(RHS));
+    }
+
+    const SmallVector& operator=(SmallVector&& RHS) {
+        SmallVectorImpl<T, AllocT>::operator=(::std::move(RHS));
+        return *this;
+    }
+
+    SmallVector(SmallVectorImpl<T, AllocT>&& RHS) : SmallVectorImpl<T, AllocT>(N) {
+        if (!RHS.empty())
+            SmallVectorImpl<T, AllocT>::operator=(::std::move(RHS));
+    }
+
+    const SmallVector& operator=(SmallVectorImpl<T, AllocT>&& RHS) {
+        SmallVectorImpl<T, AllocT>::operator=(::std::move(RHS));
+        return *this;
+    }
+};
+
+template <typename T, typename AllocT, unsigned N>
+static inline size_t capacity_in_bytes(const SmallVector<T, AllocT, N>& X) {
+    return X.capacity_in_bytes();
+}
+
+} // End pyston namespace
+
+namespace std {
+/// Implement std::swap in terms of SmallVector swap.
+template <typename T, typename AllocT>
+inline void swap(pyston::SmallVectorImpl<T, AllocT>& LHS, pyston::SmallVectorImpl<T, AllocT>& RHS) {
+    LHS.swap(RHS);
+}
+
+/// Implement std::swap in terms of SmallVector swap.
+template <typename T, typename AllocT, unsigned N>
+inline void swap(pyston::SmallVector<T, AllocT, N>& LHS, pyston::SmallVector<T, AllocT, N>& RHS) {
+    LHS.swap(RHS);
+}
+}
+
+#endif

--- a/src/gc/heap.h
+++ b/src/gc/heap.h
@@ -54,7 +54,10 @@ public:
         return reinterpret_cast<pointer>(gc_alloc(to_allocate, gc::GCKind::CONSERVATIVE));
     }
 
-    void deallocate(pointer p, size_t n) { gc::gc_free(p); }
+    void deallocate(pointer p, size_t n) {
+        if (p != NULL)
+            gc::gc_free(p);
+    }
 
     // I would never be able to come up with this on my own:
     // http://en.cppreference.com/w/cpp/memory/allocator/construct

--- a/src/gc/heap.h
+++ b/src/gc/heap.h
@@ -189,8 +189,8 @@ constexpr uintptr_t HUGE_ARENA_START = 0x3270000000L;
 // bitmap for objects of a given size (constant for the block)
 //
 static const size_t sizes[] = {
-    16,  32,  48,  64,  80,  96,  112, 128, 160, 192,
-    224, 256, 320, 384, 448, 512, 640, 768, 896, 1024 //, 1280, 1536, 1792, 2048, 2560, 3072, 3584, // 4096,
+    16,  32,  48,  64,  80,  96,  112, 128, 160,  192, 224,
+    256, 320, 384, 448, 512, 640, 768, 896, 1024, 1280 //, 1536, 1792, 2048, 2560, 3072, 3584, // 4096,
 };
 static constexpr size_t NUM_BUCKETS = sizeof(sizes) / sizeof(sizes[0]);
 

--- a/src/runtime/dict.cpp
+++ b/src/runtime/dict.cpp
@@ -419,7 +419,7 @@ Box* dictSetdefault(BoxedDict* self, Box* k, Box* v) {
     if (it != self->d.end())
         return it->second;
 
-    self->d.insert(it, std::make_pair(k, v));
+    self->d.insert(std::make_pair(k, v));
     return v;
 }
 
@@ -655,8 +655,8 @@ static Box* dict_repr(PyObject* self) noexcept {
 }
 
 void setupDict() {
-    dict_iterator_cls = BoxedHeapClass::create(type_cls, object_cls, &dictIteratorGCHandler, 0, 0, sizeof(BoxedDict),
-                                               false, "dictionary-itemiterator");
+    dict_iterator_cls = BoxedHeapClass::create(type_cls, object_cls, &dictIteratorGCHandler, 0, 0,
+                                               sizeof(BoxedDictIterator), false, "dictionary-itemiterator");
 
     dict_keys_cls = BoxedHeapClass::create(type_cls, object_cls, &dictViewGCHandler, 0, 0, sizeof(BoxedDictView), false,
                                            "dict_keys");

--- a/src/runtime/objmodel.cpp
+++ b/src/runtime/objmodel.cpp
@@ -2548,7 +2548,7 @@ extern "C" void dumpEx(void* p, int levels) {
 
         if (isSubclass(b->cls, dict_cls)) {
             BoxedDict* d = static_cast<BoxedDict*>(b);
-            printf("%ld elements\n", d->d.size());
+            printf("%u elements\n", d->d.size());
 
             if (levels > 0) {
                 int i = 0;

--- a/src/runtime/set.h
+++ b/src/runtime/set.h
@@ -15,8 +15,7 @@
 #ifndef PYSTON_RUNTIME_SET_H
 #define PYSTON_RUNTIME_SET_H
 
-#include <unordered_set>
-
+#include "core/DenseSet.h"
 #include "core/types.h"
 #include "runtime/types.h"
 
@@ -29,7 +28,7 @@ extern "C" Box* createSet();
 
 class BoxedSet : public Box {
 public:
-    typedef std::unordered_set<Box*, PyHasher, PyEq, StlCompatAllocator<Box*>> Set;
+    typedef DenseSet<Box*, llvm::DenseMapInfo<Box*>, StlCompatAllocator<detail::DenseSetPair<Box*>>> Set;
     Set s;
     Box** weakreflist; /* List of weak references */
 

--- a/src/runtime/types.h
+++ b/src/runtime/types.h
@@ -24,6 +24,7 @@
 
 #include "codegen/irgen/future.h"
 #include "core/contiguous_map.h"
+#include "core/DenseMap.h"
 #include "core/threading.h"
 #include "core/types.h"
 #include "gc/gc_alloc.h"
@@ -633,9 +634,33 @@ struct PyLt {
     bool operator()(Box*, Box*) const;
 };
 
+} // namespace pyston
+
+namespace llvm {
+template <> struct DenseMapInfo<pyston::Box*> {
+    static inline pyston::Box* getEmptyKey() { return nullptr; }
+    static inline pyston::Box* getTombstoneKey() { return (pyston::Box*)-1; }
+    static unsigned getHashValue(const pyston::Box* val) { return pyston::PyHasher()(const_cast<pyston::Box*>(val)); }
+    static bool isEqual(const pyston::Box* lhs, const pyston::Box* rhs) {
+        if (lhs == NULL)
+            return rhs == NULL;
+        if (lhs == (pyston::Box*)-1)
+            return rhs == (pyston::Box*)-1;
+
+        if (rhs == NULL || rhs == (pyston::Box*)-1)
+            return false;
+
+        return rhs && pyston::PyEq()(const_cast<pyston::Box*>(lhs), const_cast<pyston::Box*>(rhs));
+    }
+};
+
+} // namespace llvm
+
+namespace pyston {
 class BoxedDict : public Box {
 public:
-    typedef std::unordered_map<Box*, Box*, PyHasher, PyEq, StlCompatAllocator<std::pair<Box*, Box*>>> DictMap;
+    typedef DenseMap<Box*, Box*, llvm::DenseMapInfo<Box*>, detail::DenseMapPair<Box*, Box*>,
+                     StlCompatAllocator<detail::DenseMapPair<Box*, Box*>>> DictMap;
 
     DictMap d;
 


### PR DESCRIPTION
This change didn't seem to help django-template.py performance much, so I was pretty down on it, but it seems to help some microbenchmarks, and gets us -2.4% on geomean:

```
              pyston (calibration)                      :    1.0s baseline: 1.0 (-0.1%)
              pyston django_migrate.py                  :    3.6s baseline: 3.9 (-8.2%)
              pyston interp2.py                         :    6.1s baseline: 6.1 (+0.2%)
              pyston raytrace.py                        :    6.4s baseline: 6.5 (-1.6%)
              pyston nbody.py                           :    8.1s baseline: 8.6 (-6.0%)
              pyston fannkuch.py                        :    7.3s baseline: 7.3 (+0.0%)
              pyston chaos.py                           :   19.7s baseline: 20.1 (-2.1%)
              pyston fasta.py                           :    5.3s baseline: 5.5 (-4.4%)
              pyston pidigits.py                        :    5.7s baseline: 5.6 (+1.8%)
              pyston richards.py                        :    2.9s baseline: 3.0 (-1.6%)
              pyston deltablue.py                       :    2.1s baseline: 2.2 (-1.8%)
              pyston (geomean-8999)                     :    5.6s baseline: 5.7 (-2.4%)
```

This seems like something we could/should upstream to llvm as well
