### PR TITLE
Fewer mallocs

### DIFF
--- a/src/asm_writing/assembler.h
+++ b/src/asm_writing/assembler.h
@@ -94,7 +94,7 @@ public:
     Assembler(uint8_t* start, int size) : start_addr(start), end_addr(start + size), addr(start_addr), failed(false) {}
 
 #ifndef NDEBUG
-    inline void comment(std::string msg) {
+    inline void comment(const llvm::Twine& msg) {
         if (ASSEMBLY_LOGGING) {
             logger.log_comment(msg, addr - start_addr);
         }
@@ -107,7 +107,7 @@ public:
         }
     }
 #else
-    inline void comment(std::string msg) {}
+    inline void comment(const llvm::Twine& msg) {}
     inline std::string dump() { return ""; }
 #endif
 

--- a/src/asm_writing/disassemble.cpp
+++ b/src/asm_writing/disassemble.cpp
@@ -59,8 +59,8 @@ void disassemblyInitialize() {
     llvm::InitializeNativeTargetAsmParser();
 }
 
-void AssemblyLogger::log_comment(const std::string& comment, size_t offset) {
-    comments[offset].push_back(comment);
+void AssemblyLogger::log_comment(const llvm::Twine& comment, size_t offset) {
+    comments[offset].push_back(comment.str());
 }
 
 void AssemblyLogger::append_comments(llvm::raw_string_ostream& stream, size_t pos) const {

--- a/src/asm_writing/disassemble.h
+++ b/src/asm_writing/disassemble.h
@@ -17,6 +17,7 @@
 
 #include <unordered_map>
 
+#include "llvm/ADT/Twine.h"
 #include "llvm/Support/raw_ostream.h"
 
 namespace pyston {
@@ -31,7 +32,7 @@ private:
     void append_comments(llvm::raw_string_ostream&, size_t pos) const;
 
 public:
-    void log_comment(const std::string&, size_t offset);
+    void log_comment(const llvm::Twine&, size_t offset);
     std::string finalize_log(uint8_t const* start_addr, uint8_t const* end_addr) const;
 };
 }

--- a/src/asm_writing/rewriter.h
+++ b/src/asm_writing/rewriter.h
@@ -232,7 +232,7 @@ private:
     // Here "done" means that it would be okay to release all of the var's locations and
     // thus allocate new variables in that same location. To be safe, you can always just
     // only call bumpUse at the end, but in some cases it may be possible earlier.
-    std::vector<int> uses;
+    llvm::SmallVector<int, 32> uses;
     int next_use;
     void bumpUse();
     void releaseIfNoUses();
@@ -348,7 +348,7 @@ protected:
 
     Rewriter(std::unique_ptr<ICSlotRewrite> rewrite, int num_args, const std::vector<int>& live_outs);
 
-    std::vector<RewriterAction> actions;
+    llvm::SmallVector<RewriterAction, 32> actions;
     void addAction(std::function<void()> action, std::vector<RewriterVar*> const& vars, ActionType type) {
         assertPhaseCollecting();
         for (RewriterVar* var : vars) {

--- a/src/codegen/ast_interpreter.cpp
+++ b/src/codegen/ast_interpreter.cpp
@@ -77,7 +77,7 @@ public:
 
 class ASTInterpreter : public Box {
 public:
-    typedef ContiguousMap<InternedString, Box*> SymMap;
+    typedef ContiguousMap<InternedString, Box*, llvm::SmallDenseMap<InternedString, int, 16>> SymMap;
 
     ASTInterpreter(CompiledFunction* compiled_function);
 


### PR DESCRIPTION
reduces the number of calls to malloc from the biggest users (mostly ASTInterpreter + Rewriter).

```
                           0915db4ee1808a2c5b:  3501184a72c8b867da:
       django_template.py             3.9s (2)             3.8s (2)  -2.7%
            pyxl_bench.py             3.7s (2)             3.7s (2)  -0.1%
sqlalchemy_imperative2.py             4.6s (2)             4.5s (2)  -1.9%
        django_migrate.py             1.7s (2)             1.6s (2)  -7.1%
      virtualenv_bench.py             4.9s (2)             4.9s (2)  -1.5%
                  geomean                 3.5s                 3.4s  -2.7%
```