### PR TITLE
Convert "a in (b, c)" to "a == b or a == c"

### DIFF
--- a/src/codegen/compvars.cpp
+++ b/src/codegen/compvars.cpp
@@ -455,6 +455,10 @@ public:
         return new ConcreteCompilerVariable(UNKNOWN, rtn, true);
     }
 
+    CompilerVariable* contains(IREmitter& emitter, const OpInfo& info, VAR* var, CompilerVariable* lhs) override {
+        return lhs->binexp(emitter, info, var, AST_TYPE::In, Compare);
+    }
+
     Box* deserializeFromFrame(const FrameVals& vals) override {
         assert(vals.size() == 1);
         return reinterpret_cast<Box*>(vals[0]);
@@ -1081,6 +1085,10 @@ public:
         }
     }
 
+    CompilerVariable* contains(IREmitter& emitter, const OpInfo& info, VAR* var, CompilerVariable* lhs) override {
+        return makeBool(false);
+    }
+
     ConcreteCompilerType* getBoxType() override { return BOXED_INT; }
 
     Box* deserializeFromFrame(const FrameVals& vals) override {
@@ -1317,6 +1325,10 @@ public:
         CompilerVariable* rtn = converted->binexp(emitter, info, rhs, op_type, exp_type);
         converted->decvref(emitter);
         return rtn;
+    }
+
+    CompilerVariable* contains(IREmitter& emitter, const OpInfo& info, VAR* var, CompilerVariable* lhs) override {
+        return makeBool(false);
     }
 
     ConcreteCompilerType* getBoxType() override { return BOXED_FLOAT; }
@@ -1688,6 +1700,10 @@ public:
         return rtn;
     }
 
+    CompilerVariable* contains(IREmitter& emitter, const OpInfo& info, VAR* var, CompilerVariable* lhs) override {
+        return UNKNOWN->contains(emitter, info, var, lhs);
+    }
+
     CompilerVariable* getitem(IREmitter& emitter, const OpInfo& info, VAR* var, CompilerVariable* slice) override {
         static BoxedString* attr = static_cast<BoxedString*>(PyString_InternFromString("__getitem__"));
         bool no_attribute = false;
@@ -1914,6 +1930,13 @@ public:
         return rtn;
     }
 
+    CompilerVariable* contains(IREmitter& emitter, const OpInfo& info, VAR* var, CompilerVariable* lhs) override {
+        ConcreteCompilerVariable* converted = var->makeConverted(emitter, STR);
+        CompilerVariable* rtn = converted->contains(emitter, info, lhs);
+        converted->decvref(emitter);
+        return rtn;
+    }
+
     ConcreteCompilerVariable* nonzero(IREmitter& emitter, const OpInfo& info, VAR* var) override {
         return makeBool(var->getValue()->size() != 0);
     }
@@ -2031,6 +2054,10 @@ public:
         CompilerVariable* rtn = converted->binexp(emitter, info, rhs, op_type, exp_type);
         converted->decvref(emitter);
         return rtn;
+    }
+
+    CompilerVariable* contains(IREmitter& emitter, const OpInfo& info, VAR* var, CompilerVariable* lhs) override {
+        return makeBool(false);
     }
 
     ConcreteCompilerType* getBoxType() override { return BOXED_BOOL; }
@@ -2196,6 +2223,41 @@ public:
         return rtn;
     }
 
+    CompilerVariable* contains(IREmitter& emitter, const OpInfo& info, VAR* var, CompilerVariable* lhs) override {
+        llvm::SmallVector<std::pair<llvm::BasicBlock*, llvm::Value*>, 4> phi_incoming;
+
+        llvm::BasicBlock* end = emitter.createBasicBlock();
+
+        for (CompilerVariable* e : *var->getValue()) {
+            CompilerVariable* eq = lhs->binexp(emitter, info, e, AST_TYPE::Eq, Compare);
+            ConcreteCompilerVariable* eq_nonzero = eq->nonzero(emitter, info);
+            assert(eq_nonzero->getType() == BOOL);
+            llvm::Value* raw = i1FromBool(emitter, eq_nonzero);
+
+            phi_incoming.push_back(std::make_pair(emitter.currentBasicBlock(), getConstantInt(1, g.i1)));
+
+            llvm::BasicBlock* new_bb = emitter.createBasicBlock();
+            new_bb->moveAfter(emitter.currentBasicBlock());
+
+            emitter.getBuilder()->CreateCondBr(raw, end, new_bb);
+
+            emitter.setCurrentBasicBlock(new_bb);
+        }
+
+        // TODO This last block is unnecessary:
+        phi_incoming.push_back(std::make_pair(emitter.currentBasicBlock(), getConstantInt(0, g.i1)));
+        emitter.getBuilder()->CreateBr(end);
+
+        end->moveAfter(emitter.currentBasicBlock());
+        emitter.setCurrentBasicBlock(end);
+
+        auto phi = emitter.getBuilder()->CreatePHI(g.i1, phi_incoming.size());
+        for (auto p : phi_incoming) {
+            phi->addIncoming(p.second, p.first);
+        }
+        return boolFromI1(emitter, phi);
+    }
+
     CompilerVariable* callattr(IREmitter& emitter, const OpInfo& info, VAR* var, BoxedString* attr, CallattrFlags flags,
                                const std::vector<CompilerVariable*>& args,
                                const std::vector<BoxedString*>* keyword_names) override {
@@ -2317,6 +2379,10 @@ public:
 
     CompilerVariable* binexp(IREmitter& emitter, const OpInfo& info, VAR* var, CompilerVariable* rhs,
                              AST_TYPE::AST_TYPE op_type, BinExpType exp_type) override {
+        return undefVariable();
+    }
+
+    CompilerVariable* contains(IREmitter& emitter, const OpInfo& info, VAR* var, CompilerVariable* lhs) override {
         return undefVariable();
     }
 

--- a/src/codegen/compvars.h
+++ b/src/codegen/compvars.h
@@ -396,6 +396,9 @@ public:
 // assert(value->getType() == type->llvmType());
 //}
 
+// Emit the test for whether one variable 'is' another one.
+ConcreteCompilerVariable* doIs(IREmitter& emitter, CompilerVariable* lhs, CompilerVariable* rhs, bool negate);
+
 ConcreteCompilerVariable* makeBool(bool);
 ConcreteCompilerVariable* makeInt(int64_t);
 ConcreteCompilerVariable* makeFloat(double);

--- a/src/codegen/irgen/irgenerator.cpp
+++ b/src/codegen/irgen/irgenerator.cpp
@@ -766,6 +766,19 @@ private:
         assert(left);
         assert(right);
 
+        if (type == AST_TYPE::In || type == AST_TYPE::NotIn) {
+            CompilerVariable* r = right->contains(emitter, getOpInfoForNode(node, unw_info), left);
+            assert(r->getType() == BOOL);
+            if (type == AST_TYPE::NotIn) {
+                ConcreteCompilerVariable* converted = r->makeConverted(emitter, BOOL);
+                // TODO: would be faster to just do unboxBoolNegated
+                llvm::Value* raw = i1FromBool(emitter, converted);
+                raw = emitter.getBuilder()->CreateXor(raw, getConstantInt(1, g.i1));
+                r = boolFromI1(emitter, raw);
+            }
+            return r;
+        }
+
         return left->binexp(emitter, getOpInfoForNode(node, unw_info), right, type, exp_type);
     }
 

