### PR TITLE
More small improvements

### DIFF
--- a/section_ordering.txt
+++ b/section_ordering.txt
@@ -3,7 +3,11 @@
 .text.boxBool
 .text._ZN6pyston2gc10SmallArena6_allocEmi
 .text._ZNSt17_Function_handlerIFvPN6pyston2gc10SmallArena16ThreadBlockCacheEEZNS2_12freeUnmarkedERSt6vectorIPNS0_3BoxESaIS8_EEE3$_0E9_M_invokeERKSt9_Any_dataS4_
+.text._ZN6pyston2gc10SmallArena10_freeChainEPPNS1_5BlockERSt6vectorIPNS_3BoxESaIS7_EERS5_IPNS_10BoxedClassESaISC_EE
+.text._ZN6pyston9getICInfoEPv
 .text.memset
+.text.__memcmp_sse4_1
+.text.__memcpy_sse2_unaligned
 .text.gc_alloc
 .text.gc_realloc
 .text._ZN6pyston9BoxedList6ensureEi
@@ -19,3 +23,13 @@
 .text.intModInt
 .text.intAddInt
 .text.intMulInt
+.text._ZNK4llvm9StringRef4findES0_m
+.text._ZNK4llvm13StringMapImpl7FindKeyENS_9StringRefE
+.text._int_malloc
+.text._int_free
+.text.malloc
+.text.free
+.text._ULx86_64_dwarf_extract_proc_info_from_fde
+.text.createTuple
+.text._ZN6pyston18rearrangeArgumentsENS_16ParamReceiveSpecEPKNS_10ParamNamesEPKcPPNS_3BoxEPNS_15CallRewriteArgsERbNS_11ArgPassSpecES7_S7_S7_S8_PKSt6vectorIPNS_11BoxedStringESaISF_EERS7_SK_SK_S8_
+.text.sre_match

--- a/src/capi/typeobject.cpp
+++ b/src/capi/typeobject.cpp
@@ -1116,7 +1116,7 @@ static int slot_sq_contains(PyObject* self, PyObject* value) noexcept {
     }
 
 #define SLOT1(FUNCNAME, OPSTR, ARG1TYPE, ARGCODES)                                                                     \
