### PR TITLE
gc less frequently

### DIFF
--- a/src/core/stats.cpp
+++ b/src/core/stats.cpp
@@ -65,7 +65,7 @@ std::unordered_map<uint64_t*, std::string>* Stats::names;
 bool Stats::enabled;
 
 timespec Stats::start_ts;
-uint64_t Stats::start_tick;
+uint64_t Stats::start_tick = 0;
 
 StatCounter::StatCounter(const std::string& name) : counter(Stats::getStatCounter(name)) {
 }
@@ -104,7 +104,7 @@ void Stats::clear() {
 }
 
 void Stats::startEstimatingCPUFreq() {
-    if (!Stats::enabled)
+    if (Stats::start_tick != 0)
         return;
 
     clock_gettime(CLOCK_REALTIME, &Stats::start_ts);

--- a/src/gc/collector.cpp
+++ b/src/gc/collector.cpp
@@ -110,6 +110,7 @@ public:
 
     void push(void* p) {
         GC_TRACE_LOG("Pushing %p\n", p);
+        assert(((intptr_t)p) % 8 == 0);
         GCAllocation* al = GCAllocation::fromUserData(p);
         if (isMarked(al))
             return;
@@ -467,7 +468,7 @@ void endGCUnexpectedRegion() {
     should_not_reenter_gc = false;
 }
 
-void runCollection() {
+long runCollection() {
     static StatCounter sc_us("us_gc_collections");
     static StatCounter sc("gc_collections");
     sc.log();
@@ -545,10 +546,14 @@ void runCollection() {
     if (VERBOSITY("gc") >= 2)
         printf("Collection #%d done\n\n", ncollections);
 
+    global_heap.cleanupAfterCollection();
+
     long us = _t.end();
     sc_us.log(us);
 
     // dumpHeapStatistics();
+
+    return (long)(us / Stats::estimateCPUFreq());
 }
 
 } // namespace gc

--- a/src/gc/collector.h
+++ b/src/gc/collector.h
@@ -58,7 +58,7 @@ public:
     Box* operator->() { return value; }
 };
 
-void runCollection();
+long runCollection();
 
 // Python programs are allowed to pause the GC.  This is supposed to pause automatic GC,
 // but does not seem to pause manual calls to gc.collect().  So, callers should check gcIsEnabled(),


### PR DESCRIPTION
simpler logic for determining gc frequency, based on how long it took to collect.  For cpus with consistent tick rates this should be a tighter bound than wall-clock time, although given cache effects it won't be entirely deterministic.  That said, I don't think determinism is something we can continue to rely on.

this change (optimistically) increases the amount of headroom we give the mutator after each collection,
except if the collection took more than 50ms, at which point we decrease the headroom.  The factors for growth/shrinking are 1.85 and 0.35 respectively.

In practice this causes the collector to oscillate around that desired time.

pyxl_bench.py is most sensitive to this work, for reasons that are unclear.  I've actually seen collection times *drop* after increasing allocBytesForNextCollection in pyxl_bench.py.  More investigation there would be useful - it is most sensitive to any change in GC parameters.

```
       django_template.py             4.6s (2)             4.4s (4)  -4.4%
            pyxl_bench.py             3.8s (2)             3.8s (4)  -0.5%
sqlalchemy_imperative2.py             5.0s (2)             4.9s (4)  -2.2%
        django_migrate.py             1.8s (2)             1.7s (4)  -2.1%
      virtualenv_bench.py             7.8s (2)             7.6s (4)  -2.3%
                  geomean                 4.1s                 4.0s  -2.3%
```
