### PR TITLE
Fix some issues with the way we build libunwind

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,16 +79,24 @@ add_custom_target(llvm_up DEPENDS llvm_gotorev clang_gotorev)
 set(LIBUNWIND_PATCHES
   ${CMAKE_SOURCE_DIR}/libunwind_patches/0001-pyston-add-lots-of-comments.patch
   ${CMAKE_SOURCE_DIR}/libunwind_patches/0002-pyston-stop-x86_64-setcontext-restoring-uninitialize.patch
-  ${CMAKE_SOURCE_DIR}/libunwind_patches/0003-use-a-sorted-array-for-registered-objects-and-do-a-b.patch)
+  ${CMAKE_SOURCE_DIR}/libunwind_patches/0003-use-a-sorted-array-for-registered-objects-and-do-a-b.patch
+  ${CMAKE_SOURCE_DIR}/libunwind_patches/9999-is-patched-marker.patch
+)
 
 add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/gitmodules
                    COMMAND git submodule update --init
-                   COMMAND python ${CMAKE_SOURCE_DIR}/tools/git_am_automated.py libunwind ${LIBUNWIND_PATCHES}
                    COMMAND cmake -E touch ${CMAKE_BINARY_DIR}/gitmodules
                    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-                   DEPENDS ${CMAKE_SOURCE_DIR}/.gitmodules
-                   DEPENDS ${LIBUNWIND_PATCHES})
+                   DEPENDS ${CMAKE_SOURCE_DIR}/.gitmodules)
 add_custom_target(gitsubmodules DEPENDS ${CMAKE_BINARY_DIR}/gitmodules)
+
+add_custom_command(OUTPUT ${CMAKE_SOURCE_DIR}/libunwind/pyston_patched
+                   COMMAND git submodule update libunwind
+                   COMMAND python ${CMAKE_SOURCE_DIR}/tools/git_am_automated.py libunwind ${LIBUNWIND_PATCHES}
+                   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+                   DEPENDS ${LIBUNWIND_PATCHES}
+                   DEPENDS gitsubmodules)
+add_custom_target(libunwind_patched DEPENDS ${CMAKE_SOURCE_DIR}/libunwind/pyston_patched)
 
 # llvm
 set(LLVM_TARGETS_TO_BUILD "host" CACHE STRING "LLVM targets")
@@ -115,14 +123,25 @@ endif()
 ExternalProject_Add(libunwind
                     PREFIX libunwind
                     SOURCE_DIR ${CMAKE_SOURCE_DIR}/libunwind
-                    # TODO: more accurate DEPENDS - should depend on *contents* of libunwind/ source directory
-                    DEPENDS gitsubmodules
+                    DEPENDS libunwind_patched
                     UPDATE_COMMAND autoreconf -i
                     CONFIGURE_COMMAND ${CMAKE_SOURCE_DIR}/libunwind/configure ${LIBUNWIND_DEBUG_CFLAGS} --prefix=${CMAKE_BINARY_DIR}/libunwind --enable-shared=0 --disable-block-signals ${LIBUNWIND_CONSERVATIVE_CHECKS} ${LIBUNWIND_DEBUG} ${LIBUNWIND_DEBUG_FRAME}
                     LOG_UPDATE ON
                     LOG_CONFIGURE ON
                     LOG_BUILD ON
                     LOG_INSTALL ON)
+# Tell CMake that patching libunwind means that we need to rebuild it:
+ExternalProject_Add_Step(libunwind forcebuild
+    DEPENDS ${CMAKE_SOURCE_DIR}/libunwind/pyston_patched
+    DEPENDERS build
+)
+# Tell CMake that rebuilding libunwind will touch the build files (why doesn't it know this??)
+# Otherwise, if you do something that triggers a rebuild (not a fresh build) of libunwind,
+# it will take another build to realize that any source files that #include libunwind.h
+# need to get rebuilt.
+SET_SOURCE_FILES_PROPERTIES(
+    ${CMAKE_BINARY_DIR}/libunwind/include/libunwind.h PROPERTIES OBJECT_DEPENDS ${CMAKE_SOURCE_DIR}/libunwind/pyston_patched
+)
 
 # libpypa
 add_subdirectory(libpypa)

--- a/Makefile
+++ b/Makefile
@@ -844,6 +844,8 @@ $(call make_compile_config,.nosync,$(CXXFLAGS_RELEASE) -DTHREADING_USE_GRWL=0 -D
 else
 %.o: %.cpp $(CMAKE_SETUP_DBG)
 	$(NINJA) -C $(HOME)/pyston-build-dbg src/CMakeFiles/PYSTON_OBJECTS.dir/$(patsubst src/%.o,%.cpp.o,$@) $(NINJAFLAGS)
+%.release.o: %.cpp $(CMAKE_SETUP_RELEASE)
+	$(NINJA) -C $(HOME)/pyston-build-release src/CMakeFiles/PYSTON_OBJECTS.dir/$(patsubst src/%.release.o,%.cpp.o,$@) $(NINJAFLAGS)
 endif
 
 $(UNITTEST_SRCS:.cpp=.o): CXXFLAGS += -isystem $(GTEST_DIR)/include

--- a/libunwind_patches/9999-is-patched-marker.patch
+++ b/libunwind_patches/9999-is-patched-marker.patch
@@ -1,0 +1,20 @@
+From be4f78b09bcb44eaf23d103acf865d547893e2a6 Mon Sep 17 00:00:00 2001
+From: Kevin Modzelewski <kmod@dropbox.com>
+Date: Tue, 2 Jun 2015 04:25:24 +0000
+Subject: [PATCH] Add patched marker
+
+---
+ pyston_patched         | 1 +
+ 1 files changed, 1 insertions(+)
+ create mode 100644 pyston_patched
+
+diff --git a/pyston_patched b/pyston_patched
+new file mode 100644
+index 0000000..64219e8
+--- /dev/null
++++ b/pyston_patched
+@@ -0,0 +1 @@
++Patched for Pyston!
+-- 
+1.9.1
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -109,10 +109,10 @@ add_library(PYSTON_OBJECTS OBJECT ${OPTIONAL_SRCS}
 		runtime/util.cpp
 		)
 
-add_dependencies(PYSTON_OBJECTS libunwind pypa ${LLVM_LIBS})
+add_dependencies(PYSTON_OBJECTS libunwind_patched libunwind pypa ${LLVM_LIBS})
 
 add_library(PYSTON_MAIN_OBJECT OBJECT jit.cpp)
-add_dependencies(PYSTON_MAIN_OBJECT libunwind pypa liblz4 ${LLVM_LIBS})
+add_dependencies(PYSTON_MAIN_OBJECT libunwind_patched libunwind pypa liblz4 ${LLVM_LIBS})
 
 # build stdlib
 add_subdirectory(runtime/inline)


### PR DESCRIPTION
First, that we would only apply our patchset once.  If we ever revert the
patches (I'm not sure under what conditions that happens), we previously would
never apply them again.  Attempted to fix this by adding a special patch that
adds a new file that CMake looks for; if the file doesn't exist, cmake runs the
patches again.

Second, that we didn't rebuild libunwind if we apply new patches.
I'm not sure if there's a good general solution to this, but I was able
to figure out how to force libunwind to rebuild if we need to rerun the
patch command.  It took some hacking since CMake doesn't track dependencies
on external projects, so we have to add some custom dependencies.