### PR TITLE
Use None as traceback sentinel

### DIFF
--- a/src/codegen/unwinding.cpp
+++ b/src/codegen/unwinding.cpp
@@ -732,7 +732,7 @@ static std::unique_ptr<PythonFrameIteratorImpl> getTopPythonFrame() {
 // 4. Unless we've hit the end of the stack, go to 2 and keep unwinding.
 //
 static StatCounter us_gettraceback("us_gettraceback");
-BoxedTraceback* getTraceback() {
+Box* getTraceback() {
     STAT_TIMER(t0, "us_timer_gettraceback");
     if (!ENABLE_FRAME_INTROSPECTION) {
         static bool printed_warning = false;
@@ -740,7 +740,7 @@ BoxedTraceback* getTraceback() {
             printed_warning = true;
             fprintf(stderr, "Warning: can't get traceback since ENABLE_FRAME_INTROSPECTION=0\n");
         }
-        return new BoxedTraceback();
+        return None;
     }
 
     if (!ENABLE_TRACEBACKS) {
@@ -749,12 +749,12 @@ BoxedTraceback* getTraceback() {
             printed_warning = true;
             fprintf(stderr, "Warning: can't get traceback since ENABLE_TRACEBACKS=0\n");
         }
-        return new BoxedTraceback();
+        return None;
     }
 
     Timer _t("getTraceback", 1000);
 
-    Box* tb = new BoxedTraceback();
+    Box* tb = None;
     unwindPythonStack([&](PythonFrameIteratorImpl* frame_iter) {
         BoxedTraceback::here(lineInfoForFrame(frame_iter), &tb);
         return false;

--- a/src/codegen/unwinding.h
+++ b/src/codegen/unwinding.h
@@ -39,7 +39,7 @@ Box* getGlobals();     // returns either the module or a globals dict
 Box* getGlobalsDict(); // always returns a dict-like object
 CompiledFunction* getCFForAddress(uint64_t addr);
 
-BoxedTraceback* getTraceback();
+Box* getTraceback();
 
 class PythonUnwindSession;
 PythonUnwindSession* beginPythonUnwindSession();

--- a/src/runtime/stacktrace.cpp
+++ b/src/runtime/stacktrace.cpp
@@ -47,7 +47,7 @@ void showBacktrace() {
 }
 
 void raiseExc(Box* exc_obj) {
-    throw ExcInfo(exc_obj->cls, exc_obj, new BoxedTraceback());
+    throw ExcInfo(exc_obj->cls, exc_obj, None);
 }
 
 // Have a special helper function for syntax errors, since we want to include the location
@@ -245,7 +245,7 @@ ExcInfo excInfoForRaise(Box* type, Box* value, Box* tb) {
     assert(PyExceptionClass_Check(type));
 
     if (tb == NULL) {
-        tb = new BoxedTraceback();
+        tb = None;
     }
 
     return ExcInfo(type, value, tb);

--- a/src/runtime/traceback.cpp
+++ b/src/runtime/traceback.cpp
@@ -102,11 +102,9 @@ Box* BoxedTraceback::getLines(Box* b) {
     if (!tb->py_lines) {
         BoxedList* lines = new BoxedList();
         for (BoxedTraceback* wtb = tb; wtb && wtb != None; wtb = static_cast<BoxedTraceback*>(wtb->tb_next)) {
-            if (wtb->has_line) {
-                auto& line = wtb->line;
-                auto l = BoxedTuple::create({ boxString(line.file), boxString(line.func), boxInt(line.line) });
-                listAppendInternal(lines, l);
-            }
+            auto& line = wtb->line;
+            auto l = BoxedTuple::create({ boxString(line.file), boxString(line.func), boxInt(line.line) });
+            listAppendInternal(lines, l);
         }
         tb->py_lines = lines;
     }

--- a/src/runtime/traceback.h
+++ b/src/runtime/traceback.h
@@ -28,12 +28,10 @@ extern "C" BoxedClass* traceback_cls;
 class BoxedTraceback : public Box {
 public:
     Box* tb_next;
-    bool has_line;
     LineInfo line;
     Box* py_lines;
 
-    BoxedTraceback(LineInfo line, Box* tb_next) : tb_next(tb_next), has_line(true), line(line), py_lines(NULL) {}
-    BoxedTraceback() : tb_next(None), has_line(false), line(-1, -1, "", ""), py_lines(NULL) {}
+    BoxedTraceback(LineInfo line, Box* tb_next) : tb_next(tb_next), line(line), py_lines(NULL) {}
 
     DEFAULT_CLASS(traceback_cls);
 

--- a/test/tests/native_print_tb.py
+++ b/test/tests/native_print_tb.py
@@ -1,0 +1,8 @@
+import sys
+import subprocess
+
+me = sys.executable
+
+p = subprocess.Popen([me, "-c", "1/0"], stdout=subprocess.PIPE)
+
+print p.stdout.read()

--- a/tools/tester.py
+++ b/tools/tester.py
@@ -592,3 +592,5 @@ if __name__ == "__main__":
         main(origdir)
     finally:
         shutil.rmtree(tmpdir)
+
+# adding a comment here to invalidate cached expected results


### PR DESCRIPTION
some parts of the code were using uninitialized BoxedTraceback instances as the end of the traceback chain, which is always wrong.  This was handled by our traceback.py, but `printTraceback()` wasn't checking to see if `has_line` was true before printing out `"",-1`.

The fix is to always use None for this sentinel value, and remove the option of allocating an uninitialized BoxedTraceback object.