### PR TITLE
Fix irgen bug for instancemethods

### DIFF
--- a/src/runtime/types.h
+++ b/src/runtime/types.h
@@ -206,7 +206,17 @@ public:
                                 const std::vector<BoxedString*>*);
     pyston_call tpp_call;
 
-    bool hasGenericGetattr() { return tp_getattr == NULL; }
+    bool hasGenericGetattr() {
+        if (tp_getattr)
+            return false;
+
+        // instancemethod_cls should have a custom tp_getattr but is currently implemented
+        // as a hack within getattrInternalGeneric
+        if (this == instancemethod_cls)
+            return false;
+
+        return true;
+    }
 
     void freeze();
 

--- a/test/tests/instance_methods.py
+++ b/test/tests/instance_methods.py
@@ -37,3 +37,9 @@ print type(C().foo.im_func), type(C().foo.__func__)
 print type(C().foo.im_self), type(C().foo.__self__)
 print type(C().foo.im_class)
 print repr(C().foo)
+
+def f(m):
+    print m.__name__
+
+f(C.foo)
+f(C().foo)


### PR DESCRIPTION
We would try to statically-resolve their getattrs, but there's some
special casing in the getattr logic for them.  Which should be handled
by moving the special-case to a proper tp_getattr, but for now just
add the special-casing to "hasGenericGetattr" as well.