### PR TITLE
Python-level sampling profiler

### DIFF
--- a/src/codegen/ast_interpreter.cpp
+++ b/src/codegen/ast_interpreter.cpp
@@ -695,6 +695,10 @@ Value ASTInterpreter::visit_yield(AST_Yield* node) {
 }
 
 Value ASTInterpreter::visit_stmt(AST_stmt* node) {
+#if ENABLE_SAMPLING_PROFILER
+    threading::allowGLReadPreemption();
+#endif
+
     if (0) {
         printf("%20s % 2d ", source_info->getName().c_str(), current_block->idx);
         print_ast(node);

--- a/src/codegen/ast_interpreter.cpp
+++ b/src/codegen/ast_interpreter.cpp
@@ -300,8 +300,6 @@ public:
 };
 
 Value ASTInterpreter::execute(ASTInterpreter& interpreter, CFGBlock* start_block, AST_stmt* start_at) {
-    threading::allowGLReadPreemption();
-
     STAT_TIMER(t0, "us_timer_astinterpreter_execute");
 
     void* frame_addr = __builtin_frame_address(0);
@@ -314,6 +312,11 @@ Value ASTInterpreter::execute(ASTInterpreter& interpreter, CFGBlock* start_block
         start_block = interpreter.source_info->cfg->getStartingBlock();
         start_at = start_block->body[0];
     }
+
+    // Important that this happens after RegisterHelper:
+    interpreter.current_inst = start_at;
+    threading::allowGLReadPreemption();
+    interpreter.current_inst = NULL;
 
     interpreter.current_block = start_block;
     bool started = false;

--- a/src/codegen/codegen.h
+++ b/src/codegen/codegen.h
@@ -87,6 +87,8 @@ extern GlobalState g;
 // in runtime_hooks.cpp:
 void initGlobalFuncs(GlobalState& g);
 
+extern int sigprof_pending;
+
 DS_DECLARE_RWLOCK(codegen_rwlock);
 }
 

--- a/src/codegen/irgen.cpp
+++ b/src/codegen/irgen.cpp
@@ -594,7 +594,7 @@ static void emitBBs(IRGenState* irstate, TypeAnalysis* types, const OSREntryDesc
 
             // Function-entry safepoint:
             // TODO might be more efficient to do post-call safepoints?
-            generator->doSafePoint();
+            generator->doSafePoint(block->body[0]);
         } else if (entry_descriptor && block == entry_descriptor->backedge->target) {
             assert(block->predecessors.size() > 1);
             assert(osr_entry_block);
@@ -763,7 +763,7 @@ static void emitBBs(IRGenState* irstate, TypeAnalysis* types, const OSREntryDesc
             if (predecessor->idx > block->idx) {
                 // Loop safepoint:
                 // TODO does it matter which side of the backedge these are on?
-                generator->doSafePoint();
+                generator->doSafePoint(block->body[0]);
                 break;
             }
         }

--- a/src/codegen/irgen/irgenerator.cpp
+++ b/src/codegen/irgen/irgenerator.cpp
@@ -2608,6 +2608,13 @@ public:
             if (state == DEAD)
                 break;
             assert(state != FINISHED);
+
+#if ENABLE_SAMPLING_PROFILER
+            auto stmt = block->body[i];
+            if (stmt->type != AST_TYPE::Assign) // could be a landingpad
+                doSafePoint(block->body[i]);
+#endif
+
             doStmt(block->body[i], UnwindInfo(block->body[i], NULL));
         }
         if (VERBOSITY("irgenerator") >= 2) { // print ending symbol table

--- a/src/codegen/irgen/irgenerator.cpp
+++ b/src/codegen/irgen/irgenerator.cpp
@@ -2618,7 +2618,15 @@ public:
         }
     }
 
