### PR TITLE
Binary search large and huge arenas for ::allocationFrom

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -530,7 +530,8 @@ check:
 # Travis-CI do the full test.
 .PHONY: quick_check
 quick_check:
-	$(MAKE) pyston_dbg check-deps
+	$(MAKE) pyston_dbg
+	$(MAKE) check-deps
 	( cd $(CMAKE_DIR_DBG) && ctest -V -R 'check-format|unittests|pyston_defaults_tests|pyston_defaults_cpython' )
 
 

--- a/src/codegen/unwinding.cpp
+++ b/src/codegen/unwinding.cpp
@@ -118,34 +118,21 @@ void registerDynamicEhFrame(uint64_t code_addr, size_t code_size, uint64_t eh_fr
     // dyn_info that contains a binary search table.
 }
 
+struct compare_cf {
+    int operator()(const uint64_t& key, const CompiledFunction* item) const {
+        // key is the return address of the callsite, so we will check it against
+        // the region (start, end] (opposite-endedness of normal half-open regions)
+        if (key <= item->code_start)
+            return -1;
+        else if (key > item->code_start + item->code_size)
+            return 1;
+        return 0;
+    }
+};
+
 class CFRegistry {
 private:
     std::vector<CompiledFunction*> cfs;
-
-    // similar to Java's Array.binarySearch:
-    // return values are either:
-    //   >= 0 : the index where a given item was found
-    //   < 0  : a negative number that can be transformed (using "-num-1") into the insertion point
-    //
-    // addr is the return address of the callsite, so we will check it against
-    // the region (start, end] (opposite-endedness of normal half-open regions)
-    //
-    int find_cf(uint64_t addr) {
-        int l = 0;
-        int r = cfs.size() - 1;
-        while (l <= r) {
-            int mid = l + (r - l) / 2;
-            auto mid_cf = cfs[mid];
-            if (addr <= mid_cf->code_start) {
-                r = mid - 1;
-            } else if (addr > mid_cf->code_start + mid_cf->code_size) {
-                l = mid + 1;
-            } else {
-                return mid;
-            }
-        }
-        return -(l + 1);
-    }
 
 public:
     void registerCF(CompiledFunction* cf) {
@@ -154,7 +141,7 @@ public:
             return;
         }
 
-        int idx = find_cf((uint64_t)cf->code_start);
+        int idx = binarySearch((uint64_t)cf->code_start, cfs.begin(), cfs.end(), compare_cf());
         if (idx >= 0)
             RELEASE_ASSERT(0, "CompiledFunction registered twice?");
 
@@ -165,7 +152,7 @@ public:
         if (cfs.empty())
             return NULL;
 
-        int idx = find_cf(addr);
+        int idx = binarySearch(addr, cfs.begin(), cfs.end(), compare_cf());
         if (idx >= 0)
             return cfs[idx];
 

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -747,6 +747,29 @@ struct CallattrFlags {
 
     char asInt() { return (cls_only << 0) + (null_on_nonexistent << 1); }
 };
+
+// similar to Java's Array.binarySearch:
+// return values are either:
+//   >= 0 : the index where a given item was found
+//   < 0  : a negative number that can be transformed (using "-num-1") into the insertion point
+//
+template <typename T, typename RandomAccessIterator, typename Cmp>
+int binarySearch(T needle, RandomAccessIterator start, RandomAccessIterator end, Cmp cmp) {
+    int l = 0;
+    int r = end - start - 1;
+    while (l <= r) {
+        int mid = l + (r - l) / 2;
+        auto mid_item = *(start + mid);
+        int c = cmp(needle, mid_item);
+        if (c < 0)
+            r = mid - 1;
+        else if (c > 0)
+            l = mid + 1;
+        else
+            return mid;
+    }
+    return -(l + 1);
+}
 }
 
 namespace std {

--- a/src/gc/collector.cpp
+++ b/src/gc/collector.cpp
@@ -438,6 +438,8 @@ void runCollection() {
 
     Timer _t("collecting", /*min_usec=*/10000);
 
+    global_heap.prepareForCollection();
+
     markPhase();
 
     // The sweep phase will not free weakly-referenced objects, so that we can inspect their
@@ -499,6 +501,8 @@ void runCollection() {
             head->wr_callback = NULL;
         }
     }
+
+    global_heap.cleanupAfterCollection();
 
     if (VERBOSITY("gc") >= 2)
         printf("Collection #%d done\n\n", ncollections);


### PR DESCRIPTION
split this out of #660.

we build a sorted cache from our large and huge arenas before collections, to speed up all the `::allocationFrom` calls that are coming.

```
       django_template.py             4.7s (2)             4.6s (2)  -3.0%
            pyxl_bench.py             3.9s (2)             3.8s (2)  -2.0%
sqlalchemy_imperative2.py             5.1s (2)             5.0s (2)  -1.7%
        django_migrate.py             1.8s (2)             1.8s (2)  -1.7%
      virtualenv_bench.py             7.8s (2)             7.7s (2)  -1.8%
                  geomean                 4.2s                 4.1s  -2.1%
```