### PR TITLE
constant loading optimizations in rewriter

### DIFF
--- a/src/asm_writing/assembler.cpp
+++ b/src/asm_writing/assembler.cpp
@@ -789,6 +789,38 @@ void Assembler::cmp(Indirect mem, Register reg) {
     }
 }
 
+void Assembler::lea(Indirect mem, Register reg) {
+    int mem_idx = mem.base.regnum;
+    int reg_idx = reg.regnum;
+
+    int rex = REX_W;
+    if (mem_idx >= 8) {
+        rex |= REX_B;
+        mem_idx -= 8;
+    }
+    if (reg_idx >= 8) {
+        rex |= REX_R;
+        reg_idx -= 8;
+    }
+
+    assert(mem_idx >= 0 && mem_idx < 8);
+    assert(reg_idx >= 0 && reg_idx < 8);
+
+    emitRex(rex);
+    emitByte(0x8D);
+
+    if (mem.offset == 0) {
+        emitModRM(0b00, reg_idx, mem_idx);
+    } else if (-0x80 <= mem.offset && mem.offset < 0x80) {
+        emitModRM(0b01, reg_idx, mem_idx);
+        emitByte(mem.offset);
+    } else {
+        assert((-1L << 31) <= mem.offset && mem.offset < (1L << 31) - 1);
+        emitModRM(0b10, reg_idx, mem_idx);
+        emitInt(mem.offset, 4);
+    }
+}
+
 void Assembler::test(Register reg1, Register reg2) {
     int reg1_idx = reg1.regnum;
     int reg2_idx = reg2.regnum;

--- a/src/asm_writing/assembler.h
+++ b/src/asm_writing/assembler.h
@@ -136,6 +136,8 @@ public:
     void cmp(Indirect mem, Immediate imm);
     void cmp(Indirect mem, Register reg);
 
+    void lea(Indirect mem, Register reg);
+
     void test(Register reg1, Register reg2);
 
     void jmp_cond(JumpDestination dest, ConditionCode condition);

--- a/src/asm_writing/rewriter.cpp
+++ b/src/asm_writing/rewriter.cpp
@@ -620,19 +620,9 @@ RewriterVar* Rewriter::loadConst(int64_t val, Location dest) {
         return var;
     } else {
         RewriterVar* result = createNewConstantVar(val);
-        addAction([=]() { this->_loadConst(result, val, dest); }, {}, ActionType::NORMAL);
         const_loader_var = result;
         return result;
     }
-}
-
-void Rewriter::_loadConst(RewriterVar* result, int64_t val, Location dest) {
-    assembler::Register reg = allocReg(dest);
-    const_loader.loadConstIntoReg(val, reg);
-    result->initializeInReg(reg);
-
-    result->releaseIfNoUses();
-    assertConsistent();
 }
 
 RewriterVar* Rewriter::call(bool can_call_into_python, void* func_addr) {

--- a/src/asm_writing/rewriter.h
+++ b/src/asm_writing/rewriter.h
@@ -46,7 +46,6 @@ public:
         Scratch, // stack location, relative to the scratch start
 
         // For representing constants that fit in 32-bits, that can be encoded as immediates
-        Constant,
         AnyReg,        // special type for use when specifying a location as a destination
         None,          // special type that represents the lack of a location, ex where a "ret void" gets returned
         Uninitialized, // special type for an uninitialized (and invalid) location
@@ -64,9 +63,6 @@ public:
         int32_t stack_offset;
         // only valid if type == Scratch; offset from the beginning of the scratch area
         int32_t scratch_offset;
-
-        // only valid if type==Constant
-        int32_t constant_val;
 
         int32_t _data;
     };
@@ -131,7 +127,6 @@ private:
     T map_xmm[N_XMM];
     T map_scratch[N_SCRATCH];
     T map_stack[N_STACK];
-    std::unordered_map<int32_t, T> map_const;
 
 public:
     LocMap() {
@@ -159,8 +154,6 @@ public:
                 assert(0 <= l.scratch_offset / 8);
                 assert(l.scratch_offset / 8 < N_SCRATCH);
                 return map_scratch[l.scratch_offset / 8];
-            case Location::Constant:
-                return map_const[l.constant_val];
             default:
                 RELEASE_ASSERT(0, "%d", l.type);
         }
@@ -195,11 +188,6 @@ public:
         for (int i = 0; i < N_STACK; i++) {
             if (map_stack[i] != NULL) {
                 m.emplace(Location(Location::Stack, i * 8), map_stack[i]);
-            }
-        }
-        for (std::pair<int32_t, RewriterVar*> p : map_const) {
-            if (p.second != NULL) {
-                m.emplace(Location(Location::Constant, p.first), p.second);
             }
         }
         return m;

--- a/src/asm_writing/rewriter.h
+++ b/src/asm_writing/rewriter.h
@@ -429,9 +429,9 @@ private:
     void _allocateAndCopyPlus1(RewriterVar* result, RewriterVar* first_elem, RewriterVar* rest, int n_rest);
 
     // The public versions of these are in RewriterVar
-    void _addGuard(RewriterVar* var, uint64_t val);
-    void _addGuardNotEq(RewriterVar* var, uint64_t val);
-    void _addAttrGuard(RewriterVar* var, int offset, uint64_t val, bool negate = false);
+    void _addGuard(RewriterVar* var, RewriterVar* val_constant);
+    void _addGuardNotEq(RewriterVar* var, RewriterVar* val_constant);
+    void _addAttrGuard(RewriterVar* var, int offset, RewriterVar* val_constant, bool negate = false);
     void _getAttr(RewriterVar* result, RewriterVar* var, int offset, Location loc = Location::any(),
                   assembler::MovType type = assembler::MovType::Q);
     void _getAttrFloat(RewriterVar* result, RewriterVar* var, int offset, Location loc = Location::any());

--- a/src/asm_writing/rewriter.h
+++ b/src/asm_writing/rewriter.h
@@ -420,7 +420,7 @@ private:
     bool finishAssembly(ICSlotInfo* picked_slot, int continue_offset) override;
 
     void _trap();
-    void _loadConst(RewriterVar* result, int64_t val, Location loc);
+    void _loadConst(RewriterVar* result, int64_t val);
     void _call(RewriterVar* result, bool can_call_into_python, void* func_addr, const RewriterVar::SmallVector& args,
                const RewriterVar::SmallVector& args_xmm);
     void _add(RewriterVar* result, RewriterVar* a, int64_t b, Location dest);

--- a/src/asm_writing/types.h
+++ b/src/asm_writing/types.h
@@ -47,6 +47,8 @@ struct Register {
     void dump() const;
 
     static Register fromDwarf(int dwarf_regnum);
+
+    static constexpr int numRegs() { return 16; }
 };
 
 const Register RAX(0);
@@ -88,6 +90,8 @@ struct XMMRegister {
     bool operator!=(const XMMRegister& rhs) const { return !(*this == rhs); }
 
     void dump() const { printf("XMM%d\n", regnum); }
+
+    static constexpr int numRegs() { return 16; }
 };
 
 const XMMRegister XMM0(0);


### PR DESCRIPTION
This is based off of @undingen 's https://github.com/dropbox/pyston/pull/310 which optimized constant loading in the rewriter. It never got merged and the discussion there was never followed up on (until now).

Basically this is just @undingen 's patch plus some commits that
- remove the constant tracking and invalidation code
- instead, use the existing location tracking mechanism

This involves creating a RewriterVar in some cases where we previously took a constant as an argument without creating a RewriterVar.

Right now I just want to see if travis-ci passes, but I'd also like to run measurements and check that the assembly is what I expect it to be and so on.