### PR TITLE
cmake testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ before_script:
 
 script:
   - ccache -z
-  - PYSTON_RUN_ARGS=G ninja -j4 check-pyston
+  - PYSTON_RUN_ARGS=G travis_wait ninja -j4 check-pyston
   - ccache -s
 
 os:

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,11 +62,6 @@ os:
 # - osx
 
 notifications:
-  irc:
-    channels:
-      - "chat.freenode.net#pyston"
-    on_success: [change]
-
   webhooks:
     urls:
       - https://webhooks.gitter.im/e/7256425a36658faa8b9b

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,11 +49,13 @@ install:
   - cmake -GNinja -DTEST_THREADS=4 $TRAVIS_BUILD_DIR
   - ninja libunwind ext_cpython
 
+before_script:
+  - mysql -e 'create database mysqldb_test charset utf8;'
+
 script:
   - ccache -z
   - PYSTON_RUN_ARGS=G ninja -j4 check-pyston
   - ccache -s
-  - mysql -e 'create database mysqldb_test charset utf8;'
   - PYSTON_RUN_ARGS=G python $TRAVIS_BUILD_DIR/tools/tester.py -R ./pyston -a=-S -k -t600 --exit-code-only $TRAVIS_BUILD_DIR/test/extra
 
 os:

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,15 +47,17 @@ install:
   - mkdir ~/pyston-build && cd ~/pyston-build
   - make -C $TRAVIS_BUILD_DIR llvm_up
   - cmake -GNinja -DTEST_THREADS=4 -DENABLE_EXTRA_TESTS=ON $TRAVIS_BUILD_DIR
-  - ninja libunwind ext_cpython
 
 before_script:
   - mysql -e 'create database mysqldb_test charset utf8;'
 
 script:
+  - echo 'Building Pyston' && echo -en 'travis_fold:start:compiling\\r'
   - ccache -z
-  - PYSTON_RUN_ARGS=G travis_wait ninja -j4 check-pyston
+  - PYSTON_RUN_ARGS=G ninja -j4 check-deps
   - ccache -s
+  - echo -en 'travis_fold:end:compiling\\r'
+  - ctest --output-on-failure
 
 os:
   - linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ install:
   - git config --global user.name "Your Name"
   - mkdir ~/pyston-build && cd ~/pyston-build
   - make -C $TRAVIS_BUILD_DIR llvm_up
-  - cmake -GNinja -DTEST_THREADS=4 $TRAVIS_BUILD_DIR
+  - cmake -GNinja -DTEST_THREADS=4 -DENABLE_EXTRA_TESTS=ON $TRAVIS_BUILD_DIR
   - ninja libunwind ext_cpython
 
 before_script:
@@ -56,7 +56,6 @@ script:
   - ccache -z
   - PYSTON_RUN_ARGS=G ninja -j4 check-pyston
   - ccache -s
