### PR TITLE
cache + reuse 1-length strings

### DIFF
--- a/microbenchmarks/str_find_ubench.py
+++ b/microbenchmarks/str_find_ubench.py
@@ -1,0 +1,9 @@
+def f():
+    s = "hello world!" * 500
+    count = 0
+    for i in xrange(10000):
+        for c in s:
+            if c == '!':
+                count += 1
+    print count
+f()

--- a/src/runtime/inline/boxing.cpp
+++ b/src/runtime/inline/boxing.cpp
@@ -31,6 +31,11 @@ extern "C" Box* createList() {
 }
 
 BoxedString* boxString(llvm::StringRef s) {
+    if (s.size() <= 1) {
+        if (s.size() == 0)
+            return EmptyString;
+        return characters[s.data()[0] & UCHAR_MAX];
+    }
     return new (s.size()) BoxedString(s);
 }
 

--- a/src/runtime/inline/boxing.cpp
+++ b/src/runtime/inline/boxing.cpp
@@ -30,15 +30,6 @@ extern "C" Box* createList() {
     return new BoxedList();
 }
 
-BoxedString* boxString(llvm::StringRef s) {
-    if (s.size() <= 1) {
-        if (s.size() == 0)
-            return EmptyString;
-        return characters[s.data()[0] & UCHAR_MAX];
-    }
-    return new (s.size()) BoxedString(s);
-}
-
 BoxedString* boxStringTwine(const llvm::Twine& t) {
     llvm::SmallString<256> Vec;
     return boxString(t.toStringRef(Vec));

--- a/src/runtime/str.cpp
+++ b/src/runtime/str.cpp
@@ -1150,7 +1150,7 @@ extern "C" Box* strMul(BoxedString* lhs, Box* rhs) {
     else
         return NotImplemented;
     if (n <= 0)
-        return boxString("");
+        return EmptyString;
 
     // TODO: use createUninitializedString and getWriteableStringContents
     int sz = lhs->size();
@@ -1951,7 +1951,7 @@ Box* strTranslate(BoxedString* self, BoxedString* table, BoxedString* delete_cha
 Box* strLower(BoxedString* self) {
     assert(isSubclass(self->cls, str_cls));
 
-    BoxedString* rtn = static_cast<BoxedString*>(boxString(self->s()));
+    BoxedString* rtn = new (self->size()) BoxedString(self->s());
     for (int i = 0; i < rtn->size(); i++)
         rtn->data()[i] = std::tolower(rtn->data()[i]);
     return rtn;
@@ -1959,7 +1959,7 @@ Box* strLower(BoxedString* self) {
 
 Box* strUpper(BoxedString* self) {
     assert(isSubclass(self->cls, str_cls));
-    BoxedString* rtn = static_cast<BoxedString*>(boxString(self->s()));
+    BoxedString* rtn = new (self->size()) BoxedString(self->s());
     for (int i = 0; i < rtn->size(); i++)
         rtn->data()[i] = std::toupper(rtn->data()[i]);
     return rtn;
@@ -1967,7 +1967,7 @@ Box* strUpper(BoxedString* self) {
 
 Box* strSwapcase(BoxedString* self) {
     assert(isSubclass(self->cls, str_cls));
-    BoxedString* rtn = static_cast<BoxedString*>(boxString(self->s()));
+    BoxedString* rtn = new (self->size()) BoxedString(self->s());
     for (int i = 0; i < rtn->size(); i++) {
         char c = rtn->data()[i];
         if (std::islower(c))
@@ -2211,7 +2211,7 @@ extern "C" Box* strGetitem(BoxedString* self, Box* slice) {
         }
 
         char c = self->s()[n];
-        return boxString(llvm::StringRef(&c, 1));
+        return characters[c & UCHAR_MAX];
     } else if (slice->cls == slice_cls) {
         BoxedSlice* sslice = static_cast<BoxedSlice*>(slice);
 
@@ -2260,7 +2260,7 @@ public:
 
         char c = *self->it;
         ++self->it;
-        return boxString(llvm::StringRef(&c, 1));
+        return characters[c & UCHAR_MAX];
     }
 };
 
@@ -2312,7 +2312,6 @@ extern "C" int PyString_AsStringAndSize(register PyObject* obj, register char** 
 }
 
 BoxedString* createUninitializedString(ssize_t n) {
-    // I *think* this should avoid doing any copies, by using move constructors:
     return new (n) BoxedString(n, 0);
 }
 
@@ -2507,7 +2506,7 @@ static PyObject* string_zfill(PyObject* self, PyObject* args) {
 
     // Pyston change:
     // s = pad(self, fill, 0, '0');
-    s = pad((BoxedString*)self, boxInt(width), boxString("0"), JUST_RIGHT);
+    s = pad((BoxedString*)self, boxInt(width), characters['0' & UCHAR_MAX], JUST_RIGHT);
 
     if (s == NULL)
         return NULL;
@@ -2727,7 +2726,8 @@ void setupStr() {
 
     str_cls->tp_richcompare = str_richcompare;
 
-    BoxedString* spaceChar = boxString(" ");
+    BoxedString* spaceChar = characters[' ' & UCHAR_MAX];
+    assert(spaceChar);
     str_cls->giveAttr("ljust",
                       new BoxedFunction(boxRTFunction((void*)strLjust, UNKNOWN, 3, 1, false, false), { spaceChar }));
     str_cls->giveAttr("rjust",

--- a/src/runtime/str.cpp
+++ b/src/runtime/str.cpp
@@ -54,6 +54,9 @@ extern "C" PyObject* string__format__(PyObject* self, PyObject* args) noexcept;
 
 namespace pyston {
 
+BoxedString* EmptyString;
+BoxedString* characters[UCHAR_MAX + 1];
+
 BoxedString::BoxedString(const char* s, size_t n) : interned_state(SSTATE_NOT_INTERNED) {
     RELEASE_ASSERT(n != llvm::StringRef::npos, "");
     if (s) {

--- a/src/runtime/types.h
+++ b/src/runtime/types.h
@@ -915,6 +915,15 @@ Box* codeForCLFunction(CLFunction*);
 CLFunction* clfunctionFromCode(Box* code);
 
 Box* getFrame(int depth);
+
+inline BoxedString* boxString(llvm::StringRef s) {
+    if (s.size() <= 1) {
+        if (s.size() == 0)
+            return EmptyString;
+        return characters[s.data()[0] & UCHAR_MAX];
+    }
+    return new (s.size()) BoxedString(s);
+}
 }
 
 #endif

--- a/src/runtime/types.h
+++ b/src/runtime/types.h
@@ -614,6 +614,7 @@ public:
 
 extern "C" BoxedTuple* EmptyTuple;
 extern "C" BoxedString* EmptyString;
+extern BoxedString* characters[UCHAR_MAX + 1];
 
 struct PyHasher {
     size_t operator()(Box*) const;


### PR DESCRIPTION
Seems like a no-brainer, but the perf results are less convincing than I would have liked:

```
       django_template.py             8.1s (6)             8.1s (6)  +0.4%
            pyxl_bench.py             5.7s (4)             5.6s (4)  -1.8%
 sqlalchemy_imperative.py             2.7s (4)             2.7s (4)  -0.4%
        django_migrate.py            2.1s (12)            2.1s (13)  +1.0%
      virtualenv_bench.py             8.5s (8)             8.5s (4)  +0.1%
```