### PR TITLE
switch to CPython's thread._local implementation

### DIFF
--- a/from_cpython/CMakeLists.txt
+++ b/from_cpython/CMakeLists.txt
@@ -64,6 +64,7 @@ file(GLOB_RECURSE STDMODULE_SRCS Modules
     stringio.c
     stropmodule.c
     textio.c
+    threadmodule.c
     timemodule.c
     unicodedata.c
     util.c

--- a/from_cpython/Include/methodobject.h
+++ b/from_cpython/Include/methodobject.h
@@ -91,15 +91,12 @@ typedef struct PyMethodChain {
 PyAPI_FUNC(PyObject *) Py_FindMethodInChain(PyMethodChain *, PyObject *,
                                             const char *) PYSTON_NOEXCEPT;
 
-// Pyston change: not our format
-#if 0
 typedef struct {
     PyObject_HEAD
     PyMethodDef *m_ml; /* Description of the C function to call */
     PyObject    *m_self; /* Passed as 'self' arg to the C func, can be NULL */
     PyObject    *m_module; /* The __module__ attribute, can be anything */
 } PyCFunctionObject;
-#endif
 
 PyAPI_FUNC(int) PyCFunction_ClearFreeList(void) PYSTON_NOEXCEPT;
 

--- a/from_cpython/Include/methodobject.h
+++ b/from_cpython/Include/methodobject.h
@@ -14,8 +14,8 @@ extern "C" {
 
 // Pyston change: this is no longer a static object
 //PyAPI_DATA(PyTypeObject) PyCFunction_Type;
-PyAPI_DATA(PyTypeObject*) builtin_function_or_method_cls;
-#define PyCFunction_Type (*builtin_function_or_method_cls)
+PyAPI_DATA(PyTypeObject*) capifunc_cls;
+#define PyCFunction_Type (*capifunc_cls)
 
 #define PyCFunction_Check(op) (Py_TYPE(op) == &PyCFunction_Type)
 
@@ -28,6 +28,8 @@ PyAPI_FUNC(PyCFunction) PyCFunction_GetFunction(PyObject *) PYSTON_NOEXCEPT;
 PyAPI_FUNC(PyObject *) PyCFunction_GetSelf(PyObject *) PYSTON_NOEXCEPT;
 PyAPI_FUNC(int) PyCFunction_GetFlags(PyObject *) PYSTON_NOEXCEPT;
 
+// Pyston change: changed to function calls
+#if 0
 /* Macros for direct access to these values. Type checks are *not*
    done, so use with care. */
 #define PyCFunction_GET_FUNCTION(func) \
@@ -36,6 +38,13 @@ PyAPI_FUNC(int) PyCFunction_GetFlags(PyObject *) PYSTON_NOEXCEPT;
 	(((PyCFunctionObject *)func) -> m_self)
 #define PyCFunction_GET_FLAGS(func) \
 	(((PyCFunctionObject *)func) -> m_ml -> ml_flags)
+#endif
+#define PyCFunction_GET_FUNCTION(func) \
+        PyCFunction_GetFunction((PyObject*)(func))
+#define PyCFunction_GET_SELF(func) \
+        PyCFunction_GetSelf((PyObject*)(func))
+#define PyCFunction_GET_FLAGS(func) \
+        PyCFunction_GetFlags((PyObject*)(func))
 PyAPI_FUNC(PyObject *) PyCFunction_Call(PyObject *, PyObject *, PyObject *) PYSTON_NOEXCEPT;
 
 struct PyMethodDef {
@@ -82,12 +91,15 @@ typedef struct PyMethodChain {
 PyAPI_FUNC(PyObject *) Py_FindMethodInChain(PyMethodChain *, PyObject *,
                                             const char *) PYSTON_NOEXCEPT;
 
+// Pyston change: not our format
+#if 0
 typedef struct {
     PyObject_HEAD
     PyMethodDef *m_ml; /* Description of the C function to call */
     PyObject    *m_self; /* Passed as 'self' arg to the C func, can be NULL */
     PyObject    *m_module; /* The __module__ attribute, can be anything */
 } PyCFunctionObject;
+#endif
 
 PyAPI_FUNC(int) PyCFunction_ClearFreeList(void) PYSTON_NOEXCEPT;
 

--- a/from_cpython/Include/pyconfig.h
+++ b/from_cpython/Include/pyconfig.h
@@ -244,14 +244,14 @@
 #define HAVE_SYS_WAIT_H 1
 #define HAVE_TCGETPGRP 1
 #define HAVE_TCSETPGRP 1
-#define HAVE_TEMPNAM 1
+//#define HAVE_TEMPNAM 1 // pyston change: we have them but I dislike the compiler warnings they generate
 #define HAVE_TERM_H 1
 #define HAVE_TERMIOS_H 1
 #define HAVE_TGAMMA 1
 #define HAVE_TIMEGM 1
 #define HAVE_TIMES 1
 #define HAVE_TMPFILE 1
-#define HAVE_TMPNAM 1
+//#define HAVE_TMPNAM 1 // pyston change: we have them but I dislike the compiler warnings they generate
 #define HAVE_TMPNAM_R 1
 #define HAVE_TM_ZONE 1
 #define HAVE_TRUNCATE 1

--- a/from_cpython/Modules/threadmodule.c
+++ b/from_cpython/Modules/threadmodule.c
@@ -13,8 +13,10 @@
 
 #include "pythread.h"
 
-static PyObject *ThreadError;
+// Pyston change: we're only using part of this file
 static PyObject *str_dict;
+#if 0
+static PyObject *ThreadError;
 static long nb_threads = 0;
 
 /* Lock objects */
@@ -173,6 +175,7 @@ newlockobject(void)
     }
     return self;
 }
+#endif
 
 /* Thread-local objects */
 
@@ -236,7 +239,7 @@ static PyTypeObject localdummytype = {
     /* tp_name           */ "_thread._localdummy",
     /* tp_basicsize      */ sizeof(localdummyobject),
     /* tp_itemsize       */ 0,
-    /* tp_dealloc        */ (destructor)localdummy_dealloc,
+    /* tp_dealloc        */ (destructor)/*localdummy_dealloc*/ NULL,
     /* tp_print          */ 0,
     /* tp_getattr        */ 0,
     /* tp_setattr        */ 0,
@@ -389,6 +392,10 @@ local_traverse(localobject *self, visitproc visit, void *arg)
 static int
 local_clear(localobject *self)
 {
+    // Pyston change:
+    Py_FatalError("unexpected call to local_clear()");
+    abort();
+#if 0
     PyThreadState *tstate;
     Py_CLEAR(self->args);
     Py_CLEAR(self->kw);
@@ -406,6 +413,7 @@ local_clear(localobject *self)
                 PyDict_DelItem(tstate->dict, self->key);
     }
     return 0;
+#endif
 }
 
 static void
@@ -490,7 +498,7 @@ static PyTypeObject localtype = {
     /* tp_name           */ "thread._local",
     /* tp_basicsize      */ sizeof(localobject),
     /* tp_itemsize       */ 0,
-    /* tp_dealloc        */ (destructor)local_dealloc,
+    /* tp_dealloc        */ (destructor)/*local_dealloc*/ NULL,
     /* tp_print          */ 0,
     /* tp_getattr        */ 0,
     /* tp_setattr        */ 0,
@@ -589,6 +597,8 @@ _localdummy_destroyed(PyObject *localweakref, PyObject *dummyweakref)
     Py_RETURN_NONE;
 }
 
+// Pyston change:
+#if 0
 /* Module functions */
 
 struct bootstate {
@@ -846,8 +856,11 @@ requiring allocation in multiples of the system memory page size\n\
 - platform documentation should be referred to for more information\n\
 (4kB pages are common; using multiples of 4096 for the stack size is\n\
 the suggested approach in the absence of more specific information).");
+#endif
 
 static PyMethodDef thread_methods[] = {
+// Pyston change:
+#if 0
     {"start_new_thread",        (PyCFunction)thread_PyThread_start_new_thread,
                             METH_VARARGS,
                             start_new_doc},
@@ -871,6 +884,7 @@ static PyMethodDef thread_methods[] = {
     {"stack_size",              (PyCFunction)thread_stack_size,
                             METH_VARARGS,
                             stack_size_doc},
+#endif
     {NULL,                      NULL}           /* sentinel */
 };
 
@@ -909,6 +923,8 @@ initthread(void)
     if (m == NULL)
         return;
 
+    // Pyston change:
+#if 0
     /* Add a symbolic constant */
     d = PyModule_GetDict(m);
     ThreadError = PyGC_AddRoot(PyErr_NewException("thread.error", NULL, NULL));
@@ -918,17 +934,18 @@ initthread(void)
         return;
     Py_INCREF(&Locktype);
     PyDict_SetItemString(d, "LockType", (PyObject *)&Locktype);
+#endif
 
     Py_INCREF(&localtype);
     if (PyModule_AddObject(m, "_local", (PyObject *)&localtype) < 0)
         return;
 
-    nb_threads = 0;
+    //nb_threads = 0; // pyston change
 
     str_dict = PyGC_AddRoot(PyString_InternFromString("__dict__"));
     if (str_dict == NULL)
         return;
 
     /* Initialize the C thread library */
-    PyThread_init_thread();
+    //PyThread_init_thread(); // pyston change
 }

--- a/src/capi/modsupport.cpp
+++ b/src/capi/modsupport.cpp
@@ -425,8 +425,7 @@ extern "C" PyObject* Py_InitModule4(const char* name, PyMethodDef* methods, cons
     while (methods && methods->ml_name) {
         RELEASE_ASSERT((methods->ml_flags & (~(METH_VARARGS | METH_KEYWORDS | METH_NOARGS | METH_O))) == 0, "%d",
                        methods->ml_flags);
-        module->giveAttr(methods->ml_name, new BoxedCApiFunction(methods->ml_flags, passthrough, methods->ml_name,
-                                                                 methods->ml_meth, boxString(name)));
+        module->giveAttr(methods->ml_name, new BoxedCApiFunction(methods, passthrough, boxString(name)));
 
         methods++;
     }

--- a/src/capi/typeobject.cpp
+++ b/src/capi/typeobject.cpp
@@ -27,6 +27,8 @@ static const std::string _getattr_str("__getattr__");
 static const std::string _getattribute_str("__getattribute__");
 typedef int (*update_callback)(PyTypeObject*, void*);
 
+static PyObject* tp_new_wrapper(PyTypeObject* self, BoxedTuple* args, Box* kwds) noexcept;
+
 extern "C" void conservativeGCHandler(GCVisitor* v, Box* b) noexcept {
     v->visitPotentialRange((void* const*)b, (void* const*)((char*)b + b->cls->tp_basicsize));
 }
@@ -1591,8 +1593,6 @@ static const slotdef* update_one_slot(BoxedClass* type, const slotdef* p) noexce
                 else
                     use_generic = 1;
             }
-// TODO Pyston doesn't support PyCFunction_Type yet I think?
-#if 0
         } else if (Py_TYPE(descr) == &PyCFunction_Type && PyCFunction_GET_FUNCTION(descr) == (PyCFunction)tp_new_wrapper
                    && ptr == (void**)&type->tp_new) {
             /* The __new__ wrapper is not a wrapper descriptor,
@@ -1611,7 +1611,6 @@ static const slotdef* update_one_slot(BoxedClass* type, const slotdef* p) noexce
                in this reasoning that requires additional
                sanity checks.  I'll buy the first person to
                point out a bug in this reasoning a beer. */
-#endif
         } else if (offset == offsetof(BoxedClass, tp_descr_get) && descr->cls == function_cls
                    && static_cast<BoxedFunction*>(descr)->f->always_use_version) {
             type->tpp_descr_get = (descrgetfunc) static_cast<BoxedFunction*>(descr)->f->always_use_version->code;

--- a/src/capi/typeobject.cpp
+++ b/src/capi/typeobject.cpp
@@ -1744,12 +1744,16 @@ static PyObject* tp_new_wrapper(PyTypeObject* self, BoxedTuple* args, Box* kwds)
     return self->tp_new(subtype, new_args, kwds);
 }
 
+static struct PyMethodDef tp_new_methoddef[] = { { "__new__", (PyCFunction)tp_new_wrapper, METH_VARARGS | METH_KEYWORDS,
+                                                   PyDoc_STR("T.__new__(S, ...) -> "
+                                                             "a new object with type S, a subtype of T") },
+                                                 { 0, 0, 0, 0 } };
+
 static void add_tp_new_wrapper(BoxedClass* type) noexcept {
     if (type->getattr("__new__"))
         return;
 
-    type->giveAttr("__new__",
-                   new BoxedCApiFunction(METH_VARARGS | METH_KEYWORDS, type, "__new__", (PyCFunction)tp_new_wrapper));
+    type->giveAttr("__new__", new BoxedCApiFunction(tp_new_methoddef, type));
 }
 
 void add_operators(BoxedClass* cls) noexcept {

--- a/src/capi/typeobject.cpp
+++ b/src/capi/typeobject.cpp
@@ -2930,7 +2930,7 @@ extern "C" void PyType_Modified(PyTypeObject* type) noexcept {
 extern "C" int PyType_Ready(PyTypeObject* cls) noexcept {
     ASSERT(!cls->is_pyston_class, "should not call this on Pyston classes");
 
-    gc::registerNonheapRootObject(cls);
+    gc::registerNonheapRootObject(cls, sizeof(PyTypeObject));
 
     // unhandled fields:
     int ALLOWABLE_FLAGS = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC | Py_TPFLAGS_CHECKTYPES

--- a/src/capi/types.h
+++ b/src/capi/types.h
@@ -52,6 +52,8 @@ public:
 
     DEFAULT_CLASS(capifunc_cls);
 
+    PyCFunction getFunction() { return func; }
+
     static BoxedString* __repr__(BoxedCApiFunction* self) {
         assert(self->cls == capifunc_cls);
         return boxStrConstant(self->name);

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -390,6 +390,7 @@ enum class GCKind : uint8_t {
     PRECISE = 3,
     UNTRACKED = 4,
     HIDDEN_CLASS = 5,
+    CONSERVATIVE_PYTHON = 6,
 };
 
 extern "C" void* gc_alloc(size_t nbytes, GCKind kind);

--- a/src/gc/collector.cpp
+++ b/src/gc/collector.cpp
@@ -162,12 +162,13 @@ static std::unordered_set<void*> nonheap_roots;
 // way to verify it's not a nonheap root (the full check requires a hashtable lookup).
 static void* max_nonheap_root = 0;
 static void* min_nonheap_root = (void*)~0;
-void registerNonheapRootObject(void* obj) {
+void registerNonheapRootObject(void* obj, int size) {
     // I suppose that things could work fine even if this were true, but why would it happen?
     assert(global_heap.getAllocationFromInteriorPointer(obj) == NULL);
     assert(nonheap_roots.count(obj) == 0);
 
     nonheap_roots.insert(obj);
+    registerPotentialRootRange(obj, ((uint8_t*)obj) + size);
 
     max_nonheap_root = std::max(obj, max_nonheap_root);
     min_nonheap_root = std::min(obj, min_nonheap_root);
@@ -268,16 +269,6 @@ void markPhase() {
 
     threading::visitAllStacks(&visitor);
     gatherInterpreterRoots(&visitor);
-
-    for (void* p : nonheap_roots) {
-        Box* b = reinterpret_cast<Box*>(p);
-        BoxedClass* cls = b->cls;
-
-        if (cls) {
-            ASSERT(cls->gc_visit, "%s", getTypeName(b));
-            cls->gc_visit(&visitor, b);
-        }
-    }
 
     for (auto h : *getRootHandles()) {
         visitor.visit(h->value);

--- a/src/gc/collector.cpp
+++ b/src/gc/collector.cpp
@@ -180,8 +180,17 @@ bool isNonheapRoot(void* p) {
     return nonheap_roots.count(p) != 0;
 }
 
-bool isValidGCObject(void* p) {
+bool isValidGCMemory(void* p) {
     return isNonheapRoot(p) || (global_heap.getAllocationFromInteriorPointer(p)->user_data == p);
+}
+
+bool isValidGCObject(void* p) {
+    if (isNonheapRoot(p))
+        return true;
+    GCAllocation* al = global_heap.getAllocationFromInteriorPointer(p);
+    if (!al)
+        return false;
+    return al->user_data == p && (al->kind_id == GCKind::CONSERVATIVE_PYTHON || al->kind_id == GCKind::PYTHON);
 }
 
 void setIsPythonObject(Box* b) {

--- a/src/gc/collector.h
+++ b/src/gc/collector.h
@@ -61,6 +61,7 @@ void enableGC();
 // These are mostly for debugging:
 bool isValidGCObject(void* p);
 bool isNonheapRoot(void* p);
+void setIsPythonObject(Box* b);
 
 // Debugging/validation helpers: if a GC should not happen in certain sections (ex during unwinding),
 // use these functions to mark that.  This is different from disableGC/enableGC, since it causes an

--- a/src/gc/collector.h
+++ b/src/gc/collector.h
@@ -60,7 +60,8 @@ void disableGC();
 void enableGC();
 
 // These are mostly for debugging:
-bool isValidGCObject(void* p);
+bool isValidGCMemory(void* p); // if p is a valid gc-allocated pointer (or a non-heap root)
+bool isValidGCObject(void* p); // whether p is valid gc memory and is set to have Python destructor semantics applied
 bool isNonheapRoot(void* p);
 void setIsPythonObject(Box* b);
 

--- a/src/gc/collector.h
+++ b/src/gc/collector.h
@@ -31,7 +31,8 @@ void deregisterPermanentRoot(void* root_obj);
 // Register an object that was not allocated through this collector, as a root for this collector.
 // The motivating usecase is statically-allocated PyTypeObject objects, which are full Python objects
 // even if they are not heap allocated.
-void registerNonheapRootObject(void* obj);
+// This memory will be scanned conservatively.
+void registerNonheapRootObject(void* obj, int size);
 
 void registerPotentialRootRange(void* start, void* end);
 

--- a/src/gc/heap.cpp
+++ b/src/gc/heap.cpp
@@ -470,7 +470,9 @@ SmallArena::Block** SmallArena::_freeChain(Block** head, std::vector<Box*>& weak
             } else {
                 if (_doFree(al, &weakly_referenced)) {
                     b->isfree.set(atom_idx);
-                    // memset(al->user_data, 0, b->size - sizeof(GCAllocation));
+#ifndef NDEBUG
+                    memset(al->user_data, 0xbb, b->size - sizeof(GCAllocation));
+#endif
                 }
             }
         }

--- a/src/gc/heap.cpp
+++ b/src/gc/heap.cpp
@@ -152,7 +152,7 @@ bool _doFree(GCAllocation* al, std::vector<Box*>* weakly_referenced) {
     VALGRIND_ENABLE_ERROR_REPORTING;
 #endif
 
-    if (alloc_kind == GCKind::PYTHON) {
+    if (alloc_kind == GCKind::PYTHON || alloc_kind == GCKind::CONSERVATIVE_PYTHON) {
 #ifndef NVALGRIND
         VALGRIND_DISABLE_ERROR_REPORTING;
 #endif
@@ -170,7 +170,11 @@ bool _doFree(GCAllocation* al, std::vector<Box*>* weakly_referenced) {
             }
         }
 
-        ASSERT(b->cls->tp_dealloc == NULL, "%s", getTypeName(b));
+        // XXX: we are currently ignoring destructors (tp_dealloc) for extension objects, since we have
+        // historically done that (whoops) and there are too many to be worth changing for now as long
+        // as we can get real destructor support soon.
+        ASSERT(b->cls->tp_dealloc == NULL || alloc_kind == GCKind::CONSERVATIVE_PYTHON, "%s", getTypeName(b));
+
         if (b->cls->simple_destructor)
             b->cls->simple_destructor(b);
     }
@@ -208,7 +212,7 @@ struct HeapStatistics {
     int num_hcls_by_attrs[HCLS_ATTRS_STAT_MAX + 1];
     int num_hcls_by_attrs_exceed;
 
-    TypeStats python, conservative, untracked, hcls, precise;
+    TypeStats python, conservative, conservative_python, untracked, hcls, precise;
     TypeStats total;
 
     HeapStatistics(bool collect_cls_stats, bool collect_hcls_stats)
@@ -247,6 +251,17 @@ void addStatistic(HeapStatistics* stats, GCAllocation* al, int nbytes) {
     } else if (al->kind_id == GCKind::CONSERVATIVE) {
         stats->conservative.nallocs++;
         stats->conservative.nbytes += nbytes;
+    } else if (al->kind_id == GCKind::CONSERVATIVE_PYTHON) {
+        stats->conservative_python.nallocs++;
+        stats->conservative_python.nbytes += nbytes;
+
+        if (stats->collect_cls_stats) {
+            Box* b = (Box*)al->user_data;
+            auto& t = stats->by_cls[b->cls];
+
+            t.nallocs++;
+            t.nbytes += nbytes;
+        }
     } else if (al->kind_id == GCKind::UNTRACKED) {
         stats->untracked.nallocs++;
         stats->untracked.nbytes += nbytes;
@@ -288,6 +303,7 @@ void Heap::dumpHeapStatistics(int level) {
 
     stats.python.print("python");
     stats.conservative.print("conservative");
+    stats.conservative_python.print("conservative_python");
     stats.untracked.print("untracked");
     stats.hcls.print("hcls");
     stats.precise.print("precise");

--- a/src/runtime/builtin_modules/sys.cpp
+++ b/src/runtime/builtin_modules/sys.cpp
@@ -498,7 +498,7 @@ void setupSys() {
     sys_flags_cls->freeze();
 
     for (auto& md : sys_methods) {
-        sys_module->giveAttr(md.ml_name, new BoxedCApiFunction(md.ml_flags, sys_module, md.ml_name, md.ml_meth));
+        sys_module->giveAttr(md.ml_name, new BoxedCApiFunction(&md, sys_module));
     }
 
     sys_module->giveAttr("flags", new BoxedSysFlags());

--- a/src/runtime/capi.cpp
+++ b/src/runtime/capi.cpp
@@ -258,15 +258,215 @@ extern "C" PyObject* PyObject_GenericGetAttr(PyObject* o, PyObject* name) noexce
     }
 }
 
+// Note (kmod): I don't feel great about including an alternate code-path for lookups.  I also, however, don't feel
+// great about modifying our code paths to take a custom dict, and since this code is just copied from CPython
+// I feel like the risk is pretty low.
 extern "C" PyObject* _PyObject_GenericGetAttrWithDict(PyObject* obj, PyObject* name, PyObject* dict) noexcept {
-    fatalOrError(PyExc_NotImplementedError, "unimplemented");
-    return nullptr;
+    PyTypeObject* tp = Py_TYPE(obj);
+    PyObject* descr = NULL;
+    PyObject* res = NULL;
+    descrgetfunc f;
+    Py_ssize_t dictoffset;
+    PyObject** dictptr;
+
+    if (!PyString_Check(name)) {
+#ifdef Py_USING_UNICODE
+        /* The Unicode to string conversion is done here because the
+           existing tp_setattro slots expect a string object as name
+           and we wouldn't want to break those. */
+        if (PyUnicode_Check(name)) {
+            name = PyUnicode_AsEncodedString(name, NULL, NULL);
+            if (name == NULL)
+                return NULL;
+        } else
+#endif
+        {
+            PyErr_Format(PyExc_TypeError, "attribute name must be string, not '%.200s'", Py_TYPE(name)->tp_name);
+            return NULL;
+        }
+    } else
+        Py_INCREF(name);
+
+    if (tp->tp_dict == NULL) {
+        if (PyType_Ready(tp) < 0)
+            goto done;
+    }
+
+#if 0 /* XXX this is not quite _PyType_Lookup anymore */
+    /* Inline _PyType_Lookup */
+    {
+        Py_ssize_t i, n;
+        PyObject *mro, *base, *dict;
+
+        /* Look in tp_dict of types in MRO */
+        mro = tp->tp_mro;
+        assert(mro != NULL);
+        assert(PyTuple_Check(mro));
+        n = PyTuple_GET_SIZE(mro);
+        for (i = 0; i < n; i++) {
+            base = PyTuple_GET_ITEM(mro, i);
+            if (PyClass_Check(base))
+                dict = ((PyClassObject *)base)->cl_dict;
+            else {
+                assert(PyType_Check(base));
+                dict = ((PyTypeObject *)base)->tp_dict;
+            }
+            assert(dict && PyDict_Check(dict));
+            descr = PyDict_GetItem(dict, name);
+            if (descr != NULL)
+                break;
+        }
+    }
+#else
+    descr = _PyType_Lookup(tp, name);
+#endif
+
+    Py_XINCREF(descr);
+
+    f = NULL;
+    if (descr != NULL && PyType_HasFeature(descr->cls, Py_TPFLAGS_HAVE_CLASS)) {
+        f = descr->cls->tp_descr_get;
+        if (f != NULL && PyDescr_IsData(descr)) {
+            res = f(descr, obj, (PyObject*)obj->cls);
+            Py_DECREF(descr);
+            goto done;
+        }
+    }
+
+    if (dict == NULL) {
+        /* Inline _PyObject_GetDictPtr */
+        dictoffset = tp->tp_dictoffset;
+        if (dictoffset != 0) {
+            if (dictoffset < 0) {
+                Py_ssize_t tsize;
+                size_t size;
+
+                tsize = ((PyVarObject*)obj)->ob_size;
+                if (tsize < 0)
+                    tsize = -tsize;
+                size = _PyObject_VAR_SIZE(tp, tsize);
+
+                dictoffset += (long)size;
+                assert(dictoffset > 0);
+                assert(dictoffset % SIZEOF_VOID_P == 0);
+            }
+            dictptr = (PyObject**)((char*)obj + dictoffset);
+            dict = *dictptr;
+        }
+    }
+    if (dict != NULL) {
+        Py_INCREF(dict);
+        res = PyDict_GetItem(dict, name);
+        if (res != NULL) {
+            Py_INCREF(res);
+            Py_XDECREF(descr);
+            Py_DECREF(dict);
+            goto done;
+        }
+        Py_DECREF(dict);
+    }
+
+    if (f != NULL) {
+        res = f(descr, obj, (PyObject*)Py_TYPE(obj));
+        Py_DECREF(descr);
+        goto done;
+    }
+
+    if (descr != NULL) {
+        res = descr;
+        /* descr was already increfed above */
+        goto done;
+    }
+
+    PyErr_Format(PyExc_AttributeError, "'%.50s' object has no attribute '%.400s'", tp->tp_name,
+                 PyString_AS_STRING(name));
+done:
+    Py_DECREF(name);
+    return res;
 }
 
+// (see note for _PyObject_GenericGetAttrWithDict)
 extern "C" int _PyObject_GenericSetAttrWithDict(PyObject* obj, PyObject* name, PyObject* value,
                                                 PyObject* dict) noexcept {
-    fatalOrError(PyExc_NotImplementedError, "unimplemented");
-    return -1;
+    PyTypeObject* tp = Py_TYPE(obj);
+    PyObject* descr;
+    descrsetfunc f;
+    PyObject** dictptr;
+    int res = -1;
+
+    if (!PyString_Check(name)) {
+#ifdef Py_USING_UNICODE
+        /* The Unicode to string conversion is done here because the
+           existing tp_setattro slots expect a string object as name
+           and we wouldn't want to break those. */
+        if (PyUnicode_Check(name)) {
+            name = PyUnicode_AsEncodedString(name, NULL, NULL);
+            if (name == NULL)
+                return -1;
+        } else
+#endif
+        {
+            PyErr_Format(PyExc_TypeError, "attribute name must be string, not '%.200s'", Py_TYPE(name)->tp_name);
+            return -1;
+        }
+    } else
+        Py_INCREF(name);
+
+    if (tp->tp_dict == NULL) {
+        if (PyType_Ready(tp) < 0)
+            goto done;
+    }
+
+    descr = _PyType_Lookup(tp, name);
+    f = NULL;
+    if (descr != NULL && PyType_HasFeature(descr->cls, Py_TPFLAGS_HAVE_CLASS)) {
+        f = descr->cls->tp_descr_set;
+        if (f != NULL && PyDescr_IsData(descr)) {
+            res = f(descr, obj, value);
+            goto done;
+        }
+    }
+
+    if (dict == NULL) {
+        dictptr = _PyObject_GetDictPtr(obj);
+        if (dictptr != NULL) {
+            dict = *dictptr;
+            if (dict == NULL && value != NULL) {
+                dict = PyDict_New();
+                if (dict == NULL)
+                    goto done;
+                *dictptr = dict;
+            }
+        }
+    }
+    if (dict != NULL) {
+        Py_INCREF(dict);
+        if (value == NULL)
+            res = PyDict_DelItem(dict, name);
+        else
+            res = PyDict_SetItem(dict, name, value);
+        if (res < 0 && PyErr_ExceptionMatches(PyExc_KeyError))
+            PyErr_SetObject(PyExc_AttributeError, name);
+        Py_DECREF(dict);
+        goto done;
+    }
+
+    if (f != NULL) {
+        res = f(descr, obj, value);
+        goto done;
+    }
+
+    if (descr == NULL) {
+        PyErr_Format(PyExc_AttributeError, "'%.100s' object has no attribute '%.200s'", tp->tp_name,
+                     PyString_AS_STRING(name));
+        goto done;
+    }
+
+    PyErr_Format(PyExc_AttributeError, "'%.50s' object attribute '%.400s' is read-only", tp->tp_name,
+                 PyString_AS_STRING(name));
+done:
+    Py_DECREF(name);
+    return res;
 }
 
 

--- a/src/runtime/capi.cpp
+++ b/src/runtime/capi.cpp
@@ -91,8 +91,12 @@ extern "C" PyVarObject* PyObject_InitVar(PyVarObject* op, PyTypeObject* tp, Py_s
 
     RELEASE_ASSERT(op, "");
     RELEASE_ASSERT(tp, "");
+
+    gc::setIsPythonObject(op);
+
     Py_TYPE(op) = tp;
     op->ob_size = size;
+
     return op;
 }
 

--- a/src/runtime/capi.cpp
+++ b/src/runtime/capi.cpp
@@ -1273,7 +1273,7 @@ extern "C" PyCFunction PyCFunction_GetFunction(PyObject* op) noexcept {
         PyErr_BadInternalCall();
         return NULL;
     }
-    return ((PyCFunctionObject*)op)->m_ml->ml_meth;
+    return static_cast<BoxedCApiFunction*>(op)->getFunction();
 }
 
 extern "C" int _PyEval_SliceIndex(PyObject* v, Py_ssize_t* pi) noexcept {

--- a/src/runtime/capi.cpp
+++ b/src/runtime/capi.cpp
@@ -85,21 +85,6 @@ extern "C" void _PyErr_BadInternalCall(const char* filename, int lineno) noexcep
     Py_FatalError("unimplemented");
 }
 
-extern "C" PyVarObject* PyObject_InitVar(PyVarObject* op, PyTypeObject* tp, Py_ssize_t size) noexcept {
-    assert(gc::isValidGCObject(op));
-    assert(gc::isValidGCObject(tp));
-
-    RELEASE_ASSERT(op, "");
-    RELEASE_ASSERT(tp, "");
-
-    gc::setIsPythonObject(op);
-
-    Py_TYPE(op) = tp;
-    op->ob_size = size;
-
-    return op;
-}
-
 extern "C" PyObject* PyObject_Format(PyObject* obj, PyObject* format_spec) noexcept {
     PyObject* empty = NULL;
     PyObject* result = NULL;

--- a/src/runtime/capi.cpp
+++ b/src/runtime/capi.cpp
@@ -1645,7 +1645,7 @@ static Box* methodGetDoc(Box* b, void*) {
 
 extern "C" PyObject* _PyObject_GC_Malloc(size_t basicsize) noexcept {
     Box* r = ((PyObject*)PyObject_MALLOC(basicsize));
-    RELEASE_ASSERT(gc::isValidGCObject(r), "");
+    RELEASE_ASSERT(gc::isValidGCMemory(r), "");
     return r;
 }
 

--- a/src/runtime/objmodel.cpp
+++ b/src/runtime/objmodel.cpp
@@ -2338,7 +2338,7 @@ extern "C" void dumpEx(void* p, int levels) {
     printf("\n");
     printf("Raw address: %p\n", p);
 
-    bool is_gc = gc::isValidGCObject(p);
+    bool is_gc = gc::isValidGCMemory(p);
     if (!is_gc) {
         printf("non-gc memory\n");
         return;

--- a/src/runtime/objmodel.cpp
+++ b/src/runtime/objmodel.cpp
@@ -901,6 +901,16 @@ void Box::setattr(const std::string& attr, Box* val, SetattrRewriteArgs* rewrite
     abort();
 }
 
+extern "C" PyObject* _PyType_Lookup(PyTypeObject* type, PyObject* name) noexcept {
+    RELEASE_ASSERT(name->cls == str_cls, "");
+    try {
+        return typeLookup(type, static_cast<BoxedString*>(name)->s(), NULL);
+    } catch (ExcInfo e) {
+        setCAPIException(e);
+        return NULL;
+    }
+}
+
 Box* typeLookup(BoxedClass* cls, const std::string& attr, GetattrRewriteArgs* rewrite_args) {
     Box* val;
 

--- a/src/runtime/objmodel.cpp
+++ b/src/runtime/objmodel.cpp
@@ -4513,23 +4513,10 @@ Box* typeCallInternal(BoxedFunctionBase* f, CallRewriteArgs* rewrite_args, ArgPa
     // Notably, "type" itself does not.  For instance, assuming M is a subclass of
     // type, type.__new__(M, 1) will return the int class, which is not an instance of M.
 
-    static Box* object_new = NULL;
-    static Box* object_init = NULL;
     // this is ok with not using StlCompatAllocator since we will manually register these objects with the GC
     static std::vector<Box*> allowable_news;
-    if (!object_new) {
-        object_new = typeLookup(object_cls, new_str, NULL);
-        assert(object_new);
-        // I think this is unnecessary, but good form:
-        gc::registerPermanentRoot(object_new);
-
-        object_init = typeLookup(object_cls, init_str, NULL);
-        assert(object_init);
-        gc::registerPermanentRoot(object_init);
-
-        allowable_news.push_back(object_new);
-
-        for (BoxedClass* allowed_cls : { enumerate_cls, xrange_cls }) {
+    if (allowable_news.empty()) {
+        for (BoxedClass* allowed_cls : { object_cls, enumerate_cls, xrange_cls }) {
             auto new_obj = typeLookup(allowed_cls, new_str, NULL);
             gc::registerPermanentRoot(new_obj);
             allowable_news.push_back(new_obj);
@@ -4585,16 +4572,9 @@ Box* typeCallInternal(BoxedFunctionBase* f, CallRewriteArgs* rewrite_args, ArgPa
     RewriterVar* r_made = NULL;
 
     ArgPassSpec new_argspec = argspec;
-    if (npassed_args > 1 && new_attr == object_new) {
-        if (init_attr == object_init) {
-            raiseExcHelper(TypeError, objectNewParameterTypeErrorMsg());
-        } else {
-            new_argspec = ArgPassSpec(1);
-        }
-    }
 
     if (rewrite_args) {
-        if (new_attr == object_new && init_attr != object_init) {
+        if (cls->tp_new == object_cls->tp_new && cls->tp_init != object_cls->tp_init) {
             // Fast case: if we are calling object_new, we normally doesn't look at the arguments at all.
             // (Except in the case when init_attr != object_init, in which case object_new looks at the number
             // of arguments and throws an exception.)
@@ -4660,7 +4640,7 @@ Box* typeCallInternal(BoxedFunctionBase* f, CallRewriteArgs* rewrite_args, ArgPa
         }
     }
 
-    if (init_attr && init_attr != object_init) {
+    if (init_attr && made->cls->tp_init != object_cls->tp_init) {
         // TODO apply the same descriptor special-casing as in callattr?
 
         Box* initrtn;
@@ -4722,8 +4702,10 @@ Box* typeCallInternal(BoxedFunctionBase* f, CallRewriteArgs* rewrite_args, ArgPa
 Box* typeCall(Box* obj, BoxedTuple* vararg, BoxedDict* kwargs) {
     assert(vararg->cls == tuple_cls);
 
+    bool pass_kwargs = (kwargs && kwargs->d.size());
+
     int n = vararg->size();
-    int args_to_pass = n + 2; // 1 for obj, 1 for kwargs
+    int args_to_pass = n + 1 + (pass_kwargs ? 1 : 0); // 1 for obj, 1 for kwargs
 
     Box** args = NULL;
     if (args_to_pass > 3)
@@ -4734,9 +4716,11 @@ Box* typeCall(Box* obj, BoxedTuple* vararg, BoxedDict* kwargs) {
     for (int i = 0; i < n; i++) {
         getArg(i + 1, arg1, arg2, arg3, args) = vararg->elts[i];
     }
-    getArg(n + 1, arg1, arg2, arg3, args) = kwargs;
 
-    return typeCallInternal(NULL, NULL, ArgPassSpec(n + 1, 0, false, true), arg1, arg2, arg3, args, NULL);
+    if (pass_kwargs)
+        getArg(n + 1, arg1, arg2, arg3, args) = kwargs;
+
+    return typeCallInternal(NULL, NULL, ArgPassSpec(n + 1, 0, false, pass_kwargs), arg1, arg2, arg3, args, NULL);
 }
 
 extern "C" void delGlobal(Box* globals, const std::string* name) {

--- a/src/runtime/types.cpp
+++ b/src/runtime/types.cpp
@@ -1731,26 +1731,45 @@ Box* objectNewNoArgs(BoxedClass* cls) {
     return new (cls) Box();
 }
 
-Box* objectNew(BoxedClass* cls, BoxedTuple* args, BoxedDict* kwargs) {
-    assert(isSubclass(cls->cls, type_cls));
-    assert(args->cls == tuple_cls);
-    assert(kwargs->cls == dict_cls);
-
-    // We use a different strategy from CPython: we let object.__new__ take extra
-    // arguments, but raise an error if they wouldn't be handled by the corresponding init.
-    // TODO switch to the CPython approach?
-    if (args->size() != 0 || kwargs->d.size() != 0) {
-        // TODO slow (We already cache these in typeCall -- should use that here too?)
-        if (typeLookup(cls, "__new__", NULL) != typeLookup(object_cls, "__new__", NULL)
-            || typeLookup(cls, "__init__", NULL) == typeLookup(object_cls, "__init__", NULL))
-            raiseExcHelper(TypeError, objectNewParameterTypeErrorMsg());
-    }
-
-    return new (cls) Box();
+static int excess_args(PyObject* args, PyObject* kwds) noexcept {
+    return PyTuple_GET_SIZE(args) || (kwds && PyDict_Check(kwds) && PyDict_Size(kwds));
 }
 
-Box* objectInit(Box* b, BoxedTuple* args) {
-    return None;
+static PyObject* object_new(PyTypeObject* type, PyObject* args, PyObject* kwds) noexcept;
+
+static int object_init(PyObject* self, PyObject* args, PyObject* kwds) noexcept {
+    int err = 0;
+    if (excess_args(args, kwds)) {
+        PyTypeObject* type = Py_TYPE(self);
+        if (type->tp_init != object_init && type->tp_new != object_new) {
+            err = PyErr_WarnEx(PyExc_DeprecationWarning, "object.__init__() takes no parameters", 1);
+        } else if (type->tp_init != object_init || type->tp_new == object_new) {
+            PyErr_SetString(PyExc_TypeError, "object.__init__() takes no parameters");
+            err = -1;
+        }
+    }
+    return err;
+}
+
+static PyObject* object_new(PyTypeObject* type, PyObject* args, PyObject* kwds) noexcept {
+    int err = 0;
+    if (excess_args(args, kwds)) {
+        if (type->tp_new != object_new && type->tp_init != object_init) {
+            err = PyErr_WarnEx(PyExc_DeprecationWarning, "object() takes no parameters", 1);
+        } else if (type->tp_new != object_new || type->tp_init == object_init) {
+            PyErr_SetString(PyExc_TypeError, "object() takes no parameters");
+            err = -1;
+        }
+    }
+    if (err < 0)
+        return NULL;
+
+    if (type->tp_flags & Py_TPFLAGS_IS_ABSTRACT) {
+        // I don't know what this is or when it happens, but
+        // CPython does something special with it
+        Py_FatalError("unimplemented");
+    }
+    return type->tp_alloc(type, 0);
 }
 
 Box* objectRepr(Box* obj) {
@@ -2430,6 +2449,8 @@ void setupRuntime() {
 
     object_cls->tp_getattro = PyObject_GenericGetAttr;
     object_cls->tp_setattro = PyObject_GenericSetAttr;
+    object_cls->tp_init = object_init;
+    object_cls->tp_new = object_new;
     add_operators(object_cls);
 
     object_cls->finishInitialization();
@@ -2494,8 +2515,6 @@ void setupRuntime() {
     SET = typeFromClass(set_cls);
     FROZENSET = typeFromClass(frozenset_cls);
 
-    object_cls->giveAttr("__new__", new BoxedFunction(boxRTFunction((void*)objectNew, UNKNOWN, 1, 0, true, true)));
-    object_cls->giveAttr("__init__", new BoxedFunction(boxRTFunction((void*)objectInit, UNKNOWN, 1, 0, true, false)));
     object_cls->giveAttr("__repr__", new BoxedFunction(boxRTFunction((void*)objectRepr, UNKNOWN, 1, 0, false, false)));
     object_cls->giveAttr("__str__", new BoxedFunction(boxRTFunction((void*)objectStr, UNKNOWN, 1, 0, false, false)));
     object_cls->giveAttr("__hash__",
@@ -2548,6 +2567,8 @@ void setupRuntime() {
     }
     object_cls->giveAttr("__class__", new (pyston_getset_cls) BoxedGetsetDescriptor(objectClass, objectSetClass, NULL));
     object_cls->freeze();
+    assert(object_cls->tp_init == object_init);
+    assert(object_cls->tp_new == object_new);
 
     setupBool();
     setupLong();

--- a/src/runtime/types.cpp
+++ b/src/runtime/types.cpp
@@ -2233,11 +2233,11 @@ inline void initUserAttrs(Box* obj, BoxedClass* cls) {
 extern "C" void PyCallIter_AddHasNext();
 
 extern "C" PyVarObject* PyObject_InitVar(PyVarObject* op, PyTypeObject* tp, Py_ssize_t size) noexcept {
-    assert(gc::isValidGCObject(op));
-    assert(gc::isValidGCObject(tp));
+    assert(op);
+    assert(tp);
 
-    RELEASE_ASSERT(op, "");
-    RELEASE_ASSERT(tp, "");
+    assert(gc::isValidGCMemory(op));
+    assert(gc::isValidGCObject(tp));
 
     gc::setIsPythonObject(op);
 
@@ -2251,7 +2251,7 @@ extern "C" PyObject* PyObject_Init(PyObject* op, PyTypeObject* tp) noexcept {
     assert(op);
     assert(tp);
 
-    assert(gc::isValidGCObject(op));
+    assert(gc::isValidGCMemory(op));
     assert(gc::isValidGCObject(tp));
 
     gc::setIsPythonObject(op);

--- a/src/runtime/types.cpp
+++ b/src/runtime/types.cpp
@@ -144,8 +144,8 @@ extern "C" PyObject* PystonType_GenericAlloc(BoxedClass* cls, Py_ssize_t nitems)
 
 extern "C" PyObject* PyType_GenericAlloc(PyTypeObject* type, Py_ssize_t nitems) noexcept {
     PyObject* obj;
-    const size_t size = _PyObject_VAR_SIZE(type, nitems);
-    /* note that we need to add one, for the sentinel */
+    const size_t size = _PyObject_VAR_SIZE(type, nitems + 1);
+    /* note that we need to add one, for the sentinel [CPython comment] */
 
     if (PyType_IS_GC(type))
         obj = _PyObject_GC_Malloc(size);
@@ -2215,6 +2215,8 @@ extern "C" PyObject* PyObject_Init(PyObject* op, PyTypeObject* tp) noexcept {
 
     assert(gc::isValidGCObject(op));
     assert(gc::isValidGCObject(tp));
+
+    gc::setIsPythonObject(op);
 
     Py_TYPE(op) = tp;
 

--- a/test/tests/class_noctor.py
+++ b/test/tests/class_noctor.py
@@ -1,7 +1,3 @@
-# should_error
-# skip-if: sys.version_info < (2, 7, 4)
-# - Error message changed in 2.7.4
-
 # Regression test:
 # If the init function doesn't exist, shouldn't just silently ignore any args
 # that got passed
@@ -16,5 +12,8 @@ print "This should have worked"
 class D(object):
     pass
 
-d = D(1)
-print "This should have failed"
+try:
+    d = D(1)
+    print "This should have failed"
+except TypeError as e:
+    print "expected exception" # the message got changed in 2.7.4

--- a/test/tests/object_new_arguments.py
+++ b/test/tests/object_new_arguments.py
@@ -1,7 +1,3 @@
-# should_error
-# skip-if: sys.version_info < (2, 7, 4)
-# - Error message changed in 2.7.4
-
 # object.__new__ doesn't complain if __init__ is overridden:
 
 class C1(object):
@@ -16,4 +12,12 @@ object.__new__(C1, 1)
 object.__new__(C1, a=1)
 
 print "Trying C2"
-object.__new__(C2, 1)
+try:
+    object.__new__(C2, 1)
+except TypeError as e:
+    print "caught TypeError"
+
+# These are some tricky cases, since they can potentially look like arguments
+# are being passed, but really they are not.
+type.__call__(*[C2])
+type.__call__(C2, **{})

--- a/test/tests/threading_local.py
+++ b/test/tests/threading_local.py
@@ -12,12 +12,14 @@ class CustomThreadingLocal(threading.local):
         self.n += 1
         print self.a, self.n
 print CustomThreadingLocal().a
-print CustomThreadingLocal().a
+c = CustomThreadingLocal()
+print c.a
 
 def f():
+    print
     a.x = "goodbye world"
     print a.x
-    print CustomThreadingLocal().a
+    print c.a
     print CustomThreadingLocal().a
 
 def test():
@@ -35,4 +37,7 @@ for i in xrange(10):
 print a.x
 a.__setattr__('x', 5)
 print a.x
+print sorted(a.__dict__.items())
+
+del a.x
 print sorted(a.__dict__.items())

--- a/test/tests/weakrefs_extensions.py
+++ b/test/tests/weakrefs_extensions.py
@@ -1,0 +1,19 @@
+# Make sure we can support weakrefs on extension objects.
+# The _sre.SRE_Pattern type is one of the few builtin types that supports weakrefs natively.
+
+import _sre
+
+def f(n):
+    if n:
+        return f(n-1)
+    p = _sre.compile('', 0, [1])
+    print type(p)
+    return weakref.ref(p)
+
+import weakref
+r = f(20)
+
+import gc
+gc.collect()
+
+print r()


### PR DESCRIPTION
Gives us some nice features, but had some more dependencies than I anticipated:
- setting object.tp_init properly (cpython wants to check `cls->tp_init == object_cls->tp_init`)
- supporting weakrefs on extension types