### PR TITLE
Get test_iter.py to work

### DIFF
--- a/from_cpython/Include/iterobject.h
+++ b/from_cpython/Include/iterobject.h
@@ -7,6 +7,15 @@
 extern "C" {
 #endif
 
+// Pyston change: moved this from iterobject.c
+typedef struct {
+    PyObject_HEAD
+    PyObject *it_callable; /* Set to NULL when iterator is exhausted */
+    PyObject *it_sentinel; /* Set to NULL when iterator is exhausted */
+    // Pyston changes:
+    PyObject *it_nextvalue; /* Set to non-null when iterator is advanced in __hasnext__ */
+} calliterobject;
+
 // Pyston change: this is no longer a static object
 //PyAPI_DATA(PyTypeObject) PySeqIter_Type;
 

--- a/from_cpython/Lib/test/test_iter.py
+++ b/from_cpython/Lib/test/test_iter.py
@@ -1,4 +1,3 @@
-# expected: fail
 # Test iterators.
 
 import unittest

--- a/from_cpython/Objects/iterobject.c
+++ b/from_cpython/Objects/iterobject.c
@@ -66,7 +66,7 @@ calliter_next(calliterobject *it)
                 Py_CLEAR(it->it_sentinel);
             }
         }
-        else if (PyErr_ExceptionMatches(PyExc_StopIteration) || PyErr_ExceptionMatches(PyExc_IndexError)) {
+        else if (PyErr_ExceptionMatches(PyExc_StopIteration)) {
             PyErr_Clear();
             Py_CLEAR(it->it_callable);
             Py_CLEAR(it->it_sentinel);

--- a/from_cpython/Objects/iterobject.c
+++ b/from_cpython/Objects/iterobject.c
@@ -4,15 +4,6 @@
 
 #include "Python.h"
 
-extern PyTypeObject PyCallIter_Type;
-typedef struct {
-    PyObject_HEAD
-    PyObject *it_callable; /* Set to NULL when iterator is exhausted */
-    PyObject *it_sentinel; /* Set to NULL when iterator is exhausted */
-    // Pyston changes:
-    PyObject *it_nextvalue; /* Set to non-null when iterator is advanced in __hasnext__ */
-} calliterobject;
-
 PyObject *
 PyCallIter_New(PyObject *callable, PyObject *sentinel)
 {
@@ -52,7 +43,7 @@ calliter_traverse(calliterobject *it, visitproc visit, void *arg)
 
 // Pyston change: extract most of the body of calliter_iternext here
 // so we can use it from both calliter_iternext and calliter_hasnext
-static PyObject *
+PyObject *
 calliter_next(calliterobject *it)
 {
     if (it->it_callable != NULL) {
@@ -75,7 +66,7 @@ calliter_next(calliterobject *it)
                 Py_CLEAR(it->it_sentinel);
             }
         }
-        else if (PyErr_ExceptionMatches(PyExc_StopIteration)) {
+        else if (PyErr_ExceptionMatches(PyExc_StopIteration) || PyErr_ExceptionMatches(PyExc_IndexError)) {
             PyErr_Clear();
             Py_CLEAR(it->it_callable);
             Py_CLEAR(it->it_sentinel);
@@ -97,24 +88,6 @@ calliter_iternext(calliterobject *it)
 
     return calliter_next(it);
 }
-
-// Pyston addition: __hasnext__ based iteration
-static int
-calliter_hasnext(calliterobject *it)
-{
-    if (!it->it_nextvalue) {
-        it->it_nextvalue = calliter_next(it);
-    }
-    return it->it_nextvalue != NULL;
-}
-
-// Pyston change: give iter objects a __hasnext__ method
-void
-PyCallIter_AddHasNext()
-{
-    PyCallIter_Type._tpp_hasnext = calliter_hasnext;
-}
-
 
 PyTypeObject PyCallIter_Type = {
     // Pyston change:

--- a/src/capi/abstract.cpp
+++ b/src/capi/abstract.cpp
@@ -1542,13 +1542,11 @@ extern "C" int PySequence_DelSlice(PyObject* o, Py_ssize_t i1, Py_ssize_t i2) no
 }
 
 extern "C" Py_ssize_t PySequence_Count(PyObject* o, PyObject* value) noexcept {
-    fatalOrError(PyExc_NotImplementedError, "unimplemented");
-    return -1;
+    return _PySequence_IterSearch(o, value, PY_ITERSEARCH_COUNT);
 }
 
 extern "C" Py_ssize_t PySequence_Index(PyObject* o, PyObject* value) noexcept {
-    fatalOrError(PyExc_NotImplementedError, "unimplemented");
-    return -1;
+    return _PySequence_IterSearch(o, value, PY_ITERSEARCH_INDEX);
 }
 
 extern "C" PyObject* PyObject_CallFunction(PyObject* callable, const char* format, ...) noexcept {

--- a/src/codegen/compvars.cpp
+++ b/src/codegen/compvars.cpp
@@ -1086,7 +1086,10 @@ public:
     }
 
     CompilerVariable* contains(IREmitter& emitter, const OpInfo& info, VAR* var, CompilerVariable* lhs) override {
-        return makeBool(false);
+        llvm::CallSite call
+            = emitter.createCall(info.unw_info, g.funcs.raiseNotIterableError, embedConstantPtr("int", g.i8_ptr));
+        call.setDoesNotReturn();
+        return new ConcreteCompilerVariable(BOOL, llvm::UndefValue::get(BOOL->llvmType()), true);
     }
 
     ConcreteCompilerType* getBoxType() override { return BOXED_INT; }
@@ -1330,7 +1333,10 @@ public:
     }
 
     CompilerVariable* contains(IREmitter& emitter, const OpInfo& info, VAR* var, CompilerVariable* lhs) override {
-        return makeBool(false);
+        llvm::CallSite call
+            = emitter.createCall(info.unw_info, g.funcs.raiseNotIterableError, embedConstantPtr("float", g.i8_ptr));
+        call.setDoesNotReturn();
+        return new ConcreteCompilerVariable(BOOL, llvm::UndefValue::get(BOOL->llvmType()), true);
     }
 
     ConcreteCompilerType* getBoxType() override { return BOXED_FLOAT; }
@@ -2059,7 +2065,10 @@ public:
     }
 
     CompilerVariable* contains(IREmitter& emitter, const OpInfo& info, VAR* var, CompilerVariable* lhs) override {
-        return makeBool(false);
+        llvm::CallSite call
+            = emitter.createCall(info.unw_info, g.funcs.raiseNotIterableError, embedConstantPtr("bool", g.i8_ptr));
+        call.setDoesNotReturn();
+        return new ConcreteCompilerVariable(BOOL, llvm::UndefValue::get(BOOL->llvmType()), true);
     }
 
     ConcreteCompilerType* getBoxType() override { return BOXED_BOOL; }

--- a/src/runtime/inline/list.cpp
+++ b/src/runtime/inline/list.cpp
@@ -39,21 +39,42 @@ Box* listiterHasnext(Box* s) {
     assert(s->cls == list_iterator_cls);
     BoxedListIterator* self = static_cast<BoxedListIterator*>(s);
 
-    return boxBool(self->pos < self->l->size);
+    if (!self->l) {
+        raiseExcHelper(StopIteration, "");
+    }
+
+    bool ans = (self->pos < self->l->size);
+    if (!ans) {
+        self->l = NULL;
+    }
+    return boxBool(ans);
 }
 
 i1 listiterHasnextUnboxed(Box* s) {
     assert(s->cls == list_iterator_cls);
     BoxedListIterator* self = static_cast<BoxedListIterator*>(s);
 
-    return self->pos < self->l->size;
+    if (!self->l) {
+        raiseExcHelper(StopIteration, "");
+    }
+
+    bool ans = (self->pos < self->l->size);
+    if (!ans) {
+        self->l = NULL;
+    }
+    return ans;
 }
 
 Box* listiterNext(Box* s) {
     assert(s->cls == list_iterator_cls);
     BoxedListIterator* self = static_cast<BoxedListIterator*>(s);
 
+    if (!self->l) {
+        raiseExcHelper(StopIteration, "");
+    }
+
     if (!(self->pos >= 0 && self->pos < self->l->size)) {
+        self->l = NULL;
         raiseExcHelper(StopIteration, "");
     }
 

--- a/src/runtime/inline/list.cpp
+++ b/src/runtime/inline/list.cpp
@@ -40,7 +40,7 @@ Box* listiterHasnext(Box* s) {
     BoxedListIterator* self = static_cast<BoxedListIterator*>(s);
 
     if (!self->l) {
-        raiseExcHelper(StopIteration, "");
+        return False;
     }
 
     bool ans = (self->pos < self->l->size);
@@ -55,7 +55,7 @@ i1 listiterHasnextUnboxed(Box* s) {
     BoxedListIterator* self = static_cast<BoxedListIterator*>(s);
 
     if (!self->l) {
-        raiseExcHelper(StopIteration, "");
+        return false;
     }
 
     bool ans = (self->pos < self->l->size);

--- a/src/runtime/iterobject.cpp
+++ b/src/runtime/iterobject.cpp
@@ -28,6 +28,8 @@
 #include "runtime/types.h"
 #include "runtime/util.h"
 
+extern "C" PyObject* calliter_next(calliterobject* it);
+
 namespace pyston {
 
 BoxedClass* seqiter_cls;
@@ -43,11 +45,19 @@ bool seqiterHasnextUnboxed(Box* s) {
     RELEASE_ASSERT(s->cls == seqiter_cls || s->cls == seqreviter_cls, "");
     BoxedSeqIter* self = static_cast<BoxedSeqIter*>(s);
 
+    if (!self->b) {
+        return false;
+    }
+
     Box* next;
     try {
         next = getitem(self->b, boxInt(self->idx));
     } catch (ExcInfo e) {
-        return false;
+        if (e.matches(IndexError) || e.matches(StopIteration)) {
+            self->b = NULL;
+            return false;
+        } else
+            throw e;
     }
     self->idx++;
     self->next = next;
@@ -58,11 +68,19 @@ Box* seqiterHasnext(Box* s) {
     RELEASE_ASSERT(s->cls == seqiter_cls || s->cls == seqreviter_cls, "");
     BoxedSeqIter* self = static_cast<BoxedSeqIter*>(s);
 
+    if (!self->b) {
+        return False;
+    }
+
     Box* next;
     try {
         next = getitem(self->b, boxInt(self->idx));
     } catch (ExcInfo e) {
-        return False;
+        if (e.matches(IndexError) || e.matches(StopIteration)) {
+            self->b = NULL;
+            return False;
+        } else
+            throw e;
     }
     self->idx++;
     self->next = next;
@@ -73,13 +91,17 @@ Box* seqreviterHasnext(Box* s) {
     RELEASE_ASSERT(s->cls == seqiter_cls || s->cls == seqreviter_cls, "");
     BoxedSeqIter* self = static_cast<BoxedSeqIter*>(s);
 
-    if (self->idx == -1)
+    if (self->idx == -1 || !self->b)
         return False;
     Box* next;
     try {
         next = getitem(self->b, boxInt(self->idx));
     } catch (ExcInfo e) {
-        return False;
+        if (e.matches(IndexError) || e.matches(StopIteration)) {
+            self->b = NULL;
+            return False;
+        } else
+            throw e;
     }
     self->idx--;
     self->next = next;
@@ -164,6 +186,18 @@ extern "C" PyObject* PySeqIter_New(PyObject* seq) noexcept {
         return NULL;
     }
 }
+
+bool calliter_hasnext(Box* b) {
+    calliterobject* it = (calliterobject*)b;
+    if (!it->it_nextvalue) {
+        it->it_nextvalue = calliter_next(it);
+        if (PyErr_Occurred()) {
+            throwCAPIException();
+        }
+    }
+    return it->it_nextvalue != NULL;
+}
+
 
 void setupIter() {
     seqiter_cls

--- a/src/runtime/iterobject.h
+++ b/src/runtime/iterobject.h
@@ -51,6 +51,8 @@ public:
     DEFAULT_CLASS(iterwrapper_cls);
 };
 
+bool calliter_hasnext(Box* b);
+
 void setupIter();
 }
 

--- a/src/runtime/objmodel.cpp
+++ b/src/runtime/objmodel.cpp
@@ -4230,7 +4230,7 @@ Box* compareInternal(Box* lhs, Box* rhs, int op_type, CompareRewriteArgs* rewrit
             if (result < 0)
                 throwCAPIException();
             assert(result == 0 || result == 1);
-            return boxBool(result);
+            return boxBool(op_type == AST_TYPE::NotIn ? !result : result);
         }
 
         if (rewrite_args) {
@@ -4893,8 +4893,12 @@ Box* getiter(Box* o) {
     // TODO add rewriting to this?  probably want to try to avoid this path though
     static BoxedString* iter_str = internStringImmortal("__iter__");
     Box* r = callattrInternal0(o, iter_str, LookupScope::CLASS_ONLY, NULL, ArgPassSpec(0));
-    if (r)
+    if (r) {
+        if (!PyIter_Check(r)) {
+            raiseExcHelper(TypeError, "iter() returned non-iterator of type '%s'", r->cls->tp_name);
+        }
         return r;
+    }
     return getiterHelper(o);
 }
 

--- a/src/runtime/types.cpp
+++ b/src/runtime/types.cpp
@@ -2793,8 +2793,6 @@ inline void initUserAttrs(Box* obj, BoxedClass* cls) {
     }
 }
 
-extern "C" void PyCallIter_AddHasNext();
-
 extern "C" PyVarObject* PyObject_InitVar(PyVarObject* op, PyTypeObject* tp, Py_ssize_t size) noexcept {
     assert(op);
     assert(tp);
@@ -3476,8 +3474,10 @@ void setupRuntime() {
 
     PyType_Ready(&PyByteArrayIter_Type);
     PyType_Ready(&PyCapsule_Type);
-    PyCallIter_AddHasNext();
+
+    PyCallIter_Type.tpp_hasnext = calliter_hasnext;
     PyType_Ready(&PyCallIter_Type);
+
     PyType_Ready(&PyCObject_Type);
     PyType_Ready(&PyDictProxy_Type);
 


### PR DESCRIPTION
I need to clean this up, maybe write some tests for ourselves, but this nearly gets `test/cpython/test_iter.py` working.

There was a function `calliter_hasnext` in `from_cpython/Objects/iterobject.c`. It needs to throw exceptions, so I moved it to our own `iter.cpp`.

The behavior of `filter` depends on the type of its input. For filtering strings, I used cpython's code; for filtering tuples I wrote my own. I should probably pick a style. I guess `test_iter.py` doesn't implement filtering unicode, but I guess I should do that too.

The test is still throwing one exception:

```
d = {"one": 1, "two": 2, "three": 3, 1j: 2j}
for k in d:                                 
    self.assertIn(k, d)                     
    self.assertNotIn(k, d.itervalues())     
for v in d.values():                        
    self.assertIn(v, d.itervalues())
    self.assertNotIn(v, d)        
```

I have no idea why. But it's 2am, so I'll just put it up here to run tests and finish it up tomorrow.