### PR TITLE
for getattrFunc use getattrInternal instead of getattr

### DIFF
--- a/src/runtime/builtin_modules/builtins.cpp
+++ b/src/runtime/builtin_modules/builtins.cpp
@@ -427,7 +427,7 @@ Box* getattrFunc(Box* obj, Box* _str, Box* default_value) {
 
     Box* rtn = NULL;
     try {
-        rtn = getattr(obj, str->data());
+        rtn = getattrInternal(obj, str->data(), NULL);
     } catch (ExcInfo e) {
         if (!e.matches(AttributeError))
             throw e;


### PR DESCRIPTION
getattr throws an exception if the attribute is not present.  getattrFunc already throws the same exception (if there isn't a default value passed in).

For some reason Terminal.app has decided to not let me select text, but the result of this change for django-template.py is:

```
  pyston django-template.py        : 8.0s baseline: 10.9 (-26.5%)
```