### PR TITLE
Convert runtime functions to take llvm::StringRef

### DIFF
--- a/from_cpython/Objects/floatobject.c
+++ b/from_cpython/Objects/floatobject.c
@@ -412,6 +412,8 @@ float_str(PyFloatObject *v)
  * coercion to double.  So this part is painful too.
  */
 
+// Pyston change: don't need this for now
+#if 0
 static PyObject*
 float_richcompare(PyObject *v, PyObject *w, int op)
 {
@@ -625,6 +627,7 @@ float_richcompare(PyObject *v, PyObject *w, int op)
     Py_INCREF(Py_NotImplemented);
     return Py_NotImplemented;
 }
+#endif
 
 static long
 float_hash(PyFloatObject *v)
@@ -687,6 +690,8 @@ float_div(PyObject *v, PyObject *w)
     return PyFloat_FromDouble(a);
 }
 
+// Pyston change: don't need this for now
+#if 0
 static PyObject *
 float_classic_div(PyObject *v, PyObject *w)
 {
@@ -708,6 +713,7 @@ float_classic_div(PyObject *v, PyObject *w)
     PyFPE_END_PROTECT(a)
     return PyFloat_FromDouble(a);
 }
+#endif
 
 static PyObject *
 float_rem(PyObject *v, PyObject *w)