--- a/src/codegen/irgen/irgenerator.cpp
+++ b/src/codegen/irgen/irgenerator.cpp
@@ -816,17 +816,7 @@ private:
         assert(right);
 
         if (node->ops[0] == AST_TYPE::Is || node->ops[0] == AST_TYPE::IsNot) {
-            // TODO: I think we can do better here and not force the types to box themselves
-
-            ConcreteCompilerVariable* converted_left = left->makeConverted(emitter, UNKNOWN);
-            ConcreteCompilerVariable* converted_right = right->makeConverted(emitter, UNKNOWN);
-            llvm::Value* cmp;
-            if (node->ops[0] == AST_TYPE::Is)
-                cmp = emitter.getBuilder()->CreateICmpEQ(converted_left->getValue(), converted_right->getValue());
-            else
-                cmp = emitter.getBuilder()->CreateICmpNE(converted_left->getValue(), converted_right->getValue());
-
-            return boolFromI1(emitter, cmp);
+            return doIs(emitter, left, right, node->ops[0] == AST_TYPE::IsNot);
         }
 
         CompilerVariable* rtn = _evalBinExp(node, left, right, node->ops[0], Compare, unw_info);

--- a/src/codegen/irgen/util.cpp
+++ b/src/codegen/irgen/util.cpp
@@ -219,11 +219,11 @@ public:
                         if (!lookup_success) {
                             llvm::Constant* int_val
                                 = llvm::ConstantInt::get(g.i64, reinterpret_cast<uintptr_t>(addr), false);
-                            llvm::Constant* ptr_val = llvm::ConstantExpr::getIntToPtr(int_val, g.i8_ptr);
+                            llvm::Constant* ptr_val = llvm::ConstantExpr::getIntToPtr(int_val, g.i8);
                             ii->setArgOperand(i, ptr_val);
                             continue;
                         } else {
-                            ii->setArgOperand(i, module->getOrInsertGlobal(name, g.i8_ptr));
+                            ii->setArgOperand(i, module->getOrInsertGlobal(name, g.i8));
                         }
                     }
                 }

--- a/src/runtime/tuple.cpp
+++ b/src/runtime/tuple.cpp
@@ -223,10 +223,8 @@ Box* tupleNonzero(BoxedTuple* self) {
 
 Box* tupleContains(BoxedTuple* self, Box* elt) {
     int size = self->size();
-    for (int i = 0; i < size; i++) {
-        Box* e = self->elts[i];
-
-        int r = PyObject_RichCompareBool(e, elt, Py_EQ);
+    for (Box* e : *self) {
+        int r = PyObject_RichCompareBool(elt, e, Py_EQ);
         if (r == -1)
             throwCAPIException();
 

--- a/test/tests/tuples.py
+++ b/test/tests/tuples.py
@@ -221,3 +221,6 @@ try:
     print (1, 3, 5, 3).index(2)
 except ValueError as e:
     print e
+
+n = float('nan')
+print n in (n, n)


### PR DESCRIPTION
Not super common, but can seems to help since we are particularly bad at handling `a in (b, c)`.

```
       django_template.py             3.6s (2)             3.6s (2)  -0.5%
            pyxl_bench.py             3.5s (2)             3.5s (2)  -0.4%
sqlalchemy_imperative2.py             4.3s (2)             4.3s (2)  -0.9%
                  geomean                 3.8s                 3.8s  -0.6%
```