### PR TITLE
Temporarily disable type speculation

### DIFF
--- a/src/analysis/type_analysis.cpp
+++ b/src/analysis/type_analysis.cpp
@@ -115,6 +115,10 @@ private:
         assert(old_type);
         assert(speculation != TypeAnalysis::NONE);
 
+        if (VERBOSITY() >= 3)
+            printf("Would maybe try to speculate but deopt is currently broken\n");
+        return old_type;
+
         if (speculated_cls != NULL && speculated_cls->is_constant) {
             ConcreteCompilerType* speculated_type = unboxedType(typeFromClass(speculated_cls));
             if (VERBOSITY() >= 2) {

--- a/src/codegen/irgen/hooks.cpp
+++ b/src/codegen/irgen/hooks.cpp
@@ -739,7 +739,7 @@ void CompiledFunction::speculationFailed() {
                 printf("%p\n", clfunc->versions[i]);
             }
         }
-        assert(found);
+        RELEASE_ASSERT(found, "");
     }
 }
 

--- a/src/runtime/objmodel.cpp
+++ b/src/runtime/objmodel.cpp
@@ -165,6 +165,14 @@ extern "C" Box* deopt(AST_expr* expr, Box* value) {
     static StatCounter num_deopt("num_deopt");
     num_deopt.log();
 
+    printf("Deopt!\n");
+    print_ast(expr);
+    printf("\n");
+    dump(value);
+    printf("\n");
+
+    RELEASE_ASSERT(0, "deopt is currently broken...");
+
     FrameStackState frame_state = getFrameStackState();
     auto execution_point = getExecutionPoint();
 

--- a/test/tests/deopt_generator_tests.py
+++ b/test/tests/deopt_generator_tests.py
@@ -1,4 +1,5 @@
 # skip-if: '-O' in EXTRA_JIT_ARGS
+# expected: statfail
 # statcheck: 4 <= noninit_count('num_deopt') < 50
 # statcheck: 1 <= stats["num_osr_exits"] <= 2
 

--- a/test/tests/deopt_namescope_tests.py
+++ b/test/tests/deopt_namescope_tests.py
@@ -1,4 +1,5 @@
 # skip-if: '-O' in EXTRA_JIT_ARGS
+# expected: statfail
 # statcheck: 4 <= noninit_count('num_deopt') < 50
 # statcheck: 1 <= stats["num_osr_exits"] <= 2
 

--- a/test/tests/deopt_tests.py
+++ b/test/tests/deopt_tests.py
@@ -1,4 +1,5 @@
 # skip-if: '-O' in EXTRA_JIT_ARGS
+# expected: statfail
 # statcheck: 4 <= noninit_count('num_deopt') < 50
 # statcheck: 1 <= stats["num_osr_exits"] <= 2
 
@@ -81,3 +82,25 @@ def main():
         if i == 1500:
             c.pid = 1.0
 main()
+
+
+# This test tries to OSR up to the highest tier and then deopt from there:
+def test_deopt_from_maximal(C):
+    c = C()
+    c.a = 1
+    def f(c):
+        n = 1000000
+        while n:
+            c.a
+            n -= 1
+    f(c)
+    c.a = None
+    f(c)
+
+# Test for both old-style and new-style classes:
+class C:
+    pass
+class D(object):
+    pass
+test_deopt_from_maximal(C)
+test_deopt_from_maximal(D)


### PR DESCRIPTION
Unfortunately our type speculation strategy has bit-rot
over time, to the point that it's not super helpful.
Deopt (the flip side of the speculation) also has some bugs
in it which I was starting to trigger, so just disable the
whole thing for now.

Turning it off should just be a temporary measure and I'll
look soon into what we need to do to get it back on.


This had a minor but (surprisingly) somewhat positive effect on perf:
```
       django_template.py            8.0s (12)            8.0s (18)  -0.9%
            pyxl_bench.py            5.5s (12)            5.6s (18)  +1.4%
 sqlalchemy_imperative.py            2.6s (28)            2.6s (26)  -0.8%
        django_migrate.py            2.0s (12)            2.0s (10)  -0.5%
      virtualenv_bench.py            8.5s (12)            8.4s (10)  -0.8%
```
richards.py also had a 40% improvement, which was surprising .