### PR TITLE
Incremental tb improvements

### DIFF
--- a/src/codegen/ast_interpreter.cpp
+++ b/src/codegen/ast_interpreter.cpp
@@ -382,7 +382,7 @@ Box* ASTInterpreter::execJITedBlock(CFGBlock* b) {
     } catch (ExcInfo e) {
         AST_stmt* stmt = getCurrentStatement();
         if (stmt->type != AST_TYPE::Invoke)
-            throw e;
+            throwReraise(e);
 
         auto source = getCL()->source.get();
         exceptionCaughtInInterpreter(LineInfo(stmt->lineno, stmt->col_offset, source->fn, source->getName()), &e);

--- a/src/codegen/irgen/irgenerator.cpp
+++ b/src/codegen/irgen/irgenerator.cpp
@@ -110,8 +110,8 @@ static llvm::Value* getClosureElementGep(IREmitter& emitter, llvm::Value* closur
 
 static llvm::Value* getBoxedLocalsGep(llvm::IRBuilder<true>& builder, llvm::Value* v) {
     static_assert(offsetof(FrameInfo, exc) == 0, "");
-    static_assert(sizeof(ExcInfo) == 32, "");
-    static_assert(offsetof(FrameInfo, boxedLocals) == 32, "");
+    static_assert(sizeof(ExcInfo) == 24, "");
+    static_assert(offsetof(FrameInfo, boxedLocals) == 24, "");
     return builder.CreateConstInBoundsGEP2_32(v, 0, 1);
 }
 
@@ -122,9 +122,9 @@ static llvm::Value* getExcinfoGep(llvm::IRBuilder<true>& builder, llvm::Value* v
 
 static llvm::Value* getFrameObjGep(llvm::IRBuilder<true>& builder, llvm::Value* v) {
     static_assert(offsetof(FrameInfo, exc) == 0, "");
-    static_assert(sizeof(ExcInfo) == 32, "");
+    static_assert(sizeof(ExcInfo) == 24, "");
     static_assert(sizeof(Box*) == 8, "");
-    static_assert(offsetof(FrameInfo, frame_obj) == 40, "");
+    static_assert(offsetof(FrameInfo, frame_obj) == 32, "");
     return builder.CreateConstInBoundsGEP2_32(v, 0, 2);
     // TODO: this could be made more resilient by doing something like
     // gep->accumulateConstantOffset(g.tm->getDataLayout(), ap_offset)

--- a/src/codegen/unwinding.cpp
+++ b/src/codegen/unwinding.cpp
@@ -468,9 +468,9 @@ public:
 
     void reset(bool skipFirst) { skipNext = skipFirst; }
 
-    static bool shouldSkipNextFrame(PythonFrameIteratorImpl* info) {
+    static bool shouldSkipNextFrame(CompiledFunction* cf) {
         // cf->entry_descriptor will be non-null for OSR frames.
-        return (info->getId().type == PythonFrameId::COMPILED) && (info->cf->entry_descriptor);
+        return (bool)(cf && cf->entry_descriptor);
     }
 
     bool getPythonFrame(unw_cursor_t* cursor, PythonFrameIteratorImpl* info) {
@@ -498,7 +498,7 @@ public:
             // even though we're skipping this frame, we might need to
             // skip the next one e.g: we're reraising an exception
             // *from* an osr frame.
-            skipNext = shouldSkipNextFrame(info);
+            skipNext = shouldSkipNextFrame(cf);
             return false;
         }
 
@@ -523,7 +523,7 @@ public:
             }
         }
 
-        skipNext = shouldSkipNextFrame(info);
+        skipNext = shouldSkipNextFrame(cf);
         return true;
     }
 };

--- a/src/codegen/unwinding.cpp
+++ b/src/codegen/unwinding.cpp
@@ -728,6 +728,8 @@ template <typename Func> void unwindPythonStack(Func func) {
 
 static std::unique_ptr<PythonFrameIteratorImpl> getTopPythonFrame() {
     STAT_TIMER(t0, "us_timer_getTopPythonFrame", 10);
+    static StatCounter calls("num_getTopPythonFrame");
+    calls.log();
     std::unique_ptr<PythonFrameIteratorImpl> rtn(nullptr);
     unwindPythonStack([&](PythonFrameIteratorImpl* iter) {
         rtn = std::unique_ptr<PythonFrameIteratorImpl>(new PythonFrameIteratorImpl(*iter));

--- a/src/codegen/unwinding.cpp
+++ b/src/codegen/unwinding.cpp
@@ -557,9 +557,9 @@ public:
         if (!o->is_active)
             return;
 
-        v->visitIf(o->exc_info.type);
-        v->visitIf(o->exc_info.value);
-        v->visitIf(o->exc_info.traceback);
+        v->visit(o->exc_info.type);
+        v->visit(o->exc_info.value);
+        v->visit(o->exc_info.traceback);
     }
 };
 static __thread PythonUnwindSession* cur_unwind;

--- a/src/codegen/unwinding.cpp
+++ b/src/codegen/unwinding.cpp
@@ -58,8 +58,6 @@ struct uw_table_entry {
 
 namespace pyston {
 
-static BoxedClass* unwind_session_cls;
-
 // Parse an .eh_frame section, and construct a "binary search table" such as you would find in a .eh_frame_hdr section.
 // Currently only supports .eh_frame sections with exactly one fde.
 // See http://www.airs.com/blog/archives/460 for some useful info.
@@ -446,88 +444,161 @@ static inline unw_word_t get_cursor_bp(unw_cursor_t* cursor) {
     return get_cursor_reg(cursor, UNW_TDEP_BP);
 }
 
-// if the given ip/bp correspond to a jitted frame or
-// ASTInterpreter::execute_inner frame, return true and return the
-// frame information through the PythonFrameIteratorImpl* info arg.
-bool frameIsPythonFrame(unw_word_t ip, unw_word_t bp, unw_cursor_t* cursor, PythonFrameIteratorImpl* info) {
-    CompiledFunction* cf = getCFForAddress(ip);
-    CLFunction* cl = cf ? cf->clfunc : NULL;
-    bool jitted = cf != NULL;
-    bool interpreted = !jitted && inASTInterpreterExecuteInner(ip);
-    if (interpreted)
-        cl = getCLForInterpretedFrame((void*)bp);
+static const LineInfo lineInfoForFrame(PythonFrameIteratorImpl* frame_it) {
+    AST_stmt* current_stmt = frame_it->getCurrentStatement();
+    auto* cl = frame_it->getCL();
+    assert(cl);
 
-    if (!jitted && !interpreted)
-        return false;
+    auto source = cl->source.get();
 
-    *info = PythonFrameIteratorImpl(jitted ? PythonFrameId::COMPILED : PythonFrameId::INTERPRETED, ip, bp, cl, cf);
-    if (jitted) {
-        // Try getting all the callee-save registers, and save the ones we were able to get.
-        // Some of them may be inaccessible, I think because they weren't defined by that
-        // stack frame, which can show up as a -UNW_EBADREG return code.
-        for (int i = 0; i < 16; i++) {
-            if (!assembler::Register::fromDwarf(i).isCalleeSave())
-                continue;
-            unw_word_t r;
-            int code = unw_get_reg(cursor, i, &r);
-            ASSERT(code == 0 || code == -UNW_EBADREG, "%d %d", code, i);
-            if (code == 0) {
-                info->regs[i] = r;
-                info->regs_valid |= (1 << i);
-            }
-        }
-    }
-
-    return true;
+    return LineInfo(current_stmt->lineno, current_stmt->col_offset, source->fn, source->getName());
 }
 
-class PythonUnwindSession : public Box {
-    ExcInfo exc_info;
-    bool skip;
+// This class is used by both PythonExceptionUnwinder and
+// PythonUnwinder to convert from C++ frames to python frames.  It
+// assumes getPythonFrame will be call (in order) for each C++ frame
+// while unwinding, and maintains a bool flag to skip the next frame
+// to handle OSR frames (and skipping the initial frame for a
+// reraise.)
+class PythonUnwindState {
+public:
+    bool skipNext;
+
+    PythonUnwindState(bool skipFirst) : skipNext(skipFirst) {}
+
+    void reset(bool skipFirst) { skipNext = skipFirst; }
+
+    bool getPythonFrame(unw_cursor_t* cursor, PythonFrameIteratorImpl* info) {
+        unw_word_t ip = get_cursor_ip(cursor);
+        unw_word_t bp = get_cursor_bp(cursor);
+
+        CompiledFunction* cf = getCFForAddress(ip);
+        CLFunction* cl = cf ? cf->clfunc : NULL;
+        bool jitted = cl != NULL;
+        bool interpreted = !jitted && inASTInterpreterExecuteInner(ip);
+        bool deopt = !jitted && isDeopt(ip);
+
+        if (!jitted && !interpreted && !deopt) {
+            // the cursor doesn't correspond to a python frame
+            return false;
+        }
+
+        if (deopt) {
+            assert(!skipNext);
+            skipNext = true;
+            return false;
+        }
+
+        if (skipNext) {
+            skipNext = false;
+            return false;
+        }
+
+        if (interpreted)
+            cl = getCLForInterpretedFrame((void*)bp);
+
+        *info = PythonFrameIteratorImpl(jitted ? PythonFrameId::COMPILED : PythonFrameId::INTERPRETED, ip, bp, cl, cf);
+        if (jitted) {
+            // Try getting all the callee-save registers, and save the ones we were able to get.
+            // Some of them may be inaccessible, I think because they weren't defined by that
+            // stack frame, which can show up as a -UNW_EBADREG return code.
+            for (int i = 0; i < 16; i++) {
+                if (!assembler::Register::fromDwarf(i).isCalleeSave())
+                    continue;
+                unw_word_t r;
+                int code = unw_get_reg(cursor, i, &r);
+                ASSERT(code == 0 || code == -UNW_EBADREG, "%d %d", code, i);
+                if (code == 0) {
+                    info->regs[i] = r;
+                    info->regs_valid |= (1 << i);
+                }
+            }
+        }
+
+        // cf->entry_descriptor will be non-null for OSR frames.
+        bool was_osr = (info->getId().type == PythonFrameId::COMPILED) && (info->cf->entry_descriptor);
+        skipNext = was_osr;
+
+        return true;
+    }
+};
+
+// A simple unwinder class used by unwindPythonStack, used to
+// enumerate all python frames on the stack, and traces from
+// generators to the context from which they were called.
+//
+class PythonUnwinder {
+private:
+    PythonUnwindState state;
+
+public:
+    PythonUnwinder() : state(false) {}
+
+    // returns true (and frame_iter is populated) when the cursor
+    // points to a frame that our caller needs to handle (i.e. a valid
+    // python frame that would show up in a traceback).
+    //
+    // will often unwind multiple C++ frames per call.
+    //
+    bool getNextPythonFrame(unw_cursor_t* cursor, unw_context_t* ctx, PythonFrameIteratorImpl* frame_iter) {
+        while (true) {
+            int r = unw_step(cursor);
+
+            assert(r >= 0);
+            if (r == 0)
+                return false; // no more frames to unwind through
+
+            if (inGeneratorEntry(get_cursor_ip(cursor))) {
+                // for generators continue unwinding in the context in which the generator got called
+                Context* remote_ctx = getReturnContextForGeneratorFrame((void*)get_cursor_bp(cursor));
+                // setup unw_context_t struct from the infos we have, seems like this is enough to make unwinding work.
+                memset(ctx, 0, sizeof(unw_context_t));
+                ctx->uc_mcontext.gregs[REG_R12] = remote_ctx->r12;
+                ctx->uc_mcontext.gregs[REG_R13] = remote_ctx->r13;
+                ctx->uc_mcontext.gregs[REG_R14] = remote_ctx->r14;
+                ctx->uc_mcontext.gregs[REG_R15] = remote_ctx->r15;
+                ctx->uc_mcontext.gregs[REG_RBX] = remote_ctx->rbx;
+                ctx->uc_mcontext.gregs[REG_RBP] = remote_ctx->rbp;
+                ctx->uc_mcontext.gregs[REG_RIP] = remote_ctx->rip;
+                ctx->uc_mcontext.gregs[REG_RSP] = (greg_t)remote_ctx;
+                unw_init_local(cursor, ctx);
+            }
+
+            if (state.getPythonFrame(cursor, frame_iter))
+                return true;
+        }
+    }
+};
+
+// The more complicated unwinder that forms the bridge between C++
+// unwinding and python traceback generation.
+//
+//
+class PythonExceptionUnwinder {
+public:
     bool is_active;
     Timer t;
 
-public:
-    DEFAULT_CLASS_SIMPLE(unwind_session_cls);
+    ExcInfo exc_info;
 
-    PythonUnwindSession() : exc_info(NULL, NULL, NULL), skip(false), is_active(false), t(/*min_usec=*/10000) {}
+    PythonUnwindState state;
 
-    ExcInfo* getExcInfoStorage() {
-        RELEASE_ASSERT(is_active, "");
-        return &exc_info;
-    }
-    bool shouldSkipFrame() const { return skip; }
-    void setShouldSkipNextFrame(bool skip) { this->skip = skip; }
-    bool isActive() const { return is_active; }
+    PythonExceptionUnwinder() : is_active(false), t(/*min_usec=*/10000), exc_info(NULL, NULL, NULL), state(false) {}
 
     void begin() {
         RELEASE_ASSERT(!is_active, "");
-        exc_info = ExcInfo(NULL, NULL, NULL);
-        skip = false;
         is_active = true;
+#if STAT_EXCEPTIONS
         t.restart();
+#endif
+        state.reset(cur_exception_reraise);
+        cur_exception_reraise = false;
 
+#if STAT_EXCEPTIONS
         static StatCounter stat("unwind_sessions");
         stat.log();
-    }
-    void end() {
-        RELEASE_ASSERT(is_active, "");
-        is_active = false;
+#endif
 
-        static StatCounter stat("us_unwind_session");
-        stat.log(t.end());
-    }
-
-    void addTraceback(const LineInfo& line_info) {
-        RELEASE_ASSERT(is_active, "");
-        if (exc_info.reraise) {
-            exc_info.reraise = false;
-            return;
-        }
-        BoxedTraceback::here(line_info, &exc_info.traceback);
-    }
-
-    void logException() {
 #if STAT_EXCEPTIONS
         static StatCounter num_exceptions("num_exceptions");
         num_exceptions.log();
@@ -544,15 +615,28 @@ public:
 #endif
     }
 
-    static void gcHandler(GCVisitor* v, Box* _o) {
-        assert(_o->cls == unwind_session_cls);
+    void end() {
+        RELEASE_ASSERT(is_active, "");
+        is_active = false;
 
-        PythonUnwindSession* o = static_cast<PythonUnwindSession*>(_o);
+#if STAT_EXCEPTIONS
+        static StatCounter stat("us_unwind_session");
+        stat.log(t.end());
+#endif
+    }
+    void unwindingThroughFrame(unw_cursor_t* cursor) {
+        PythonFrameIteratorImpl frame_iter;
+        if (state.getPythonFrame(cursor, &frame_iter))
+            BoxedTraceback::here(lineInfoForFrame(&frame_iter), &exc_info.traceback);
+    }
+
+    static void gcHandler(GCVisitor* v, void* _o) {
+        PythonExceptionUnwinder* o = static_cast<PythonExceptionUnwinder*>(_o);
 
         // this is our hack for eventually collecting
         // exceptions/tracebacks after the exception has been caught.
         // If a collection happens and a given thread's
-        // PythonUnwindSession isn't active, its exception info can be
+        // PythonExceptionUnwinder isn't active, its exception info can be
         // collected.
         if (!o->is_active)
             return;
@@ -561,84 +645,65 @@ public:
         v->visit(o->exc_info.value);
         v->visit(o->exc_info.traceback);
     }
-};
-static __thread PythonUnwindSession* cur_unwind;
 
-PythonUnwindSession* beginPythonUnwindSession() {
-    if (!cur_unwind) {
-        cur_unwind = new PythonUnwindSession();
-        pyston::gc::registerPermanentRoot(cur_unwind);
+    static PythonExceptionUnwinder* get() {
+        if (!cur_unwind) {
+            cur_unwind = new PythonExceptionUnwinder();
+            pyston::gc::registerRootCallback(cur_unwind, PythonExceptionUnwinder::gcHandler);
+        }
+        return cur_unwind;
     }
+
+    static __thread PythonExceptionUnwinder* cur_unwind;
+    static __thread bool cur_exception_reraise;
+};
+
+__thread PythonExceptionUnwinder* PythonExceptionUnwinder::cur_unwind;
+__thread bool PythonExceptionUnwinder::cur_exception_reraise;
+
+// a special version of c++'s throw that just sets our per-thread flag
+// before throwing.  the flag will be copied into our unwinder's state
+// when the C++ unwind starts.
+void throwReraise(ExcInfo e) {
+    PythonExceptionUnwinder::cur_exception_reraise = true;
+    throw e;
+}
+
+void* allocatePythonExceptionStorage() {
+    auto cur_unwind = PythonExceptionUnwinder::get();
+    return &cur_unwind->exc_info;
+}
+
+PythonExceptionUnwinder* beginPythonException() {
+    auto cur_unwind = PythonExceptionUnwinder::get();
     cur_unwind->begin();
     return cur_unwind;
 }
 
-PythonUnwindSession* getActivePythonUnwindSession() {
-    RELEASE_ASSERT(cur_unwind && cur_unwind->isActive(), "");
+PythonExceptionUnwinder* getActivePythonException() {
+    auto cur_unwind = PythonExceptionUnwinder::get();
+    RELEASE_ASSERT(cur_unwind->is_active, "");
     return cur_unwind;
 }
 
-void endPythonUnwindSession(PythonUnwindSession* unwind) {
-    RELEASE_ASSERT(unwind && unwind == cur_unwind, "");
+void endPythonException(PythonExceptionUnwinder* unwind) {
+    RELEASE_ASSERT(unwind && unwind == PythonExceptionUnwinder::cur_unwind, "");
     unwind->end();
-}
-void* getPythonUnwindSessionExceptionStorage(PythonUnwindSession* unwind) {
-    RELEASE_ASSERT(unwind && unwind == cur_unwind, "");
-    PythonUnwindSession* state = static_cast<PythonUnwindSession*>(unwind);
-    return state->getExcInfoStorage();
-}
-
-void throwingException(PythonUnwindSession* unwind) {
-    RELEASE_ASSERT(unwind && unwind == cur_unwind, "");
-    unwind->logException();
-}
-
-static const LineInfo lineInfoForFrame(PythonFrameIteratorImpl* frame_it) {
-    AST_stmt* current_stmt = frame_it->getCurrentStatement();
-    auto* cl = frame_it->getCL();
-    assert(cl);
-
-    auto source = cl->source.get();
-
-    return LineInfo(current_stmt->lineno, current_stmt->col_offset, source->fn, source->getName());
 }
 
 void exceptionCaughtInInterpreter(LineInfo line_info, ExcInfo* exc_info) {
-    // basically the same as PythonUnwindSession::addTraceback, but needs to
-    // be callable after an PythonUnwindSession has ended.  The interpreter
-    // will call this from catch blocks if it needs to ensure that a
-    // line is added.  Right now this only happens in
-    // ASTInterpreter::visit_invoke.
-
-    // It's basically the same except for one thing: we don't have to
-    // worry about the 'skip' (osr) state that PythonUnwindSession handles
-    // here, because the only way we could have gotten into the ast
-    // interpreter is if the exception wasn't caught, and if there was
-    // the osr frame for the one the interpreter is running, it would
-    // have already caught it.
-    if (exc_info->reraise) {
-        exc_info->reraise = false;
+    auto cur_unwind = PythonExceptionUnwinder::cur_unwind;
+    // XXX pretty terribly abstraction leak here.. :/
+    if (cur_unwind->state.skipNext) {
         return;
     }
     BoxedTraceback::here(line_info, &exc_info->traceback);
 }
 
-void unwindingThroughFrame(PythonUnwindSession* unwind_session, unw_cursor_t* cursor) {
-    unw_word_t ip = get_cursor_ip(cursor);
-    unw_word_t bp = get_cursor_bp(cursor);
-
-    PythonFrameIteratorImpl frame_iter;
-    if (isDeopt(ip)) {
-        assert(!unwind_session->shouldSkipFrame());
-        unwind_session->setShouldSkipNextFrame(true);
-    } else if (frameIsPythonFrame(ip, bp, cursor, &frame_iter)) {
-        if (!unwind_session->shouldSkipFrame())
-            unwind_session->addTraceback(lineInfoForFrame(&frame_iter));
-
-        // frame_iter->cf->entry_descriptor will be non-null for OSR frames.
-        bool was_osr = (frame_iter.getId().type == PythonFrameId::COMPILED) && (frame_iter.cf->entry_descriptor);
-        unwind_session->setShouldSkipNextFrame(was_osr);
-    }
+void unwindingThroughFrame(PythonExceptionUnwinder* unwind, unw_cursor_t* cursor) {
+    auto cur_unwind = PythonExceptionUnwinder::get();
+    RELEASE_ASSERT(unwind == cur_unwind, "");
+    unwind->unwindingThroughFrame(cursor);
 }
 
 // While I'm not a huge fan of the callback-passing style, libunwind cursors are only valid for
@@ -646,64 +711,19 @@ void unwindingThroughFrame(PythonUnwindSession* unwind_session, unw_cursor_t* cu
 // C++11 range loops, for example).
 // Return true from the handler to stop iteration at that frame.
 template <typename Func> void unwindPythonStack(Func func) {
-    PythonUnwindSession* unwind_session = new PythonUnwindSession();
-
-    unwind_session->begin();
-
     unw_context_t ctx;
     unw_cursor_t cursor;
     unw_getcontext(&ctx);
     unw_init_local(&cursor, &ctx);
 
-    while (true) {
-        int r = unw_step(&cursor);
+    PythonUnwinder unwinder;
+    PythonFrameIteratorImpl frame_iter;
 
-        assert(r >= 0);
-        if (r == 0)
-            break;
-
-        unw_word_t ip = get_cursor_ip(&cursor);
-        unw_word_t bp = get_cursor_bp(&cursor);
-        // TODO: this should probably just call unwindingThroughFrame?
-
-        bool stop_unwinding = false;
-
-        PythonFrameIteratorImpl frame_iter;
-        if (isDeopt(ip)) {
-            assert(!unwind_session->shouldSkipFrame());
-            unwind_session->setShouldSkipNextFrame(true);
-        } else if (frameIsPythonFrame(ip, bp, &cursor, &frame_iter)) {
-            if (!unwind_session->shouldSkipFrame())
-                stop_unwinding = func(&frame_iter);
-
-            // frame_iter->cf->entry_descriptor will be non-null for OSR frames.
-            bool was_osr = (frame_iter.getId().type == PythonFrameId::COMPILED) && (frame_iter.cf->entry_descriptor);
-            unwind_session->setShouldSkipNextFrame(was_osr);
-        }
-
+    while (unwinder.getNextPythonFrame(&cursor, &ctx, &frame_iter)) {
+        bool stop_unwinding = func(&frame_iter);
         if (stop_unwinding)
             break;
-
-        if (inGeneratorEntry(ip)) {
-            // for generators continue unwinding in the context in which the generator got called
-            Context* remote_ctx = getReturnContextForGeneratorFrame((void*)bp);
-            // setup unw_context_t struct from the infos we have, seems like this is enough to make unwinding work.
-            memset(&ctx, 0, sizeof(ctx));
-            ctx.uc_mcontext.gregs[REG_R12] = remote_ctx->r12;
-            ctx.uc_mcontext.gregs[REG_R13] = remote_ctx->r13;
-            ctx.uc_mcontext.gregs[REG_R14] = remote_ctx->r14;
-            ctx.uc_mcontext.gregs[REG_R15] = remote_ctx->r15;
-            ctx.uc_mcontext.gregs[REG_RBX] = remote_ctx->rbx;
-            ctx.uc_mcontext.gregs[REG_RBP] = remote_ctx->rbp;
-            ctx.uc_mcontext.gregs[REG_RIP] = remote_ctx->rip;
-            ctx.uc_mcontext.gregs[REG_RSP] = (greg_t)remote_ctx;
-            unw_init_local(&cursor, &ctx);
-        }
-
-        // keep unwinding
     }
-
-    unwind_session->end();
 }
 
 static std::unique_ptr<PythonFrameIteratorImpl> getTopPythonFrame() {
@@ -1192,11 +1212,5 @@ void logByCurrentPythonLine(const std::string& stat_name) {
 
 llvm::JITEventListener* makeTracebacksListener() {
     return new TracebacksEventListener();
-}
-
-void setupUnwinding() {
-    unwind_session_cls = BoxedHeapClass::create(type_cls, object_cls, PythonUnwindSession::gcHandler, 0, 0,
-                                                sizeof(PythonUnwindSession), false, "unwind_session");
-    unwind_session_cls->freeze();
 }
 }

--- a/src/core/threading.cpp
+++ b/src/core/threading.cpp
@@ -114,14 +114,10 @@ public:
 
     void accept(gc::GCVisitor* v) {
         auto pub_state = public_thread_state;
-        if (pub_state->curexc_type)
-            v->visit(pub_state->curexc_type);
-        if (pub_state->curexc_value)
-            v->visit(pub_state->curexc_value);
-        if (pub_state->curexc_traceback)
-            v->visit(pub_state->curexc_traceback);
-        if (pub_state->dict)
-            v->visit(pub_state->dict);
+        v->visit(pub_state->curexc_type);
+        v->visit(pub_state->curexc_value);
+        v->visit(pub_state->curexc_traceback);
+        v->visit(pub_state->dict);
 
         for (auto& stack_info : previous_stacks) {
             v->visit(stack_info.next_generator);

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -685,12 +685,11 @@ public:
 
 struct ExcInfo {
     Box* type, *value, *traceback;
-    bool reraise;
 
 #ifndef NDEBUG
     ExcInfo(Box* type, Box* value, Box* traceback);
 #else
-    ExcInfo(Box* type, Box* value, Box* traceback) : type(type), value(value), traceback(traceback), reraise(false) {}
+    ExcInfo(Box* type, Box* value, Box* traceback) : type(type), value(value), traceback(traceback) {}
 #endif
     bool matches(BoxedClass* cls) const;
     void printExcAndTraceback() const;

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -50,10 +50,6 @@ public:
     GCVisitor(TraceStack* stack) : stack(stack) {}
 
     // These all work on *user* pointers, ie pointers to the user_data section of GCAllocations
-    void visitIf(void* p) {
-        if (p)
-            visit(p);
-    }
     void visit(void* p);
     void visitRange(void* const* start, void* const* end);
     void visitPotential(void* p);

--- a/src/gc/collector.h
+++ b/src/gc/collector.h
@@ -44,6 +44,10 @@ void registerNonheapRootObject(void* obj, int size);
 
 void registerPotentialRootRange(void* start, void* end);
 
+typedef void (*GCHandler)(GCVisitor* v, void*);
+void registerRootCallback(void* obj, GCHandler handler);
+void deregisterRootCallback(void* obj, GCHandler handler);
+
 // If you want to have a static root "location" where multiple values could be stored, use this:
 class GCRootHandle {
 public:

--- a/src/runtime/generator.cpp
+++ b/src/runtime/generator.cpp
@@ -396,14 +396,10 @@ extern "C" void generatorGCHandler(GCVisitor* v, Box* b) {
     if (num_args > 3)
         v->visitPotentialRange(reinterpret_cast<void* const*>(&g->args->elts[0]),
                                reinterpret_cast<void* const*>(&g->args->elts[num_args - 3]));
-    if (g->returnValue)
-        v->visit(g->returnValue);
-    if (g->exception.type)
-        v->visit(g->exception.type);
-    if (g->exception.value)
-        v->visit(g->exception.value);
-    if (g->exception.traceback)
-        v->visit(g->exception.traceback);
+    v->visit(g->returnValue);
+    v->visit(g->exception.type);
+    v->visit(g->exception.value);
+    v->visit(g->exception.traceback);
 
     if (g->running) {
         v->visitPotentialRange((void**)&g->returnContext,

--- a/src/runtime/iterobject.cpp
+++ b/src/runtime/iterobject.cpp
@@ -114,8 +114,7 @@ static void seqiterGCVisit(GCVisitor* v, Box* b) {
 
     BoxedSeqIter* si = static_cast<BoxedSeqIter*>(b);
     v->visit(si->b);
-    if (si->next)
-        v->visit(si->next);
+    v->visit(si->next);
 }
 
 static void iterwrapperGCVisit(GCVisitor* v, Box* b) {
@@ -124,8 +123,7 @@ static void iterwrapperGCVisit(GCVisitor* v, Box* b) {
 
     BoxedIterWrapper* iw = static_cast<BoxedIterWrapper*>(b);
     v->visit(iw->iter);
-    if (iw->next)
-        v->visit(iw->next);
+    v->visit(iw->next);
 }
 
 bool iterwrapperHasnextUnboxed(Box* s) {

--- a/src/runtime/stacktrace.cpp
+++ b/src/runtime/stacktrace.cpp
@@ -176,14 +176,12 @@ extern "C" void raise0() {
     if (exc_info->type == None)
         raiseExcHelper(TypeError, "exceptions must be old-style classes or derived from BaseException, not NoneType");
 
-    exc_info->reraise = true;
     assert(!PyErr_Occurred());
-    throw * exc_info;
+    throwReraise(*exc_info);
 }
 
 #ifndef NDEBUG
-ExcInfo::ExcInfo(Box* type, Box* value, Box* traceback)
-    : type(type), value(value), traceback(traceback), reraise(false) {
+ExcInfo::ExcInfo(Box* type, Box* value, Box* traceback) : type(type), value(value), traceback(traceback) {
 }
 #endif
 
@@ -258,9 +256,11 @@ extern "C" void raise3(Box* arg0, Box* arg1, Box* arg2) {
     bool reraise = arg2 != NULL && arg2 != None;
     auto exc_info = excInfoForRaise(arg0, arg1, arg2);
 
-    exc_info.reraise = reraise;
     assert(!PyErr_Occurred());
-    throw exc_info;
+    if (reraise)
+        throwReraise(exc_info);
+    else
+        throw exc_info;
 }
 
 void raiseExcHelper(BoxedClass* cls, Box* arg) {

--- a/src/runtime/super.cpp
+++ b/src/runtime/super.cpp
@@ -42,12 +42,9 @@ public:
         BoxedSuper* o = static_cast<BoxedSuper*>(_o);
 
         boxGCHandler(v, o);
-        if (o->type)
-            v->visit(o->type);
-        if (o->obj)
-            v->visit(o->obj);
-        if (o->obj_type)
-            v->visit(o->obj_type);
+        v->visit(o->type);
+        v->visit(o->obj);
+        v->visit(o->obj_type);
     }
 };
 

--- a/src/runtime/traceback.cpp
+++ b/src/runtime/traceback.cpp
@@ -40,10 +40,8 @@ void BoxedTraceback::gcHandler(GCVisitor* v, Box* b) {
     assert(b->cls == traceback_cls);
     BoxedTraceback* self = static_cast<BoxedTraceback*>(b);
 
-    if (self->py_lines)
-        v->visit(self->py_lines);
-    if (self->tb_next)
-        v->visit(self->tb_next);
+    v->visit(self->py_lines);
+    v->visit(self->tb_next);
 
     boxGCHandler(v, b);
 }

--- a/src/runtime/types.cpp
+++ b/src/runtime/types.cpp
@@ -430,20 +430,11 @@ extern "C" void functionGCHandler(GCVisitor* v, Box* b) {
     BoxedFunction* f = (BoxedFunction*)b;
 
     // TODO eventually f->name should always be non-NULL, then there'd be no need for this check
-    if (f->name)
-        v->visit(f->name);
-
-    if (f->modname)
-        v->visit(f->modname);
-
-    if (f->doc)
-        v->visit(f->doc);
-
-    if (f->closure)
-        v->visit(f->closure);
-
-    if (f->globals)
-        v->visit(f->globals);
+    v->visit(f->name);
+    v->visit(f->modname);
+    v->visit(f->doc);
+    v->visit(f->closure);
+    v->visit(f->globals);
 
     // It's ok for f->defaults to be NULL here even if f->ndefaults isn't,
     // since we could be collecting from inside a BoxedFunctionBase constructor
@@ -564,8 +555,7 @@ extern "C" void boxGCHandler(GCVisitor* v, Box* b) {
             HCAttrs* attrs = b->getHCAttrsPtr();
 
             v->visit(attrs->hcls);
-            if (attrs->attr_list)
-                v->visit(attrs->attr_list);
+            v->visit(attrs->attr_list);
         }
 
         if (b->cls->instancesHaveDictAttrs()) {
@@ -1007,16 +997,11 @@ extern "C" void typeGCHandler(GCVisitor* v, Box* b) {
 
     BoxedClass* cls = (BoxedClass*)b;
 
-    if (cls->tp_base)
-        v->visit(cls->tp_base);
-    if (cls->tp_dict)
-        v->visit(cls->tp_dict);
-    if (cls->tp_mro)
-        v->visit(cls->tp_mro);
-    if (cls->tp_bases)
-        v->visit(cls->tp_bases);
-    if (cls->tp_subclasses)
-        v->visit(cls->tp_subclasses);
+    v->visit(cls->tp_base);
+    v->visit(cls->tp_dict);
+    v->visit(cls->tp_mro);
+    v->visit(cls->tp_bases);
+    v->visit(cls->tp_subclasses);
 
     if (cls->tp_flags & Py_TPFLAGS_HEAPTYPE) {
         BoxedHeapClass* hcls = static_cast<BoxedHeapClass*>(cls);
@@ -1081,14 +1066,10 @@ extern "C" void propertyGCHandler(GCVisitor* v, Box* b) {
 
     BoxedProperty* prop = (BoxedProperty*)b;
 
-    if (prop->prop_get)
-        v->visit(prop->prop_get);
-    if (prop->prop_set)
-        v->visit(prop->prop_set);
-    if (prop->prop_del)
-        v->visit(prop->prop_del);
-    if (prop->prop_doc)
-        v->visit(prop->prop_doc);
+    v->visit(prop->prop_get);
+    v->visit(prop->prop_set);
+    v->visit(prop->prop_del);
+    v->visit(prop->prop_doc);
 }
 
 extern "C" void staticmethodGCHandler(GCVisitor* v, Box* b) {
@@ -1096,8 +1077,7 @@ extern "C" void staticmethodGCHandler(GCVisitor* v, Box* b) {
 
     BoxedStaticmethod* sm = (BoxedStaticmethod*)b;
 
-    if (sm->sm_callable)
-        v->visit(sm->sm_callable);
+    v->visit(sm->sm_callable);
 }
 
 extern "C" void classmethodGCHandler(GCVisitor* v, Box* b) {
@@ -1105,8 +1085,7 @@ extern "C" void classmethodGCHandler(GCVisitor* v, Box* b) {
 
     BoxedClassmethod* cm = (BoxedClassmethod*)b;
 
-    if (cm->cm_callable)
-        v->visit(cm->cm_callable);
+    v->visit(cm->cm_callable);
 }
 
 // This probably belongs in list.cpp?
@@ -1150,10 +1129,8 @@ extern "C" void sliceGCHandler(GCVisitor* v, Box* b) {
 }
 
 static int call_gc_visit(PyObject* val, void* arg) {
-    if (val) {
-        GCVisitor* v = static_cast<GCVisitor*>(arg);
-        v->visit(val);
-    }
+    GCVisitor* v = static_cast<GCVisitor*>(arg);
+    v->visit(val);
     return 0;
 }
 
@@ -1192,12 +1169,10 @@ extern "C" void closureGCHandler(GCVisitor* v, Box* b) {
     boxGCHandler(v, b);
 
     BoxedClosure* c = (BoxedClosure*)b;
-    if (c->parent)
-        v->visit(c->parent);
+    v->visit(c->parent);
 
     for (int i = 0; i < c->nelts; i++) {
-        if (c->elts[i])
-            v->visit(c->elts[i]);
+        v->visit(c->elts[i]);
     }
 }
 

--- a/src/runtime/types.cpp
+++ b/src/runtime/types.cpp
@@ -3269,7 +3269,6 @@ void setupRuntime() {
 
     closure_cls->freeze();
 
-    setupUnwinding();
     setupInterpreter();
     setupCAPI();
 


### PR DESCRIPTION
0fbafcf is the meat of this change.  brain dump follows:

We have two `*Unwinders` classes which deal with the two scenarios that call for unwinding:
1. `PythonUnwinder`: used for stack introspection/traceback generation on abort() (basically used only in unwindPythonStack).  Includes code specifically to trace through generators to their calling contexts.
2. `PythonExceptionUnwinder`: used for mapping between C++ unwinding and python unwinding.

These two use the same state class to tell if a given frame should be part of the traceback: `PythonUnwindState`.  `PythonUnwindState` has 1 piece of state, `skipNext`.  It has a method that it assumes will be called for all frames during a given unwind:

`bool getPythonFrame(unw_cursor_t* cursor, PythonFrameIteratorImpl* info) `

which will return true (and fill in *info) if the cursor corresponds to a python frame that the caller should deal with (i.e. it wasn't skipped due to re-raise or OSR.)

using `PythonUnwinder` + `PythonUnwindState` results in unwindPythonStack being pretty tiny now, just a loop over the frames it should be interested in.


For `PythonExceptionUnwinder` things are necessarily a little more complex, but this PR should simplify all the interactions it had with cxx_unwind.cpp:

Each thread has its own local `PythonExceptionUnwinder` instance and a boolean flag for whether a given C++ exception was a python re-raise.  I added the api `throwReraise` which sets this flag to true before doing the throw.  This gets rid of that additional bool in ExcInfo.

the api now corresponds more closely to the C++ unwinder:

1. `__cxa_allocate_exception` now calls (and returns the return value of) `pyston::allocatePythonExceptionStorage()`
2. `__cxa_throw` now calls `pyston::beginPythonException` before starting the unwind loop
3. `unwind_loop` calls `pyston::unwindingThroughFrame` for every C++ frame.
3. `unwind_loop` now calls `pyston::endPythonException` before branching to pa non-cleanup handler.

the `PythonExceptionUnwinder` uses `PythonUnwindState` as well, and resets the state upon every `beginPythonException` call (supplying the thread local reraise flag as the initial value of `skipNext`).

---

somewhat unrelated, but I got rid of the Box subclass used so we could scan the ExcInfo fields and added a handler function that can be used to scan roots.  This saves us 1 allocation for every getTopFrame call (36762 in django_template.py) and c++ exception thrown.

I'm surprised that the perf win from the reduced allocations disappeared after rebasing, but the change *definitely* cleans this up.

```
       django_template.py             5.5s (4)             5.5s (4)  +0.3%
            pyxl_bench.py             4.0s (4)             4.0s (4)  -0.3%
 sqlalchemy_imperative.py             2.2s (4)             2.2s (4)  +0.2%
        django_migrate.py             2.0s (4)             2.0s (4)  -0.4%
      virtualenv_bench.py             8.0s (4)             8.2s (4)  +1.5%
                  geomean                 3.8s                 3.8s  +0.2%
```