### PR TITLE
gc less frequently, and make collections faster

### DIFF
--- a/src/core/stats.cpp
+++ b/src/core/stats.cpp
@@ -102,9 +102,6 @@ void Stats::clear() {
 }
 
 void Stats::startEstimatingCPUFreq() {
-    if (!Stats::enabled)
-        return;
-
     clock_gettime(CLOCK_REALTIME, &Stats::start_ts);
     Stats::start_tick = getCPUTicks();
 }

--- a/src/gc/collector.cpp
+++ b/src/gc/collector.cpp
@@ -96,6 +96,7 @@ public:
 
     void push(void* p) {
         GC_TRACE_LOG("Pushing %p\n", p);
+        assert(((intptr_t)p) % 8 == 0);
         GCAllocation* al = GCAllocation::fromUserData(p);
         if (isMarked(al))
             return;
@@ -404,6 +405,8 @@ void endGCUnexpectedRegion() {
     should_not_reenter_gc = false;
 }
 
+extern size_t heap_size;
+extern size_t heap_occupancy;
 void runCollection() {
     static StatCounter sc("gc_collections");
     sc.log();
@@ -414,6 +417,10 @@ void runCollection() {
 
     if (VERBOSITY("gc") >= 2)
         printf("Collection #%d\n", ncollections);
+#if GC_COLLECTION_STATS
+    printf("Collection #%d, heap size = %.02fM, pre-gc occupancy ~= %.02fM", ncollections,
+           heap_size / (1024.0 * 1024.0), heap_size * HEAP_OCCUPANCY_FRACTION / (1024.0 * 1024.0));
+#endif
 
     // The bulk of the GC work is not reentrant-safe.
     // In theory we should never try to reenter that section, but it's happened due to bugs,
@@ -425,6 +432,8 @@ void runCollection() {
     should_not_reenter_gc = true; // begin non-reentrant section
 
     Timer _t("collecting", /*min_usec=*/10000);
+
+    global_heap.prepareForCollection();
 
     markPhase();
 
@@ -444,6 +453,10 @@ void runCollection() {
     std::vector<BoxedClass*> classes_to_free;
 
     sweepPhase(weakly_referenced, classes_to_free);
+
+#if GC_COLLECTION_STATS
+    printf(", post-gc occupancy = %.02fM) . ", heap_occupancy / (1024 * 1024.0));
+#endif
 
     // Handle weakrefs in two passes:
     // - first, find all of the weakref objects whose callbacks we need to call.  we need to iterate
@@ -491,10 +504,15 @@ void runCollection() {
     if (VERBOSITY("gc") >= 2)
         printf("Collection #%d done\n\n", ncollections);
 
+    global_heap.cleanupAfterCollection();
+
     long us = _t.end();
     static StatCounter sc_us("gc_collections_us");
     sc_us.log(us);
 
+#if GC_COLLECTION_STATS
+    printf("  %ldms\n", (uint64_t)(us / 1000 / Stats::estimateCPUFreq()));
+#endif
     // dumpHeapStatistics();
 }
 


### PR DESCRIPTION
This is not quite read for merging.  a little refactoring needs to be done.

---

Found this while investigating slowdown/speedup of benchmarks due to the run allocator work.

This change adds two knobs to configure gc frequency - heap occupancy percentage, and time
between collections.

The idea is that the collector tries to collect no more frequently than every QUICK_GC_FREQUENCY(500)
milliseconds.  If it NUM_QUICK_GC(2) collections in a row, it increases the size of the heap.

We also resize the heap if after a collection memory usage is above a certain threshold (right now it's
the same percentage as what triggered the collection.  should probably tune this more when/if we get
benchmarks when a lot of live objects after a collection - right now none of them actually hit this.)

further work might be to shrink the heap if collections start taking too much time.