-    void doSafePoint() override { emitter.getBuilder()->CreateCall(g.funcs.allowGLReadPreemption); }
+    void doSafePoint(AST_stmt* next_statement) override {
+// If the sampling profiler is turned on (and eventually, destructors), we need frame-introspection
+// support while in allowGLReadPreemption:
+#if ENABLE_SAMPLING_PROFILER
+        emitter.createCall(UnwindInfo(next_statement, NULL), g.funcs.allowGLReadPreemption);
+#else
+        emitter.getBuilder()->CreateCall(g.funcs.allowGLReadPreemption);
+#endif
+    }
 };
 
 IRGenerator* createIRGenerator(IRGenState* irstate, std::unordered_map<CFGBlock*, llvm::BasicBlock*>& entry_blocks,

--- a/src/codegen/irgen/irgenerator.h
+++ b/src/codegen/irgen/irgenerator.h
@@ -127,7 +127,7 @@ public:
     virtual void copySymbolsFrom(SymbolTable* st) = 0;
     virtual void run(const CFGBlock* block) = 0; // primary entry point
     virtual EndingState getEndingSymbolTable() = 0;
-    virtual void doSafePoint() = 0;
+    virtual void doSafePoint(AST_stmt* next_statement) = 0;
     virtual void addFrameStackmapArgs(PatchpointInfo* pp, AST_stmt* current_stmt,
                                       std::vector<llvm::Value*>& stackmap_args) = 0;
 };

--- a/src/codegen/parser.cpp
+++ b/src/codegen/parser.cpp
@@ -1000,7 +1000,7 @@ AST_Module* parse_file(const char* fn) {
 
     if (ENABLE_PYPA_PARSER) {
         AST_Module* rtn = pypa_parse(fn);
-        RELEASE_ASSERT(rtn, "unknown parse error");
+        RELEASE_ASSERT(rtn, "unknown parse error (possibly: '%s'?)", strerror(errno));
         return rtn;
     }
 

--- a/src/codegen/unwinding.cpp
+++ b/src/codegen/unwinding.cpp
@@ -345,7 +345,7 @@ public:
                     return reinterpret_cast<AST_stmt*>(readLocation(e.locations[0]));
                 }
             }
-            abort();
+            RELEASE_ASSERT(0, "no frame info found at offset 0x%x / ip 0x%lx!", offset, ip);
         } else if (id.type == PythonFrameId::INTERPRETED) {
             return getCurrentStatementForInterpretedFrame((void*)id.bp);
         }

--- a/src/core/options.h
+++ b/src/core/options.h
@@ -47,6 +47,8 @@ extern bool ENABLE_ICS, ENABLE_ICGENERICS, ENABLE_ICGETITEMS, ENABLE_ICSETITEMS,
 
 // Due to a temporary LLVM limitation, represent bools as i64's instead of i1's.
 extern bool BOOLS_AS_I64;
+
+#define ENABLE_SAMPLING_PROFILER 0
 }
 }
 

--- a/src/runtime/stacktrace.cpp
+++ b/src/runtime/stacktrace.cpp
@@ -101,7 +101,16 @@ void raiseSyntaxErrorHelper(const std::string& file, const std::string& func, AS
 }
 
 void _printStacktrace() {
+    static bool recursive = false;
+
+    if (recursive) {
+        fprintf(stderr, "_printStacktrace ran into an issue; refusing to try it again!\n");
+        return;
+    }
+
+    recursive = true;
     printTraceback(getTraceback());
+    recursive = false;
 }
 
 // where should this go...

--- a/src/runtime/traceback.cpp
+++ b/src/runtime/traceback.cpp
@@ -85,6 +85,7 @@ void printTraceback(Box* b) {
                 fprintf(stderr, "    %.*s\n", (int)r, ptr);
                 free(buf);
             }
+            fclose(f);
         }
     }
 }

--- a/tools/process_stackdump.py
+++ b/tools/process_stackdump.py
@@ -9,7 +9,7 @@ if __name__ == "__main__":
         for l in f:
             if l.startswith("Traceback"):
                 if cur_traceback:
