### PR TITLE
Some small micro-optimizations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -997,7 +997,7 @@ endef
 
 .PHONY: perf_report
 perf_report:
-	perf report -v -n -g flat,1000 | bash $(TOOLS_DIR)/cumulate.sh | less -S
+	perf report -n
 
 .PHONY: run run_% dbg_% debug_% perf_%
 run: run_dbg

--- a/src/codegen/ast_interpreter.cpp
+++ b/src/codegen/ast_interpreter.cpp
@@ -103,7 +103,7 @@ public:
     // This must not be inlined, because we rely on being able to detect when we're inside of it (by checking whether
     // %rip is inside its instruction range) during a stack-trace in order to produce tracebacks inside interpreted
     // code.
-    __attribute__((__no_inline__)) static Value
+    __attribute__((__no_inline__)) __attribute__((noinline)) static Value
         executeInner(ASTInterpreter& interpreter, CFGBlock* start_block, AST_stmt* start_at, RegisterHelper* reg);
 
 

--- a/src/runtime/inline/boxing.cpp
+++ b/src/runtime/inline/boxing.cpp
@@ -47,12 +47,5 @@ i64 unboxInt(Box* b) {
     return ((BoxedInt*)b)->n;
 }
 
-Box* boxInt(int64_t n) {
-    if (0 <= n && n < NUM_INTERNED_INTS) {
-        return interned_ints[n];
-    }
-    return new BoxedInt(n);
-}
-
 // BoxedInt::BoxedInt(int64_t n) : Box(int_cls), n(n) {}
 }

--- a/src/runtime/int.h
+++ b/src/runtime/int.h
@@ -64,9 +64,6 @@ extern "C" Box* intNew1(Box* cls);
 extern "C" Box* intNew2(Box* cls, Box* val);
 extern "C" Box* intInit1(Box* self);
 extern "C" Box* intInit2(BoxedInt* self, Box* val);
-
-#define NUM_INTERNED_INTS 100
-extern BoxedInt* interned_ints[NUM_INTERNED_INTS];
 }
 
 #endif

--- a/src/runtime/types.h
+++ b/src/runtime/types.h
@@ -105,7 +105,7 @@ extern BoxedModule* sys_module, *builtins_module, *math_module, *time_module, *t
 }
 
 extern "C" Box* boxBool(bool);
-extern "C" Box* boxInt(i64);
+extern "C" Box* boxInt(i64) __attribute__((visibility("default")));
 extern "C" i64 unboxInt(Box*);
 extern "C" Box* boxFloat(double d);
 extern "C" Box* boxInstanceMethod(Box* obj, Box* func, Box* type);
@@ -923,6 +923,15 @@ inline BoxedString* boxString(llvm::StringRef s) {
         return characters[s.data()[0] & UCHAR_MAX];
     }
     return new (s.size()) BoxedString(s);
+}
+
+#define NUM_INTERNED_INTS 100
+extern BoxedInt* interned_ints[NUM_INTERNED_INTS];
+extern "C" inline Box* boxInt(int64_t n) {
+    if (0 <= n && n < NUM_INTERNED_INTS) {
+        return interned_ints[n];
+    }
+    return new BoxedInt(n);
 }
 }
 


### PR DESCRIPTION
Mostly related to making sure that some hot paths get
inlined better, particularly for allocation/sweeping.

These changes make a simple for-loop benchmark (which
is just dependent on allocation speed) about 25% faster.

Overall perf doesn't change that much, but the for loop case was bothering me :P
```
       django_template.py             8.1s (2)             8.0s (2)  -0.5%
            pyxl_bench.py             5.2s (2)             5.2s (2)  +0.1%
 sqlalchemy_imperative.py             2.7s (2)             2.6s (2)  -0.9%
        django_migrate.py             2.1s (2)             2.1s (2)  -0.3%
      virtualenv_bench.py             8.4s (2)             8.3s (2)  -0.5%
                  geomean                 4.6s                 4.5s  -0.4%
```