### PR TITLE
don't mmap such small regions

### DIFF
--- a/src/gc/heap.cpp
+++ b/src/gc/heap.cpp
@@ -469,7 +469,7 @@ SmallArena::Block** SmallArena::_freeChain(Block** head, std::vector<Box*>& weak
 
 
 SmallArena::Block* SmallArena::_allocBlock(uint64_t size, Block** prev) {
-    Block* rtn = (Block*)doMmap(sizeof(Block));
+    Block* rtn = (Block*)allocFromArena(sizeof(Block));
     assert(rtn);
     rtn->size = size;
     rtn->num_obj = BLOCK_SIZE / size;
@@ -752,7 +752,7 @@ retry:
     if (free_chunks)
         return (LargeObj*)free_chunks;
 
-    section = (LargeBlock*)doMmap(BLOCK_SIZE);
+    section = (LargeBlock*)allocFromArena(BLOCK_SIZE);
 
     if (!section)
         return NULL;
@@ -819,7 +819,8 @@ GCAllocation* HugeArena::alloc(size_t size) {
 
     size_t total_size = size + sizeof(HugeObj);
     total_size = (total_size + PAGE_SIZE - 1) & ~(PAGE_SIZE - 1);
-    HugeObj* rtn = (HugeObj*)doMmap(total_size);
+    extendMapping(total_size);
+    HugeObj* rtn = (HugeObj*)allocFromArena(total_size);
     rtn->obj_size = size;
 
     nullNextPrev(rtn);


### PR DESCRIPTION
linux clusters page faults so the larger the regions we mmap the better, and larger regions don't cost us anything.

On jitdev, `/proc/sys/vm/page-cluster` contains '3', which means the kernel tries to read-ahead 8 (2^3) pages whenever there's a page fault.  For the small arena, we were only mmaping 16k at a time, so we would have twice the number of page faults for the small arena.  Instead of just upping it from 16k to 32k, I made the mappings much larger initially (e.g. 64 megs for the small arena), and the increments by which they grow also much larger (16megs for small arena.)

We don't really pay anything for doing this, since it's just a vm reservation, so there's no reason *not* to save the syscalls.

```
                           06a07a2c6f0a19fdbb:  cdfbb8ee6b7ce5f185:
       django_template.py             6.1s (2)             5.7s (2)  -6.4%
            pyxl_bench.py             4.2s (2)             4.0s (2)  -4.6%
 sqlalchemy_imperative.py             2.4s (2)             2.3s (2)  -4.4%
        django_migrate.py             2.0s (2)             2.0s (2)  -3.6%
      virtualenv_bench.py             8.2s (2)             8.2s (2)  -0.8%
                  geomean                 4.0s                 3.8s  -4.0%
```