### PR TITLE
factor out find_cf to pyston::binarySearch, and use to locate large/huge objects

### DIFF
--- a/src/core/types.h
+++ b/src/core/types.h
@@ -720,6 +720,29 @@ struct CallattrFlags {
 
     char asInt() { return (cls_only << 0) + (null_on_nonexistent << 1); }
 };
+
+// similar to Java's Array.binarySearch:
+// return values are either:
+//   >= 0 : the index where a given item was found
+//   < 0  : a negative number that can be transformed (using "-num-1") into the insertion point
+//
+template <typename T, typename RandomAccessIterator, typename Cmp>
+int binarySearch(T needle, RandomAccessIterator start, RandomAccessIterator end, Cmp cmp) {
+    int l = 0;
+    int r = end - start - 1;
+    while (l <= r) {
+        int mid = l + (r - l) / 2;
+        auto mid_item = *(start + mid);
+        int c = cmp(needle, mid_item);
+        if (c < 0)
+            r = mid - 1;
+        else if (c > 0)
+            l = mid + 1;
+        else
+            return mid;
+    }
+    return -(l + 1);
+}
 }
 
 namespace std {

--- a/src/gc/heap.h
+++ b/src/gc/heap.h
@@ -380,8 +380,8 @@ private:
 
     static constexpr int NUM_FREE_LISTS = 32;
 
+    std::vector<LargeObj*> allocated_objects;
     Heap* heap;
-    LargeObj* head;
     LargeBlock* blocks;
     LargeFreeChunk* free_lists[NUM_FREE_LISTS]; /* 0 is for larger sizes */
 
@@ -391,7 +391,7 @@ private:
     void _freeLargeObj(LargeObj* obj);
 
 public:
-    LargeArena(Heap* heap) : heap(heap), head(NULL), blocks(NULL) {}
+    LargeArena(Heap* heap) : heap(heap), blocks(NULL) {}
 
     /* Largest object that can be allocated in a large block. */
     static constexpr size_t ALLOC_SIZE_LIMIT = BLOCK_SIZE - CHUNK_SIZE - sizeof(LargeObj);
@@ -426,11 +426,11 @@ public:
 private:
     struct HugeObj {
         HugeObj* next, **prev;
-        size_t obj_size;
+        size_t size;
         GCAllocation data[0];
 
         int mmap_size() {
-            size_t total_size = obj_size + sizeof(HugeObj);
+            size_t total_size = size + sizeof(HugeObj);
             total_size = (total_size + PAGE_SIZE - 1) & ~(PAGE_SIZE - 1);
             return total_size;
         }
@@ -446,8 +446,7 @@ private:
 
     void _freeHugeObj(HugeObj* lobj);
 
-    HugeObj* head;
-
+    std::vector<HugeObj*> allocated_objects;
     Heap* heap;
 };
 


### PR DESCRIPTION
LargeArena::allocationFrom has been showing up in the perf traces forever, and it's only going to get worse with the finalizer passes.