### PR TITLE
Some `__future__` import stuff

### DIFF
--- a/from_cpython/Include/Python.h
+++ b/from_cpython/Include/Python.h
@@ -111,6 +111,8 @@
 
 #include "pyfpe.h"
 
+#include "code.h"
+
 #define Py_single_input 256
 #define Py_file_input 257
 #define Py_eval_input 258

--- a/from_cpython/Lib/test/test_binop.py
+++ b/from_cpython/Lib/test/test_binop.py
@@ -1,5 +1,3 @@
-# expected: fail
-# need `exec' support
 """Tests for binary operators on subtypes of built-in types."""
 
 import unittest

--- a/src/capi/abstract.cpp
+++ b/src/capi/abstract.cpp
@@ -18,6 +18,7 @@
 #include "Python.h"
 
 #include "capi/types.h"
+#include "core/ast.h"
 #include "core/threading.h"
 #include "core/types.h"
 #include "runtime/classobj.h"

--- a/src/codegen/ast_interpreter.cpp
+++ b/src/codegen/ast_interpreter.cpp
@@ -373,9 +373,6 @@ Value ASTInterpreter::execute(ASTInterpreter& interpreter, CFGBlock* start_block
 }
 
 Value ASTInterpreter::doBinOp(Box* left, Box* right, int op, BinExpType exp_type) {
-    if (op == AST_TYPE::Div && (source_info->parent_module->future_flags & FF_DIVISION)) {
-        op = AST_TYPE::TrueDiv;
-    }
     switch (exp_type) {
         case BinExpType::AugBinOp:
             return augbinop(left, right, op);
@@ -1017,7 +1014,7 @@ Value ASTInterpreter::visit_exec(AST_Exec* node) {
     Box* globals = node->globals == NULL ? NULL : visit_expr(node->globals).o;
     Box* locals = node->locals == NULL ? NULL : visit_expr(node->locals).o;
 
-    exec(code, globals, locals);
+    exec(code, globals, locals, this->source_info->future_flags);
 
     return Value();
 }

--- a/src/codegen/codegen.cpp
+++ b/src/codegen/codegen.cpp
@@ -34,8 +34,15 @@ namespace pyston {
 
 DS_DEFINE_RWLOCK(codegen_rwlock);
 
-SourceInfo::SourceInfo(BoxedModule* m, ScopingAnalysis* scoping, AST* ast, std::vector<AST_stmt*> body, std::string fn)
-    : parent_module(m), scoping(scoping), ast(ast), cfg(NULL), fn(std::move(fn)), body(std::move(body)) {
+SourceInfo::SourceInfo(BoxedModule* m, ScopingAnalysis* scoping, FutureFlags future_flags, AST* ast,
+                       std::vector<AST_stmt*> body, std::string fn)
+    : parent_module(m),
+      scoping(scoping),
+      future_flags(future_flags),
+      ast(ast),
+      cfg(NULL),
+      fn(std::move(fn)),
+      body(std::move(body)) {
     assert(this->fn.size());
 
     switch (ast->type) {

--- a/src/codegen/irgen/future.cpp
+++ b/src/codegen/irgen/future.cpp
@@ -12,7 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "future.h"
+#include "codegen/irgen/future.h"
+
+#include <map>
+
+#include "core/ast.h"
 
 namespace pyston {
 
@@ -59,7 +63,7 @@ inline bool is_stmt_string(AST_stmt* stmt) {
     return stmt->type == AST_TYPE::Expr && static_cast<AST_Expr*>(stmt)->value->type == AST_TYPE::Str;
 }
 
-FutureFlags getFutureFlags(AST_Module* m, const char* file) {
+FutureFlags getFutureFlags(std::vector<AST_stmt*> const& body, const char* file) {
     FutureFlags ff = 0;
 
     // Set the defaults for the future flags depending on what version we are
@@ -73,8 +77,8 @@ FutureFlags getFutureFlags(AST_Module* m, const char* file) {
     // occur at the beginning of the file.
     bool future_import_allowed = true;
     BadFutureImportVisitor import_visitor(file);
-    for (int i = 0; i < m->body.size(); i++) {
-        AST_stmt* stmt = m->body[i];
+    for (int i = 0; i < body.size(); i++) {
+        AST_stmt* stmt = body[i];
 
         if (stmt->type == AST_TYPE::ImportFrom && static_cast<AST_ImportFrom*>(stmt)->module.str() == "__future__") {
             if (future_import_allowed) {

--- a/src/codegen/irgen/future.cpp
+++ b/src/codegen/irgen/future.cpp
@@ -16,6 +16,8 @@
 
 #include <map>
 
+#include "Python.h"
+
 #include "core/ast.h"
 
 namespace pyston {
@@ -27,13 +29,15 @@ struct FutureOption {
 };
 
 const std::map<std::string, FutureOption> future_options
-    = { { "absolute_import", { version_hex(2, 5, 0), version_hex(3, 0, 0), FF_ABSOLUTE_IMPORT } },
-        { "division", { version_hex(2, 2, 0), version_hex(3, 0, 0), FF_DIVISION } },
-        { "generators", { version_hex(2, 2, 0), version_hex(3, 0, 0), FF_GENERATOR } },
-        { "unicode_literals", { version_hex(2, 6, 0), version_hex(3, 0, 0), FF_UNICODE_LITERALS } },
-        { "print_function", { version_hex(2, 6, 0), version_hex(3, 0, 0), FF_PRINT_FUNCTION } },
-        { "nested_scopes", { version_hex(2, 1, 0), version_hex(2, 2, 0), FF_NESTED_SCOPES } },
-        { "with_statement", { version_hex(2, 5, 0), version_hex(3, 6, 0), FF_WITH_STATEMENT } } };
+    = { { "absolute_import", { version_hex(2, 5, 0), version_hex(3, 0, 0), CO_FUTURE_ABSOLUTE_IMPORT } },
+        { "division", { version_hex(2, 2, 0), version_hex(3, 0, 0), CO_FUTURE_DIVISION } },
+        { "unicode_literals", { version_hex(2, 6, 0), version_hex(3, 0, 0), CO_FUTURE_UNICODE_LITERALS } },
+        { "print_function", { version_hex(2, 6, 0), version_hex(3, 0, 0), CO_FUTURE_PRINT_FUNCTION } },
+        { "with_statement", { version_hex(2, 5, 0), version_hex(3, 6, 0), CO_FUTURE_WITH_STATEMENT } },
+
+        // These are mandatory in all versions we care about (>= 2.3)
+        { "generators", { version_hex(2, 2, 0), version_hex(3, 0, 0), CO_GENERATOR } },
+        { "nested_scopes", { version_hex(2, 1, 0), version_hex(2, 2, 0), CO_NESTED } } };
 
 void raiseFutureImportErrorNotFound(const char* file, AST* node, const char* name) {
     raiseSyntaxErrorHelper(file, "", node, "future feature %s is not defined", name);

--- a/src/codegen/irgen/future.h
+++ b/src/codegen/irgen/future.h
@@ -21,14 +21,6 @@
 
 namespace pyston {
 
-#define FF_ABSOLUTE_IMPORT 0x01
-#define FF_DIVISION 0x02
-#define FF_GENERATOR 0x04
-#define FF_UNICODE_LITERALS 0x08
-#define FF_PRINT_FUNCTION 0x10
-#define FF_NESTED_SCOPES 0x20
-#define FF_WITH_STATEMENT 0x40
-
 // Loop through import statements to find __future__ imports throwing errors for
 // bad __future__ imports. Returns the futures that are turned on. This is used
 // for irgeneration; the parser still has to handle some futures on its own,

--- a/src/codegen/irgen/future.h
+++ b/src/codegen/irgen/future.h
@@ -15,10 +15,8 @@
 #ifndef PYSTON_CODEGEN_IRGEN_FUTURE_H
 #define PYSTON_CODEGEN_IRGEN_FUTURE_H
 
-#include <map>
+#include <vector>
 
-#include "core/ast.h"
-#include "core/options.h"
 #include "core/types.h"
 
 namespace pyston {
@@ -31,13 +29,11 @@ namespace pyston {
 #define FF_NESTED_SCOPES 0x20
 #define FF_WITH_STATEMENT 0x40
 
-typedef int FutureFlags;
-
 // Loop through import statements to find __future__ imports throwing errors for
 // bad __future__ imports. Returns the futures that are turned on. This is used
 // for irgeneration; the parser still has to handle some futures on its own,
 // when they are relevant for the parser.
-FutureFlags getFutureFlags(AST_Module* m, const char* file);
+FutureFlags getFutureFlags(std::vector<AST_stmt*> const& body, const char* file);
 }
 
 #endif

--- a/src/codegen/irgen/hooks.h
+++ b/src/codegen/irgen/hooks.h
@@ -17,6 +17,8 @@
 
 #include <string>
 
+#include "core/types.h"
+
 namespace pyston {
 
 struct CompiledFunction;
@@ -37,7 +39,7 @@ void compileAndRunModule(AST_Module* m, BoxedModule* bm);
 // will we always want to generate unique function names? (ie will this function always be reasonable?)
 CompiledFunction* cfForMachineFunctionName(const std::string&);
 
-extern "C" Box* exec(Box* boxedCode, Box* globals, Box* locals);
+extern "C" Box* exec(Box* boxedCode, Box* globals, Box* locals, FutureFlags caller_future_flags);
 extern "C" Box* eval(Box* boxedCode, Box* globals, Box* locals);
 extern "C" Box* compile(Box* source, Box* filename, Box* mode, Box** _args /* flags, dont_inherit */);
 }

--- a/src/codegen/unwinding.h
+++ b/src/codegen/unwinding.h
@@ -98,6 +98,8 @@ struct FrameStackState {
 
 // Returns all the stack locals, including hidden ones.
 FrameStackState getFrameStackState();
+
+CompiledFunction* getTopCompiledFunction();
 }
 
 #endif

--- a/src/core/cfg.cpp
+++ b/src/core/cfg.cpp
@@ -19,6 +19,8 @@
 #include <cstdio>
 #include <cstdlib>
 
+#include "Python.h"
+
 #include "analysis/scoping_analysis.h"
 #include "core/ast.h"
 #include "core/options.h"
@@ -1481,7 +1483,7 @@ public:
             // level == -1 means check both sys path and relative for imports.
             // so if `from __future__ import absolute_import` was used in the file, set level to 0
             int level;
-            if (!(future_flags & FF_ABSOLUTE_IMPORT))
+            if (!(future_flags & CO_FUTURE_ABSOLUTE_IMPORT))
                 level = -1;
             else
                 level = 0;
@@ -1532,7 +1534,7 @@ public:
         // level == -1 means check both sys path and relative for imports.
         // so if `from __future__ import absolute_import` was used in the file, set level to 0
         int level;
-        if (node->level == 0 && !(future_flags & FF_ABSOLUTE_IMPORT))
+        if (node->level == 0 && !(future_flags & CO_FUTURE_ABSOLUTE_IMPORT))
             level = -1;
         else
             level = node->level;
@@ -1729,7 +1731,7 @@ public:
     }
 
     AST_TYPE::AST_TYPE remapBinOpType(AST_TYPE::AST_TYPE op_type) {
-        if (op_type == AST_TYPE::Div && (future_flags & (FF_DIVISION))) {
+        if (op_type == AST_TYPE::Div && (future_flags & (CO_FUTURE_DIVISION))) {
             return AST_TYPE::TrueDiv;
         } else {
             return op_type;

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -242,6 +242,8 @@ private:
     ParamNames() : takes_param_names(false) {}
 };
 
+typedef int FutureFlags;
+
 class BoxedModule;
 class ScopeInfo;
 class InternedStringPool;
@@ -249,6 +251,7 @@ class SourceInfo {
 public:
     BoxedModule* parent_module;
     ScopingAnalysis* scoping;
+    FutureFlags future_flags;
     AST* ast;
     CFG* cfg;
     bool is_generator;
@@ -267,7 +270,8 @@ public:
 
     Box* getDocString();
 
-    SourceInfo(BoxedModule* m, ScopingAnalysis* scoping, AST* ast, std::vector<AST_stmt*> body, std::string fn);
+    SourceInfo(BoxedModule* m, ScopingAnalysis* scoping, FutureFlags future_flags, AST* ast,
+               std::vector<AST_stmt*> body, std::string fn);
 };
 
 typedef std::vector<CompiledFunction*> FunctionList;

--- a/src/runtime/builtin_modules/ast.cpp
+++ b/src/runtime/builtin_modules/ast.cpp
@@ -21,6 +21,7 @@
 #include "llvm/Support/Path.h"
 
 #include "codegen/unwinding.h"
+#include "core/ast.h"
 #include "core/types.h"
 #include "gc/collector.h"
 #include "runtime/file.h"

--- a/src/runtime/builtin_modules/builtins.cpp
+++ b/src/runtime/builtin_modules/builtins.cpp
@@ -1282,9 +1282,11 @@ void setupBuiltins() {
     builtins_module->giveAttr("execfile",
                               new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)execfile, UNKNOWN, 1), "execfile"));
 
-    builtins_module->giveAttr(
-        "compile", new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)compile, UNKNOWN, 5, 2, false, false),
-                                                    "compile", { boxInt(0), boxInt(0) }));
+    CLFunction* compile_func = createRTFunction(
+        5, 2, false, false, ParamNames({ "source", "filename", "mode", "flags", "dont_inherit" }, "", ""));
+    addRTFunction(compile_func, (void*)compile, UNKNOWN, { UNKNOWN, UNKNOWN, UNKNOWN, UNKNOWN, UNKNOWN });
+    builtins_module->giveAttr("compile",
+                              new BoxedBuiltinFunctionOrMethod(compile_func, "compile", { boxInt(0), boxInt(0) }));
 
     builtins_module->giveAttr(
         "map", new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)map, LIST, 1, 0, true, false), "map"));

--- a/src/runtime/code.cpp
+++ b/src/runtime/code.cpp
@@ -18,6 +18,7 @@
 
 #include "code.h"
 
+#include "core/ast.h"
 #include "gc/collector.h"
 #include "runtime/objmodel.h"
 #include "runtime/set.h"

--- a/src/runtime/cxx_unwind.cpp
+++ b/src/runtime/cxx_unwind.cpp
@@ -22,10 +22,11 @@
 
 #include "codegen/ast_interpreter.h" // interpreter_instr_addr
 #include "codegen/unwinding.h"       // getCFForAddress
-#include "core/stats.h"              // StatCounter
-#include "core/types.h"              // for ExcInfo
-#include "core/util.h"               // Timer
-#include "runtime/generator.h"       // generatorEntry
+#include "core/ast.h"
+#include "core/stats.h"        // StatCounter
+#include "core/types.h"        // for ExcInfo
+#include "core/util.h"         // Timer
+#include "runtime/generator.h" // generatorEntry
 
 #define UNW_LOCAL_ONLY
 #include <libunwind.h>

--- a/src/runtime/dict.cpp
+++ b/src/runtime/dict.cpp
@@ -15,6 +15,7 @@
 #include "runtime/dict.h"
 
 #include "capi/types.h"
+#include "core/ast.h"
 #include "core/common.h"
 #include "core/stats.h"
 #include "core/types.h"

--- a/src/runtime/frame.cpp
+++ b/src/runtime/frame.cpp
@@ -16,6 +16,7 @@
 #include "pythread.h"
 
 #include "codegen/unwinding.h"
+#include "core/ast.h"
 #include "runtime/types.h"
 
 namespace pyston {

--- a/src/runtime/import.cpp
+++ b/src/runtime/import.cpp
@@ -22,6 +22,7 @@
 #include "codegen/irgen/hooks.h"
 #include "codegen/parser.h"
 #include "codegen/unwinding.h"
+#include "core/ast.h"
 #include "runtime/capi.h"
 #include "runtime/objmodel.h"
 

--- a/src/runtime/int.cpp
+++ b/src/runtime/int.cpp
@@ -18,6 +18,7 @@
 #include <sstream>
 
 #include "capi/typeobject.h"
+#include "core/ast.h"
 #include "core/common.h"
 #include "core/options.h"
 #include "core/stats.h"

--- a/src/runtime/stacktrace.cpp
+++ b/src/runtime/stacktrace.cpp
@@ -17,6 +17,7 @@
 #include <dlfcn.h>
 
 #include "codegen/unwinding.h"
+#include "core/ast.h"
 #include "core/options.h"
 #include "gc/collector.h"
 #include "runtime/objmodel.h"

--- a/src/runtime/types.cpp
+++ b/src/runtime/types.cpp
@@ -22,10 +22,12 @@
 
 #include "llvm/Support/raw_ostream.h"
 
+#include "analysis/scoping_analysis.h"
 #include "capi/typeobject.h"
 #include "capi/types.h"
 #include "codegen/ast_interpreter.h"
 #include "codegen/unwinding.h"
+#include "core/ast.h"
 #include "core/options.h"
 #include "core/stats.h"
 #include "core/types.h"

--- a/test/tests/compile_future.py
+++ b/test/tests/compile_future.py
@@ -5,4 +5,10 @@ print 1 / 2
 exec "print 1 / 2"
 exec compile("print 1 / 2", "<string>", "exec")
 # But you can explicitly request that they not be inherited:
-# exec compile("print 1 / 2", "<string>", "exec", flags=0, dont_inherit=True)
+exec compile("print 1 / 2", "<string>", "exec", flags=0, dont_inherit=True)
+exec compile("print 1 / 2", "<string>", "exec", flags=division.compiler_flag, dont_inherit=True)
+
+# test the above but with eval
+print eval(compile("1 / 2", "<string>", "eval"))
+print eval(compile("1 / 2", "<string>", "eval", flags=0, dont_inherit=True))
+print eval(compile("1 / 2", "<string>", "eval", flags=division.compiler_flag, dont_inherit=True))

--- a/test/tests/compile_future2.py
+++ b/test/tests/compile_future2.py
@@ -1,0 +1,17 @@
+# co is compiled without the __future__ division import.
+# So even though the import is present in the exec statements,
+# the code will be evaluated without it. Each should print 0.
+
+co = compile("1 / 2", "<string>", "eval")
+
+exec """
+from __future__ import division
+print eval(co)
+"""
+
+co = compile("print 1 / 2", "<string>", "exec")
+
+exec """
+from __future__ import division
+exec co
+"""

--- a/test/tests/exec_future_import.py
+++ b/test/tests/exec_future_import.py
@@ -1,0 +1,28 @@
+print 1 / 2
+
+exec """
+print 1 / 2
+"""
+
+exec """
+from __future__ import division
+print 1 / 2
+"""
+
+exec """
+from __future__ import division
+exec "print 1 / 2"
+"""
+
+print 1 / 2
+
+print eval("1 / 2")
+
+exec """
+print eval("1 / 2")
+"""
+
+exec """
+from __future__ import division
+print eval("1 / 2")
+"""

--- a/test/tests/exec_future_import2.py
+++ b/test/tests/exec_future_import2.py
@@ -1,0 +1,21 @@
+from __future__ import division
+
+print 1 / 2
+
+exec """print 1 / 2"""
+
+exec """
+from __future__ import division
+print 1 / 2
+"""
+
+print eval("1 / 2")
+
+exec """
+print eval("1 / 2")
+"""
+
+exec """
+from __future__ import division
+print eval("1 / 2")
+"""


### PR DESCRIPTION
- Move `FutureFlags` from `BoxedModule` to `SourceInfo`.
- Handle `__future__` imports in exec statements.
- Handle the `division` import in cfg gen rather than later.

(This was prompted by a cpython test case that uses `from __future__ import division` in an exec statement.)

Seems like there is still a lot of cleaning up to do, but this is a step in the right direction. Notably, we have our own constants for the future imports, even though they're defined in cpython too.