### PR TITLE
add PyFloat_FromString and PyLong_FromUnicode and use them in floatNew/longNew

### DIFF
--- a/src/runtime/objmodel.cpp
+++ b/src/runtime/objmodel.cpp
@@ -4668,7 +4668,8 @@ Box* typeCallInternal(BoxedFunctionBase* f, CallRewriteArgs* rewrite_args, ArgPa
         if (!ok && (cls == int_cls || cls == float_cls || cls == long_cls)) {
             if (npassed_args == 1)
                 ok = true;
-            else if (npassed_args == 2 && (arg2->cls == int_cls || arg2->cls == str_cls || arg2->cls == float_cls))
+            else if (npassed_args == 2 && (arg2->cls == int_cls || arg2->cls == str_cls || arg2->cls == &PyUnicode_Type
+                                           || arg2->cls == float_cls))
                 ok = true;
         }
 


### PR DESCRIPTION
this brings us closer to cpython's behavior (not all the way, we'll need to add class slots for that)

but this does save us a little in terms of allocation cost, and we're able to rewrite `float` typeCalls that take a unicode argument (which they do in django).

Not a huge savings, though:

```
                      2e879e2fcc137870be:  dfcb9c903cafbe74fa:
  django_template.py             8.2s (8)             8.1s (8)  -0.6%
       pyxl_bench.py             0.1s (8)             0.1s (8)  -0.2%
sqlalchemy_imperative.py             0.1s (8)             0.1s (8)  -0.1%
   django_migrate.py             2.2s (8)             2.2s (8)  -1.1%
 virtualenv_bench.py             8.6s (8)             8.6s (8)  -0.2%
          interp2.py             4.9s (8)             4.7s (8)  -4.3%
         raytrace.py             6.5s (8)             6.3s (8)  -3.1%
            nbody.py             9.2s (8)             9.1s (8)  -1.6%
         fannkuch.py             7.4s (8)             7.3s (8)  -1.0%
            chaos.py            20.5s (8)            19.8s (8)  -3.4%
            fasta.py             5.2s (8)             5.3s (8)  +1.9%
         pidigits.py             6.2s (8)             6.1s (8)  -1.3%
         richards.py             2.6s (8)             2.6s (8)  +0.6%
        deltablue.py             1.8s (8)             1.8s (8)  -0.7%
             geomean                 3.2s                 3.2s  -1.1%
```
