### PR TITLE
baseline jit: directly emit patchpoints instead of using runtime ICs

### DIFF
--- a/src/asm_writing/assembler.cpp
+++ b/src/asm_writing/assembler.cpp
@@ -1034,6 +1034,16 @@ void Assembler::emitAnnotation(int num) {
     nop();
 }
 
+void Assembler::skipBytes(int num) {
+    if (addr + num >= end_addr) {
+        addr = end_addr;
+        failed = true;
+        return;
+    }
+
+    addr += num;
+}
+
 ForwardJump::ForwardJump(Assembler& assembler, ConditionCode condition)
     : assembler(assembler), condition(condition), jmp_inst(assembler.curInstPointer()) {
     assembler.jmp_cond(JumpDestination::fromStart(assembler.bytesWritten() + max_jump_size), condition);

--- a/src/asm_writing/assembler.h
+++ b/src/asm_writing/assembler.h
@@ -193,6 +193,7 @@ public:
     void fillWithNops();
     void fillWithNopsExcept(int bytes);
     void emitAnnotation(int num);
+    void skipBytes(int num);
 
     uint8_t* startAddr() const { return start_addr; }
     int bytesLeft() const { return end_addr - addr; }

--- a/src/asm_writing/rewriter.cpp
+++ b/src/asm_writing/rewriter.cpp
@@ -970,10 +970,12 @@ void Rewriter::_call(RewriterVar* result, bool has_side_effects, void* func_addr
         assert(assembler->hasFailed() || asm_address == (uint64_t)assembler->curInstPointer());
     }
 
-    assert(vars_by_location.count(assembler::RAX) == 0);
-    result->initializeInReg(assembler::RAX);
+    if (!failed) {
+        assert(vars_by_location.count(assembler::RAX) == 0);
+        result->initializeInReg(assembler::RAX);
 
-    assertConsistent();
+        assertConsistent();
+    }
 
     result->releaseIfNoUses();
 }

--- a/src/asm_writing/rewriter.cpp
+++ b/src/asm_writing/rewriter.cpp
@@ -792,10 +792,8 @@ RewriterVar* Rewriter::call(bool has_side_effects, void* func_addr, const Rewrit
     return result;
 }
 
