### PR TITLE
more rewriting

### DIFF
--- a/src/asm_writing/icinfo.cpp
+++ b/src/asm_writing/icinfo.cpp
@@ -290,6 +290,10 @@ bool ICInfo::shouldAttempt() {
         retry_in--;
         return false;
     }
+    // Note(kmod): in some pathological deeply-recursive cases, it's important that we set the
+    // retry counter even if we attempt it again.  We could probably handle this by setting
+    // the backoff to 0 on commit, and then setting the retry to the backoff here.
+
     return !isMegamorphic();
 }
 

--- a/src/asm_writing/rewriter.h
+++ b/src/asm_writing/rewriter.h
@@ -321,7 +321,7 @@ private:
         // Loads the constant into any register or if already in a register just return it
         assembler::Register loadConst(uint64_t val, Location otherThan = Location::any());
 
-        llvm::DenseMap<uint64_t, RewriterVar*> constToVar;
+        std::unordered_map<uint64_t, RewriterVar*> constToVar;
     };
 
 

--- a/src/runtime/objmodel.cpp
+++ b/src/runtime/objmodel.cpp
@@ -4821,7 +4821,7 @@ Box* typeCallInternal(BoxedFunctionBase* f, CallRewriteArgs* rewrite_args, ArgPa
     // this is ok with not using StlCompatAllocator since we will manually register these objects with the GC
     static std::vector<Box*> allowable_news;
     if (allowable_news.empty()) {
-        for (BoxedClass* allowed_cls : { object_cls, enumerate_cls, xrange_cls }) {
+        for (BoxedClass* allowed_cls : { object_cls, enumerate_cls, xrange_cls, tuple_cls, list_cls, dict_cls }) {
             auto new_obj = typeLookup(allowed_cls, new_str, NULL);
             gc::registerPermanentRoot(new_obj);
             allowable_news.push_back(new_obj);

--- a/src/runtime/objmodel.cpp
+++ b/src/runtime/objmodel.cpp
@@ -3136,7 +3136,10 @@ Box* callFunc(BoxedFunctionBase* func, CallRewriteArgs* rewrite_args, ArgPassSpe
                 RELEASE_ASSERT(rewrite_args->args, "");
                 args_array->setAttr(0, rewrite_args->args);
             }
-            args_array->setAttr(8, rewriter->loadConst((intptr_t)keyword_names));
+            if (argspec.num_keywords)
+                args_array->setAttr(8, rewriter->loadConst((intptr_t)keyword_names));
+            else
+                args_array->setAttr(8, rewriter->loadConst(0));
 
             RewriterVar::SmallVector arg_vec;
             arg_vec.push_back(rewrite_args->obj);

--- a/test/tests/weakref1.py
+++ b/test/tests/weakref1.py
@@ -19,4 +19,10 @@ def fact(n):
 
 w = doStuff()
 fact(10) # try to clear some memory
+
+def recurse(f, n):
+    if n:
+        return recurse(f, n - 1)
+    return f()
+recurse(gc.collect, 50)
 gc.collect()

--- a/test/tests/weakref_proxy.py
+++ b/test/tests/weakref_proxy.py
@@ -21,6 +21,12 @@ def getWR():
 
 wr = getWR()
 fact(100) # try to clear some memory
+
+def recurse(f, n):
+    if n:
+        return recurse(f, n - 1)
+    return f()
+recurse(gc.collect, 50)
 gc.collect()
 
 try:


### PR DESCRIPTION
Mostly related to callsites.  django_template hits an interesting case where we can't rewrite callsites that always throw exceptions.

```
       django_template.py             6.0s (2)             6.0s (2)  -1.1%
            pyxl_bench.py             4.2s (2)             4.1s (2)  -2.2%
 sqlalchemy_imperative.py             2.3s (2)             2.3s (2)  -1.6%
        django_migrate.py             2.0s (2)             2.0s (2)  -2.1%
      virtualenv_bench.py             8.1s (2)             8.1s (2)  +0.1%
                  geomean                 4.0s                 3.9s  -1.4%
```