### PR TITLE
tp_richcompare

### DIFF
--- a/libunwind_patches/0003-use-a-sorted-array-for-registered-objects-and-do-a-b.patch
+++ b/libunwind_patches/0003-use-a-sorted-array-for-registered-objects-and-do-a-b.patch
@@ -119,7 +119,7 @@ diff --git a/src/mi/dyn-register.c b/src/mi/dyn-register.c
 index c28954a..c4f88b1 100644
 --- a/src/mi/dyn-register.c
 +++ b/src/mi/dyn-register.c
-@@ -32,13 +32,28 @@ _U_dyn_register (unw_dyn_info_t *di)
+@@ -32,13 +32,27 @@ _U_dyn_register (unw_dyn_info_t *di)
  {
    mutex_lock (&_U_dyn_info_list_lock);
    {
@@ -148,8 +148,7 @@ index c28954a..c4f88b1 100644
 +          break;
 +      }
 +
-+      if (_U_dyn_info_list_size > 1)
-+          memmove(&_U_dyn_info_list[i+1], &_U_dyn_info_list[i], (_U_dyn_info_list_size - i) * sizeof(unw_dyn_info_t*));
++      memmove(&_U_dyn_info_list[i+1], &_U_dyn_info_list[i], (_U_dyn_info_list_size - i) * sizeof(unw_dyn_info_t*));
 +      _U_dyn_info_list[i] = di;
 +      _U_dyn_info_list_size ++;
    }

