### PR TITLE
use libc malloc/realloc/free for unicode character data instead of conservative allocations

### DIFF
--- a/from_cpython/Include/pymem.h
+++ b/from_cpython/Include/pymem.h
@@ -51,6 +51,8 @@ extern "C" {
    performed on failure (no exception is set, no warning is printed, etc).
 */
 
+PyAPI_FUNC(void *) gc_compat_malloc_untracked(size_t) PYSTON_NOEXCEPT;
+
 PyAPI_FUNC(void *) gc_compat_malloc(size_t) PYSTON_NOEXCEPT;
 PyAPI_FUNC(void *) gc_compat_realloc(void *, size_t) PYSTON_NOEXCEPT;
 PyAPI_FUNC(void) gc_compat_free(void *) PYSTON_NOEXCEPT;

--- a/from_cpython/Objects/unicodeobject.c
+++ b/from_cpython/Objects/unicodeobject.c
@@ -349,7 +349,9 @@ PyUnicodeObject *_PyUnicode_New(Py_ssize_t length)
         }
         else {
             size_t new_size = sizeof(Py_UNICODE) * ((size_t)length + 1);
-            unicode->str = (Py_UNICODE*) PyObject_MALLOC(new_size);
+            // Pyston change: use gc_compat_malloc_untracked, so we won't scan this
+            //unicode->str = (Py_UNICODE*) PyObject_MALLOC(new_size);
+            unicode->str = (Py_UNICODE*) gc_compat_malloc_untracked(new_size);
         }
         PyObject_INIT(unicode, &PyUnicode_Type);
     }
@@ -359,7 +361,9 @@ PyUnicodeObject *_PyUnicode_New(Py_ssize_t length)
         if (unicode == NULL)
             return NULL;
         new_size = sizeof(Py_UNICODE) * ((size_t)length + 1);
-        unicode->str = (Py_UNICODE*) PyObject_MALLOC(new_size);
+        // Pyston change: use gc_compat_malloc_untracked here:
+        //unicode->str = (Py_UNICODE*) PyObject_MALLOC(new_size);
+        unicode->str = (Py_UNICODE*) gc_compat_malloc_untracked(new_size);
     }
 
     if (!unicode->str) {

--- a/src/gc/gc_alloc.cpp
+++ b/src/gc/gc_alloc.cpp
@@ -35,6 +35,10 @@ namespace gc {
 uint64_t* gc_alloc_stattimer_counter = Stats::getStatCounter("us_timer_gc_alloc");
 #endif
 
+extern "C" void* gc_compat_malloc_untracked(size_t sz) noexcept {
+    return gc_alloc(sz, GCKind::UNTRACKED);
+}
+
 extern "C" void* gc_compat_malloc(size_t sz) noexcept {
     return gc_alloc(sz, GCKind::CONSERVATIVE);
 }


### PR DESCRIPTION
allocate unicode str data from the malloc heap, not our gc heap.  we could force it to UNTRACKED to save on scan time, but it's still added memory pressure causing more gc's.

not the most spectacular investigate.py result:
```
                           79505a1af7e19aa679:  72b38b34575a04aa61:

       django_template.py             5.2s (4)             5.1s (4)  -0.4%

            pyxl_bench.py             4.0s (4)             4.0s (4)  +0.3%

sqlalchemy_imperative2.py             6.6s (4)             6.7s (4)  +0.3%

        django_migrate.py             2.0s (4)             1.9s (4)  -0.3%

      virtualenv_bench.py             8.2s (4)             8.2s (4)  -0.4%

                  geomean                 4.7s                 4.7s  -0.1%
```

but once jemalloc is turned on the gap widens a bit more:

```
                           79505a1af7e19aa679:  72b38b34575a04aa61:

       django_template.py             4.9s (6)             4.8s (6)  -2.6%

            pyxl_bench.py             3.8s (6)             3.8s (6)  +0.5%

sqlalchemy_imperative2.py             6.1s (6)             6.1s (6)  -0.7%

        django_migrate.py             1.8s (6)             1.8s (6)  +0.9%

      virtualenv_bench.py             7.9s (6)             7.8s (6)  -0.6%

                  geomean                 4.4s                 4.3s  -0.5%
```