-void Rewriter::_call(RewriterVar* result, bool has_side_effects, void* func_addr, const RewriterVar::SmallVector& args,
-                     const RewriterVar::SmallVector& args_xmm) {
-    assembler->comment("_call");
-
+void Rewriter::_setupCall(RewriterVar* result, bool has_side_effects, const RewriterVar::SmallVector& args,
+                          const RewriterVar::SmallVector& args_xmm) {
     if (has_side_effects)
         assert(done_guarding);
 
@@ -827,9 +825,6 @@ void Rewriter::_call(RewriterVar* result, bool has_side_effects, void* func_addr
             marked_inside_ic = true;
         }
     }
-
-    // RewriterVarUsage scratch = createNewVar(Location::any());
-    assembler::Register r = allocReg(assembler::R11);
 
     for (int i = 0; i < args.size(); i++) {
         Location l(Location::forArg(i));
@@ -950,6 +945,19 @@ void Rewriter::_call(RewriterVar* result, bool has_side_effects, void* func_addr
         assert(!l.isClobberedByCall());
     }
 #endif
+}
+
+void Rewriter::_call(RewriterVar* result, bool has_side_effects, void* func_addr, const RewriterVar::SmallVector& args,
+                     const RewriterVar::SmallVector& args_xmm) {
+    assembler->comment("_call");
+
+    // RewriterVarUsage scratch = createNewVar(Location::any());
+    assembler::Register r = allocReg(assembler::R11);
+
+    _setupCall(result, has_side_effects, args, args_xmm);
+
+    // make sure setupCall doesn't use R11
+    assert(vars_by_location.count(assembler::R11) == 0);
 
     uint64_t asm_address = (uint64_t)assembler->curInstPointer() + 5;
     uint64_t real_asm_address = asm_address + (uint64_t)rewrite->getSlotStart() - (uint64_t)assembler->startAddr();
@@ -1737,10 +1745,10 @@ Rewriter::Rewriter(std::unique_ptr<ICSlotRewrite> rewrite, int num_args, const s
     // the entire scratch space.
     bool VALIDATE_SCRATCH_SPACE = false;
     if (VALIDATE_SCRATCH_SPACE) {
-        int scratch_size = rewrite->getScratchSize();
+        int scratch_size = this->rewrite->getScratchSize();
         for (int i = 0; i < scratch_size; i += 8) {
             assembler->movq(assembler::Immediate(0x12345678UL),
-                            assembler::Indirect(assembler::RSP, i + rewrite->getScratchRspOffset()));
+                            assembler::Indirect(assembler::RSP, i + this->rewrite->getScratchRspOffset()));
         }
     }
 }

--- a/src/asm_writing/rewriter.h
+++ b/src/asm_writing/rewriter.h
@@ -19,6 +19,7 @@
 #include <memory>
 #include <tuple>
 
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallSet.h"
 
@@ -349,7 +350,7 @@ protected:
     Rewriter(std::unique_ptr<ICSlotRewrite> rewrite, int num_args, const std::vector<int>& live_outs);
 
     llvm::SmallVector<RewriterAction, 32> actions;
-    void addAction(std::function<void()> action, std::vector<RewriterVar*> const& vars, ActionType type) {
+    void addAction(std::function<void()> action, llvm::ArrayRef<RewriterVar*> vars, ActionType type) {
         assertPhaseCollecting();
         for (RewriterVar* var : vars) {
             assert(var != NULL);
@@ -413,6 +414,8 @@ protected:
 
     void _trap();
     void _loadConst(RewriterVar* result, int64_t val);
+    void _setupCall(RewriterVar* result, bool has_side_effects, const RewriterVar::SmallVector& args,
+                    const RewriterVar::SmallVector& args_xmm);
     void _call(RewriterVar* result, bool has_side_effects, void* func_addr, const RewriterVar::SmallVector& args,
                const RewriterVar::SmallVector& args_xmm);
     void _add(RewriterVar* result, RewriterVar* a, int64_t b, Location dest);

--- a/src/runtime/ics.h
+++ b/src/runtime/ics.h
@@ -77,83 +77,11 @@ public:
     }
 };
 
-class RuntimeCallIC : public RuntimeIC {
-public:
-    RuntimeCallIC() : RuntimeIC((void*)runtimeCall, 2, 320) {}
-
-    Box* call(Box* obj, ArgPassSpec argspec, Box* arg1, Box* arg2, Box* arg3, Box** args) {
-        return (Box*)call_ptr(obj, argspec, arg1, arg2, arg3, args);
-    }
-};
-
-class UnaryopIC : public RuntimeIC {
-public:
-    UnaryopIC() : RuntimeIC((void*)unaryop, 2, 160) {}
-
-    Box* call(Box* obj, int op_type) { return (Box*)call_ptr(obj, op_type); }
-};
-
-class AugBinopIC : public RuntimeIC {
-public:
-    AugBinopIC() : RuntimeIC((void*)augbinop, 2, 240) {}
-
-    Box* call(Box* lhs, Box* rhs, int op_type) { return (Box*)call_ptr(lhs, rhs, op_type); }
-};
-
 class BinopIC : public RuntimeIC {
 public:
     BinopIC() : RuntimeIC((void*)binop, 2, 240) {}
 
     Box* call(Box* lhs, Box* rhs, int op_type) { return (Box*)call_ptr(lhs, rhs, op_type); }
-};
-
-class CompareIC : public RuntimeIC {
-public:
-    CompareIC() : RuntimeIC((void*)compare, 2, 240) {}
-
-    Box* call(Box* lhs, Box* rhs, int op_type) { return (Box*)call_ptr(lhs, rhs, op_type); }
-};
-
-class GetItemIC : public RuntimeIC {
-public:
-    GetItemIC() : RuntimeIC((void*)getitem, 2, 512) {}
-
-    Box* call(Box* obj, Box* attr) { return (Box*)call_ptr(obj, attr); }
-};
-
-class SetItemIC : public RuntimeIC {
-public:
-    SetItemIC() : RuntimeIC((void*)setitem, 2, 512) {}
-
-    Box* call(Box* obj, Box* attr, Box* v) { return (Box*)call_ptr(obj, attr, v); }
-};
-
-class GetAttrIC : public RuntimeIC {
-public:
-    GetAttrIC() : RuntimeIC((void*)getattr, 2, 512) {}
-
-    Box* call(Box* obj, BoxedString* attr) { return (Box*)call_ptr(obj, attr); }
-};
-
-class SetAttrIC : public RuntimeIC {
-public:
-    SetAttrIC() : RuntimeIC((void*)setattr, 2, 512) {}
-
-    Box* call(Box* obj, BoxedString* attr, Box* v) { return (Box*)call_ptr(obj, attr, v); }
-};
-
-class GetGlobalIC : public RuntimeIC {
-public:
-    GetGlobalIC() : RuntimeIC((void*)getGlobal, 2, 512) {}
-
-    Box* call(Box* obj, BoxedString* s) { return (Box*)call_ptr(obj, s); }
-};
-
-class SetGlobalIC : public RuntimeIC {
-public:
-    SetGlobalIC() : RuntimeIC((void*)setGlobal, 2, 512) {}
-
-    Box* call(Box* obj, BoxedString* s, Box* v) { return (Box*)call_ptr(obj, s, v); }
 };
 
 class NonzeroIC : public RuntimeIC {

--- a/src/runtime/types.cpp
+++ b/src/runtime/types.cpp
@@ -932,6 +932,8 @@ static Box* typeCallInner(CallRewriteArgs* rewrite_args, ArgPassSpec argspec, Bo
                 rewrite_args->rewriter->call(true, (void*)assertInitNone, srewrite_args.out_rtn);
             }
         } else {
+            rewrite_args = NULL;
+
             init_attr = processDescriptor(init_attr, made, cls);
 
             ArgPassSpec init_argspec = argspec;


### PR DESCRIPTION
In order to speedup baseline JITed code directly emit patchpoints.
- reduces number of calls
- reduces number of EH frames
- supports stack args (currently hard coded to 8args)
- maybe slightly faster unwinding because of of reduced call nesting  

I choose to directly add the stack args support to the baseline jit instead of the rewriter because I think to get this right for all cases is harder and in the baseline jit I have special knowledge about the stack layout which makes it easier.

```
pyston django_template.py                 :    3.7s base_3: 3.9 (-4.0%)
pyston pyxl_bench.py                      :    3.4s base_3: 3.6 (-6.0%)
pyston sqlalchemy_imperative2.py          :    4.6s base_3: 4.7 (-2.0%)
pyston django_migrate.py                  :    1.7s base_3: 1.7 (-0.8%)
```