### PR TITLE
For issue #254, add lt, le, gt, ge to old-style class

### DIFF
--- a/src/runtime/classobj.cpp
+++ b/src/runtime/classobj.cpp
@@ -741,6 +741,22 @@ Box* _instanceBinary(Box* _inst, Box* other, const char* attr) {
     return runtimeCall(func, ArgPassSpec(1), other, NULL, NULL, NULL, NULL);
 }
 
+Box* instanceGt(Box* _inst, Box* other) {
+    return _instanceBinary(_inst, other, "__gt__");
+}
+
+Box* instanceGe(Box* _inst, Box* other) {
+    return _instanceBinary(_inst, other, "__ge__");
+}
+
+Box* instanceLt(Box* _inst, Box* other) {
+    return _instanceBinary(_inst, other, "__lt__");
+}
+
+Box* instanceLe(Box* _inst, Box* other) {
+    return _instanceBinary(_inst, other, "__le__");
+}
+
 Box* instanceEq(Box* _inst, Box* other) {
     return _instanceBinary(_inst, other, "__eq__");
 }
@@ -856,6 +872,10 @@ void setupClassobj() {
                            new BoxedFunction(boxRTFunction((void*)instanceCall, UNKNOWN, 1, 0, true, true)));
     instance_cls->giveAttr("__eq__", new BoxedFunction(boxRTFunction((void*)instanceEq, UNKNOWN, 2)));
     instance_cls->giveAttr("__ne__", new BoxedFunction(boxRTFunction((void*)instanceNe, UNKNOWN, 2)));
+    instance_cls->giveAttr("__lt__", new BoxedFunction(boxRTFunction((void*)instanceLt, UNKNOWN, 2)));
+    instance_cls->giveAttr("__le__", new BoxedFunction(boxRTFunction((void*)instanceLe, UNKNOWN, 2)));
+    instance_cls->giveAttr("__gt__", new BoxedFunction(boxRTFunction((void*)instanceGt, UNKNOWN, 2)));
+    instance_cls->giveAttr("__ge__", new BoxedFunction(boxRTFunction((void*)instanceGe, UNKNOWN, 2)));
 
     instance_cls->freeze();
     instance_cls->tp_getattro = instance_getattro;

--- a/test/tests/oldstyle_classes.py
+++ b/test/tests/oldstyle_classes.py
@@ -133,26 +133,16 @@ class LessEqualTest:
         self._a = a
 
     def __lt__(self, other):
+        print "lt"
         return self._a < other._a
 
-    def __eq__(self, other):
-        return self._a == other._a
-
-    def __ne__(self, other):
-        return self._a != other._a
-
     def __le__(self, other):
+        print "le"
         return self._a <= other._a
 
 ca = LessEqualTest(3)
 cb = LessEqualTest(2)
 cc = LessEqualTest(2)
-
-print(ca == cb)
-print(ca == cc)
-
-print(ca != cb)
-print(ca != cc)
 
 print(ca < cb)
 print(cb < ca)
@@ -163,7 +153,7 @@ print(ca <= cc)
 # CompareA only defines __lt__ and __le__ but appears on the right-hand-side
 print(ca > cb)
 print(ca >= cb)
-print(ca > cb)
+print(cb > ca)
 print(cb > cc)
 
 class GreatEqualTest:
@@ -171,9 +161,11 @@ class GreatEqualTest:
         self._a = a
 
     def __gt__(self, other):
+        print "gt"
         return self._a > other._a
 
     def __ge__(self, other):
+        print "ge"
         return self._a >= other._a
 
 cd = GreatEqualTest(4)

--- a/test/tests/oldstyle_classes.py
+++ b/test/tests/oldstyle_classes.py
@@ -128,6 +128,69 @@ print issubclass(OldStyleClass, object)
 print isinstance(OldStyleClass(), OldStyleClass)
 print issubclass(OldStyleClass, OldStyleClass)
 
+class LessEqualTest:
+    def __init__(self, a):
+        self._a = a
+
+    def __lt__(self, other):
+        return self._a < other._a
+
+    def __eq__(self, other):
+        return self._a == other._a
+
+    def __ne__(self, other):
+        return self._a != other._a
+
+    def __le__(self, other):
+        return self._a <= other._a
+
+ca = LessEqualTest(3)
+cb = LessEqualTest(2)
+cc = LessEqualTest(2)
+
+print(ca == cb)
+print(ca == cc)
+
+print(ca != cb)
+print(ca != cc)
+
+print(ca < cb)
+print(cb < ca)
+
+print(ca <= cb)
+print(ca <= cc)
+
+# CompareA only defines __lt__ and __le__ but appears on the right-hand-side
+print(ca > cb)
+print(ca >= cb)
+print(ca > cb)
+print(cb > cc)
+
+class GreatEqualTest:
+    def __init__(self, a):
+        self._a = a
+
+    def __gt__(self, other):
+        return self._a > other._a
+
+    def __ge__(self, other):
+        return self._a >= other._a
+
+cd = GreatEqualTest(4)
+ce = GreatEqualTest(5)
+cf = GreatEqualTest(4)
+
+print(cd >= ce)
+print(cd > ce)
+print(cd >= cf)
+print(cd > cf)
+
+# CompareB only defines __gt__ and __ge__ but appears on the right-hand-side
+print(cd <= ce)
+print(cd < ce)
+print(cd <= cf)
+print(cd < cf)
+
 class GetattrTest:
     def __getattr__(self, attr):
         print "getattr", attr


### PR DESCRIPTION
The first contribution target [#245](https://github.com/dropbox/pyston/issues/254). Add lt/le/gt/ge to old-style class. Pass the tests and format check.