### PR TITLE
Include total-tests-run in our test-suite-results checking

### DIFF
--- a/test/extra/cheetah_test.py
+++ b/test/extra/cheetah_test.py
@@ -7,5 +7,5 @@ create_virtenv(ENV_NAME, ["cheetah==2.4.4"], force_create = True)
 cheetah_exe = os.path.join(ENV_NAME, "bin", "cheetah")
 env = os.environ
 env["PATH"] = env["PATH"] + ":" + os.path.join(ENV_NAME, "bin")
-expected = [{'errors': 4, 'failures': 53}, {'errors': 232, 'failures': 53}]
+expected = [{'ran': 2138, 'errors': 4, 'failures': 53}, {'ran': 2138, 'errors': 232, 'failures': 53}]
 run_test([cheetah_exe, "test"], cwd=ENV_NAME, expected=expected, env=env)

--- a/test/extra/mysqldb_test.py
+++ b/test/extra/mysqldb_test.py
@@ -28,7 +28,7 @@ def install_and_test_mysqldb():
 
     env = os.environ
     env["TESTDB"] = "travis.cnf" 
-    expected = []
+    expected = [{"ran": 69}]
     run_test([nosetests_exe], cwd=MYSQLDB_DIR, expected=expected, env=env)
 
 packages = ["nose==1.3.7"]

--- a/test/extra/protobuf_test.py
+++ b/test/extra/protobuf_test.py
@@ -25,7 +25,7 @@ def install_and_test_protobuf():
     env["LD_LIBRARY_PATH"] = os.path.join(INSTALL_DIR, "lib")
     subprocess.check_call([PYTHON_EXE, "setup.py", "build"], cwd=PROTOBUF_PY_DIR, env=env)
     
-    expected = [{"failures": 0, "errors": 1}]
+    expected = [{"ran": 216, "failures": 0, "errors": 1}]
     run_test([PYTHON_EXE, "setup.py", "test"], cwd=PROTOBUF_PY_DIR, expected=expected, env=env)
     
 create_virtenv(ENV_NAME, None, force_create = True)

--- a/test/extra/pyicu_test.py
+++ b/test/extra/pyicu_test.py
@@ -36,7 +36,7 @@ def install_and_test_pyicu():
     subprocess.check_call([PYTHON_EXE, "setup.py", "build"], cwd=PYICU_DIR, env=env)
     subprocess.check_call([PYTHON_EXE, "setup.py", "install"], cwd=PYICU_DIR, env=env)
     
-    expected = []
+    expected = [{'ran': 17}]
     run_test([PYTHON_EXE, "setup.py", "test"], cwd=PYICU_DIR, expected=expected)
     
 create_virtenv(ENV_NAME, None, force_create = True)

--- a/test/extra/test_helper.py
+++ b/test/extra/test_helper.py
@@ -36,22 +36,35 @@ def pip_install(name, package_list):
 
 def parse_output(output):
     result = []
-    it = re.finditer("FAILED \(failures=(\d+), errors=(\d+)\)", output)
-    for m in it:
-        d = { "failures" : int(m.group(1)), "errors" : int(m.group(2)) }
-        result.append(d)
-    it = re.finditer("FAILED \(errors=(\d+), failures=(\d+)\)", output)
-    for m in it:
-        d = { "failures" : int(m.group(2)), "errors" : int(m.group(1)) }
-        result.append(d)
-    it = re.finditer("FAILED \(failures=(\d+)\)", output)
-    for m in it:
-        d = { "failures" : int(m.group(1)), "errors" : 0 }
-        result.append(d)
-    it = re.finditer("FAILED \(errors=(\d+)\)", output)
-    for m in it:
-        d = { "failures" : 0, "errors" : int(m.group(1)) }
-        result.append(d)
+    for l in output.split('\n'):
+        m = re.match("Ran (\d+) tests in", l)
+        if m:
+            result.append({"ran": int(m.group(1))})
+
+        m = re.match("FAILED \(failures=(\d+), errors=(\d+)\)", l)
+        if m:
+            d = result[-1]
+            assert d.keys() == ["ran"]
+            d['failures'] = int(m.group(1))
+            d['errors'] = int(m.group(2))
+        m = re.match("FAILED \(errors=(\d+), failures=(\d+)\)", l)
+        if m:
+            d = result[-1]
+            assert d.keys() == ["ran"]
+            d['failures'] = int(m.group(2))
+            d['errors'] = int(m.group(1))
+        m = re.match("FAILED \(failures=(\d+)\)", l)
+        if m:
+            d = result[-1]
+            assert d.keys() == ["ran"]
+            d['failures'] = int(m.group(1))
+            d['errors'] = 0
+        m = re.match("FAILED \(errors=(\d+)\)", l)
+        if m:
+            d = result[-1]
+            assert d.keys() == ["ran"]
+            d['failures'] = 0
+            d['errors'] = int(m.group(1))
     return result
 
 def run_test(cmd, cwd, expected, env = None):


### PR DESCRIPTION
I'm seeing fewer failures locally than specified in the file, and
I'm guessing it's because I'm somehow skipping some tests, but I'm
not sure.