@@ -2081,6 +2087,8 @@ PyDoc_STRVAR(float_doc,
 Convert a string or number to a floating point number, if possible.");
 
 
+// Pyston change: don't need this for now
+#if 0
 static PyNumberMethods float_as_number = {
     float_add,          /*nb_add*/
     float_sub,          /*nb_subtract*/
@@ -2121,6 +2129,7 @@ static PyNumberMethods float_as_number = {
     0,                  /* nb_inplace_floor_divide */
     0,                  /* nb_inplace_true_divide */
 };
+#endif
 
 // pyston change: don't need this
 #if 0

--- a/src/codegen/ast_interpreter.cpp
+++ b/src/codegen/ast_interpreter.cpp
@@ -959,15 +959,15 @@ Value ASTInterpreter::visit_print(AST_Print* node) {
         // begin code for handling of softspace
         bool new_softspace = (i < nvals - 1) || (!node->nl);
         if (softspace(dest, new_softspace)) {
-            callattrInternal(dest, &write_str, CLASS_OR_INST, 0, ArgPassSpec(1), boxString(space_str), 0, 0, 0, 0);
+            callattrInternal(dest, write_str, CLASS_OR_INST, 0, ArgPassSpec(1), boxString(space_str), 0, 0, 0, 0);
         }
 
         Box* str_or_unicode_var = (var->cls == unicode_cls) ? var : str(var);
-        callattrInternal(dest, &write_str, CLASS_OR_INST, 0, ArgPassSpec(1), str_or_unicode_var, 0, 0, 0, 0);
+        callattrInternal(dest, write_str, CLASS_OR_INST, 0, ArgPassSpec(1), str_or_unicode_var, 0, 0, 0, 0);
     }
 
     if (node->nl) {
-        callattrInternal(dest, &write_str, CLASS_OR_INST, 0, ArgPassSpec(1), boxString(newline_str), 0, 0, 0, 0);
+        callattrInternal(dest, write_str, CLASS_OR_INST, 0, ArgPassSpec(1), boxString(newline_str), 0, 0, 0, 0);
         if (nvals == 0) {
             softspace(dest, false);
         }

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -480,18 +480,18 @@ public:
     BoxedDict* getDict();
 
 
-    void setattr(const std::string& attr, Box* val, SetattrRewriteArgs* rewrite_args);
-    void giveAttr(const std::string& attr, Box* val) {
+    void setattr(llvm::StringRef attr, Box* val, SetattrRewriteArgs* rewrite_args);
+    void giveAttr(llvm::StringRef attr, Box* val) {
         assert(!this->hasattr(attr));
         this->setattr(attr, val, NULL);
     }
 
     // getattr() does the equivalent of PyDict_GetItem(obj->dict, attr): it looks up the attribute's value on the
     // object's attribute storage. it doesn't look at other objects or do any descriptor logic.
-    Box* getattr(const std::string& attr, GetattrRewriteArgs* rewrite_args);
-    Box* getattr(const std::string& attr) { return getattr(attr, NULL); }
-    bool hasattr(const std::string& attr) { return getattr(attr) != NULL; }
-    void delattr(const std::string& attr, DelattrRewriteArgs* rewrite_args);
+    Box* getattr(llvm::StringRef attr, GetattrRewriteArgs* rewrite_args);
+    Box* getattr(llvm::StringRef attr) { return getattr(attr, NULL); }
+    bool hasattr(llvm::StringRef attr) { return getattr(attr) != NULL; }
+    void delattr(llvm::StringRef attr, DelattrRewriteArgs* rewrite_args);
 
     // Only valid for hc-backed instances:
     Box* getAttrWrapper();

--- a/src/runtime/objmodel.h
+++ b/src/runtime/objmodel.h
@@ -53,7 +53,7 @@ extern "C" void my_assert(bool b);
 extern "C" Box* getattr(Box* obj, const char* attr);
 extern "C" void setattr(Box* obj, const char* attr, Box* attr_val);
 extern "C" void delattr(Box* obj, const char* attr);
-extern "C" void delattrGeneric(Box* obj, const std::string& attr, DelattrRewriteArgs* rewrite_args);
+extern "C" void delattrGeneric(Box* obj, llvm::StringRef attr, DelattrRewriteArgs* rewrite_args);
 extern "C" bool nonzero(Box* obj);
 extern "C" Box* runtimeCall(Box*, ArgPassSpec, Box*, Box*, Box*, Box**, const std::vector<const std::string*>*);
 extern "C" Box* callattr(Box*, const std::string*, CallattrFlags, ArgPassSpec, Box*, Box*, Box*, Box**,
@@ -97,7 +97,7 @@ extern "C" void dump(void* p);
 extern "C" void dumpEx(void* p, int levels = 0);
 
 struct SetattrRewriteArgs;
-void setattrGeneric(Box* obj, const std::string& attr, Box* val, SetattrRewriteArgs* rewrite_args);
+void setattrGeneric(Box* obj, llvm::StringRef attr, Box* val, SetattrRewriteArgs* rewrite_args);
 
 struct BinopRewriteArgs;
 extern "C" Box* binopInternal(Box* lhs, Box* rhs, int op_type, bool inplace, BinopRewriteArgs* rewrite_args);
@@ -119,27 +119,26 @@ enum LookupScope {
     INST_ONLY = 2,
     CLASS_OR_INST = 3,
 };
-extern "C" Box* callattrInternal(Box* obj, const std::string* attr, LookupScope, CallRewriteArgs* rewrite_args,
+extern "C" Box* callattrInternal(Box* obj, llvm::StringRef attr, LookupScope, CallRewriteArgs* rewrite_args,
                                  ArgPassSpec argspec, Box* arg1, Box* arg2, Box* arg3, Box** args,
                                  const std::vector<const std::string*>* keyword_names);
-extern "C" void delattr_internal(Box* obj, const std::string& attr, bool allow_custom,
-                                 DelattrRewriteArgs* rewrite_args);
+extern "C" void delattr_internal(Box* obj, llvm::StringRef attr, bool allow_custom, DelattrRewriteArgs* rewrite_args);
 struct CompareRewriteArgs;
 Box* compareInternal(Box* lhs, Box* rhs, int op_type, CompareRewriteArgs* rewrite_args);
 
 // This is the equivalent of PyObject_GetAttr. Unlike getattrInternalGeneric, it checks for custom __getattr__ or
 // __getattribute__ methods.
-Box* getattrInternal(Box* obj, const std::string& attr, GetattrRewriteArgs* rewrite_args);
+Box* getattrInternal(Box* obj, llvm::StringRef attr, GetattrRewriteArgs* rewrite_args);
 
 // This is the equivalent of PyObject_GenericGetAttr, which performs the default lookup rules for getattr() (check for
 // data descriptor, check for instance attribute, check for non-data descriptor). It does not check for __getattr__ or
 // __getattribute__.
-Box* getattrInternalGeneric(Box* obj, const std::string& attr, GetattrRewriteArgs* rewrite_args, bool cls_only,
+Box* getattrInternalGeneric(Box* obj, llvm::StringRef attr, GetattrRewriteArgs* rewrite_args, bool cls_only,
                             bool for_call, Box** bind_obj_out, RewriterVar** r_bind_obj_out);
 
 // This is the equivalent of _PyType_Lookup(), which calls Box::getattr() on each item in the object's MRO in the
 // appropriate order. It does not do any descriptor logic.
-Box* typeLookup(BoxedClass* cls, const std::string& attr, GetattrRewriteArgs* rewrite_args);
+Box* typeLookup(BoxedClass* cls, llvm::StringRef attr, GetattrRewriteArgs* rewrite_args);
 
 extern "C" void raiseAttributeErrorStr(const char* typeName, const char* attr) __attribute__((__noreturn__));
 extern "C" void raiseAttributeError(Box* obj, const char* attr) __attribute__((__noreturn__));

--- a/src/runtime/types.cpp
+++ b/src/runtime/types.cpp
@@ -1653,7 +1653,7 @@ public:
         BoxedDict* dict = (BoxedDict*)AttrWrapper::copy(_self);
         assert(dict->cls == dict_cls);
         const std::string eq_str = "__eq__";
-        return callattrInternal(dict, &eq_str, LookupScope::CLASS_ONLY, NULL, ArgPassSpec(1), _other, NULL, NULL, NULL,
+        return callattrInternal(dict, eq_str, LookupScope::CLASS_ONLY, NULL, ArgPassSpec(1), _other, NULL, NULL, NULL,
                                 NULL);
     }
 

--- a/src/runtime/types.h
+++ b/src/runtime/types.h
@@ -239,8 +239,7 @@ public:
                                   int weaklist_offset, int instance_size, bool is_user_defined, BoxedString* name,
                                   BoxedTuple* bases, size_t nslots);
     static BoxedHeapClass* create(BoxedClass* metatype, BoxedClass* base, gcvisit_func gc_visit, int attrs_offset,
-                                  int weaklist_offset, int instance_size, bool is_user_defined,
-                                  const std::string& name);
+                                  int weaklist_offset, int instance_size, bool is_user_defined, llvm::StringRef name);
 
 private:
     // These functions are not meant for external callers and will mostly just be called
@@ -354,10 +353,10 @@ public:
     }
 
     // Only valid for NORMAL hidden classes:
-    HiddenClass* getOrMakeChild(const std::string& attr);
+    HiddenClass* getOrMakeChild(llvm::StringRef attr);
 
     // Only valid for NORMAL or SINGLETON hidden classes:
-    int getOffset(const std::string& attr) {
+    int getOffset(llvm::StringRef attr) {
         assert(type == NORMAL || type == SINGLETON);
         auto it = attr_offsets.find(attr);
         if (it == attr_offsets.end())
@@ -380,7 +379,7 @@ public:
     HiddenClass* getAttrwrapperChild();
 
     // Only valid for NORMAL hidden classes:
-    HiddenClass* delAttrToMakeHC(const std::string& attr);
+    HiddenClass* delAttrToMakeHC(llvm::StringRef attr);
 };
 
 class BoxedInt : public Box {

--- a/test/tests/weakref4.py
+++ b/test/tests/weakref4.py
@@ -7,14 +7,13 @@ def doStuff():
   wr = weakref.ref(meth)
   return wr
 
-def fact(n):
-    if n <= 1:
-        return n
-    return n * fact(n-1)
+def recurse(f, n):
+    if n:
+        return recurse(f, n-1)
+    return f()
 
 
-w = doStuff()
-print fact(10) # try to clear some memory
+w = recurse(doStuff, 100)
 
 # Try creating a large object to make sure we can handle them:
 def f():
@@ -24,7 +23,7 @@ def f():
     return weakref.ref(C)
 
 
-r = f()
+r = recurse(f, 100)
 
 import gc
 gc.collect()

--- a/tools/perf_collect.sh
+++ b/tools/perf_collect.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -e
+
+if [ "$#" -eq 0 ] ; then
+    echo "Usage: perf_collect.sh [commands to run benchmark]"
+    exit 1
+fi
+
+perf record -o $1.data -g -- $@
+perf report -i $1.data -n --no-call-graph | bash tools/cumulate.sh > $1.txt
+echo "Report saved in $1.txt (raw perf data saved in $1.data)"

--- a/tools/perf_diff.py
+++ b/tools/perf_diff.py
@@ -6,7 +6,7 @@ def tally(fn):
     for l in open(fn):
         samples = int(l.split()[3])
         func = l.split()[-1]
-        counts[func] = samples
+        counts[func] = counts.get(func, 0) + samples
 
     return counts
 


### PR DESCRIPTION
```
   pyston django_migrate.py                  :    2.3s baseline: 2.3 (-1.7%)
   pyston django-template.py                 :   15.1s baseline: 15.4 (-1.6%)
   pyston interp2.py                         :    5.3s baseline: 6.3 (-15.1%)
   pyston raytrace.py                        :    6.1s baseline: 6.2 (-0.7%)
   pyston nbody.py                           :    8.4s baseline: 8.1 (+4.1%)
   pyston fannkuch.py                        :    7.5s baseline: 7.5 (+0.2%)
   pyston chaos.py                           :   20.2s baseline: 20.0 (+0.7%)
   pyston fasta.py                           :    5.4s baseline: 5.4 (+0.3%)
   pyston pidigits.py                        :    5.7s baseline: 5.7 (+0.0%)
   pyston richards.py                        :    2.5s baseline: 2.7 (-6.2%)
   pyston deltablue.py                       :    1.8s baseline: 1.8 (-0.0%)
   pyston (geomean-3424)                     :    5.7s baseline: 5.8 (-2.0%)
```

The nbody regression seems to just be benchmark sensitivity -- as far as I can tell it comes from a single function `unpackIntoArray` that gets called the same number of times and has the same assembly.  I'm going to work on getting a virtualenv test in and maybe we should just remove the old benchmarks.