-                    tracebacks.append(''.join(cur_traceback).strip())
+                    tracebacks.append(''.join(cur_traceback).rstrip())
                 cur_traceback = []
             elif not (l.startswith("  File") or l.startswith("    ")):
                 print "non-traceback line?  ", l.strip()
@@ -17,22 +17,28 @@ if __name__ == "__main__":
             else:
                 cur_traceback.append(l)
     if cur_traceback:
-        tracebacks.append(''.join(cur_traceback).strip())
+        tracebacks.append(''.join(cur_traceback).rstrip())
         cur_traceback = []
 
     counts = {}
     for t in tracebacks:
+        locations = [l for l in t.split('\n') if l.startswith("  File")]
+
+        last_file = locations[-1].split('"')[1]
+        last_function = locations[-1].split()[-1][:-1]
+
         # dedupe on:
         # key = t # full traceback
         # key = '\n'.join(t.split('\n')[-8:]) # last 4 stack frames
         # key = '\n'.join(t.split('\n')[-4:]) # last 2 stack frames
         # key = '\n'.join(t.split('\n')[-2:]) # last stack frame
-        key = t.split('  File "')[-1].split()[0][:-2] # filename of last stack trace
+        # key = last_file, last_function
+        key = last_file
         counts[key] = counts.get(key, 0) + 1
 
     n = len(tracebacks)
 
-    NUM_DISPLAY = 20
+    NUM_DISPLAY = 6
 
     entries = sorted(counts.items(), key=lambda (k, v): v)
 

--- a/tools/process_stackdump.py
+++ b/tools/process_stackdump.py
@@ -1,0 +1,49 @@
+import sys
+
+if __name__ == "__main__":
+    fn = sys.argv[1]
+
+    tracebacks = []
+    cur_traceback = []
+    with open(fn) as f:
+        for l in f:
+            if l.startswith("Traceback"):
+                if cur_traceback:
+                    tracebacks.append(''.join(cur_traceback).strip())
+                cur_traceback = []
+            else:
+                cur_traceback.append(l)
+    if cur_traceback:
+        tracebacks.append(''.join(cur_traceback).strip())
+        cur_traceback = []
+
+    counts = {}
+    for t in tracebacks:
+        # dedupe on:
+        # key = t # full traceback
+        # key = '\n'.join(t.split('\n')[-8:]) # last 4 stack frames
+        # key = '\n'.join(t.split('\n')[-2:]) # last stack frame
+        key = t.split('  File "')[-1].split()[0][:-2] # filename of last stack trace
+        counts[key] = counts.get(key, 0) + 1
+
+    n = len(tracebacks)
+
+    NUM_DISPLAY = 20
+
+    entries = sorted(counts.items(), key=lambda (k, v): v)
+
+    if len(counts) > NUM_DISPLAY:
+        num_hidden = 0
+        counts_hidden = 0
+
+        for k, v in entries[:-NUM_DISPLAY]:
+            num_hidden += 1
+            counts_hidden += v
+        print "Hiding %d entries that occurred %d (%.1f%%) times" % (num_hidden, counts_hidden, 100.0 * counts_hidden / n)
+
+    for k, v in sorted(counts.items(), key=lambda (k, v): v)[-NUM_DISPLAY:]:
+        print
+        print "Occurs %d (%.1f%%) times:" % (v, 100.0 * v / n)
+        print k
+
+    print "Total tracebacks:", n

--- a/tools/process_stackdump.py
+++ b/tools/process_stackdump.py
@@ -11,6 +11,9 @@ if __name__ == "__main__":
                 if cur_traceback:
                     tracebacks.append(''.join(cur_traceback).strip())
                 cur_traceback = []
+            elif not (l.startswith("  File") or l.startswith("    ")):
+                print "non-traceback line?  ", l.strip()
+                continue
             else:
                 cur_traceback.append(l)
     if cur_traceback:
@@ -22,6 +25,7 @@ if __name__ == "__main__":
         # dedupe on:
         # key = t # full traceback
         # key = '\n'.join(t.split('\n')[-8:]) # last 4 stack frames
