### PR TITLE
Specify /bin/bash for the Makefile, as some distros may have other shells as /bin/sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+SHELL := /bin/bash
+
 # prints variables for debugging
 print-%: ; @echo $($*)
 


### PR DESCRIPTION
Specify /bin/bash for the Makefile, as some distros may have other shells (eg, ubuntu image for docker has /bin/sh pointing to /bin/dash).
This causes failures when bash extensions are used (in my case, the time command cannot run)