### PR TITLE
Use less large constants

### DIFF
--- a/src/asm_writing/assembler.cpp
+++ b/src/asm_writing/assembler.cpp
@@ -670,7 +670,24 @@ void Assembler::decl(Indirect mem) {
     }
 }
 
+void Assembler::incl(Immediate imm) {
+    emitByte(0xff);
+    emitByte(0x04);
+    emitByte(0x25);
+    emitInt(imm.val, 4);
+}
 
+void Assembler::decl(Immediate imm) {
+    emitByte(0xff);
+    emitByte(0x0c);
+    emitByte(0x25);
+    emitInt(imm.val, 4);
+}
+
+void Assembler::call(Immediate imm) {
+    emitByte(0xe8);
+    emitInt(imm.val, 4);
+}
 
 void Assembler::callq(Register r) {
     assert(r == R11 && "untested");

--- a/src/asm_writing/assembler.h
+++ b/src/asm_writing/assembler.h
@@ -149,9 +149,14 @@ public:
 
     void add(Immediate imm, Register reg);
     void sub(Immediate imm, Register reg);
+
     void incl(Indirect mem);
     void decl(Indirect mem);
 
+    void incl(Immediate mem);
+    void decl(Immediate mem);
+
+    void call(Immediate imm); // the value is the offset
     void callq(Register reg);
     void retq();
     void leave();
@@ -187,6 +192,7 @@ public:
     void fillWithNopsExcept(int bytes);
     void emitAnnotation(int num);
 
+    uint8_t* startAddr() const { return start_addr; }
     int bytesLeft() const { return end_addr - addr; }
     int bytesWritten() const { return addr - start_addr; }
     uint8_t* curInstPointer() { return addr; }

--- a/src/asm_writing/icinfo.h
+++ b/src/asm_writing/icinfo.h
@@ -48,7 +48,7 @@ public:
     class CommitHook {
     public:
         virtual ~CommitHook() {}
-        virtual bool finishAssembly(ICSlotInfo* picked_slot, int fastpath_offset) = 0;
+        virtual bool finishAssembly(int fastpath_offset) = 0;
     };
 
 private:
@@ -60,6 +60,8 @@ private:
 
     std::vector<std::pair<ICInvalidator*, int64_t>> dependencies;
 
+    ICSlotInfo* ic_entry;
+
     ICSlotRewrite(ICInfo* ic, const char* debug_name);
 
 public:
@@ -69,10 +71,13 @@ public:
     int getSlotSize();
     int getScratchRspOffset();
     int getScratchSize();
+    uint8_t* getSlotStart();
 
     TypeRecorder* getTypeRecorder();
 
     assembler::GenericRegister returnRegister();
+
+    ICSlotInfo* prepareEntry();
 
     void addDependenceOn(ICInvalidator&);
     void commit(CommitHook* hook);

--- a/src/asm_writing/rewriter.h
+++ b/src/asm_writing/rewriter.h
@@ -317,6 +317,8 @@ protected:
 
     std::unique_ptr<ICSlotRewrite> rewrite;
     assembler::Assembler* assembler;
+    ICSlotInfo* picked_slot;
+
     ConstLoader const_loader;
     std::vector<RewriterVar*> vars;
 
@@ -370,7 +372,6 @@ protected:
     }
     bool added_changing_action;
     bool marked_inside_ic;
-    std::vector<void**> mark_addr_addrs;
 
     int last_guard_action;
 
@@ -408,7 +409,7 @@ protected:
     // Do the bookkeeping to say that var is no longer in location l
     void removeLocationFromVar(RewriterVar* var, Location l);
 
-    bool finishAssembly(ICSlotInfo* picked_slot, int continue_offset) override;
+    bool finishAssembly(int continue_offset) override;
 
     void _trap();
     void _loadConst(RewriterVar* result, int64_t val);


### PR DESCRIPTION
The incl, decl, and call can use the smaller instructions sometimes instead of loading large constants.

I also now allocate the slot before emitting assembly, to make it easier to emit assembly which depends on its address. (This was an easy change to make, since we emit all the assembly in the commit, anyway.)

Average IC size goes down from 143 bytes to 130 bytes. 

```
       django_template.py            5.1s (14)             5.1s (4)  -0.8%
            pyxl_bench.py            4.2s (14)             4.1s (4)  -2.4%
 sqlalchemy_imperative.py            2.1s (14)             2.1s (4)  -0.4%
        django_migrate.py            1.9s (14)             1.9s (4)  -1.1%
      virtualenv_bench.py            8.3s (14)             8.3s (4)  -0.1%
                  geomean                 3.7s                 3.7s  -0.9%
```