-  - PYSTON_RUN_ARGS=G python $TRAVIS_BUILD_DIR/tools/tester.py -R ./pyston -a=-S -k -t600 --exit-code-only $TRAVIS_BUILD_DIR/test/extra
 
 os:
   - linux

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ if(NOT ${CMAKE_BUILD_TYPE} STREQUAL "Release" AND NOT ${CMAKE_BUILD_TYPE} STREQU
 endif()
 
 option(ENABLE_CCACHE "enable caching compiler output" ON)
+option(ENABLE_EXTRA_TESTS "pyston extra tests" OFF)
 option(ENABLE_GIL "threading use GIL" ON)
 option(ENABLE_GOLD "enable the gold linker" ON)
 option(ENABLE_GPERFTOOLS "enable the google performance tools" OFF)
@@ -236,6 +237,11 @@ add_test(NAME pyston_defaults_cpython_tests COMMAND ${PYTHON_EXE} ${CMAKE_SOURCE
 add_test(NAME pyston_defaults_integration_tests COMMAND ${PYTHON_EXE} ${CMAKE_SOURCE_DIR}/tools/tester.py -R ./pyston -j${TEST_THREADS} -a=-S -k --exit-code-only --skip-failing -t600 ${CMAKE_SOURCE_DIR}/test/integration)
 add_test(NAME pyston_max_compilation_tier COMMAND ${PYTHON_EXE} ${CMAKE_SOURCE_DIR}/tools/tester.py -R ./pyston -j${TEST_THREADS} -a=-O -a=-S -k ${CMAKE_SOURCE_DIR}/test/tests)
 add_test(NAME pyston_old_parser COMMAND ${PYTHON_EXE} ${CMAKE_SOURCE_DIR}/tools/tester.py -a=-x -R ./pyston -j${TEST_THREADS} -a=-n -a=-S -k ${CMAKE_SOURCE_DIR}/test/tests)
+
+if(ENABLE_EXTRA_TESTS)
+  add_test(NAME extra_tests COMMAND ${PYTHON_EXE} ${CMAKE_SOURCE_DIR}/tools/tester.py -R ./pyston -a=-S -k -t600 --exit-code-only ${CMAKE_SOURCE_DIR}/test/extra)
+endif()
+
 
 # format
 file(GLOB_RECURSE FORMAT_FILES ${CMAKE_SOURCE_DIR}/src/*.h ${CMAKE_SOURCE_DIR}/src/*.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -247,7 +247,7 @@ add_test(NAME pyston_defaults_cpython_tests COMMAND ${PYTHON_EXE} ${CMAKE_SOURCE
 add_test(NAME pyston_defaults_integration_tests COMMAND ${PYTHON_EXE} ${CMAKE_SOURCE_DIR}/tools/tester.py -R ./pyston -j${TEST_THREADS} -k -a=-S --exit-code-only --skip-failing -t600 ${CMAKE_SOURCE_DIR}/test/integration)
 
 if(ENABLE_EXTRA_TESTS)
-  add_test(NAME extra_tests COMMAND ${PYTHON_EXE} ${CMAKE_SOURCE_DIR}/tools/tester.py -R ./pyston -j${TEST_THREADS} -a=-S -k -t600 --exit-code-only ${CMAKE_SOURCE_DIR}/test/extra)
+  add_test(NAME pyston_defaults_extra_tests COMMAND ${PYTHON_EXE} ${CMAKE_SOURCE_DIR}/tools/tester.py -R ./pyston -j${TEST_THREADS} -k -a=-S -t600 --exit-code-only ${CMAKE_SOURCE_DIR}/test/extra)
 endif()
 
 
@@ -260,7 +260,8 @@ add_custom_target(check-format ${CMAKE_SOURCE_DIR}/tools/check_format.sh ${LLVM_
 add_custom_target(lint ${PYTHON_EXE} ${CMAKE_SOURCE_DIR}/tools/lint.py WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/src)
 
 # check
-add_custom_target(check-pyston COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure DEPENDS pyston copy_stdlib copy_libpyston clang-format ext_cpython ext_pyston unittests sharedmods)
+add_custom_target(check-deps DEPENDS pyston copy_stdlib copy_libpyston clang-format ext_cpython ext_pyston unittests sharedmods)
+add_custom_target(check-pyston COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure DEPENDS check-deps)
 
 # {run,dbg,perf,memcheck,memleaks,cachegrind}_TESTNAME
 file(GLOB RUNTARGETS ${CMAKE_SOURCE_DIR}/test/tests/*.py ${CMAKE_SOURCE_DIR}/microbenchmarks/*.py ${CMAKE_SOURCE_DIR}/minibenchmarks/*.py)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -231,15 +231,23 @@ add_test(NAME lint COMMAND ${PYTHON_EXE} ${CMAKE_SOURCE_DIR}/tools/lint.py WORKI
 add_test(NAME check-format COMMAND ${CMAKE_SOURCE_DIR}/tools/check_format.sh ${LLVM_TOOLS_BINARY_DIR}/clang-format WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/src)
 add_test(NAME gc_unittest COMMAND gc_unittest)
 add_test(NAME analysis_unittest COMMAND analysis_unittest)
-add_test(NAME pyston_defaults COMMAND ${PYTHON_EXE} ${CMAKE_SOURCE_DIR}/tools/tester.py -R ./pyston -j${TEST_THREADS} -a=-S -k ${CMAKE_SOURCE_DIR}/test/tests)
-# we pass -I to cpython tests and skip failing ones b/c they are slooow otherwise
-add_test(NAME pyston_defaults_cpython_tests COMMAND ${PYTHON_EXE} ${CMAKE_SOURCE_DIR}/tools/tester.py -R ./pyston -j${TEST_THREADS} -a=-S -k --exit-code-only --skip-failing -t30 ${CMAKE_SOURCE_DIR}/test/cpython)
-add_test(NAME pyston_defaults_integration_tests COMMAND ${PYTHON_EXE} ${CMAKE_SOURCE_DIR}/tools/tester.py -R ./pyston -j${TEST_THREADS} -a=-S -k --exit-code-only --skip-failing -t600 ${CMAKE_SOURCE_DIR}/test/integration)
-add_test(NAME pyston_max_compilation_tier COMMAND ${PYTHON_EXE} ${CMAKE_SOURCE_DIR}/tools/tester.py -R ./pyston -j${TEST_THREADS} -a=-O -a=-S -k ${CMAKE_SOURCE_DIR}/test/tests)
+
+# test/tests
+add_test(NAME pyston_defaults COMMAND ${PYTHON_EXE} ${CMAKE_SOURCE_DIR}/tools/tester.py -R ./pyston -j${TEST_THREADS} -k -a=-S ${CMAKE_SOURCE_DIR}/test/tests)
 add_test(NAME pyston_old_parser COMMAND ${PYTHON_EXE} ${CMAKE_SOURCE_DIR}/tools/tester.py -a=-x -R ./pyston -j${TEST_THREADS} -a=-n -a=-S -k ${CMAKE_SOURCE_DIR}/test/tests)
+# skip -O for dbg
+if(${CMAKE_BUILD_TYPE} STREQUAL "Release")
+  add_test(NAME pyston_max_compilation_tier COMMAND ${PYTHON_EXE} ${CMAKE_SOURCE_DIR}/tools/tester.py -R ./pyston -j${TEST_THREADS} -k -a=-n -a=-x -a=-S ${CMAKE_SOURCE_DIR}/test/tests)
+endif()
+
+# cpython tests - we pass -I to cpython tests and skip failing ones b/c they are slooow otherwise
+add_test(NAME pyston_defaults_cpython_tests COMMAND ${PYTHON_EXE} ${CMAKE_SOURCE_DIR}/tools/tester.py -R ./pyston -j${TEST_THREADS} -k -a=-S --exit-code-only --skip-failing -t30 ${CMAKE_SOURCE_DIR}/test/cpython)
+
+# integration tests
+add_test(NAME pyston_defaults_integration_tests COMMAND ${PYTHON_EXE} ${CMAKE_SOURCE_DIR}/tools/tester.py -R ./pyston -j${TEST_THREADS} -k -a=-S --exit-code-only --skip-failing -t600 ${CMAKE_SOURCE_DIR}/test/integration)
 
 if(ENABLE_EXTRA_TESTS)
-  add_test(NAME extra_tests COMMAND ${PYTHON_EXE} ${CMAKE_SOURCE_DIR}/tools/tester.py -R ./pyston -a=-S -k -t600 --exit-code-only ${CMAKE_SOURCE_DIR}/test/extra)
+  add_test(NAME extra_tests COMMAND ${PYTHON_EXE} ${CMAKE_SOURCE_DIR}/tools/tester.py -R ./pyston -j${TEST_THREADS} -a=-S -k -t600 --exit-code-only ${CMAKE_SOURCE_DIR}/test/extra)
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -232,22 +232,20 @@ add_test(NAME check-format COMMAND ${CMAKE_SOURCE_DIR}/tools/check_format.sh ${L
 add_test(NAME gc_unittest COMMAND gc_unittest)
 add_test(NAME analysis_unittest COMMAND analysis_unittest)
 
-# test/tests
-add_test(NAME pyston_defaults COMMAND ${PYTHON_EXE} ${CMAKE_SOURCE_DIR}/tools/tester.py -R ./pyston -j${TEST_THREADS} -k -a=-S --order-by-mtime ${CMAKE_SOURCE_DIR}/test/tests)
-add_test(NAME pyston_old_parser COMMAND ${PYTHON_EXE} ${CMAKE_SOURCE_DIR}/tools/tester.py -a=-x -R ./pyston -j${TEST_THREADS} -a=-n -a=-S -k ${CMAKE_SOURCE_DIR}/test/tests)
-# skip -O for dbg
+macro(add_pyston_test testname directory)
+  add_test(NAME pyston_${testname}_${directory} COMMAND ${PYTHON_EXE} ${CMAKE_SOURCE_DIR}/tools/tester.py -R ./pyston -j${TEST_THREADS} -k -a=-S ${ARGV2} ${ARGV3} ${ARGV4} ${CMAKE_SOURCE_DIR}/test/${directory})
+endmacro()
+
+# tests         testname directory arguments
+add_pyston_test(defaults tests --order-by-mtime)
+add_pyston_test(old_parser tests -a=-n -a=-x)
 if(${CMAKE_BUILD_TYPE} STREQUAL "Release")
-  add_test(NAME pyston_max_compilation_tier COMMAND ${PYTHON_EXE} ${CMAKE_SOURCE_DIR}/tools/tester.py -R ./pyston -j${TEST_THREADS} -k -a=-n -a=-x -a=-S ${CMAKE_SOURCE_DIR}/test/tests)
+  add_pyston_test(max_compilation_tier tests -a=-O -a=-x)
 endif()
-
-# cpython tests - we pass -I to cpython tests and skip failing ones b/c they are slooow otherwise
-add_test(NAME pyston_defaults_cpython_tests COMMAND ${PYTHON_EXE} ${CMAKE_SOURCE_DIR}/tools/tester.py -R ./pyston -j${TEST_THREADS} -k -a=-S --exit-code-only --skip-failing -t30 ${CMAKE_SOURCE_DIR}/test/cpython)
-
-# integration tests
-add_test(NAME pyston_defaults_integration_tests COMMAND ${PYTHON_EXE} ${CMAKE_SOURCE_DIR}/tools/tester.py -R ./pyston -j${TEST_THREADS} -k -a=-S --exit-code-only --skip-failing -t600 ${CMAKE_SOURCE_DIR}/test/integration)
-
+add_pyston_test(defaults cpython --exit-code-only --skip-failing -t30)
+add_pyston_test(defaults integration --exit-code-only --skip-failing -t600)
 if(ENABLE_EXTRA_TESTS)
-  add_test(NAME pyston_defaults_extra_tests COMMAND ${PYTHON_EXE} ${CMAKE_SOURCE_DIR}/tools/tester.py -R ./pyston -j${TEST_THREADS} -k -a=-S -t600 --exit-code-only ${CMAKE_SOURCE_DIR}/test/extra)
+  add_pyston_test(defaults extra -t600 --exit-code-only)
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,7 +233,7 @@ add_test(NAME gc_unittest COMMAND gc_unittest)
 add_test(NAME analysis_unittest COMMAND analysis_unittest)
 
 # test/tests
-add_test(NAME pyston_defaults COMMAND ${PYTHON_EXE} ${CMAKE_SOURCE_DIR}/tools/tester.py -R ./pyston -j${TEST_THREADS} -k -a=-S ${CMAKE_SOURCE_DIR}/test/tests)
+add_test(NAME pyston_defaults COMMAND ${PYTHON_EXE} ${CMAKE_SOURCE_DIR}/tools/tester.py -R ./pyston -j${TEST_THREADS} -k -a=-S --order-by-mtime ${CMAKE_SOURCE_DIR}/test/tests)
 add_test(NAME pyston_old_parser COMMAND ${PYTHON_EXE} ${CMAKE_SOURCE_DIR}/tools/tester.py -a=-x -R ./pyston -j${TEST_THREADS} -a=-n -a=-S -k ${CMAKE_SOURCE_DIR}/test/tests)
 # skip -O for dbg
 if(${CMAKE_BUILD_TYPE} STREQUAL "Release")

--- a/Makefile
+++ b/Makefile
@@ -512,28 +512,12 @@ cpplint:
 .PHONY: check
 check:
 	@# These are ordered roughly in decreasing order of (chance will expose issue) / (time to run test)
-	$(MAKE) lint
-	$(MAKE) check_format
+
 	$(MAKE) pyston_dbg $(CHECK_DEPS)
-
-	$(PYTHON) $(TOOLS_DIR)/tester.py -R pyston_dbg -j$(TEST_THREADS) -k -a=-S $(TESTS_DIR) $(ARGS)
-	@# we pass -I to cpython tests & skip failing ones because they are sloooow otherwise
-	$(PYTHON) $(TOOLS_DIR)/tester.py -R pyston_dbg -j$(TEST_THREADS) -k -a=-S --exit-code-only --skip-failing -t30 $(TEST_DIR)/cpython $(ARGS)
-	$(PYTHON) $(TOOLS_DIR)/tester.py -R pyston_dbg -j$(TEST_THREADS) -k -a=-S --exit-code-only --skip-failing -t600 $(TEST_DIR)/integration $(ARGS)
-	$(PYTHON) $(TOOLS_DIR)/tester.py -R pyston_dbg -j$(TEST_THREADS) -k -a=-n -a=-x -a=-S $(TESTS_DIR) $(ARGS)
-	@# skip -O for dbg
-
-	$(MAKE) run_unittests ARGS=
+	( cd $(CMAKE_DIR_DBG) && ctest -V )
 
 	$(MAKE) pyston_release
-	@# It can be useful to test release mode, since it actually exposes different functionality
-	@# since we can make different decisions about which internal functions to inline or not.
-	$(PYTHON) $(TOOLS_DIR)/tester.py -R pyston_release -j$(TEST_THREADS) -k -a=-S $(TESTS_DIR) $(ARGS)
-	@# we pass -I to cpython tests and skip failing ones because they are sloooow otherwise
-	$(PYTHON) $(TOOLS_DIR)/tester.py -R pyston_release -j$(TEST_THREADS) -k -a=-S --exit-code-only --skip-failing $(TEST_DIR)/cpython $(ARGS)
-	$(PYTHON) $(TOOLS_DIR)/tester.py -R pyston_release -j$(TEST_THREADS) -k -a=-S --exit-code-only --skip-failing -t120 $(TEST_DIR)/integration $(ARGS)
-	@# skip -n for dbg
-	$(PYTHON) $(TOOLS_DIR)/tester.py -R pyston_release -j$(TEST_THREADS) -k -a=-O -a=-x -a=-S $(TESTS_DIR) $(ARGS)
+	( cd $(CMAKE_DIR_RELEASE) && ctest -V -R pyston )
 
 	echo "All tests passed"
 

--- a/Makefile
+++ b/Makefile
@@ -527,7 +527,7 @@ check:
 .PHONY: quick_check
 quick_check:
 	$(MAKE) pyston_dbg check-deps
-	( cd $(CMAKE_DIR_DBG) && ctest -V -R 'check-format|unittests|pyston_defaults|pyston_cpython' )
+	( cd $(CMAKE_DIR_DBG) && ctest -V -R 'check-format|unittests|pyston_defaults_tests|pyston_defaults_cpython' )
 
 
 Makefile.local:

--- a/Makefile
+++ b/Makefile
@@ -527,10 +527,7 @@ check:
 .PHONY: quick_check
 quick_check:
 	$(MAKE) pyston_dbg check-deps
-	$(MAKE) check_format
-	$(MAKE) unittests
-	$(PYTHON) $(TOOLS_DIR)/tester.py -R pyston_dbg -j$(TEST_THREADS) -a=-S -k --order-by-mtime $(TESTS_DIR) $(ARGS)
-	$(PYTHON) $(TOOLS_DIR)/tester.py -R pyston_dbg -j$(TEST_THREADS) -a=-S -k --exit-code-only --skip-failing $(TEST_DIR)/cpython $(ARGS)
+	( cd $(CMAKE_DIR_DBG) && ctest -V -R 'check-format|unittests|pyston_defaults|pyston_cpython' )
 
 
 Makefile.local:


### PR DESCRIPTION
 * add cmake option ENABLE_EXTRA_TESTS for tests that should only run on travis-ci
 * change `make check` and `make quick_check` testing to use ctest
  * this removes duplication, matches local testing to travis-ci, and provides a nice test summary

The exact `make check` and ctest test options have drifted a bit. This might be a good time to verify exactly what you want the testing to be.