### PR TITLE
Slightly speedup ASTInterpreter::initArguments

### DIFF
--- a/src/core/types.h
+++ b/src/core/types.h
@@ -95,6 +95,7 @@ class AST;
 class AST_FunctionDef;
 class AST_arguments;
 class AST_expr;
+class AST_Name;
 class AST_stmt;
 
 class PhiAnalysis;
@@ -147,6 +148,12 @@ struct ParamNames {
     std::vector<llvm::StringRef> args;
     llvm::StringRef vararg, kwarg;
 
+    // This members are only set if the InternedStringPool& constructor is used (aka. source is available)!
+    // They are used as an optimization while interpreting because the AST_Names nodes cache important stuff
+    // (InternedString, lookup_type) which would otherwise have to get recomputed all the time.
+    std::vector<AST_Name*> arg_names;
+    AST_Name* vararg_name, *kwarg_name;
+
     explicit ParamNames(AST* ast, InternedStringPool& pool);
     ParamNames(const std::vector<llvm::StringRef>& args, llvm::StringRef vararg, llvm::StringRef kwarg);
     static ParamNames empty() { return ParamNames(); }
@@ -156,7 +163,7 @@ struct ParamNames {
     }
 
 private:
-    ParamNames() : takes_param_names(false) {}
+    ParamNames() : takes_param_names(false), vararg_name(NULL), kwarg_name(NULL) {}
 };
 
 // Probably overkill to copy this from ArgPassSpec


### PR DESCRIPTION
This function can get quite hot because now with the baseline jit we execute it much more often.
I'm not really excited about adding the ```InternedString``` fields to ```ParamNames``` but I don't know where to add them else.
```
                           e648044ce2266a3fc6:  b8f5647281593fc5ed:
       django_template.py             3.5s (4)             3.4s (4)  -0.7%
            pyxl_bench.py             3.3s (4)             3.3s (4)  -0.6%
sqlalchemy_imperative2.py             4.1s (4)             4.1s (4)  -0.7%
                  geomean                 3.6s                 3.6s  -0.7%
```