+        # key = '\n'.join(t.split('\n')[-4:]) # last 2 stack frames
         # key = '\n'.join(t.split('\n')[-2:]) # last stack frame
         key = t.split('  File "')[-1].split()[0][:-2] # filename of last stack trace
         counts[key] = counts.get(key, 0) + 1
@@ -46,4 +50,5 @@ if __name__ == "__main__":
         print "Occurs %d (%.1f%%) times:" % (v, 100.0 * v / n)
         print k
 
+    print
     print "Total tracebacks:", n


### PR DESCRIPTION
Super simple and not very reliable, but can give some decent high-level insight into what's going on.  Specifically, it assigns all the time to the *next* python statement, which makes it a bit hard to interpret (fixing this probably involves figuring out how to handle signals for real).  I wrote a little script to collate the results with different levels of granularity, and interestingly the file-level granularity seems pretty useful.

For example, here's some of the output for django-template:

```
Hiding 117 entries that occurred 392 (12.8%) times

Occurs 81 (2.6%) times:
minibenchmarks/../test/integration/django/django/template/defaulttags.py

Occurs 88 (2.9%) times:
minibenchmarks/../test/integration/django/django/template/smartif.py

Occurs 122 (4.0%) times:
/home/kmod/pyston-build-release/from_cpython/Lib/sre_parse.py

Occurs 167 (5.5%) times:
/home/kmod/pyston-build-release/from_cpython/Lib/sre_compile.py

Occurs 2211 (72.2%) times:
minibenchmarks/../test/integration/django/django/template/base.py

Total tracebacks: 3061
```

Diving deeper shows some of the wonkiness -- there are a bunch of "line -1" entries in there, and I suspect that the `if nodelist` entry is really due to the statement before it `nodelist = getattr(self, attr, None)`
```
Hiding 406 entries that occurred 1311 (42.8%) times

Occurs 75 (2.5%) times:
    return TranslateNode(parser.compile_filter(value), noop, asvar,
  File "minibenchmarks/../test/integration/django/django/templatetags/i18n.py", line 82, in __init__:
    self.filter_expression.var = Variable("'%s'" %
  File "minibenchmarks/../test/integration/django/django/template/base.py", line -1, in __init__:

Occurs 136 (4.4%) times:
    return FilterExpression(token, self)
  File "minibenchmarks/../test/integration/django/django/template/base.py", line 566, in __init__:
    var_obj = Variable(constant).resolve({})
  File "minibenchmarks/../test/integration/django/django/template/base.py", line -1, in __init__:

Occurs 580 (18.9%) times:
    return FilterExpression(token, self)
  File "minibenchmarks/../test/integration/django/django/template/base.py", line 573, in __init__:
    var_obj = Variable(var)
  File "minibenchmarks/../test/integration/django/django/template/base.py", line -1, in __init__:

Occurs 959 (31.3%) times:
  File "minibenchmarks/../test/integration/django/django/template/base.py", line 854, in get_nodes_by_type:
    nodes.extend(node.get_nodes_by_type(nodetype))
  File "minibenchmarks/../test/integration/django/django/template/base.py", line 830, in get_nodes_by_type:
    if nodelist:

Total tracebacks: 3061
```

But here's something pretty interesting -- our startup time (ie setting the number of iterations to 0) on that benchmark is quite bad, and it appears to be regex-related:
```
Hiding 108 entries that occurred 193 (37.1%) times

Occurs 8 (1.5%) times:
minibenchmarks/../test/integration/django/django/db/models/signals.py

Occurs 12 (2.3%) times:
/home/kmod/pyston-build-release/from_cpython/Lib/abc.py

Occurs 12 (2.3%) times:
minibenchmarks/../test/integration/django/django/utils/functional.py

Occurs 123 (23.7%) times:
/home/kmod/pyston-build-release/from_cpython/Lib/sre_parse.py

Occurs 172 (33.1%) times:
/home/kmod/pyston-build-release/from_cpython/Lib/sre_compile.py

Total tracebacks: 520
```