--- a/src/capi/object.cpp
+++ b/src/capi/object.cpp
@@ -764,7 +764,7 @@ static int try_3way_compare(PyObject* v, PyObject* w) {
     0 if v == w;
     1 if v >  w.
 */
-static int default_3way_compare(PyObject* v, PyObject* w) {
+/* Pyston change: static*/ int default_3way_compare(PyObject* v, PyObject* w) {
     int c;
     const char* vname, *wname;
 
@@ -865,7 +865,7 @@ extern "C" int PyObject_Compare(PyObject* v, PyObject* w) noexcept {
 }
 
 /* Return (new reference to) Py_True or Py_False. */
-static PyObject* convert_3way_to_object(int op, int c) noexcept {
+/* Pyston change: static */ PyObject* convert_3way_to_object(int op, int c) noexcept {
     PyObject* result;
     switch (op) {
         case Py_LT:

--- a/src/capi/typeobject.cpp
+++ b/src/capi/typeobject.cpp
@@ -761,7 +761,15 @@ static PyObject* half_richcompare(PyObject* self, PyObject* other, int op) noexc
     return res;
 }
 
-static PyObject* slot_tp_richcompare(PyObject* self, PyObject* other, int op) noexcept {
+/* Pyston change: static*/ PyObject* slot_tp_richcompare(PyObject* self, PyObject* other, int op) noexcept {
+    static StatCounter slowpath_richcompare("slowpath_richcompare");
+    slowpath_richcompare.log();
+#if 0
+    std::string per_name_stat_name = "slowpath_richcompare." + std::string(self->cls->tp_name);
+    int id = Stats::getStatId(per_name_stat_name);
+    Stats::log(id);
+#endif
+
     PyObject* res;
 
     if (Py_TYPE(self)->tp_richcompare == slot_tp_richcompare) {

--- a/src/capi/typeobject.h
+++ b/src/capi/typeobject.h
@@ -33,6 +33,8 @@ void commonClassSetup(BoxedClass* cls);
 PyTypeObject* best_base(PyObject* bases) noexcept;
 PyObject* mro_external(PyObject* self) noexcept;
 int type_set_bases(PyTypeObject* type, PyObject* value, void* context) noexcept;
+
+PyObject* slot_tp_richcompare(PyObject* self, PyObject* other, int op) noexcept;
 }
 
 #endif

--- a/src/capi/types.h
+++ b/src/capi/types.h
@@ -237,6 +237,9 @@ public:
     }
 };
 
+PyObject* convert_3way_to_object(int op, int c) noexcept;
+int default_3way_compare(PyObject* v, PyObject* w);
+
 } // namespace pyston
 
 #endif

--- a/src/runtime/builtin_modules/builtins.cpp
+++ b/src/runtime/builtin_modules/builtins.cpp
@@ -162,10 +162,11 @@ extern "C" Box* min(Box* arg0, BoxedTuple* args) {
         if (!minElement) {
             minElement = e;
         } else {
-            Box* comp_result = compareInternal(minElement, e, AST_TYPE::Gt, NULL);
-            if (nonzero(comp_result)) {
+            int r = PyObject_RichCompareBool(minElement, e, Py_GT);
+            if (r == -1)
+                throwCAPIException();
+            if (r)
                 minElement = e;
-            }
         }
     }
 
@@ -192,10 +193,11 @@ extern "C" Box* max(Box* arg0, BoxedTuple* args) {
         if (!maxElement) {
             maxElement = e;
         } else {
-            Box* comp_result = compareInternal(maxElement, e, AST_TYPE::Lt, NULL);
-            if (nonzero(comp_result)) {
+            int r = PyObject_RichCompareBool(maxElement, e, Py_LT);
+            if (r == -1)
+                throwCAPIException();
+            if (r)
                 maxElement = e;
-            }
         }
     }
 

--- a/src/runtime/capi.cpp
+++ b/src/runtime/capi.cpp
@@ -1650,6 +1650,13 @@ static Box* methodGetDoc(Box* b, void*) {
     return None;
 }
 
+static Box* wrapperdescrGetDoc(Box* b, void*) {
+    assert(b->cls == wrapperdescr_cls);
+    auto s = static_cast<BoxedWrapperDescriptor*>(b)->wrapper->doc;
+    assert(s.size());
+    return boxString(s);
+}
+
 /* extension modules might be compiled with GC support so these
    functions must always be available */
 
@@ -1738,6 +1745,8 @@ void setupCAPI() {
                                new BoxedFunction(boxRTFunction((void*)BoxedWrapperDescriptor::__get__, UNKNOWN, 3)));
     wrapperdescr_cls->giveAttr("__call__", new BoxedFunction(boxRTFunction((void*)BoxedWrapperDescriptor::__call__,
                                                                            UNKNOWN, 2, 0, true, true)));
+    wrapperdescr_cls->giveAttr("__doc__",
+                               new (pyston_getset_cls) BoxedGetsetDescriptor(wrapperdescrGetDoc, NULL, NULL));
     wrapperdescr_cls->freeze();
 
     wrapperobject_cls->giveAttr(

--- a/src/runtime/capi.cpp
+++ b/src/runtime/capi.cpp
@@ -586,8 +586,11 @@ extern "C" long _Py_HashPointer(void* p) noexcept {
 }
 
 extern "C" int PyObject_IsTrue(PyObject* o) noexcept {
+    if (o->cls == bool_cls)
+        return o == True;
+
     try {
-        return nonzero(o);
+        return o->nonzeroIC();
     } catch (ExcInfo e) {
         fatalOrError(PyExc_NotImplementedError, "unimplemented");
         return -1;

--- a/src/runtime/long.cpp
+++ b/src/runtime/long.cpp
@@ -20,6 +20,8 @@
 
 #include "llvm/Support/raw_ostream.h"
 
+#include "capi/typeobject.h"
+#include "capi/types.h"
 #include "core/common.h"
 #include "core/options.h"
 #include "core/stats.h"
@@ -846,104 +848,18 @@ extern "C" Box* longXor(BoxedLong* v1, Box* _v2) {
     return NotImplemented;
 }
 
-// TODO reduce duplication between these 6 functions, and add double support
-Box* longGt(BoxedLong* v1, Box* _v2) {
-    if (!isSubclass(v1->cls, long_cls))
-        raiseExcHelper(TypeError, "descriptor '__gt__' requires a 'long' object but received a '%s'", getTypeName(v1));
+static PyObject* long_richcompare(Box* _v1, Box* _v2, int op) noexcept {
+    RELEASE_ASSERT(isSubclass(_v1->cls, long_cls), "");
+    BoxedLong* v1 = static_cast<BoxedLong*>(_v1);
 
     if (isSubclass(_v2->cls, long_cls)) {
         BoxedLong* v2 = static_cast<BoxedLong*>(_v2);
 
-        return boxBool(mpz_cmp(v1->n, v2->n) > 0);
+        return convert_3way_to_object(op, mpz_cmp(v1->n, v2->n));
     } else if (isSubclass(_v2->cls, int_cls)) {
         BoxedInt* v2 = static_cast<BoxedInt*>(_v2);
 
-        return boxBool(mpz_cmp_si(v1->n, v2->n) > 0);
-    } else {
-        return NotImplemented;
-    }
-}
-
-Box* longGe(BoxedLong* v1, Box* _v2) {
-    if (!isSubclass(v1->cls, long_cls))
-        raiseExcHelper(TypeError, "descriptor '__ge__' requires a 'long' object but received a '%s'", getTypeName(v1));
-
-    if (isSubclass(_v2->cls, long_cls)) {
-        BoxedLong* v2 = static_cast<BoxedLong*>(_v2);
-
-        return boxBool(mpz_cmp(v1->n, v2->n) >= 0);
-    } else if (isSubclass(_v2->cls, int_cls)) {
-        BoxedInt* v2 = static_cast<BoxedInt*>(_v2);
-
-        return boxBool(mpz_cmp_si(v1->n, v2->n) >= 0);
-    } else {
-        return NotImplemented;
-    }
-}
-
-Box* longLt(BoxedLong* v1, Box* _v2) {
-    if (!isSubclass(v1->cls, long_cls))
-        raiseExcHelper(TypeError, "descriptor '__lt__' requires a 'long' object but received a '%s'", getTypeName(v1));
-
-    if (isSubclass(_v2->cls, long_cls)) {
-        BoxedLong* v2 = static_cast<BoxedLong*>(_v2);
-
-        return boxBool(mpz_cmp(v1->n, v2->n) < 0);
-    } else if (isSubclass(_v2->cls, int_cls)) {
-        BoxedInt* v2 = static_cast<BoxedInt*>(_v2);
-
-        return boxBool(mpz_cmp_si(v1->n, v2->n) < 0);
-    } else {
-        return NotImplemented;
-    }
-}
-
-Box* longLe(BoxedLong* v1, Box* _v2) {
-    if (!isSubclass(v1->cls, long_cls))
-        raiseExcHelper(TypeError, "descriptor '__le__' requires a 'long' object but received a '%s'", getTypeName(v1));
-
-    if (isSubclass(_v2->cls, long_cls)) {
-        BoxedLong* v2 = static_cast<BoxedLong*>(_v2);
-
-        return boxBool(mpz_cmp(v1->n, v2->n) <= 0);
-    } else if (isSubclass(_v2->cls, int_cls)) {
-        BoxedInt* v2 = static_cast<BoxedInt*>(_v2);
-
-        return boxBool(mpz_cmp_si(v1->n, v2->n) <= 0);
-    } else {
-        return NotImplemented;
-    }
-}
-
-Box* longEq(BoxedLong* v1, Box* _v2) {
-    if (!isSubclass(v1->cls, long_cls))
-        raiseExcHelper(TypeError, "descriptor '__eq__' requires a 'long' object but received a '%s'", getTypeName(v1));
-
-    if (isSubclass(_v2->cls, long_cls)) {
-        BoxedLong* v2 = static_cast<BoxedLong*>(_v2);
-
-        return boxBool(mpz_cmp(v1->n, v2->n) == 0);
-    } else if (isSubclass(_v2->cls, int_cls)) {
-        BoxedInt* v2 = static_cast<BoxedInt*>(_v2);
-
-        return boxBool(mpz_cmp_si(v1->n, v2->n) == 0);
-    } else {
-        return NotImplemented;
-    }
-}
-
-Box* longNe(BoxedLong* v1, Box* _v2) {
-    if (!isSubclass(v1->cls, long_cls))
-        raiseExcHelper(TypeError, "descriptor '__ne__' requires a 'long' object but received a '%s'", getTypeName(v1));
-
-    if (isSubclass(_v2->cls, long_cls)) {
-        BoxedLong* v2 = static_cast<BoxedLong*>(_v2);
-
-        return boxBool(mpz_cmp(v1->n, v2->n) != 0);
-    } else if (isSubclass(_v2->cls, int_cls)) {
-        BoxedInt* v2 = static_cast<BoxedInt*>(_v2);
-
-        return boxBool(mpz_cmp_si(v1->n, v2->n) != 0);
+        return convert_3way_to_object(op, mpz_cmp_si(v1->n, v2->n));
     } else {
         return NotImplemented;
     }
@@ -1457,12 +1373,8 @@ void setupLong() {
     long_cls->giveAttr("__xor__", new BoxedFunction(boxRTFunction((void*)longXor, UNKNOWN, 2)));
     long_cls->giveAttr("__rxor__", long_cls->getattr("__xor__"));
 
-    long_cls->giveAttr("__gt__", new BoxedFunction(boxRTFunction((void*)longGt, UNKNOWN, 2)));
-    long_cls->giveAttr("__ge__", new BoxedFunction(boxRTFunction((void*)longGe, UNKNOWN, 2)));
-    long_cls->giveAttr("__lt__", new BoxedFunction(boxRTFunction((void*)longLt, UNKNOWN, 2)));
-    long_cls->giveAttr("__le__", new BoxedFunction(boxRTFunction((void*)longLe, UNKNOWN, 2)));
-    long_cls->giveAttr("__eq__", new BoxedFunction(boxRTFunction((void*)longEq, UNKNOWN, 2)));
-    long_cls->giveAttr("__ne__", new BoxedFunction(boxRTFunction((void*)longNe, UNKNOWN, 2)));
+    // Note: CPython implements long comparisons using tp_compare
+    long_cls->tp_richcompare = long_richcompare;
 
     long_cls->giveAttr("__lshift__", new BoxedFunction(boxRTFunction((void*)longLshift, UNKNOWN, 2)));
     long_cls->giveAttr("__rshift__", new BoxedFunction(boxRTFunction((void*)longRshift, UNKNOWN, 2)));
@@ -1488,6 +1400,7 @@ void setupLong() {
     long_cls->giveAttr("numerator", new (pyston_getset_cls) BoxedGetsetDescriptor(longLong, NULL, NULL));
     long_cls->giveAttr("denominator", new (pyston_getset_cls) BoxedGetsetDescriptor(long1, NULL, NULL));
 
+    add_operators(long_cls);
     long_cls->freeze();
 
     long_cls->tp_as_number->nb_power = long_pow;

--- a/src/runtime/tuple.cpp
+++ b/src/runtime/tuple.cpp
@@ -225,89 +225,6 @@ Box* tupleRepr(BoxedTuple* t) {
     return boxString(os.str());
 }
 
-Box* _tupleCmp(BoxedTuple* lhs, BoxedTuple* rhs, AST_TYPE::AST_TYPE op_type) {
-    int lsz = lhs->size();
-    int rsz = rhs->size();
-
-    bool is_order
-        = (op_type == AST_TYPE::Lt || op_type == AST_TYPE::LtE || op_type == AST_TYPE::Gt || op_type == AST_TYPE::GtE);
-
-    int n = std::min(lsz, rsz);
-    for (int i = 0; i < n; i++) {
-        Box* is_eq = compareInternal(lhs->elts[i], rhs->elts[i], AST_TYPE::Eq, NULL);
-        bool bis_eq = nonzero(is_eq);
-
-        if (bis_eq)
-            continue;
-
-        if (op_type == AST_TYPE::Eq) {
-            return boxBool(false);
-        } else if (op_type == AST_TYPE::NotEq) {
-            return boxBool(true);
-        } else {
-            Box* r = compareInternal(lhs->elts[i], rhs->elts[i], op_type, NULL);
-            return r;
-        }
-    }
-
-    if (op_type == AST_TYPE::Lt)
-        return boxBool(lsz < rsz);
-    else if (op_type == AST_TYPE::LtE)
-        return boxBool(lsz <= rsz);
-    else if (op_type == AST_TYPE::Gt)
-        return boxBool(lsz > rsz);
-    else if (op_type == AST_TYPE::GtE)
-        return boxBool(lsz >= rsz);
-    else if (op_type == AST_TYPE::Eq)
-        return boxBool(lsz == rsz);
-    else if (op_type == AST_TYPE::NotEq)
-        return boxBool(lsz != rsz);
-
-    RELEASE_ASSERT(0, "%d", op_type);
-}
-
-Box* tupleLt(BoxedTuple* self, Box* rhs) {
-    if (!isSubclass(rhs->cls, tuple_cls)) {
-        return NotImplemented;
-    }
-    return _tupleCmp(self, static_cast<BoxedTuple*>(rhs), AST_TYPE::Lt);
-}
-
-Box* tupleLe(BoxedTuple* self, Box* rhs) {
-    if (!isSubclass(rhs->cls, tuple_cls)) {
-        return NotImplemented;
-    }
-    return _tupleCmp(self, static_cast<BoxedTuple*>(rhs), AST_TYPE::LtE);
-}
-
-Box* tupleGt(BoxedTuple* self, Box* rhs) {
-    if (!isSubclass(rhs->cls, tuple_cls)) {
-        return NotImplemented;
-    }
-    return _tupleCmp(self, static_cast<BoxedTuple*>(rhs), AST_TYPE::Gt);
-}
-
-Box* tupleGe(BoxedTuple* self, Box* rhs) {
-    if (!isSubclass(rhs->cls, tuple_cls)) {
-        return NotImplemented;
-    }
-    return _tupleCmp(self, static_cast<BoxedTuple*>(rhs), AST_TYPE::GtE);
-}
-
-Box* tupleEq(BoxedTuple* self, Box* rhs) {
-    if (!isSubclass(rhs->cls, tuple_cls)) {
-        return NotImplemented;
-    }
-    return _tupleCmp(self, static_cast<BoxedTuple*>(rhs), AST_TYPE::Eq);
-}
-
-Box* tupleNe(BoxedTuple* self, Box* rhs) {
-    if (!isSubclass(rhs->cls, tuple_cls)) {
-        return NotImplemented;
-    }
-    return _tupleCmp(self, static_cast<BoxedTuple*>(rhs), AST_TYPE::NotEq);
-}
-
 Box* tupleNonzero(BoxedTuple* self) {
     RELEASE_ASSERT(isSubclass(self->cls, tuple_cls), "");
     return boxBool(self->size() != 0);
@@ -442,6 +359,90 @@ static int64_t tuple_hash(BoxedTuple* v) noexcept {
     return x;
 }
 
+static PyObject* tuplerichcompare(PyObject* v, PyObject* w, int op) noexcept {
+    BoxedTuple* vt, *wt;
+    Py_ssize_t i;
+    Py_ssize_t vlen, wlen;
+
+    if (!PyTuple_Check(v) || !PyTuple_Check(w)) {
+        Py_INCREF(Py_NotImplemented);
+        return Py_NotImplemented;
+    }
+
+    vt = (BoxedTuple*)v;
+    wt = (BoxedTuple*)w;
+
+    vlen = Py_SIZE(vt);
+    wlen = Py_SIZE(wt);
+
+    /* Note:  the corresponding code for lists has an "early out" test
+     * here when op is EQ or NE and the lengths differ.  That pays there,
+     * but Tim was unable to find any real code where EQ/NE tuple
+     * compares don't have the same length, so testing for it here would
+     * have cost without benefit.
+     */
+
+    /* Search for the first index where items are different.
+     * Note that because tuples are immutable, it's safe to reuse
+     * vlen and wlen across the comparison calls.
+     */
+    for (i = 0; i < vlen && i < wlen; i++) {
+        int k = PyObject_RichCompareBool(vt->elts[i], wt->elts[i], Py_EQ);
+        if (k < 0)
+            return NULL;
+        if (!k)
+            break;
+    }
+
+    if (i >= vlen || i >= wlen) {
+        /* No more items to compare -- compare sizes */
+        int cmp;
+        PyObject* res;
+        switch (op) {
+            case Py_LT:
+                cmp = vlen < wlen;
+                break;
+            case Py_LE:
+                cmp = vlen <= wlen;
+                break;
+            case Py_EQ:
+                cmp = vlen == wlen;
+                break;
+            case Py_NE:
+                cmp = vlen != wlen;
+                break;
+            case Py_GT:
+                cmp = vlen > wlen;
+                break;
+            case Py_GE:
+                cmp = vlen >= wlen;
+                break;
+            default:
+                return NULL; /* cannot happen */
+        }
+        if (cmp)
+            res = Py_True;
+        else
+            res = Py_False;
+        Py_INCREF(res);
+        return res;
+    }
+
+    /* We have an item that differs -- shortcuts for EQ/NE */
+    if (op == Py_EQ) {
+        Py_INCREF(Py_False);
+        return Py_False;
+    }
+    if (op == Py_NE) {
+        Py_INCREF(Py_True);
+        return Py_True;
+    }
+
+    /* Compare the final item again using the proper operator */
+    return PyObject_RichCompare(vt->elts[i], wt->elts[i], op);
+}
+
+
 void setupTuple() {
     tuple_iterator_cls = BoxedHeapClass::create(type_cls, object_cls, &tupleIteratorGCHandler, 0, 0,
                                                 sizeof(BoxedTupleIterator), false, "tuple");
@@ -460,12 +461,7 @@ void setupTuple() {
                         new BoxedFunction(boxRTFunction((void*)tupleIter, typeFromClass(tuple_iterator_cls), 1)));
 
 
-    tuple_cls->giveAttr("__lt__", new BoxedFunction(boxRTFunction((void*)tupleLt, UNKNOWN, 2)));
-    tuple_cls->giveAttr("__le__", new BoxedFunction(boxRTFunction((void*)tupleLe, UNKNOWN, 2)));
-    tuple_cls->giveAttr("__gt__", new BoxedFunction(boxRTFunction((void*)tupleGt, UNKNOWN, 2)));
-    tuple_cls->giveAttr("__ge__", new BoxedFunction(boxRTFunction((void*)tupleGe, UNKNOWN, 2)));
-    tuple_cls->giveAttr("__eq__", new BoxedFunction(boxRTFunction((void*)tupleEq, UNKNOWN, 2)));
-    tuple_cls->giveAttr("__ne__", new BoxedFunction(boxRTFunction((void*)tupleNe, UNKNOWN, 2)));
+    tuple_cls->tp_richcompare = tuplerichcompare;
 
     tuple_cls->giveAttr("__nonzero__", new BoxedFunction(boxRTFunction((void*)tupleNonzero, BOXED_BOOL, 1)));
 

--- a/test/tests/comparisons.py
+++ b/test/tests/comparisons.py
@@ -1,12 +1,12 @@
 def f(a, b):
-    print a, b, "<", a < b
-    print a, b, "<=", a <= b
-    print a, b, ">", a > b
-    print a, b, ">=", a >= b
-    print a, b, "==", a == b
-    print a, b, "!=", a != b
-    print a, b, "is", a is b
-    print a, b, "is not", a is not b
+    print repr(a), repr(b), "<", a < b
+    print repr(a), repr(b), "<=", a <= b
+    print repr(a), repr(b), ">", a > b
+    print repr(a), repr(b), ">=", a >= b
+    print repr(a), repr(b), "==", a == b
+    print repr(a), repr(b), "!=", a != b
+    print repr(a), repr(b), "is", a is b
+    print repr(a), repr(b), "is not", a is not b
 
 class C(object):
     pass
@@ -14,7 +14,7 @@ class C(object):
 class Z(object):
     pass
 
-args = [0, 1, 0.1, 1.1, "hello", float('nan'), float('inf'), float('-inf')]#, C(), Z()]
+args = [0, 1, 0.1, 1.1, "hello", float('nan'), float('inf'), float('-inf'), 0L, 1L]#, C(), Z()]
 
 for i in xrange(len(args)):
     for j in xrange(i):


### PR DESCRIPTION
```
              pyston django_migrate.py                  :    2.1s baseline: 2.2 (-0.5%)
              pyston virtualenv_bench.py                :    5.7s baseline: 5.7 (-0.1%)
              pyston django-template.py                 :   10.8s baseline: 11.1 (-2.4%)
              pyston interp2.py                         :    5.1s baseline: 5.2 (-3.2%)
              pyston raytrace.py                        :    6.3s baseline: 6.3 (-1.1%)
              pyston nbody.py                           :    8.6s baseline: 8.3 (+3.8%)
              pyston fannkuch.py                        :    7.3s baseline: 7.2 (+2.0%)
              pyston chaos.py                           :   18.9s baseline: 20.0 (-5.6%)
              pyston fasta.py                           :    5.3s baseline: 5.2 (+0.6%)
              pyston pidigits.py                        :    5.6s baseline: 5.6 (+0.3%)
              pyston richards.py                        :    2.4s baseline: 2.4 (+2.6%)
              pyston deltablue.py                       :    1.7s baseline: 1.8 (-6.7%)
              pyston (geomean-1a6f)                     :    5.4s baseline: 5.4 (-0.9%)
```

I wasn't able to reproduce the nbody regression on my local machine so I'm going to chalk it up to benchmark behavior.