### PR TITLE
fix null check

### DIFF
--- a/src/gc/collector.cpp
+++ b/src/gc/collector.cpp
@@ -229,7 +229,7 @@ bool GCVisitor::isValid(void* p) {
 
 void GCVisitor::visit(void* p) {
     if ((uintptr_t)p < SMALL_ARENA_START || (uintptr_t)p >= HUGE_ARENA_START + ARENA_SIZE) {
-        ASSERT(isNonheapRoot(p), "%p", p);
+        ASSERT(!p || isNonheapRoot(p), "%p", p);
         return;
     }
 


### PR DESCRIPTION
sorry about that - for some reason I had it in my head that travis-ci still did quick_check against pyston_dbg