### PR TITLE
Slightly change generator StopIteration handling

### DIFF
--- a/src/runtime/generator.cpp
+++ b/src/runtime/generator.cpp
@@ -124,7 +124,7 @@ static void generatorSendInternal(BoxedGenerator* self, Box* v) {
     // check if the generator already exited
     if (self->entryExited) {
         freeGeneratorStack(self);
-        return;
+        raiseExcHelper(StopIteration, (const char*)nullptr);
     }
 
     self->returnValue = v;
@@ -189,9 +189,10 @@ Box* generatorSend(Box* s, Box* v) {
         // exc.
         assert(self->exception.type == NULL || self->exception.matches(StopIteration));
         ExcInfo old_exc = self->exception;
-        self->exception = excInfoForRaise(StopIteration, None, None);
+        // Clear the exception for GC purposes:
+        self->exception = ExcInfo(nullptr, nullptr, nullptr);
         if (old_exc.type == NULL)
-            old_exc = self->exception;
+            raiseExcHelper(StopIteration, (const char*)nullptr);
         raiseRaw(old_exc);
     }
 

--- a/test/tests/generators.py
+++ b/test/tests/generators.py
@@ -108,9 +108,23 @@ g10.next()
 try:
     g10.next()
 except StopIteration as e:
-    print "Cought exc1:", type(e), e
+    print "Caught exc1:", type(e), e
 try:
     g10.next()
 except StopIteration as e:
-    print "Cought exc2:", type(e), e
+    print "Caught exc2:", type(e), e
 
+
+def f():
+    yield 1/0
+g = f()
+
+try:
+    g.next()
+except Exception as e:
+    print type(e), e # ZeroDivisionError
+
+try:
+    g.next()
+except Exception as e:
+    print type(e), e # StopIteration


### PR DESCRIPTION
Unconditionally raise a StopIteration when trying to iterate
a finished generator, regardless of what originally stopped
it from iterating.