### PR TITLE
Optimize creating tuples from lists

### DIFF
--- a/microbenchmarks/sre_optimize_unicode.py
+++ b/microbenchmarks/sre_optimize_unicode.py
@@ -1,0 +1,11 @@
+import sre_compile
+import sre_constants
+
+def identity(o):
+    return o
+
+charset = [(sre_constants.RANGE, (128, 65535))]
+
+for i in xrange(100):
+    sre_compile._optimize_unicode(charset, identity)
+    # print sre_compile._optimize_charset(charset, identity)

--- a/microbenchmarks/tuple_ubench.py
+++ b/microbenchmarks/tuple_ubench.py
@@ -1,0 +1,4 @@
+l = range(256)
+
+for i in xrange(200000):
+    tuple(l)

--- a/src/runtime/tuple.cpp
+++ b/src/runtime/tuple.cpp
@@ -135,7 +135,7 @@ int BoxedTuple::Resize(BoxedTuple** pv, size_t newsize) noexcept {
 
     BoxedTuple* resized = new (newsize)
         BoxedTuple(newsize); // we want an uninitialized tuple, but this will memset it with 0.
-    memmove(resized->elts, t->elts, t->size());
+    memmove(resized->elts, t->elts, sizeof(Box*) * t->size());
 
     *pv = resized;
     return 0;

--- a/src/runtime/tuple.cpp
+++ b/src/runtime/tuple.cpp
@@ -286,6 +286,15 @@ extern "C" Box* tupleNew(Box* _cls, BoxedTuple* args, BoxedDict* kwargs) {
                 raiseExcHelper(TypeError, "'%s' is an invalid keyword argument for this function", kw->data());
         }
 
+        if (cls == tuple_cls) {
+            // Call PySequence_Tuple since it has some perf special-cases
+            // that can make it quite a bit faster than the generic pyElements iteration:
+            Box* r = PySequence_Tuple(elements);
+            if (!r)
+                throwCAPIException();
+            return r;
+        }
+
         std::vector<Box*, StlCompatAllocator<Box*>> elts;
         for (auto e : elements->pyElements())
             elts.push_back(e);

--- a/test/tests/sre_compile_test.py
+++ b/test/tests/sre_compile_test.py
@@ -1,13 +1,18 @@
-# skip-if: True
-# This test works but 1) is very slow [the importing is, not the regex itself], and 2) throws warnings
-# This test also seems to leak a lot of memory.
-
 import sre_compile
+import sre_constants
+
 r = sre_compile.compile("a(b+)c", 0)
 print r.match("")
 print r.match("ac")
 print r.match("abc").groups()
 for i in xrange(100000):
     r.match("abbc").groups()
-    if i % 1000 == 0:
+    if i % 10000 == 0:
         print i
+
+def identity(o):
+    return o
+
+charset = [(sre_constants.RANGE, (128, 65535))]
+
+print sre_compile._optimize_charset(charset, identity)


### PR DESCRIPTION
Before we would do this using `pyElements()`, which has some nice special-casing for lists, but I guess the overhead from that is still so much higher than iterating over a C array.  Or I guess in this case, it's just memcopying a region of memory so it's hard to beat.