### PR TITLE
Use the padding bytes at the end of BoxedString

### DIFF
--- a/src/runtime/types.cpp
+++ b/src/runtime/types.cpp
@@ -2394,7 +2394,9 @@ void setupRuntime() {
     basestring_cls = new (0) BoxedHeapClass(object_cls, NULL, 0, 0, sizeof(Box), false, NULL);
 
     // We add 1 to the tp_basicsize of the BoxedString in order to hold the null byte at the end.
-    str_cls = new (0) BoxedHeapClass(basestring_cls, NULL, 0, 0, sizeof(BoxedString) + 1, false, NULL);
+    // We use offsetof(BoxedString, s_data) as opposed to sizeof(BoxedString) so that we can
+    // use the extra padding bytes at the end of the BoxedString.
+    str_cls = new (0) BoxedHeapClass(basestring_cls, NULL, 0, 0, offsetof(BoxedString, s_data) + 1, false, NULL);
     str_cls->tp_flags |= Py_TPFLAGS_STRING_SUBCLASS;
     str_cls->tp_itemsize = sizeof(char);
 

--- a/src/runtime/types.h
+++ b/src/runtime/types.h
@@ -440,7 +440,7 @@ public:
 
         assert(str_cls->tp_alloc == PystonType_GenericAlloc);
         assert(str_cls->tp_itemsize == 1);
-        assert(str_cls->tp_basicsize == sizeof(BoxedString) + 1);
+        assert(str_cls->tp_basicsize == offsetof(BoxedString, s_data) + 1);
         assert(str_cls->is_pyston_class);
         assert(str_cls->attrs_offset == 0);
 
@@ -453,7 +453,7 @@ public:
         return rtn;
     }
 
-    // these should be private, but strNew needs them
+    // these should be private, but str.cpp needs them
     BoxedString(const char* s, size_t n) __attribute__((visibility("default")));
     explicit BoxedString(size_t n, char c) __attribute__((visibility("default")));
     explicit BoxedString(llvm::StringRef s) __attribute__((visibility("default")));
@@ -463,6 +463,8 @@ private:
     void* operator new(size_t size) = delete;
 
     char s_data[0];
+
+    friend void setupRuntime();
 };
 
 template <typename T> struct StringHash {


### PR DESCRIPTION
CPython has this optimization as well, and it should
save us an average of 7 bytes per string.