### PR TITLE
reduce api conversions

### DIFF
--- a/microbenchmarks/itertools_chain_bench.py
+++ b/microbenchmarks/itertools_chain_bench.py
@@ -1,0 +1,13 @@
+# simple benchmark to test iteration over extension objects
+
+import itertools
+
+def f(c):
+    for i in c:
+        pass
+
+l = []
+for i in xrange(100):
+    l.append(itertools.chain(*[range(500) for j in xrange(500)]))
+c = itertools.chain(*l)
+f(c)

--- a/microbenchmarks/loop.py
+++ b/microbenchmarks/loop.py
@@ -1,0 +1,5 @@
+def f(n):
+    for i in xrange(n):
+        pass
+f(100000000)
+

--- a/microbenchmarks/unicode_ctor_bench.py
+++ b/microbenchmarks/unicode_ctor_bench.py
@@ -1,0 +1,6 @@
+def f():
+    u = u"a" * 100
+    c = unicode
+    for i in xrange(2000000):
+        c(u)
+f()

--- a/src/asm_writing/rewriter.cpp
+++ b/src/asm_writing/rewriter.cpp
@@ -743,10 +743,13 @@ void Rewriter::_call(RewriterVar* result, bool has_side_effects, void* func_addr
     if (has_side_effects) {
         // We need some fixed amount of space at the beginning of the IC that we can use to invalidate
         // it by writing a jmp.
-        // FIXME this check is conservative, since actually we just have to verify that the return
+        // TODO this check is conservative, since actually we just have to verify that the return
         // address is at least IC_INVALDITION_HEADER_SIZE bytes past the beginning, but we're
         // checking based on the beginning of the call.  I think the load+call might actually
         // always larger than the invalidation jmp.
+        while (assembler->bytesWritten() < IC_INVALDITION_HEADER_SIZE)
+            assembler->nop();
+
         assert(assembler->bytesWritten() >= IC_INVALDITION_HEADER_SIZE);
     }
 

--- a/src/capi/typeobject.cpp
+++ b/src/capi/typeobject.cpp
@@ -957,7 +957,7 @@ static PyObject* slot_tp_getattr_hook(PyObject* self, PyObject* name) noexcept {
     return res;
 }
 
-static PyObject* slot_tp_new(PyTypeObject* self, PyObject* args, PyObject* kwds) noexcept {
+/* Pyston change: static */ PyObject* slot_tp_new(PyTypeObject* self, PyObject* args, PyObject* kwds) noexcept {
     STAT_TIMER(t0, "us_timer_slot_tpnew", SLOT_AVOIDABILITY(self));
 
     try {

--- a/src/capi/typeobject.cpp
+++ b/src/capi/typeobject.cpp
@@ -827,7 +827,7 @@ static PyObject* slot_tp_iter(PyObject* self) noexcept {
     return PySeqIter_New(self);
 }
 
-static PyObject* slot_tp_iternext(PyObject* self) noexcept {
+/* Pyston change: static */ PyObject* slot_tp_iternext(PyObject* self) noexcept {
     STAT_TIMER(t0, "us_timer_slot_tpiternext", SLOT_AVOIDABILITY(self));
 
     static PyObject* next_str;

--- a/src/capi/typeobject.h
+++ b/src/capi/typeobject.h
@@ -36,6 +36,7 @@ int type_set_bases(PyTypeObject* type, PyObject* value, void* context) noexcept;
 
 PyObject* slot_tp_richcompare(PyObject* self, PyObject* other, int op) noexcept;
 PyObject* slot_tp_iternext(PyObject* self) noexcept;
+PyObject* slot_tp_new(PyTypeObject* self, PyObject* args, PyObject* kwds) noexcept;
 }
 
 #endif

--- a/src/capi/typeobject.h
+++ b/src/capi/typeobject.h
@@ -35,6 +35,7 @@ PyObject* mro_external(PyObject* self) noexcept;
 int type_set_bases(PyTypeObject* type, PyObject* value, void* context) noexcept;
 
 PyObject* slot_tp_richcompare(PyObject* self, PyObject* other, int op) noexcept;
+PyObject* slot_tp_iternext(PyObject* self) noexcept;
 }
 
 #endif

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -531,7 +531,6 @@ public:
     BoxedString* reprICAsString();
     bool nonzeroIC();
     Box* hasnextOrNullIC();
-    Box* nextIC();
 
     friend class AttrWrapper;
 };

--- a/src/runtime/builtin_modules/builtins.cpp
+++ b/src/runtime/builtin_modules/builtins.cpp
@@ -248,7 +248,7 @@ Box* open(Box* arg1, Box* arg2, Box* arg3) {
 extern "C" Box* chr(Box* arg) {
     i64 n = PyInt_AsLong(arg);
     if (n == -1 && PyErr_Occurred())
-        raiseExcHelper(TypeError, "an integer is required");
+        throwCAPIException();
 
     if (n < 0 || n >= 256) {
         raiseExcHelper(ValueError, "chr() arg not in range(256)");

--- a/src/runtime/capi.cpp
+++ b/src/runtime/capi.cpp
@@ -633,25 +633,6 @@ extern "C" int PyObject_Print(PyObject* obj, FILE* fp, int flags) noexcept {
     return internal_print(obj, fp, flags, 0);
 };
 
-extern "C" PyObject* PyIter_Next(PyObject* iter) noexcept {
-    try {
-        Box* hasnext = iter->hasnextOrNullIC();
-        if (hasnext) {
-            if (hasnext->nonzeroIC())
-                return iter->nextIC();
-            else
-                return NULL;
-        } else {
-            return iter->nextIC();
-        }
-    } catch (ExcInfo e) {
-        if (e.matches(StopIteration))
-            return NULL;
-        setCAPIException(e);
-    }
-    return NULL;
-}
-
 extern "C" int PyCallable_Check(PyObject* x) noexcept {
     if (x == NULL)
         return 0;

--- a/src/runtime/descr.cpp
+++ b/src/runtime/descr.cpp
@@ -347,6 +347,9 @@ Box* BoxedMethodDescriptor::callInternal(BoxedFunctionBase* f, CallRewriteArgs* 
         RELEASE_ASSERT(0, "0x%x", call_flags);
     }
 
+    if (!rtn)
+        throwCAPIException();
+
     rewrite_args->rewriter->call(true, (void*)checkAndThrowCAPIException);
     rewrite_args->out_rtn = r_rtn;
     rewrite_args->out_success = true;

--- a/src/runtime/ics.h
+++ b/src/runtime/ics.h
@@ -68,7 +68,7 @@ protected:
 
 class CallattrIC : public RuntimeIC {
 public:
-    CallattrIC() : RuntimeIC((void*)callattr, 1, 160) {}
+    CallattrIC() : RuntimeIC((void*)callattr, 1, 320) {}
 
     Box* call(Box* obj, BoxedString* attr, CallattrFlags flags, ArgPassSpec spec, Box* arg0, Box* arg1, Box* arg2,
               Box** args, const std::vector<BoxedString*>* keyword_names) {

--- a/src/runtime/iterators.cpp
+++ b/src/runtime/iterators.cpp
@@ -44,8 +44,10 @@ public:
         Box* next = PyIter_Next(iterator);
         if (next)
             value = next;
-        else
+        else {
+            checkAndThrowCAPIException();
             *this = *end();
+        }
     }
 
     Box* getValue() override { return value; }

--- a/src/runtime/iterators.cpp
+++ b/src/runtime/iterators.cpp
@@ -41,24 +41,11 @@ public:
     void next() override {
         STAT_TIMER(t0, "us_timer_iteratorgeneric_next", 0);
 
-        assert(iterator);
-        Box* hasnext = iterator->hasnextOrNullIC();
-        if (hasnext) {
-            if (hasnext->nonzeroIC()) {
-                value = iterator->nextIC();
-            } else {
-                *this = *end();
-            }
-        } else {
-            try {
-                value = iterator->nextIC();
-            } catch (ExcInfo e) {
-                if (e.matches(StopIteration))
-                    *this = *end();
-                else
-                    throw e;
-            }
-        }
+        Box* next = PyIter_Next(iterator);
+        if (next)
+            value = next;
+        else
+            *this = *end();
     }
 
     Box* getValue() override { return value; }

--- a/src/runtime/iterobject.cpp
+++ b/src/runtime/iterobject.cpp
@@ -132,20 +132,14 @@ bool iterwrapperHasnextUnboxed(Box* s) {
     RELEASE_ASSERT(s->cls == iterwrapper_cls, "");
     BoxedIterWrapper* self = static_cast<BoxedIterWrapper*>(s);
 
-    static BoxedString* next_str = static_cast<BoxedString*>(PyString_InternFromString("next"));
-    Box* next;
-    try {
-        next = callattr(self->iter, next_str, CallattrFlags({.cls_only = true, .null_on_nonexistent = false }),
-                        ArgPassSpec(0), NULL, NULL, NULL, NULL, NULL);
-    } catch (ExcInfo e) {
-        if (e.matches(StopIteration)) {
-            self->next = NULL;
-            return false;
-        }
-        throw e;
-    }
+    Box* next = PyIter_Next(self->iter);
     self->next = next;
-    return true;
+    if (!next) {
+        if (PyErr_Occurred() && !PyErr_ExceptionMatches(PyExc_StopIteration))
+            throwCAPIException();
+        PyErr_Clear();
+    }
+    return next != NULL;
 }
 
 Box* iterwrapperHasnext(Box* s) {

--- a/src/runtime/list.cpp
+++ b/src/runtime/list.cpp
@@ -101,7 +101,7 @@ extern "C" Box* listPop(BoxedList* self, Box* idx) {
 
     int64_t n = PyInt_AsSsize_t(idx);
     if (n == -1 && PyErr_Occurred())
-        raiseExcHelper(TypeError, "an integer is required");
+        throwCAPIException();
 
     if (n < 0)
         n = self->size + n;

--- a/src/runtime/objmodel.cpp
+++ b/src/runtime/objmodel.cpp
@@ -3514,12 +3514,12 @@ Box* runtimeCallInternal(Box* obj, CallRewriteArgs* rewrite_args, ArgPassSpec ar
     int npassed_args = argspec.totalPassed();
 
     if (obj->cls != function_cls && obj->cls != builtin_function_or_method_cls && obj->cls != instancemethod_cls) {
-        STAT_TIMER(t0, "us_timer_slowpath_runtimecall_nonfunction", 20);
-
         // TODO: maybe eventually runtimeCallInternal should just be the default tpp_call?
         if (obj->cls->tpp_call) {
             return obj->cls->tpp_call(obj, rewrite_args, argspec, arg1, arg2, arg3, args, keyword_names);
         }
+
+        STAT_TIMER(t0, "us_timer_slowpath_runtimecall_nonfunction", 20);
 
 #if 0
         std::string per_name_stat_name = "zzz_runtimecall_nonfunction_" + std::string(obj->cls->tp_name);

--- a/src/runtime/objmodel.cpp
+++ b/src/runtime/objmodel.cpp
@@ -3515,6 +3515,7 @@ Box* callCLFunc(CLFunction* f, CallRewriteArgs* rewrite_args, int num_output_arg
     ASSERT(chosen_cf->spec->rtn_type->isFitBy(r->cls), "%s (%p) was supposed to return %s, but gave a %s",
            g.func_addr_registry.getFuncNameAtAddress(chosen_cf->code, true, NULL).c_str(), chosen_cf->code,
            chosen_cf->spec->rtn_type->debugName().c_str(), r->cls->tp_name);
+    assert(!PyErr_Occurred());
 
     return r;
 }

--- a/src/runtime/stacktrace.cpp
+++ b/src/runtime/stacktrace.cpp
@@ -47,6 +47,7 @@ void showBacktrace() {
 }
 
 void raiseExc(Box* exc_obj) {
+    assert(!PyErr_Occurred());
     throw ExcInfo(exc_obj->cls, exc_obj, None);
 }
 
@@ -56,6 +57,7 @@ void raiseSyntaxError(const char* msg, int lineno, int col_offset, llvm::StringR
     Box* exc = runtimeCall(SyntaxError, ArgPassSpec(1), boxString(msg), NULL, NULL, NULL, NULL);
 
     auto tb = new BoxedTraceback(LineInfo(lineno, col_offset, file, func), None);
+    assert(!PyErr_Occurred());
     throw ExcInfo(exc->cls, exc, tb);
 }
 
@@ -175,6 +177,7 @@ extern "C" void raise0() {
         raiseExcHelper(TypeError, "exceptions must be old-style classes or derived from BaseException, not NoneType");
 
     exc_info->reraise = true;
+    assert(!PyErr_Occurred());
     throw * exc_info;
 }
 
@@ -256,6 +259,7 @@ extern "C" void raise3(Box* arg0, Box* arg1, Box* arg2) {
     auto exc_info = excInfoForRaise(arg0, arg1, arg2);
 
     exc_info.reraise = reraise;
+    assert(!PyErr_Occurred());
     throw exc_info;
 }
 

--- a/src/runtime/types.cpp
+++ b/src/runtime/types.cpp
@@ -604,6 +604,42 @@ static void assertInitNone(Box* obj) {
     }
 }
 
+static PyObject* cpython_type_call(PyTypeObject* type, PyObject* args, PyObject* kwds) noexcept {
+    PyObject* obj;
+
+    if (type->tp_new == NULL) {
+        PyErr_Format(PyExc_TypeError, "cannot create '%.100s' instances", type->tp_name);
+        return NULL;
+    }
+
+    obj = type->tp_new(type, args, kwds);
+    if (obj != NULL) {
+        /* Ugly exception: when the call was type(something),
+         *            don't call tp_init on the result. */
+        if (type == &PyType_Type && PyTuple_Check(args) && PyTuple_GET_SIZE(args) == 1
+            && (kwds == NULL || (PyDict_Check(kwds) && PyDict_Size(kwds) == 0)))
+            return obj;
+        /* If the returned object is not an instance of type,
+         *            it won't be initialized. */
+        if (!PyType_IsSubtype(obj->cls, type))
+            return obj;
+        type = obj->cls;
+        if (PyType_HasFeature(type, Py_TPFLAGS_HAVE_CLASS) && type->tp_init != NULL
+            && type->tp_init(obj, args, kwds) < 0) {
+            Py_DECREF(obj);
+            obj = NULL;
+        }
+    }
+    return obj;
+}
+
+static PyObject* cpythonTypeCall(BoxedClass* type, PyObject* args, PyObject* kwds) {
+    Box* r = cpython_type_call(type, args, kwds);
+    if (!r)
+        throwCAPIException();
+    return r;
+}
+
 static Box* typeCallInner(CallRewriteArgs* rewrite_args, ArgPassSpec argspec, Box* arg1, Box* arg2, Box* arg3,
                           Box** args, const std::vector<BoxedString*>* keyword_names) {
     int npassed_args = argspec.totalPassed();
@@ -617,6 +653,29 @@ static Box* typeCallInner(CallRewriteArgs* rewrite_args, ArgPassSpec argspec, Bo
     }
 
     BoxedClass* cls = static_cast<BoxedClass*>(_cls);
+
+    if (cls->tp_new != object_cls->tp_new && cls->tp_new != slot_tp_new) {
+        // Looks like we're calling an extension class and we're not going to be able to
+        // separately rewrite the new + init calls.  But we can rewrite the fact that we
+        // should just call the cpython version, which will end up working pretty well.
+        ParamReceiveSpec paramspec(1, false, true, true);
+        bool rewrite_success = false;
+        Box* oarg1, *oarg2, *oarg3, ** oargs = NULL;
+        rearrangeArguments(paramspec, NULL, "", NULL, rewrite_args, rewrite_success, argspec, arg1, arg2, arg3, args,
+                           keyword_names, oarg1, oarg2, oarg3, oargs);
+        assert(oarg1 == cls);
+
+        if (!rewrite_success)
+            rewrite_args = NULL;
+
+        if (rewrite_args) {
+            rewrite_args->out_rtn = rewrite_args->rewriter->call(true, (void*)cpythonTypeCall, rewrite_args->arg1,
+                                                                 rewrite_args->arg2, rewrite_args->arg3);
+            rewrite_args->out_success = true;
+        }
+
+        return cpythonTypeCall(cls, oarg2, oarg3);
+    }
 
     RewriterVar* r_ccls = NULL;
     RewriterVar* r_new = NULL;
@@ -793,7 +852,10 @@ static Box* typeCallInner(CallRewriteArgs* rewrite_args, ArgPassSpec argspec, Bo
                "We should only have allowed the rewrite to continue if we were guaranteed that made "
                "would have class cls!");
     } else {
-        made = runtimeCallInternal(new_attr, NULL, new_argspec, cls, arg2, arg3, args, keyword_names);
+        if (cls->tp_new == object_cls->tp_new && cls->tp_init != object_cls->tp_init)
+            made = objectNewNoArgs(cls);
+        else
+            made = runtimeCallInternal(new_attr, NULL, new_argspec, cls, arg2, arg3, args, keyword_names);
     }
 
     assert(made);


### PR DESCRIPTION
ie try to call c slots when they were requested.  this PR does that for tp_iternext, and somewhat for tp_new/tp_init.

```
       django_template.py             5.3s (2)             5.2s (2)  -1.3%
            pyxl_bench.py             4.0s (4)             4.1s (4)  +1.7%
sqlalchemy_imperative2.py             6.7s (2)             5.6s (2)  -16.3%
        django_migrate.py             1.9s (4)             1.9s (4)  -0.6%
      virtualenv_bench.py             8.1s (2)             8.0s (2)  -0.3%
                  geomean                 4.7s                 4.5s  -3.6%
```