### PR TITLE
assembler: Use 32bit moves if the immediate fits inside 32bit

### DIFF
--- a/src/asm_writing/assembler.h
+++ b/src/asm_writing/assembler.h
@@ -114,8 +114,8 @@ public:
     void nop() { emitByte(0x90); }
     void trap() { emitByte(0xcc); }
 
-    // some things (such as objdump) call this "movabs" if the immediate is 64-bit
-    void mov(Immediate imm, Register dest);
+    // emits a movabs if the immediate is a 64bit value or force_64bit_load = true otherwise it emits a 32bit mov
+    void mov(Immediate imm, Register dest, bool force_64bit_load = false);
     // not sure if we should use the 'q' suffix here, but this is the most ambiguous one;
     // this does a 64-bit store of a 32-bit value.
     void movq(Immediate imm, Indirect dest);

--- a/src/asm_writing/types.h
+++ b/src/asm_writing/types.h
@@ -158,6 +158,11 @@ struct Immediate {
 
     explicit Immediate(uint64_t val) : val(val) {}
     explicit Immediate(void* val) : val((uint64_t)val) {}
+
+    bool fitsInto32Bit() const {
+        uint32_t val_32bit = (uint32_t)val;
+        return val_32bit == val;
+    }
 };
 
 struct JumpDestination {


### PR DESCRIPTION
makes the encoding 4-5byte shorter and works because the upper 32bit will get auto cleared
This is quite common in code generated by the new JIT