### PR TITLE
do 100 queries per insert instead of 1000 after all inserts.

### DIFF
--- a/minibenchmarks/sqlalchemy_declarative.py
+++ b/minibenchmarks/sqlalchemy_declarative.py
@@ -64,9 +64,8 @@ for i in xrange(100):
     session.add(new_address)
     session.commit()
 
-
-# now do 1000 queries
-for i in xrange(1000):
-    session.query(Person).all()
+    # do 100 queries per insert
+    for i in xrange(100):
+        session.query(Person).all()
 
 print "done"

--- a/minibenchmarks/sqlalchemy_imperative.py
+++ b/minibenchmarks/sqlalchemy_imperative.py
@@ -56,10 +56,9 @@ for i in xrange(100):
     new_address = Address.insert()
     new_address.execute(post_code='00000')#, person=new_person)
 
-
-# now do 1000 queries
-for i in xrange(1000):
-    s = Person.select()
-    rs = s.execute()
+    # do 100 queries per insert
+    for i in xrange(100):
+        s = Person.select()
+        rs = s.execute()
 
 print "done"


### PR DESCRIPTION
this increases cpython time on _imperative.py to ~2 seconds (and lowers pyston's % from ~480% to ~380%).
the declarative benchmark takes 10 seconds for cpython with this change, but it doesn't work on pyston at all yet.

the imperative case shows this at the top of `perf report`:

```
-   7.59%  pyston_release  pyston               [.] llvm::StringMapImpl::FindKey(llvm::StringRef) const           
   - llvm::StringMapImpl::FindKey(llvm::StringRef) const                                                          
      - 49.37% pyston::getattrInternalGeneric(pyston::Box*, llvm::StringRef, pyston::GetattrRewriteArgs*, bool, bo
         - 41.03% getattr                                                                                         
            - 21.88% PyObject_GetAttr                                                                             
               - 57.14% dotted_getattr                                                                            
                    attrgetter_call                                                                               
                    pyston::wrap_call(pyston::Box*, pyston::Box*, void*, pyston::Box*)                            
                  + pyston::BoxedWrapperObject::__call__(pyston::BoxedWrapperObject*, pyston::Box*, pyston::Box*) 
               + 42.86% pyston::recursive_isinstance(pyston::Box*, pyston::Box*)                                  
            + 18.75% _froms_e3_215                                                                                
            + 15.62% visit_select_e2_189                                                                          
            + 9.38% pyston::(anonymous namespace)::ASTInterpreter::visit_expr(pyston::AST_expr*)                  
            + 6.25% _froms_e2_130                                                                                 
            + 6.25% _columns_plus_names_e2_193                                                                    
            + 3.12% _compose_select_body_e1_121                                                                   
            + 3.12% bind_e2_173                                                                                   
            + 3.12% __init___e2_186                                                                              
            + 3.12% _get_display_froms_e2_191                                                                     
            + 3.12% _compose_select_body_e2_195                                                                   
            + 3.12% visit_table_e2_199                                                                            
            + 3.12% PyObject_GetAttrString                                                                        
         - 26.92% PyObject_GenericGetAttr                                                                         
            - pyston::slot_tp_getattr_hook(pyston::Box*, pyston::Box*)                                            
               + 71.43% getattr                                                                                   
               + 19.05% callattrInternal                                                                          
               + 9.52% pyston::getattrInternalEx(pyston::Box*, pyston::BoxedString*, pyston::GetattrRewriteArgs*, 
         + 21.79% callattrInternal                                                                                
         + 8.97% nonzero                                                                                          
         + 1.28% pyston::getattrInternalEx(pyston::Box*, pyston::BoxedString*, pyston::GetattrRewriteArgs*, bool, 
      + 22.78% pyston::typeLookup(pyston::BoxedClass*, llvm::StringRef, pyston::GetattrRewriteArgs*)              
        11.39% 0x7f50000000000000                                                                                 
      + 6.33% pyston::typeCallInternal(pyston::BoxedFunctionBase*, pyston::CallRewriteArgs*, pyston::ArgPassSpec, 
      + 5.70% pyston::setattrGeneric(pyston::Box*, pyston::BoxedString*, pyston::Box*, pyston::SetattrRewriteArgs*
      + 1.27% pyston::BoxedModule::getStringConstant(llvm::StringRef)                                             
      + 1.27% pyston::Box::setattr(llvm::StringRef, pyston::Box*, pyston::SetattrRewriteArgs*)                    
      + 0.63% pyston::AttrWrapper::setitem(pyston::Box*, pyston::Box*, pyston::Box*)                              
      + 0.63% getGlobal                                                                                           
      + 0.63% pyston::_instanceGetattribute(pyston::Box*, pyston::Box*, bool)                                     
```