### PR TITLE
fix two minor bugs

### DIFF
--- a/from_cpython/Include/stringobject.h
+++ b/from_cpython/Include/stringobject.h
@@ -106,7 +106,14 @@ PyAPI_FUNC(int) _PyString_CheckInterned(PyObject *) PYSTON_NOEXCEPT;
 /* Macro, trading safety for speed */
 // Pyston changes: these aren't direct macros any more [they potentially could be though]
 #define PyString_AS_STRING(op) PyString_AsString((PyObject*)op)
-#define PyString_GET_SIZE(op)  PyString_Size((PyObject*)op)
+// Note: there are buggy extension modules (unicodedata.c) that rely on the fact that
+// PyString_GET_SIZE does *not* have the same behavior as PyString_Size.  In particular,
+// you can get away with calling PyString_GET_SIZE on a unicode object and getting the
+// length of the unicode string, not the length of the bytes it encodes to in the default
+// encoding.
+// So, set up a different function for those callers to use.
+PyAPI_FUNC(Py_ssize_t) _PyString_SizeMacro(PyObject *) PYSTON_NOEXCEPT;
+#define PyString_GET_SIZE(op)  _PyString_SizeMacro((PyObject*)op)
 //#define PyString_AS_STRING(op) (((PyStringObject *)(op))->ob_sval)
 //#define PyString_GET_SIZE(op)  Py_SIZE(op)
 

--- a/src/capi/codecs.cpp
+++ b/src/capi/codecs.cpp
@@ -744,14 +744,10 @@ static int _PyCodecRegistry_Init(void) {
     if (interp->codec_search_path != NULL)
         return 0;
 
-    interp->codec_search_path = PyList_New(0);
-    interp->codec_search_cache = PyDict_New();
-    interp->codec_error_registry = PyDict_New();
-
     // Pyston change: register roots
-    gc::registerPermanentRoot(interp->codec_search_path);
-    gc::registerPermanentRoot(interp->codec_search_cache);
-    gc::registerPermanentRoot(interp->codec_error_registry);
+    interp->codec_search_path = PyGC_AddRoot(PyList_New(0));
+    interp->codec_search_cache = PyGC_AddRoot(PyDict_New());
+    interp->codec_error_registry = PyGC_AddRoot(PyDict_New());
 
     if (interp->codec_error_registry) {
         for (i = 0; i < sizeof(methods) / sizeof(methods[0]); ++i) {

--- a/src/runtime/str.cpp
+++ b/src/runtime/str.cpp
@@ -2349,6 +2349,16 @@ extern "C" Py_ssize_t PyString_Size(PyObject* op) noexcept {
     return len;
 }
 
+extern "C" Py_ssize_t _PyString_SizeMacro(PyObject* op) noexcept {
+    if (PyString_Check(op))
+        return static_cast<BoxedString*>(op)->size();
+
+    if (PyUnicode_Check(op))
+        return Py_SIZE(op);
+
+    RELEASE_ASSERT(0, "Need to verify the behavior of PyString_GET_SIZE on %s objects", op->cls->tp_name);
+}
+
 extern "C" int _PyString_Resize(PyObject** pv, Py_ssize_t newsize) noexcept {
     // This is only allowed to be called when there is only one user of the string (ie a refcount of 1 in CPython)
 


### PR DESCRIPTION
Was running pyston at higher collection frequencies and ran into these issues.  After these fixes it looks like we can pass the integration tests when doing 100x collections, except for virtualenv_test.py which runs into the issue @rudi-c was running into (if we free a class in the same collection as some of its objects).