### PR TITLE
Don't have cheetah_test look for system cheetah

### DIFF
--- a/test/extra/cheetah_test.py
+++ b/test/extra/cheetah_test.py
@@ -6,6 +6,6 @@ create_virtenv(ENV_NAME, ["cheetah==2.4.4"], force_create = True)
 
 cheetah_exe = os.path.join(ENV_NAME, "bin", "cheetah")
 env = os.environ
-env["PATH"] = env["PATH"] + ":" + os.path.join(ENV_NAME, "bin")
+env["PATH"] = os.path.join(ENV_NAME, "bin")
 expected = [{'ran': 2138, 'errors': 4, 'failures': 53}, {'ran': 2138, 'errors': 232, 'failures': 53}]
 run_test([cheetah_exe, "test"], cwd=ENV_NAME, expected=expected, env=env)


### PR DESCRIPTION
cheetah's tests do a PATH search for the "cheetah" executable,
and since we were appending the test-cheetah's location to PATH,
it would find the system cheetah preferentially to the test cheetah.

This is fine since on most systems there isn't a system cheetah, but
somehow mine has one.  The system cheetah will invoke the system python,
which will end up passing more of the tests.

We could prepend PATH instead of append to it, but it looks like the
the tests don't need anything else, so for now don't pass in anything else
in PATH.