### PR TITLE
rewrite wrapperdescriptors

### DIFF
--- a/src/asm_writing/icinfo.h
+++ b/src/asm_writing/icinfo.h
@@ -80,6 +80,8 @@ public:
 
     const ICInfo* getICInfo() { return ic; }
 
+    const char* debugName() { return debug_name; }
+
     friend class ICInfo;
 };
 

--- a/src/asm_writing/rewriter.cpp
+++ b/src/asm_writing/rewriter.cpp
@@ -232,6 +232,30 @@ assembler::Register Rewriter::ConstLoader::loadConst(uint64_t val, Location othe
     return reg;
 }
 
+void Rewriter::restoreArgs() {
+    ASSERT(!done_guarding, "this will probably work but why are we calling this at this time");
+
+    for (int i = 0; i < args.size(); i++) {
+        args[i]->bumpUse();
+
+        Location l = Location::forArg(i);
+        if (l.type == Location::Stack)
+            continue;
+
+        assert(l.type == Location::Register);
+        assembler::Register r = l.asRegister();
+
+        if (!args[i]->isInLocation(l)) {
+            allocReg(r);
+            args[i]->getInReg(r);
+        }
+    }
+
+    for (int i = 0; i < args.size(); i++) {
+        assert(args[i]->isInLocation(args[i]->arg_loc));
+    }
+}
+
 void RewriterVar::addGuard(uint64_t val) {
     RewriterVar* val_var = rewriter->loadConst(val);
     rewriter->addAction([=]() { rewriter->_addGuard(this, val_var); }, { this, val_var }, ActionType::GUARD);
@@ -240,6 +264,8 @@ void RewriterVar::addGuard(uint64_t val) {
 void Rewriter::_addGuard(RewriterVar* var, RewriterVar* val_constant) {
     assert(val_constant->is_constant);
     uint64_t val = val_constant->constant_value;
+
+    restoreArgs();
 
     assembler::Register var_reg = var->getInReg();
     if (isLargeConstant(val)) {
@@ -264,6 +290,8 @@ void RewriterVar::addGuardNotEq(uint64_t val) {
 void Rewriter::_addGuardNotEq(RewriterVar* var, RewriterVar* val_constant) {
     assert(val_constant->is_constant);
     uint64_t val = val_constant->constant_value;
+
+    restoreArgs();
 
     assembler::Register var_reg = var->getInReg();
     if (isLargeConstant(val)) {
@@ -291,6 +319,8 @@ void RewriterVar::addAttrGuard(int offset, uint64_t val, bool negate) {
 void Rewriter::_addAttrGuard(RewriterVar* var, int offset, RewriterVar* val_constant, bool negate) {
     assert(val_constant->is_constant);
     uint64_t val = val_constant->constant_value;
+
+    restoreArgs();
 
     // TODO if var is a constant, we will end up emitting something like
     //   mov $0x123, %rax
@@ -621,35 +651,35 @@ RewriterVar* Rewriter::loadConst(int64_t val, Location dest) {
     return const_loader_var;
 }
 
-RewriterVar* Rewriter::call(bool can_call_into_python, void* func_addr) {
+RewriterVar* Rewriter::call(bool has_side_effects, void* func_addr) {
     RewriterVar::SmallVector args;
     RewriterVar::SmallVector args_xmm;
-    return call(can_call_into_python, func_addr, args, args_xmm);
+    return call(has_side_effects, func_addr, args, args_xmm);
 }
 
-RewriterVar* Rewriter::call(bool can_call_into_python, void* func_addr, RewriterVar* arg0) {
+RewriterVar* Rewriter::call(bool has_side_effects, void* func_addr, RewriterVar* arg0) {
     RewriterVar::SmallVector args;
     RewriterVar::SmallVector args_xmm;
     args.push_back(arg0);
-    return call(can_call_into_python, func_addr, args, args_xmm);
+    return call(has_side_effects, func_addr, args, args_xmm);
 }
 
-RewriterVar* Rewriter::call(bool can_call_into_python, void* func_addr, RewriterVar* arg0, RewriterVar* arg1) {
+RewriterVar* Rewriter::call(bool has_side_effects, void* func_addr, RewriterVar* arg0, RewriterVar* arg1) {
     RewriterVar::SmallVector args;
     RewriterVar::SmallVector args_xmm;
     args.push_back(arg0);
     args.push_back(arg1);
-    return call(can_call_into_python, func_addr, args, args_xmm);
+    return call(has_side_effects, func_addr, args, args_xmm);
 }
 
-RewriterVar* Rewriter::call(bool can_call_into_python, void* func_addr, RewriterVar* arg0, RewriterVar* arg1,
+RewriterVar* Rewriter::call(bool has_side_effects, void* func_addr, RewriterVar* arg0, RewriterVar* arg1,
                             RewriterVar* arg2) {
     RewriterVar::SmallVector args;
     RewriterVar::SmallVector args_xmm;
     args.push_back(arg0);
     args.push_back(arg1);
     args.push_back(arg2);
-    return call(can_call_into_python, func_addr, args, args_xmm);
+    return call(has_side_effects, func_addr, args, args_xmm);
 }
 
 static const Location caller_save_registers[]{
@@ -660,7 +690,7 @@ static const Location caller_save_registers[]{
     assembler::XMM11, assembler::XMM12, assembler::XMM13, assembler::XMM14, assembler::XMM15,
 };
 
-RewriterVar* Rewriter::call(bool can_call_into_python, void* func_addr, const RewriterVar::SmallVector& args,
+RewriterVar* Rewriter::call(bool has_side_effects, void* func_addr, const RewriterVar::SmallVector& args,
                             const RewriterVar::SmallVector& args_xmm) {
     RewriterVar* result = createNewVar();
     std::vector<RewriterVar*> uses;
@@ -672,19 +702,22 @@ RewriterVar* Rewriter::call(bool can_call_into_python, void* func_addr, const Re
         assert(v != NULL);
         uses.push_back(v);
     }
-    addAction([=]() { this->_call(result, can_call_into_python, func_addr, args, args_xmm); }, uses,
-              ActionType::MUTATION);
+
+    ActionType type;
+    if (has_side_effects)
+        type = ActionType::MUTATION;
+    else
+        type = ActionType::NORMAL;
+    addAction([=]() { this->_call(result, has_side_effects, func_addr, args, args_xmm); }, uses, type);
     return result;
 }
 
-void Rewriter::_call(RewriterVar* result, bool can_call_into_python, void* func_addr,
-                     const RewriterVar::SmallVector& args, const RewriterVar::SmallVector& args_xmm) {
-    // TODO figure out why this is here -- what needs to be done differently
-    // if can_call_into_python is true?
-    // assert(!can_call_into_python);
-    assert(done_guarding);
+void Rewriter::_call(RewriterVar* result, bool has_side_effects, void* func_addr, const RewriterVar::SmallVector& args,
+                     const RewriterVar::SmallVector& args_xmm) {
+    if (has_side_effects)
+        assert(done_guarding);
 
-    if (can_call_into_python) {
+    if (has_side_effects) {
         // We need some fixed amount of space at the beginning of the IC that we can use to invalidate
         // it by writing a jmp.
         // FIXME this check is conservative, since actually we just have to verify that the return
@@ -694,7 +727,7 @@ void Rewriter::_call(RewriterVar* result, bool can_call_into_python, void* func_
         assert(assembler->bytesWritten() >= IC_INVALDITION_HEADER_SIZE);
     }
 
-    if (can_call_into_python) {
+    if (has_side_effects) {
         if (!marked_inside_ic) {
             // assembler->trap();
 
@@ -922,7 +955,7 @@ void Rewriter::commit() {
     // Emit assembly for each action, and set done_guarding when
     // we reach the last guard.
 
-    // Note: If an arg finishes its uses before we're done gurading, we don't release it at that point;
+    // Note: If an arg finishes its uses before we're done guarding, we don't release it at that point;
     // instead, we release it here, at the point when we set done_guarding.
     // An alternate, maybe cleaner, way to accomplish this would be to add a use for each arg
     // at each guard in the var's `uses` list.
@@ -1290,12 +1323,6 @@ assembler::Indirect Rewriter::indirectFor(Location l) {
 void Rewriter::spillRegister(assembler::Register reg, Location preserve) {
     assert(preserve.type == Location::Register || preserve.type == Location::AnyReg);
 
-    if (!done_guarding) {
-        for (int i = 0; i < args.size(); i++) {
-            assert(args[i]->arg_loc != Location(reg));
-        }
-    }
-
     RewriterVar* var = vars_by_location[reg];
     assert(var);
 
@@ -1334,12 +1361,6 @@ void Rewriter::spillRegister(assembler::Register reg, Location preserve) {
 
 void Rewriter::spillRegister(assembler::XMMRegister reg) {
     assertPhaseEmitting();
-
-    if (!done_guarding) {
-        for (int i = 0; i < args.size(); i++) {
-            assert(!args[i]->isInLocation(Location(reg)));
-        }
-    }
 
     RewriterVar* var = vars_by_location[reg];
     assert(var);

--- a/src/asm_writing/rewriter.cpp
+++ b/src/asm_writing/rewriter.cpp
@@ -888,15 +888,22 @@ void Rewriter::commit() {
     assert(!finished);
     initPhaseEmitting();
 
+    static StatCounter ic_rewrites_aborted_assemblyfail("ic_rewrites_aborted_assemblyfail");
+    static StatCounter ic_rewrites_aborted_failed("ic_rewrites_aborted_failed");
+
     if (failed) {
+        ic_rewrites_aborted_failed.log();
         this->abort();
         return;
     }
 
-    static StatCounter ic_rewrites_aborted_assemblyfail("ic_rewrites_aborted_assemblyfail");
-
     auto on_assemblyfail = [&]() {
         ic_rewrites_aborted_assemblyfail.log();
+#if 0
+        std::string per_name_stat_name = "ic_rewrites_aborted_assemblyfail_" + std::string(debugName());
+        uint64_t* counter = Stats::getStatCounter(per_name_stat_name);
+        Stats::log(counter);
+#endif
         this->abort();
     };
 
@@ -944,6 +951,7 @@ void Rewriter::commit() {
         actions[i].action();
 
         if (failed) {
+            ic_rewrites_aborted_failed.log();
             this->abort();
             return;
         }

--- a/src/asm_writing/rewriter.cpp
+++ b/src/asm_writing/rewriter.cpp
@@ -251,6 +251,12 @@ void Rewriter::restoreArgs() {
         }
     }
 
+    assertArgsInPlace();
+}
+
+void Rewriter::assertArgsInPlace() {
+    ASSERT(!done_guarding, "this will probably work but why are we calling this at this time");
+
     for (int i = 0; i < args.size(); i++) {
         assert(args[i]->isInLocation(args[i]->arg_loc));
     }
@@ -274,6 +280,8 @@ void Rewriter::_addGuard(RewriterVar* var, RewriterVar* val_constant) {
     } else {
         assembler->cmp(var_reg, assembler::Immediate(val));
     }
+
+    assertArgsInPlace();
     assembler->jne(assembler::JumpDestination::fromStart(rewrite->getSlotSize()));
 
     var->bumpUse();
@@ -300,6 +308,8 @@ void Rewriter::_addGuardNotEq(RewriterVar* var, RewriterVar* val_constant) {
     } else {
         assembler->cmp(var_reg, assembler::Immediate(val));
     }
+
+    assertArgsInPlace();
     assembler->je(assembler::JumpDestination::fromStart(rewrite->getSlotSize()));
 
     var->bumpUse();
@@ -345,6 +355,8 @@ void Rewriter::_addAttrGuard(RewriterVar* var, int offset, RewriterVar* val_cons
     } else {
         assembler->cmp(assembler::Indirect(var_reg, offset), assembler::Immediate(val));
     }
+
+    assertArgsInPlace();
     if (negate)
         assembler->je(assembler::JumpDestination::fromStart(rewrite->getSlotSize()));
     else

--- a/src/asm_writing/rewriter.cpp
+++ b/src/asm_writing/rewriter.cpp
@@ -1673,7 +1673,7 @@ Rewriter* Rewriter::createRewriter(void* rtn_addr, int num_args, const char* deb
 
     // Horrible non-robust optimization: addresses below this address are probably in the binary (ex the interpreter),
     // so don't do the more-expensive hash table lookup to find it.
-    if (rtn_addr > (void*)0x1800000) {
+    if (rtn_addr > (void*)0x1000000) {
         ic = getICInfo(rtn_addr);
     } else {
         ASSERT(!getICInfo(rtn_addr), "%p", rtn_addr);

--- a/src/asm_writing/rewriter.h
+++ b/src/asm_writing/rewriter.h
@@ -391,9 +391,11 @@ private:
         return done_guarding;
     }
 
-    // Make sure our original args are currently in their original positions.
-    // ie if we are about to guard and then branch to the slowpath callsite.
+    // Move the original IC args back into their original registers:
     void restoreArgs();
+    // Assert that our original args are correctly placed in case we need to
+    // bail out of the IC:
+    void assertArgsInPlace();
 
     // Allocates a register.  dest must be of type Register or AnyReg
     // If otherThan is a register, guaranteed to not use that register.

--- a/src/asm_writing/rewriter.h
+++ b/src/asm_writing/rewriter.h
@@ -474,6 +474,8 @@ public:
 
     TypeRecorder* getTypeRecorder();
 
+    const char* debugName() { return rewrite->debugName(); }
+
     void trap();
     RewriterVar* loadConst(int64_t val, Location loc = Location::any());
     // can_call_into_python: whether this call could result in arbitrary Python code being called.

--- a/src/asm_writing/rewriter.h
+++ b/src/asm_writing/rewriter.h
@@ -371,6 +371,9 @@ private:
                 failed = true;
                 return;
             }
+            for (RewriterVar* arg : args) {
+                arg->uses.push_back(actions.size());
+            }
             assert(!added_changing_action);
             last_guard_action = (int)actions.size();
         }
@@ -387,6 +390,10 @@ private:
         assertPhaseEmitting();
         return done_guarding;
     }
+
+    // Make sure our original args are currently in their original positions.
+    // ie if we are about to guard and then branch to the slowpath callsite.
+    void restoreArgs();
 
     // Allocates a register.  dest must be of type Register or AnyReg
     // If otherThan is a register, guaranteed to not use that register.
@@ -414,7 +421,7 @@ private:
 
     void _trap();
     void _loadConst(RewriterVar* result, int64_t val);
-    void _call(RewriterVar* result, bool can_call_into_python, void* func_addr, const RewriterVar::SmallVector& args,
+    void _call(RewriterVar* result, bool has_side_effects, void* func_addr, const RewriterVar::SmallVector& args,
                const RewriterVar::SmallVector& args_xmm);
     void _add(RewriterVar* result, RewriterVar* a, int64_t b, Location dest);
     int _allocate(RewriterVar* result, int n);
@@ -448,6 +455,11 @@ private:
                 assert(p.second->locations.count(p.first) == 1);
             }
         }
+        if (!done_guarding) {
+            for (RewriterVar* arg : args) {
+                assert(!arg->locations.empty());
+            }
+        }
 #endif
     }
 
@@ -478,17 +490,19 @@ public:
 
     void trap();
     RewriterVar* loadConst(int64_t val, Location loc = Location::any());
-    // can_call_into_python: whether this call could result in arbitrary Python code being called.
-    // This causes some extra bookkeeping to prevent, ex this patchpoint to be rewritten when
-    // entered recursively.  Setting to false disables this for slightly better performance, but
-    // it's not huge so if in doubt just pass "true".
-    RewriterVar* call(bool can_call_into_python, void* func_addr, const RewriterVar::SmallVector& args,
+    // has_side_effects: whether this call could have "side effects".  the exact side effects we've
+    // been concerned about have changed over time, so it's better to err on the side of saying "true",
+    // but currently you can only set it to false if 1) you will not call into Python code, which basically
+    // can have any sorts of side effects, but in particular could result in the IC being reentrant, and
+    // 2) does not have any side-effects that would be user-visible if we bailed out from the middle of the
+    // inline cache.  (Extra allocations don't count even though they're potentially visible if you look
+    // hard enough.)
+    RewriterVar* call(bool has_side_effects, void* func_addr, const RewriterVar::SmallVector& args,
                       const RewriterVar::SmallVector& args_xmm = RewriterVar::SmallVector());
-    RewriterVar* call(bool can_call_into_python, void* func_addr);
-    RewriterVar* call(bool can_call_into_python, void* func_addr, RewriterVar* arg0);
-    RewriterVar* call(bool can_call_into_python, void* func_addr, RewriterVar* arg0, RewriterVar* arg1);
-    RewriterVar* call(bool can_call_into_python, void* func_addr, RewriterVar* arg0, RewriterVar* arg1,
-                      RewriterVar* arg2);
+    RewriterVar* call(bool has_side_effects, void* func_addr);
+    RewriterVar* call(bool has_side_effects, void* func_addr, RewriterVar* arg0);
+    RewriterVar* call(bool has_side_effects, void* func_addr, RewriterVar* arg0, RewriterVar* arg1);
+    RewriterVar* call(bool has_side_effects, void* func_addr, RewriterVar* arg0, RewriterVar* arg1, RewriterVar* arg2);
     RewriterVar* add(RewriterVar* a, int64_t b, Location dest);
     // Allocates n pointer-sized stack slots:
     RewriterVar* allocate(int n);

--- a/src/codegen/ast_interpreter.cpp
+++ b/src/codegen/ast_interpreter.cpp
@@ -278,6 +278,7 @@ ASTInterpreter::ASTInterpreter(CompiledFunction* compiled_function)
       generator(0),
       edgecount(0),
       frame_info(ExcInfo(NULL, NULL, NULL)),
+      globals(0),
       frame_addr(0) {
 
     CLFunction* f = compiled_function->clfunc;

--- a/src/codegen/ast_interpreter.cpp
+++ b/src/codegen/ast_interpreter.cpp
@@ -386,7 +386,7 @@ Value ASTInterpreter::executeInner(ASTInterpreter& interpreter, CFGBlock* start_
 }
 
 Value ASTInterpreter::execute(ASTInterpreter& interpreter, CFGBlock* start_block, AST_stmt* start_at) {
-    UNAVOIDABLE_STAT_TIMER(t0, "us_timer_astinterpreter_execute");
+    UNAVOIDABLE_STAT_TIMER(t0, "us_timer_in_interpreter");
 
     RegisterHelper frame_registerer;
 
@@ -605,7 +605,7 @@ Value ASTInterpreter::visit_jump(AST_Jump* node) {
                 arg_array.push_back(it.second);
             }
 
-            UNAVOIDABLE_STAT_TIMER(t0, "us_timer_astinterpreter_jump_osrexit");
+            UNAVOIDABLE_STAT_TIMER(t0, "us_timer_in_jitted_code");
             CompiledFunction* partial_func = compilePartialFuncInternal(&exit);
             auto arg_tuple = getTupleFromArgsArray(&arg_array[0], arg_array.size());
             Box* r = partial_func->call(std::get<0>(arg_tuple), std::get<1>(arg_tuple), std::get<2>(arg_tuple),
@@ -1295,7 +1295,7 @@ const void* interpreter_instr_addr = (void*)&ASTInterpreter::executeInner;
 
 Box* astInterpretFunction(CompiledFunction* cf, int nargs, Box* closure, Box* generator, Box* globals, Box* arg1,
                           Box* arg2, Box* arg3, Box** args) {
-    UNAVOIDABLE_STAT_TIMER(t0, "us_timer_astInterpretFunction");
+    UNAVOIDABLE_STAT_TIMER(t0, "us_timer_in_interpreter");
 
     assert((!globals) == cf->clfunc->source->scoping->areGlobalsFromModule());
     bool can_reopt = ENABLE_REOPT && !FORCE_INTERPRETER && (globals == NULL);

--- a/src/codegen/entry.cpp
+++ b/src/codegen/entry.cpp
@@ -362,7 +362,7 @@ static void handle_sigprof(int signum) {
     sigprof_pending++;
 }
 
-//#define INVESTIGATE_STAT_TIMER "us_timer_chosen_cf_body_jitted"
+//#define INVESTIGATE_STAT_TIMER "us_timer_in_jitted_code"
 #ifdef INVESTIGATE_STAT_TIMER
 static uint64_t* stat_counter = Stats::getStatCounter(INVESTIGATE_STAT_TIMER);
 static void handle_sigprof_investigate_stattimer(int signum) {

--- a/src/codegen/parser.cpp
+++ b/src/codegen/parser.cpp
@@ -1159,6 +1159,7 @@ AST_Module* caching_parse_file(const char* fn) {
             if (strncmp(&file_data[0], getMagic(), MAGIC_STRING_LENGTH) != 0) {
                 if (VERBOSITY() || tries == MAX_TRIES) {
                     fprintf(stderr, "Warning: corrupt or non-Pyston .pyc file found; ignoring\n");
+                    fprintf(stderr, "%d %d %d %d\n", file_data[0], file_data[1], file_data[2], file_data[3]);
                 }
                 good = false;
             }

--- a/src/core/stats.cpp
+++ b/src/core/stats.cpp
@@ -50,6 +50,12 @@ StatTimer* StatTimer::createStack(StatTimer& timer) {
     timer.pushTopLevel(at_time);
     return prev_stack;
 }
+
+uint64_t* StatTimer::getCurrentCounter() {
+    if (stack)
+        return stack->_statcounter;
+    return NULL;
+}
 #endif
 
 std::unordered_map<uint64_t*, std::string>* Stats::names;

--- a/src/core/stats.h
+++ b/src/core/stats.h
@@ -206,6 +206,8 @@ public:
     static StatTimer* createStack(StatTimer& timer);
     static StatTimer* swapStack(StatTimer* s);
 
+    static uint64_t* getCurrentCounter();
+
     static void assertActive() { ASSERT(stack && !stack->isPaused(), ""); }
 };
 class ScopedStatTimer {

--- a/src/core/threading.cpp
+++ b/src/core/threading.cpp
@@ -167,8 +167,10 @@ static void pushThreadState(ThreadStateInternal* thread_state, ucontext_t* conte
 #endif
 
     assert(stack_low < stack_high);
+    GC_TRACE_LOG("Visiting other thread's stack\n");
     cur_visitor->visitPotentialRange((void**)stack_low, (void**)stack_high);
 
+    GC_TRACE_LOG("Visiting other thread's threadstate + generator stacks\n");
     thread_state->accept(cur_visitor);
 }
 
@@ -195,8 +197,12 @@ static void visitLocalStack(gc::GCVisitor* v) {
 #endif
 
     assert(stack_low < stack_high);
+
+    GC_TRACE_LOG("Visiting current stack from %p to %p\n", stack_low, stack_high);
+
     v->visitPotentialRange((void**)stack_low, (void**)stack_high);
 
+    GC_TRACE_LOG("Visiting current thread's threadstate + generator stacks\n");
     current_internal_thread_state->accept(v);
 }
 

--- a/src/gc/collector.h
+++ b/src/gc/collector.h
@@ -22,6 +22,14 @@
 namespace pyston {
 namespace gc {
 
+#define TRACE_GC_MARKING 0
+#if TRACE_GC_MARKING
+extern FILE* trace_fp;
+#define GC_TRACE_LOG(...) fprintf(pyston::gc::trace_fp, __VA_ARGS__)
+#else
+#define GC_TRACE_LOG(...)
+#endif
+
 // Mark this gc-allocated object as being a root, even if there are no visible references to it.
 // (Note: this marks the gc allocation itself, not the pointer that points to one.  For that, use
 // a GCRootHandle)

--- a/src/gc/gc_alloc.h
+++ b/src/gc/gc_alloc.h
@@ -48,7 +48,7 @@ extern "C" inline void* gc_alloc(size_t bytes, GCKind kind_id) {
     // This stat timer is quite expensive, not just because this function is extremely hot,
     // but also because it tends to increase the size of this function enough that we can't
     // inline it, which is especially useful for this function.
-    ScopedStatTimer gc_alloc_stattimer(gc_alloc_stattimer_counter);
+    ScopedStatTimer gc_alloc_stattimer(gc_alloc_stattimer_counter, 15);
 #endif
     size_t alloc_bytes = bytes + sizeof(GCAllocation);
 

--- a/src/runtime/generator.cpp
+++ b/src/runtime/generator.cpp
@@ -118,6 +118,8 @@ Box* generatorIter(Box* s) {
 
 // called from both generatorHasNext and generatorSend/generatorNext (but only if generatorHasNext hasn't been called)
 static void generatorSendInternal(BoxedGenerator* self, Box* v) {
+    STAT_TIMER(t0, "us_timer_generator_switching", 0);
+
     if (self->running)
         raiseExcHelper(ValueError, "generator already executing");
 
@@ -260,6 +262,8 @@ Box* generatorHasnext(Box* s) {
 
 
 extern "C" Box* yield(BoxedGenerator* obj, Box* value) {
+    STAT_TIMER(t0, "us_timer_generator_switching", 0);
+
     assert(obj->cls == generator_cls);
     BoxedGenerator* self = static_cast<BoxedGenerator*>(obj);
     self->returnValue = value;

--- a/src/runtime/ics.h
+++ b/src/runtime/ics.h
@@ -78,7 +78,7 @@ public:
 
 class BinopIC : public RuntimeIC {
 public:
-    BinopIC() : RuntimeIC((void*)binop, 2, 160) {}
+    BinopIC() : RuntimeIC((void*)binop, 2, 240) {}
 
     Box* call(Box* lhs, Box* rhs, int op_type) { return (Box*)call_ptr(lhs, rhs, op_type); }
 };

--- a/src/runtime/iterators.cpp
+++ b/src/runtime/iterators.cpp
@@ -39,6 +39,8 @@ public:
     }
 
     void next() override {
+        STAT_TIMER(t0, "us_timer_iteratorgeneric_next", 0);
+
         assert(iterator);
         Box* hasnext = iterator->hasnextOrNullIC();
         if (hasnext) {

--- a/src/runtime/objmodel.cpp
+++ b/src/runtime/objmodel.cpp
@@ -2021,7 +2021,7 @@ void setattrGeneric(Box* obj, BoxedString* attr, Box* val, SetattrRewriteArgs* r
 }
 
 extern "C" void setattr(Box* obj, BoxedString* attr, Box* attr_val) {
-    STAT_TIMER(t0, "us_timer_slowpath_setsattr", 10);
+    STAT_TIMER(t0, "us_timer_slowpath_setattr", 10);
 
     static StatCounter slowpath_setattr("slowpath_setattr");
     slowpath_setattr.log();

--- a/src/runtime/objmodel.cpp
+++ b/src/runtime/objmodel.cpp
@@ -984,7 +984,7 @@ Box* typeLookup(BoxedClass* cls, llvm::StringRef attr, GetattrRewriteArgs* rewri
 
 bool isNondataDescriptorInstanceSpecialCase(Box* descr) {
     return descr->cls == function_cls || descr->cls == instancemethod_cls || descr->cls == staticmethod_cls
-           || descr->cls == classmethod_cls;
+           || descr->cls == classmethod_cls || descr->cls == wrapperdescr_cls;
 }
 
 Box* nondataDescriptorInstanceSpecialCases(GetattrRewriteArgs* rewrite_args, Box* obj, Box* descr, RewriterVar* r_descr,
@@ -1058,7 +1058,7 @@ Box* nondataDescriptorInstanceSpecialCases(GetattrRewriteArgs* rewrite_args, Box
         if (!for_call) {
             if (rewrite_args) {
                 rewrite_args->out_rtn
-                    = rewrite_args->rewriter->call(true, (void*)boxInstanceMethod, r_im_self, r_im_func, r_im_class);
+                    = rewrite_args->rewriter->call(false, (void*)boxInstanceMethod, r_im_self, r_im_func, r_im_class);
                 rewrite_args->out_success = true;
             }
             return boxInstanceMethod(im_self, im_func, im_class);
@@ -1071,12 +1071,7 @@ Box* nondataDescriptorInstanceSpecialCases(GetattrRewriteArgs* rewrite_args, Box
             }
             return im_func;
         }
-    }
-
-    else if (descr->cls == staticmethod_cls) {
-        static StatCounter slowpath("slowpath_staticmethod_get");
-        slowpath.log();
-
+    } else if (descr->cls == staticmethod_cls) {
         BoxedStaticmethod* sm = static_cast<BoxedStaticmethod*>(descr);
         if (sm->sm_callable == NULL) {
             raiseExcHelper(RuntimeError, "uninitialized staticmethod object");
@@ -1090,6 +1085,23 @@ Box* nondataDescriptorInstanceSpecialCases(GetattrRewriteArgs* rewrite_args, Box
         }
 
         return sm->sm_callable;
+    } else if (descr->cls == wrapperdescr_cls) {
+        BoxedWrapperDescriptor* self = static_cast<BoxedWrapperDescriptor*>(descr);
+        Box* inst = obj;
+        Box* owner = obj->cls;
+
+        Box* r = BoxedWrapperDescriptor::__get__(self, inst, owner);
+
+        if (rewrite_args) {
+            // TODO: inline this?
+            RewriterVar* r_rtn = rewrite_args->rewriter->call(
+                /* has_side_effects= */ false, (void*)&BoxedWrapperDescriptor::__get__, r_descr, rewrite_args->obj,
+                r_descr->getAttr(offsetof(Box, cls), Location::forArg(2)));
+
+            rewrite_args->out_success = true;
+            rewrite_args->out_rtn = r_rtn;
+        }
+        return r;
     }
 
     return NULL;
@@ -1120,14 +1132,13 @@ Box* descriptorClsSpecialCases(GetattrRewriteArgs* rewrite_args, BoxedClass* cls
         return descr;
     }
 
-    // Special case: member descriptor
-    if (descr->cls == member_descriptor_cls) {
+    // These classes are descriptors, but only have special behavior when involved
+    // in instance lookups
+    if (descr->cls == member_descriptor_cls || descr->cls == wrapperdescr_cls) {
         if (rewrite_args)
             r_descr->addAttrGuard(BOX_CLS_OFFSET, (uint64_t)descr->cls);
 
         if (rewrite_args) {
-            // Actually just return val (it's a descriptor but only
-            // has special behaviour for instance lookups - see below)
             rewrite_args->out_rtn = r_descr;
             rewrite_args->out_success = true;
         }
@@ -1332,7 +1343,7 @@ Box* dataDescriptorInstanceSpecialCases(GetattrRewriteArgs* rewrite_args, llvm::
 
             RewriterVar* r_closure = r_descr->getAttr(offsetof(BoxedGetsetDescriptor, closure));
             rewrite_args->out_rtn = rewrite_args->rewriter->call(
-                /* can_call_into_python */ true, (void*)getset_descr->get, rewrite_args->obj, r_closure);
+                /* has_side_effects */ true, (void*)getset_descr->get, rewrite_args->obj, r_closure);
 
             if (descr->cls == capi_getset_cls)
                 // TODO I think we are supposed to check the return value?
@@ -1896,7 +1907,7 @@ bool dataDescriptorSetSpecialCases(Box* obj, Box* val, Box* descr, SetattrRewrit
             args.push_back(r_val);
             args.push_back(r_closure);
             rewrite_args->rewriter->call(
-                /* can_call_into_python */ true, (void*)getset_descr->set, args);
+                /* has_side_effects */ true, (void*)getset_descr->set, args);
 
             if (descr->cls == capi_getset_cls)
                 // TODO I think we are supposed to check the return value?
@@ -3583,6 +3594,13 @@ extern "C" Box* runtimeCall(Box* obj, ArgPassSpec argspec, Box* arg1, Box* arg2,
     std::unique_ptr<Rewriter> rewriter(Rewriter::createRewriter(
         __builtin_extract_return_addr(__builtin_return_address(0)), num_orig_args, "runtimeCall"));
     Box* rtn;
+
+#if 0 && STAT_TIMERS
+    static uint64_t* st_id = Stats::getStatCounter("us_timer_slowpath_runtimecall_patchable");
+    static uint64_t* st_id_nopatch = Stats::getStatCounter("us_timer_slowpath_runtimecall_nopatch");
+    bool havepatch = (bool)getICInfo(__builtin_extract_return_addr(__builtin_return_address(0)));
+    ScopedStatTimer st(havepatch ? st_id : st_id_nopatch, 10);
+#endif
 
     if (rewriter.get()) {
         // TODO feel weird about doing this; it either isn't necessary

--- a/src/runtime/objmodel.cpp
+++ b/src/runtime/objmodel.cpp
@@ -128,7 +128,7 @@ static uint64_t* pylt_timer_counter = Stats::getStatCounter("us_timer_PyLt");
 #endif
 size_t PyHasher::operator()(Box* b) const {
 #if EXPENSIVE_STAT_TIMERS
-    ScopedStatTimer _st(pyhasher_timer_counter);
+    ScopedStatTimer _st(pyhasher_timer_counter, 10);
 #endif
     if (b->cls == str_cls) {
         StringHash<char> H;
@@ -141,7 +141,7 @@ size_t PyHasher::operator()(Box* b) const {
 
 bool PyEq::operator()(Box* lhs, Box* rhs) const {
 #if EXPENSIVE_STAT_TIMERS
-    ScopedStatTimer _st(pyeq_timer_counter);
+    ScopedStatTimer _st(pyeq_timer_counter, 10);
 #endif
 
     int r = PyObject_RichCompareBool(lhs, rhs, Py_EQ);
@@ -152,7 +152,7 @@ bool PyEq::operator()(Box* lhs, Box* rhs) const {
 
 bool PyLt::operator()(Box* lhs, Box* rhs) const {
 #if EXPENSIVE_STAT_TIMERS
-    ScopedStatTimer _st(pylt_timer_counter);
+    ScopedStatTimer _st(pylt_timer_counter, 10);
 #endif
 
     int r = PyObject_RichCompareBool(lhs, rhs, Py_LT);
@@ -3415,10 +3415,10 @@ Box* callCLFunc(CLFunction* f, CallRewriteArgs* rewrite_args, int num_output_arg
     // distinguish lexically between calls that target jitted python
     // code and calls that target to builtins.
     if (f->source) {
-        UNAVOIDABLE_STAT_TIMER(t0, "us_timer_chosen_cf_body_jitted");
+        UNAVOIDABLE_STAT_TIMER(t0, "us_timer_in_jitted_code");
         r = callChosenCF(chosen_cf, closure, generator, oarg1, oarg2, oarg3, oargs);
     } else {
-        UNAVOIDABLE_STAT_TIMER(t0, "us_timer_chosen_cf_body_builtins");
+        UNAVOIDABLE_STAT_TIMER(t0, "us_timer_in_builtins");
         r = callChosenCF(chosen_cf, closure, generator, oarg1, oarg2, oarg3, oargs);
     }
 


### PR DESCRIPTION
This was one of the main source of missed runtimeCall/callattr rewrites.  I think we still can do better by not hitting the wrapper in the first place.

A few other misc things in the pr:
- some more messing around with the stat timers
- some more GC debugging helpers + fix a pre-existing gc issue

```
       django_template.py             6.4s (2)             6.0s (2)  -4.9%
            pyxl_bench.py             4.2s (2)             4.2s (2)  -1.1%
 sqlalchemy_imperative.py             2.4s (2)             2.3s (2)  -2.2%
        django_migrate.py             2.1s (2)             2.0s (2)  -4.2%
      virtualenv_bench.py             8.2s (2)             8.1s (2)  -1.7%
                  geomean                 4.1s                 3.9s  -2.9%
```

I'm not super happy only getting a few percent at a time, but I think the stat timers are getting pretty good at this point and do a pretty good job of pointing to the next thing to do.