-    static PyObject* FUNCNAME(PyObject* self, ARG1TYPE arg1) noexcept {                                                \
+    /* Pyston change: static */ PyObject* FUNCNAME(PyObject* self, ARG1TYPE arg1) noexcept {                           \
         static PyObject* cache_str;                                                                                    \
         return call_method(self, OPSTR, &cache_str, "(" ARGCODES ")", arg1);                                           \
     }

--- a/src/capi/typeobject.cpp
+++ b/src/capi/typeobject.cpp
@@ -1078,7 +1078,7 @@ static int slot_sq_ass_slice(PyObject* self, Py_ssize_t i, Py_ssize_t j, PyObjec
     return 0;
 }
 
-static int slot_sq_contains(PyObject* self, PyObject* value) noexcept {
+/* Pyston change: static*/ int slot_sq_contains(PyObject* self, PyObject* value) noexcept {
     STAT_TIMER(t0, "us_timer_slot_sqcontains", SLOT_AVOIDABILITY(self));
 
     PyObject* func, *res, *args;

--- a/src/capi/typeobject.cpp
+++ b/src/capi/typeobject.cpp
@@ -1006,7 +1006,7 @@ PyObject* slot_sq_item(PyObject* self, Py_ssize_t i) noexcept {
     }
 }
 
-static Py_ssize_t slot_sq_length(PyObject* self) noexcept {
+/* Pyston change: static */ Py_ssize_t slot_sq_length(PyObject* self) noexcept {
     STAT_TIMER(t0, "us_timer_slot_sqlength", SLOT_AVOIDABILITY(self));
 
     static PyObject* len_str;

--- a/src/capi/typeobject.h
+++ b/src/capi/typeobject.h
@@ -37,6 +37,7 @@ int type_set_bases(PyTypeObject* type, PyObject* value, void* context) noexcept;
 PyObject* slot_tp_richcompare(PyObject* self, PyObject* other, int op) noexcept;
 PyObject* slot_tp_iternext(PyObject* self) noexcept;
 PyObject* slot_tp_new(PyTypeObject* self, PyObject* args, PyObject* kwds) noexcept;
+PyObject* slot_mp_subscript(PyObject* self, PyObject* arg1) noexcept;
 }
 
 #endif

--- a/src/capi/typeobject.h
+++ b/src/capi/typeobject.h
@@ -38,6 +38,7 @@ PyObject* slot_tp_richcompare(PyObject* self, PyObject* other, int op) noexcept;
 PyObject* slot_tp_iternext(PyObject* self) noexcept;
 PyObject* slot_tp_new(PyTypeObject* self, PyObject* args, PyObject* kwds) noexcept;
 PyObject* slot_mp_subscript(PyObject* self, PyObject* arg1) noexcept;
+int slot_sq_contains(PyObject* self, PyObject* value) noexcept;
 }
 
 #endif

--- a/src/capi/typeobject.h
+++ b/src/capi/typeobject.h
@@ -39,6 +39,7 @@ PyObject* slot_tp_iternext(PyObject* self) noexcept;
 PyObject* slot_tp_new(PyTypeObject* self, PyObject* args, PyObject* kwds) noexcept;
 PyObject* slot_mp_subscript(PyObject* self, PyObject* arg1) noexcept;
 int slot_sq_contains(PyObject* self, PyObject* value) noexcept;
+Py_ssize_t slot_sq_length(PyObject* self) noexcept;
 }
 
 #endif

--- a/src/codegen/baseline_jit.cpp
+++ b/src/codegen/baseline_jit.cpp
@@ -176,6 +176,8 @@ RewriterVar* JitFragmentWriter::emitCallattr(RewriterVar* obj, BoxedString* attr
 }
 
 RewriterVar* JitFragmentWriter::emitCompare(RewriterVar* lhs, RewriterVar* rhs, int op_type) {
+// TODO: can directly emit the assembly for Is/IsNot
+
 #if ENABLE_BASELINEJIT_ICS
     return call(false, (void*)compareICHelper, imm(new CompareIC), lhs, rhs, imm(op_type));
 #else

--- a/src/codegen/baseline_jit.cpp
+++ b/src/codegen/baseline_jit.cpp
@@ -56,7 +56,7 @@ JitCodeBlock::JitCodeBlock(llvm::StringRef name)
     // generate eh frame...
     frame_manager.writeAndRegister(code.get(), code_size);
 
-    g.func_addr_registry.registerFunction(("bjit: " + name).str(), code.get(), code_size, NULL);
+    g.func_addr_registry.registerFunction(("bjit_" + name).str(), code.get(), code_size, NULL);
 }
 
 std::unique_ptr<JitFragmentWriter> JitCodeBlock::newFragment(CFGBlock* block, int patch_jump_offset) {

--- a/src/codegen/irgen/irgenerator.cpp
+++ b/src/codegen/irgen/irgenerator.cpp
@@ -811,6 +811,20 @@ private:
         assert(left);
         assert(right);
 
+        if (node->ops[0] == AST_TYPE::Is || node->ops[0] == AST_TYPE::IsNot) {
+            // TODO: I think we can do better here and not force the types to box themselves
+
+            ConcreteCompilerVariable* converted_left = left->makeConverted(emitter, UNKNOWN);
+            ConcreteCompilerVariable* converted_right = right->makeConverted(emitter, UNKNOWN);
+            llvm::Value* cmp;
+            if (node->ops[0] == AST_TYPE::Is)
+                cmp = emitter.getBuilder()->CreateICmpEQ(converted_left->getValue(), converted_right->getValue());
+            else
+                cmp = emitter.getBuilder()->CreateICmpNE(converted_left->getValue(), converted_right->getValue());
+
+            return boolFromI1(emitter, cmp);
+        }
+
         CompilerVariable* rtn = _evalBinExp(node, left, right, node->ops[0], Compare, unw_info);
         left->decvref(emitter);
         right->decvref(emitter);

--- a/src/runtime/inline/boxing.h
+++ b/src/runtime/inline/boxing.h
@@ -37,6 +37,12 @@ extern "C" inline Box* boxBool(bool b) {
     return rtn;
 }
 
+extern "C" inline Box* boxBoolNegated(bool b) __attribute__((visibility("default")));
+extern "C" inline Box* boxBoolNegated(bool b) {
+    Box* rtn = b ? False : True;
+    return rtn;
+}
+
 extern "C" inline bool unboxBool(Box* b) __attribute__((visibility("default")));
 extern "C" inline bool unboxBool(Box* b) {
     assert(b->cls == bool_cls);

--- a/src/runtime/inline/link_forcer.cpp
+++ b/src/runtime/inline/link_forcer.cpp
@@ -57,6 +57,7 @@ void force() {
     FORCE(unboxCLFunction);
     FORCE(boxInstanceMethod);
     FORCE(boxBool);
+    FORCE(boxBoolNegated);
     FORCE(unboxBool);
     FORCE(createTuple);
     FORCE(createDict);

--- a/src/runtime/objmodel.cpp
+++ b/src/runtime/objmodel.cpp
@@ -2254,6 +2254,16 @@ extern "C" bool nonzero(Box* obj) {
             rewriter->commitReturning(r_rtn);
         }
         return r;
+    } else if (obj->cls == unicode_cls) {
+        PyUnicodeObject* unicode_obj = reinterpret_cast<PyUnicodeObject*>(obj);
+        bool r = (unicode_obj->length != 0);
+
+        if (rewriter.get()) {
+            RewriterVar* r_rtn
+                = r_obj->getAttr(offsetof(PyUnicodeObject, length))->toBool(rewriter->getReturnDestination());
+            rewriter->commitReturning(r_rtn);
+        }
+        return r;
     }
 
     // TODO: rewrite these.

--- a/src/runtime/types.h
+++ b/src/runtime/types.h
@@ -106,6 +106,7 @@ extern BoxedModule* sys_module, *builtins_module, *math_module, *time_module, *t
 }
 
 extern "C" Box* boxBool(bool);
+extern "C" Box* boxBoolNegated(bool);
 extern "C" Box* boxInt(i64) __attribute__((visibility("default")));
 extern "C" i64 unboxInt(Box*);
 extern "C" Box* boxFloat(double d);


### PR DESCRIPTION
Mostly around optimizing unicode handling.  The gains are pretty small so I tried again to mess around with section_ordering.txt.

```
       django_template.py             4.5s (2)             4.2s (2)  -5.8%
            pyxl_bench.py             3.9s (4)             3.9s (2)  -0.6%
sqlalchemy_imperative2.py             5.2s (2)             5.1s (2)  -1.2%
        django_migrate.py             1.9s (2)             1.9s (2)  +0.0%
      virtualenv_bench.py             5.2s (2)             5.1s (2)  -1.3%
                  geomean                 3.9s                 3.8s  -1.8%
```