### PR TITLE
Refactor offset macros to use the C++ built-in instead.

### DIFF
--- a/src/core/common.h
+++ b/src/core/common.h
@@ -67,8 +67,6 @@
 
 #define UNIMPLEMENTED() RELEASE_ASSERT(0, "unimplemented")
 
-#define OFFSET(cls, attr) ((char*)&(((cls*)0x01)->attr) - (char*)0x1)
-
 // Allow using std::pair as keys in hashtables:
 namespace std {
 template <typename T1, typename T2> struct hash<pair<T1, T2>> {

--- a/src/runtime/types.cpp
+++ b/src/runtime/types.cpp
@@ -94,10 +94,6 @@ void setupGC();
 
 bool IN_SHUTDOWN = false;
 
-#define SLICE_START_OFFSET ((char*)&(((BoxedSlice*)0x01)->start) - (char*)0x1)
-#define SLICE_STOP_OFFSET ((char*)&(((BoxedSlice*)0x01)->stop) - (char*)0x1)
-#define SLICE_STEP_OFFSET ((char*)&(((BoxedSlice*)0x01)->step) - (char*)0x1)
-
 void FrameInfo::gcVisit(GCVisitor* visitor) {
     visitor->visit(boxedLocals);
     visitor->visit(exc.traceback);
@@ -3297,9 +3293,9 @@ void setupRuntime() {
     slice_cls->giveAttr("__new__",
                         new BoxedFunction(boxRTFunction((void*)sliceNew, UNKNOWN, 4, 2, false, false), { NULL, None }));
     slice_cls->giveAttr("__repr__", new BoxedFunction(boxRTFunction((void*)sliceRepr, STR, 1)));
-    slice_cls->giveAttr("start", new BoxedMemberDescriptor(BoxedMemberDescriptor::OBJECT, SLICE_START_OFFSET));
-    slice_cls->giveAttr("stop", new BoxedMemberDescriptor(BoxedMemberDescriptor::OBJECT, SLICE_STOP_OFFSET));
-    slice_cls->giveAttr("step", new BoxedMemberDescriptor(BoxedMemberDescriptor::OBJECT, SLICE_STEP_OFFSET));
+    slice_cls->giveAttr("start", new BoxedMemberDescriptor(BoxedMemberDescriptor::OBJECT, offsetof(BoxedSlice, start)));
+    slice_cls->giveAttr("stop", new BoxedMemberDescriptor(BoxedMemberDescriptor::OBJECT, offsetof(BoxedSlice, stop)));
+    slice_cls->giveAttr("step", new BoxedMemberDescriptor(BoxedMemberDescriptor::OBJECT, offsetof(BoxedSlice, step)));
     slice_cls->freeze();
 
     attrwrapper_cls->giveAttr("__setitem__", new BoxedFunction(boxRTFunction((void*)AttrWrapper::setitem, UNKNOWN, 3)));


### PR DESCRIPTION
#define SOMETHING_OFFSET -> offsetof(...)

Generates the same assembly, more standard and less `#define`s