### PR TITLE
add tpp_call for faster calling of non-functions

### DIFF
--- a/from_cpython/Include/object.h
+++ b/from_cpython/Include/object.h
@@ -461,6 +461,7 @@ struct _typeobject {
     bool _flags[3];
     void* _tpp_descr_get;
     void* _tpp_hasnext;
+    void* _tpp_call;
 };
 
 /* The *real* layout of a type object when allocated on the heap */

--- a/src/asm_writing/rewriter.cpp
+++ b/src/asm_writing/rewriter.cpp
@@ -1314,12 +1314,12 @@ RewriterVar* Rewriter::allocateAndCopyPlus1(RewriterVar* first_elem, RewriterVar
 void Rewriter::_allocateAndCopyPlus1(RewriterVar* result, RewriterVar* first_elem, RewriterVar* rest_ptr, int n_rest) {
     int offset = _allocate(result, n_rest + 1);
 
-    assembler::Register tmp = first_elem->getInReg();
-    assembler->mov(tmp, assembler::Indirect(assembler::RSP, 8 * offset + rewrite->getScratchRspOffset()));
+    assembler::Register first_reg = first_elem->getInReg();
+    assembler->mov(first_reg, assembler::Indirect(assembler::RSP, 8 * offset + rewrite->getScratchRspOffset()));
 
     if (n_rest > 0) {
         assembler::Register src_ptr = rest_ptr->getInReg();
-        // TODO if this triggers we'll need a way to allocate two distinct registers
+        assembler::Register tmp = allocReg(Location::any(), /* otherThan */ src_ptr);
         assert(tmp != src_ptr);
 
         for (int i = 0; i < n_rest; i++) {

--- a/src/asm_writing/rewriter.cpp
+++ b/src/asm_writing/rewriter.cpp
@@ -694,6 +694,17 @@ RewriterVar* Rewriter::call(bool has_side_effects, void* func_addr, RewriterVar*
     return call(has_side_effects, func_addr, args, args_xmm);
 }
 
+RewriterVar* Rewriter::call(bool has_side_effects, void* func_addr, RewriterVar* arg0, RewriterVar* arg1,
+                            RewriterVar* arg2, RewriterVar* arg3) {
+    RewriterVar::SmallVector args;
+    RewriterVar::SmallVector args_xmm;
+    args.push_back(arg0);
+    args.push_back(arg1);
+    args.push_back(arg2);
+    args.push_back(arg3);
+    return call(has_side_effects, func_addr, args, args_xmm);
+}
+
 static const Location caller_save_registers[]{
     assembler::RAX,   assembler::RCX,   assembler::RDX,   assembler::RSI,   assembler::RDI,
     assembler::R8,    assembler::R9,    assembler::R10,   assembler::R11,   assembler::XMM0,

--- a/src/asm_writing/rewriter.h
+++ b/src/asm_writing/rewriter.h
@@ -505,6 +505,8 @@ public:
     RewriterVar* call(bool has_side_effects, void* func_addr, RewriterVar* arg0);
     RewriterVar* call(bool has_side_effects, void* func_addr, RewriterVar* arg0, RewriterVar* arg1);
     RewriterVar* call(bool has_side_effects, void* func_addr, RewriterVar* arg0, RewriterVar* arg1, RewriterVar* arg2);
+    RewriterVar* call(bool has_side_effects, void* func_addr, RewriterVar* arg0, RewriterVar* arg1, RewriterVar* arg2,
+                      RewriterVar* arg3);
     RewriterVar* add(RewriterVar* a, int64_t b, Location dest);
     // Allocates n pointer-sized stack slots:
     RewriterVar* allocate(int n);

--- a/src/codegen/ast_interpreter.cpp
+++ b/src/codegen/ast_interpreter.cpp
@@ -752,7 +752,7 @@ Value ASTInterpreter::visit_stmt(AST_stmt* node) {
 #endif
 
     if (0) {
-        printf("%20s % 2d ", source_info->getName().c_str(), current_block->idx);
+        printf("%20s % 2d ", source_info->getName().data(), current_block->idx);
         print_ast(node);
         printf("\n");
     }

--- a/src/codegen/irgen/hooks.cpp
+++ b/src/codegen/irgen/hooks.cpp
@@ -87,7 +87,7 @@ InternedStringPool& SourceInfo::getInternedStrings() {
     return scoping->getInternedStrings();
 }
 
-const std::string SourceInfo::getName() {
+llvm::StringRef SourceInfo::getName() {
     assert(ast);
     switch (ast->type) {
         case AST_TYPE::ClassDef:

--- a/src/core/cfg.cpp
+++ b/src/core/cfg.cpp
@@ -2595,7 +2595,7 @@ CFG* computeCFG(SourceInfo* source, std::vector<AST_stmt*> body) {
         if (b->predecessors.size() == 0) {
             if (b != rtn->getStartingBlock()) {
                 rtn->print();
-                printf("%s\n", source->getName().c_str());
+                printf("%s\n", source->getName().data());
             }
             ASSERT(b == rtn->getStartingBlock(), "%d", b->idx);
         }

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -300,7 +300,7 @@ public:
     // body and we have to create one.  Ideally, we'd be able to avoid the space duplication for non-lambdas.
     const std::vector<AST_stmt*> body;
 
-    const std::string getName();
+    llvm::StringRef getName();
     InternedString mangleName(InternedString id);
 
     Box* getDocString();

--- a/src/runtime/code.cpp
+++ b/src/runtime/code.cpp
@@ -72,7 +72,7 @@ public:
     static Box* argcount(Box* b, void*) {
         RELEASE_ASSERT(b->cls == code_cls, "");
 
-        return boxInt(static_cast<BoxedCode*>(b)->f->num_args);
+        return boxInt(static_cast<BoxedCode*>(b)->f->paramspec.num_args);
     }
 
     static Box* varnames(Box* b, void*) {

--- a/src/runtime/generator.cpp
+++ b/src/runtime/generator.cpp
@@ -310,7 +310,7 @@ extern "C" BoxedGenerator::BoxedGenerator(BoxedFunctionBase* function, Box* arg1
 #endif
 {
 
-    int numArgs = function->f->num_args;
+    int numArgs = function->f->numReceivedArgs();
     if (numArgs > 3) {
         numArgs -= 3;
         this->args = new (numArgs) GCdArray();
@@ -384,7 +384,7 @@ extern "C" void generatorGCHandler(GCVisitor* v, Box* b) {
     BoxedGenerator* g = (BoxedGenerator*)b;
 
     v->visit(g->function);
-    int num_args = g->function->f->num_args;
+    int num_args = g->function->f->numReceivedArgs();
     if (num_args >= 1)
         v->visit(g->arg1);
     if (num_args >= 2)

--- a/src/runtime/objmodel.cpp
+++ b/src/runtime/objmodel.cpp
@@ -2985,8 +2985,6 @@ void rearrangeArguments(ParamReceiveSpec paramspec, const ParamNames* param_name
 
     if (rewrite_args) {
         rewrite_success = false; // default case
-        assert(rewrite_args->args_guarded && "need to guard args here");
-        assert(rewrite_args->func_guarded && "this is the callers responsibility");
     }
 
     // Fast path: if it's a simple-enough call, we don't have to do anything special.  On a simple

--- a/src/runtime/objmodel.h
+++ b/src/runtime/objmodel.h
@@ -112,8 +112,6 @@ Box* runtimeCallInternal(Box* obj, CallRewriteArgs* rewrite_args, ArgPassSpec ar
 
 Box* lenCallInternal(BoxedFunctionBase* f, CallRewriteArgs* rewrite_args, ArgPassSpec argspec, Box* arg1, Box* arg2,
                      Box* arg3, Box** args, const std::vector<BoxedString*>* keyword_names);
-Box* typeCallInternal(BoxedFunctionBase* f, CallRewriteArgs* rewrite_args, ArgPassSpec argspec, Box* arg1, Box* arg2,
-                      Box* arg3, Box** args, const std::vector<BoxedString*>* keyword_names);
 
 Box* callFunc(BoxedFunctionBase* func, CallRewriteArgs* rewrite_args, ArgPassSpec argspec, Box* arg1, Box* arg2,
               Box* arg3, Box** args, const std::vector<BoxedString*>* keyword_names);
@@ -153,7 +151,11 @@ Box* typeCall(Box*, BoxedTuple*, BoxedDict*);
 Box* typeNew(Box* cls, Box* arg1, Box* arg2, Box** _args);
 bool isUserDefined(BoxedClass* cls);
 
+// These process a potential descriptor, differing in their behavior if the object was not a descriptor.
+// the OrNull variant returns NULL to signify it wasn't a descriptor, and the processDescriptor version
+// returns obj.
 Box* processDescriptor(Box* obj, Box* inst, Box* owner);
+Box* processDescriptorOrNull(Box* obj, Box* inst, Box* owner);
 
 Box* callCLFunc(CLFunction* f, CallRewriteArgs* rewrite_args, int num_output_args, BoxedClosure* closure,
                 BoxedGenerator* generator, Box* globals, Box* oarg1, Box* oarg2, Box* oarg3, Box** oargs);

--- a/src/runtime/rewrite_args.h
+++ b/src/runtime/rewrite_args.h
@@ -124,6 +124,7 @@ struct CompareRewriteArgs {
 // Passes the output arguments back through oarg.  Passes the rewrite success by setting rewrite_success.
 // Directly modifies rewrite_args args in place, but only if rewrite_success got set.
 // oargs needs to be pre-allocated by the caller, since it's assumed that they will want to use alloca.
+// The caller is responsible for guarding for paramspec, argspec, param_names, and defaults.
 // TODO Fix this function's signature.  should we pass back out through args?  the common case is that they
 // match anyway.  Or maybe it should call a callback function, which could save on the common case.
 void rearrangeArguments(ParamReceiveSpec paramspec, const ParamNames* param_names, const char* func_name,

--- a/src/runtime/rewrite_args.h
+++ b/src/runtime/rewrite_args.h
@@ -131,9 +131,10 @@ void rearrangeArguments(ParamReceiveSpec paramspec, const ParamNames* param_name
                         Box* arg1, Box* arg2, Box* arg3, Box** args, const std::vector<BoxedString*>* keyword_names,
                         Box*& oarg1, Box*& oarg2, Box*& oarg3, Box** oargs);
 
-// new_args should be allocated by the caller if at least three args get passed in
-ArgPassSpec bindObjIntoArgs(Box* obj, CallRewriteArgs* rewrite_args, ArgPassSpec argspec, Box*& arg1, Box*& arg2,
-                            Box*& arg3, Box** args, Box** new_args);
+// new_args should be allocated by the caller if at least three args get passed in.
+// rewrite_args will get modified in place.
+ArgPassSpec bindObjIntoArgs(Box* bind_obj, RewriterVar* r_bind_obj, CallRewriteArgs* rewrite_args, ArgPassSpec argspec,
+                            Box*& arg1, Box*& arg2, Box*& arg3, Box** args, Box** new_args);
 } // namespace pyston
 
 #endif

--- a/src/runtime/rewrite_args.h
+++ b/src/runtime/rewrite_args.h
@@ -130,6 +130,10 @@ void rearrangeArguments(ParamReceiveSpec paramspec, const ParamNames* param_name
                         Box** defaults, CallRewriteArgs* rewrite_args, bool& rewrite_success, ArgPassSpec argspec,
                         Box* arg1, Box* arg2, Box* arg3, Box** args, const std::vector<BoxedString*>* keyword_names,
                         Box*& oarg1, Box*& oarg2, Box*& oarg3, Box** oargs);
+
+// new_args should be allocated by the caller if at least three args get passed in
+ArgPassSpec bindObjIntoArgs(Box* obj, CallRewriteArgs* rewrite_args, ArgPassSpec argspec, Box*& arg1, Box*& arg2,
+                            Box*& arg3, Box** args, Box** new_args);
 } // namespace pyston
 
 #endif

--- a/src/runtime/rewrite_args.h
+++ b/src/runtime/rewrite_args.h
@@ -121,6 +121,15 @@ struct CompareRewriteArgs {
         : rewriter(rewriter), lhs(lhs), rhs(rhs), destination(destination), out_success(false), out_rtn(NULL) {}
 };
 
+// Passes the output arguments back through oarg.  Passes the rewrite success by setting rewrite_success.
+// Directly modifies rewrite_args args in place, but only if rewrite_success got set.
+// oargs needs to be pre-allocated by the caller, since it's assumed that they will want to use alloca.
+// TODO Fix this function's signature.  should we pass back out through args?  the common case is that they
+// match anyway.  Or maybe it should call a callback function, which could save on the common case.
+void rearrangeArguments(ParamReceiveSpec paramspec, const ParamNames* param_names, const char* func_name,
+                        Box** defaults, CallRewriteArgs* rewrite_args, bool& rewrite_success, ArgPassSpec argspec,
+                        Box* arg1, Box* arg2, Box* arg3, Box** args, const std::vector<BoxedString*>* keyword_names,
+                        Box*& oarg1, Box*& oarg2, Box*& oarg3, Box** oargs);
 } // namespace pyston
 
 #endif

--- a/src/runtime/types.cpp
+++ b/src/runtime/types.cpp
@@ -547,7 +547,15 @@ static Box* typeTppCall(Box* self, CallRewriteArgs* rewrite_args, ArgPassSpec ar
         new_args = (Box**)alloca(sizeof(Box*) * (npassed_args + 1 - 3));
     }
 
-    ArgPassSpec new_argspec = bindObjIntoArgs(self, rewrite_args, argspec, arg1, arg2, arg3, args, new_args);
+    RewriterVar* r_bind_obj = NULL;
+    if (rewrite_args) {
+        r_bind_obj = rewrite_args->obj;
+        rewrite_args->obj = NULL;
+    }
+
+    ArgPassSpec new_argspec
+        = bindObjIntoArgs(self, r_bind_obj, rewrite_args, argspec, arg1, arg2, arg3, args, new_args);
+
     return typeCallInner(rewrite_args, new_argspec, arg1, arg2, arg3, new_args, keyword_names);
 }
 

--- a/src/runtime/types.cpp
+++ b/src/runtime/types.cpp
@@ -316,7 +316,7 @@ extern "C" BoxedFunctionBase::BoxedFunctionBase(CLFunction* f)
         this->doc = None;
     }
 
-    assert(f->num_defaults == ndefaults);
+    assert(f->paramspec.num_defaults == ndefaults);
 }
 
 extern "C" BoxedFunctionBase::BoxedFunctionBase(CLFunction* f, std::initializer_list<Box*> defaults,
@@ -338,7 +338,7 @@ extern "C" BoxedFunctionBase::BoxedFunctionBase(CLFunction* f, std::initializer_
         this->doc = None;
     }
 
-    assert(f->num_defaults == ndefaults);
+    assert(f->paramspec.num_defaults == ndefaults);
 }
 
 BoxedFunction::BoxedFunction(CLFunction* f) : BoxedFunction(f, {}) {

--- a/src/runtime/types.h
+++ b/src/runtime/types.h
@@ -201,6 +201,10 @@ public:
 
     pyston_inquiry tpp_hasnext;
 
+    typedef Box* (*pyston_call)(Box*, CallRewriteArgs*, ArgPassSpec, Box*, Box*, Box*, Box**,
+                                const std::vector<BoxedString*>*);
+    pyston_call tpp_call;
+
     bool hasGenericGetattr() { return tp_getattr == NULL; }
 
     void freeze();
@@ -1002,6 +1006,17 @@ extern "C" inline Box* boxInt(int64_t n) {
         return interned_ints[n];
     }
     return new BoxedInt(n);
+}
+
+// Helper function: fetch an arg from our calling convention
+inline Box*& getArg(int idx, Box*& arg1, Box*& arg2, Box*& arg3, Box** args) {
+    if (idx == 0)
+        return arg1;
+    if (idx == 1)
+        return arg2;
+    if (idx == 2)
+        return arg3;
+    return args[idx - 3];
 }
 }
 

--- a/src/runtime/types.h
+++ b/src/runtime/types.h
@@ -911,6 +911,8 @@ public:
     DEFAULT_CLASS(wrapperobject_cls);
 
     static Box* __call__(BoxedWrapperObject* self, Box* args, Box* kwds);
+    static Box* tppCall(Box* _self, CallRewriteArgs* rewrite_args, ArgPassSpec argspec, Box* arg1, Box* arg2, Box* arg3,
+                        Box** args, const std::vector<BoxedString*>* keyword_names);
     static void gcHandler(GCVisitor* v, Box* _o);
 };
 

--- a/test/extra/test_helper.py
+++ b/test/extra/test_helper.py
@@ -78,7 +78,7 @@ def run_test(cmd, cwd, expected, env = None):
     if expected == result:
         print "Received expected output"
     else:
-        print >> sys.stderr, output
+        print >> sys.stderr, '\n'.join(output.split('\n')[:200])
         print >> sys.stderr, "WRONG output"
         print >> sys.stderr, "is:", result
         print >> sys.stderr, "expected:", expected


### PR DESCRIPTION
Previously, we would call non-functions by doing something like `getattr(func_like_obj, '__call__')()`, ie doing an attribute lookup and then another round of figuring out how to call the object.  Now instead, we have class-level function pointers that we can set that will bypass this extra overhead.

This is "tpp_call" and not CPython's tp_call, since it uses our internal rewriter-capable interface.

There's some more cleanup that can be done; we have a similar mechanism on functions ("internal callable") which is much less useful with this new strategy.  Most of the internal callables are on classes '__call__` functions, and they should probably just be converted to tpp_call pointers.  I did this for typeCall, though it ended up being pretty messy.

The bulk of the changes in this PR are refactoring to make it easier to do all the argument munging and the associated rewrites.  This also makes the existing code cleaner, imo.  The final commit adds a tpp_call for BoxedWrapperObjects (ie what `unicode.__repr__` is), which results in a decent speedup on django_template.py:

```
       django_template.py             5.6s (2)             5.2s (2)  -7.6%
            pyxl_bench.py             3.9s (2)             4.0s (2)  +0.6%
 sqlalchemy_imperative.py             2.2s (2)             2.2s (2)  -1.1%
        django_migrate.py             1.9s (2)             1.9s (2)  -0.7%
      virtualenv_bench.py             8.0s (2)             8.1s (2)  +0.2%
                  geomean                 3.8s                 3.7s  -1.8%
```