### PR TITLE
Don't guard types sometimes

### DIFF
--- a/src/asm_writing/rewriter.h
+++ b/src/asm_writing/rewriter.h
@@ -218,6 +218,8 @@ public:
 
     template <typename Src, typename Dst> inline RewriterVar* getAttrCast(int offset, Location loc = Location::any());
 
+    bool isConstant() { return is_constant; }
+
 private:
     Rewriter* rewriter;
 

--- a/src/runtime/objmodel.cpp
+++ b/src/runtime/objmodel.cpp
@@ -719,7 +719,10 @@ Box* Box::getattr(llvm::StringRef attr, GetattrRewriteArgs* rewrite_args) {
                     REWRITE_ABORTED("");
                     rewrite_args = NULL;
                 } else {
-                    rewrite_args->obj->addAttrGuard(cls->attrs_offset + offsetof(HCAttrs, hcls), (intptr_t)hcls);
+                    if (!(rewrite_args->obj->isConstant() && cls == type_cls
+                          && static_cast<BoxedClass*>(this)->is_constant)) {
+                        rewrite_args->obj->addAttrGuard(cls->attrs_offset + offsetof(HCAttrs, hcls), (intptr_t)hcls);
+                    }
                     if (hcls->type == HiddenClass::SINGLETON)
                         hcls->addDependence(rewrite_args->rewriter);
                 }
@@ -971,6 +974,9 @@ Box* typeLookup(BoxedClass* cls, llvm::StringRef attr, GetattrRewriteArgs* rewri
                 assert(rewrite_args->obj == obj_saved);
             } else {
                 rewrite_args->obj = rewrite_args->rewriter->loadConst((intptr_t)base, Location::any());
+                if (static_cast<BoxedClass*>(base)->is_constant) {
+                    rewrite_args->obj_cls_guarded = true;
+                }
             }
             val = base->getattr(attr, rewrite_args);
             assert(rewrite_args->out_success);

--- a/src/runtime/objmodel.cpp
+++ b/src/runtime/objmodel.cpp
@@ -669,7 +669,7 @@ BoxedDict* Box::getDict() {
 static StatCounter box_getattr_slowpath("slowpath_box_getattr");
 Box* Box::getattr(llvm::StringRef attr, GetattrRewriteArgs* rewrite_args) {
 
-    if (rewrite_args)
+    if (rewrite_args && !rewrite_args->obj_cls_guarded)
         rewrite_args->obj->addAttrGuard(offsetof(Box, cls), (intptr_t)cls);
 
 #if 0
@@ -5052,6 +5052,7 @@ extern "C" Box* getGlobal(Box* globals, BoxedString* name) {
         if (rewriter.get()) {
             RewriterVar* builtins = rewriter->loadConst((intptr_t)builtins_module, Location::any());
             GetattrRewriteArgs rewrite_args(rewriter.get(), builtins, rewriter->getReturnDestination());
+            rewrite_args.obj_cls_guarded = true; // always builtin module
             rtn = builtins_module->getattr(name->s(), &rewrite_args);
 
             if (!rtn || !rewrite_args.out_success) {

--- a/src/runtime/rewrite_args.h
+++ b/src/runtime/rewrite_args.h
@@ -28,6 +28,7 @@ struct GetattrRewriteArgs {
     RewriterVar* out_rtn;
 
     bool obj_hcls_guarded;
+    bool obj_cls_guarded;
 
     GetattrRewriteArgs(Rewriter* rewriter, RewriterVar* obj, Location destination)
         : rewriter(rewriter),
@@ -35,7 +36,8 @@ struct GetattrRewriteArgs {
           destination(destination),
           out_success(false),
           out_rtn(NULL),
-          obj_hcls_guarded(false) {}
+          obj_hcls_guarded(false),
+          obj_cls_guarded(false) {}
 };
 
 struct SetattrRewriteArgs {


### PR DESCRIPTION
We were doing some unnecessary guards, like guarding the types of constant objects. Fixing this saves about 10 bytes on average per IC, and has a comparable small improvement in performance:

```
       django_template.py             5.1s (6)             5.1s (8)  -1.6%
            pyxl_bench.py             4.2s (6)             4.1s (6)  -2.4%
 sqlalchemy_imperative.py             2.1s (6)             2.0s (6)  -2.5%
        django_migrate.py             2.0s (6)             1.9s (6)  -1.9%
      virtualenv_bench.py             8.4s (6)             8.3s (6)  -0.5%
                  geomean                 3.8s                 3.7s  -1.8%
```