### PR TITLE
fix analysis unittests by not asserting clfunc is non-NULL

### DIFF
--- a/src/codegen/osrentry.h
+++ b/src/codegen/osrentry.h
@@ -31,7 +31,7 @@ struct StackMap;
 
 class OSREntryDescriptor {
 private:
-    OSREntryDescriptor(CLFunction* clfunc, AST_Jump* backedge) : clfunc(clfunc), backedge(backedge) { assert(clfunc); }
+    OSREntryDescriptor(CLFunction* clfunc, AST_Jump* backedge) : clfunc(clfunc), backedge(backedge) { }
 
 public:
     CLFunction* clfunc;


### PR DESCRIPTION
the analysis unittest creates an OSREntryDescriptor with clfunc=NULL.

Maybe the 'correct' fix is to change the unittest to not create an invalid OSREntryDescriptor, but I don't see an easy way to do that.