### PR TITLE
speed calling of (some) capi code

### DIFF
--- a/from_cpython/Include/methodobject.h
+++ b/from_cpython/Include/methodobject.h
@@ -83,6 +83,14 @@ PyAPI_FUNC(PyObject *) PyCFunction_NewEx(PyMethodDef *, PyObject *,
 
 #define METH_COEXIST   0x0040
 
+/* Pyston additions: */
+#define METH_O2        0x0080
+#define METH_O3        (METH_O | METH_O2)
+// The number of defaults:
+#define METH_D1        0x0200
+#define METH_D2        0x0400
+#define METH_D3        (METH_D1 | METH_D2)
+
 typedef struct PyMethodChain {
     PyMethodDef *methods;		/* Methods of this type */
     struct PyMethodChain *link;	/* NULL or base type */

--- a/from_cpython/Objects/stringobject.c
+++ b/from_cpython/Objects/stringobject.c
@@ -24,15 +24,25 @@ PyObject * _do_string_format(PyObject *self, PyObject *args, PyObject *kwargs) {
 }
 
 PyObject *
-string_count(PyStringObject *self, PyObject *args)
+string_count(PyStringObject *self,
+             PyObject *sub_obj, PyObject* obj_start, PyObject** args)
 {
-    PyObject *sub_obj;
     const char *str = PyString_AS_STRING(self), *sub;
     Py_ssize_t sub_len;
     Py_ssize_t start = 0, end = PY_SSIZE_T_MAX;
+    PyObject* obj_end = args[0];
 
+    /*
     if (!stringlib_parse_args_finds("count", args, &sub_obj, &start, &end))
         return NULL;
+    */
+
+    if (obj_start && obj_start != Py_None)
+        if (!_PyEval_SliceIndex(obj_start, &start))
+            return 0;
+    if (obj_end && obj_end != Py_None)
+        if (!_PyEval_SliceIndex(obj_end, &end))
+            return 0;
 
     if (PyString_Check(sub_obj)) {
         sub = PyString_AS_STRING(sub_obj);

--- a/from_cpython/Objects/unicodeobject.c
+++ b/from_cpython/Objects/unicodeobject.c
@@ -6300,16 +6300,31 @@ Unicode string S[start:end].  Optional arguments start and end are\n\
 interpreted as in slice notation.");
 
 static PyObject *
-unicode_count(PyUnicodeObject *self, PyObject *args)
+unicode_count(PyUnicodeObject *self,
+              PyObject *subobj, PyObject* obj_start, PyObject** args)
 {
     PyUnicodeObject *substring;
     Py_ssize_t start = 0;
     Py_ssize_t end = PY_SSIZE_T_MAX;
     PyObject *result;
+    PyObject* obj_end = args[0];
 
+    /*
     if (!stringlib_parse_args_finds_unicode("count", args, &substring,
                                             &start, &end))
         return NULL;
+    */
+
+    if (obj_start && obj_start != Py_None)
+        if (!_PyEval_SliceIndex(obj_start, &start))
+            return 0;
+    if (obj_end && obj_end != Py_None)
+        if (!_PyEval_SliceIndex(obj_end, &end))
+            return 0;
+
+    substring = (PyUnicodeObject*)PyUnicode_FromObject(subobj);
+    if (!substring)
+        return 0;
 
     ADJUST_INDICES(start, end, self->length);
     result = PyInt_FromSsize_t(
@@ -7656,16 +7671,26 @@ prefix can also be a tuple of strings to try.");
 
 static PyObject *
 unicode_startswith(PyUnicodeObject *self,
-                   PyObject *args)
+                   PyObject *subobj, PyObject* obj_start, PyObject** args)
 {
-    PyObject *subobj;
     PyUnicodeObject *substring;
     Py_ssize_t start = 0;
     Py_ssize_t end = PY_SSIZE_T_MAX;
     int result;
+    PyObject* obj_end = args[0];
 
+    /*
     if (!stringlib_parse_args_finds("startswith", args, &subobj, &start, &end))
         return NULL;
+    */
+
+    if (obj_start && obj_start != Py_None)
+        if (!_PyEval_SliceIndex(obj_start, &start))
+            return 0;
+    if (obj_end && obj_end != Py_None)
+        if (!_PyEval_SliceIndex(obj_end, &end))
+            return 0;
+
     if (PyTuple_Check(subobj)) {
         Py_ssize_t i;
         for (i = 0; i < PyTuple_GET_SIZE(subobj); i++) {
@@ -7814,7 +7839,7 @@ static PyMethodDef unicode_methods[] = {
     {"capitalize", (PyCFunction) unicode_capitalize, METH_NOARGS, capitalize__doc__},
     {"title", (PyCFunction) unicode_title, METH_NOARGS, title__doc__},
     {"center", (PyCFunction) unicode_center, METH_VARARGS, center__doc__},
-    {"count", (PyCFunction) unicode_count, METH_VARARGS, count__doc__},
+    {"count", (PyCFunction) unicode_count, METH_O3 | METH_D2, count__doc__},
     {"expandtabs", (PyCFunction) unicode_expandtabs, METH_VARARGS, expandtabs__doc__},
     {"find", (PyCFunction) unicode_find, METH_VARARGS, find__doc__},
     {"partition", (PyCFunction) unicode_partition, METH_O, partition__doc__},
@@ -7834,7 +7859,7 @@ static PyMethodDef unicode_methods[] = {
     {"swapcase", (PyCFunction) unicode_swapcase, METH_NOARGS, swapcase__doc__},
     {"translate", (PyCFunction) unicode_translate, METH_O, translate__doc__},
     {"upper", (PyCFunction) unicode_upper, METH_NOARGS, upper__doc__},
-    {"startswith", (PyCFunction) unicode_startswith, METH_VARARGS, startswith__doc__},
+    {"startswith", (PyCFunction) unicode_startswith, METH_O3 | METH_D2, startswith__doc__},
     {"endswith", (PyCFunction) unicode_endswith, METH_VARARGS, endswith__doc__},
     {"islower", (PyCFunction) unicode_islower, METH_NOARGS, islower__doc__},
     {"isupper", (PyCFunction) unicode_isupper, METH_NOARGS, isupper__doc__},

--- a/microbenchmarks/django_parsing.py
+++ b/microbenchmarks/django_parsing.py
@@ -3,13 +3,9 @@ import sys
 sys.path.append(os.path.join(os.path.dirname(__file__), "../test/integration/django"))
 
 from django.template.base import Lexer, Parser
+from django.conf import settings
+from django.apps import apps
 import time
-
-try:
-    import __pyston__
-    pyston_loaded = True
-except:
-    pyston_loaded = False
 
 template_source = u"""
 {% extends "admin/base_site.html" %}
@@ -96,8 +92,21 @@ template_source = u"""
 {% endblock %}
 """
 
+settings.configure()
+
+apps.populate((
+    'django.contrib.admin',
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'django.contrib.sessions',
+    'django.contrib.messages',
+    'django.contrib.staticfiles',
+))
+
 elapsed = 0
-for i in xrange(10000):
-    # print i
-    lexer = Lexer(template_source, None)
-    lexer.tokenize()
+lexer = Lexer(template_source, None)
+tokens = lexer.tokenize()
+
+for i in xrange(500):
+    parser = Parser(list(tokens))
+    parser.parse()

--- a/src/runtime/str.cpp
+++ b/src/runtime/str.cpp
@@ -2655,7 +2655,7 @@ static PyBufferProcs string_as_buffer = {
 };
 
 static PyMethodDef string_methods[] = {
-    { "count", (PyCFunction)string_count, METH_VARARGS, NULL },
+    { "count", (PyCFunction)string_count, METH_O3 | METH_D2, NULL },
     { "join", (PyCFunction)string_join, METH_O, NULL },
     { "split", (PyCFunction)string_split, METH_VARARGS, NULL },
     { "rsplit", (PyCFunction)string_rsplit, METH_VARARGS, NULL },

--- a/src/runtime/types.cpp
+++ b/src/runtime/types.cpp
@@ -2906,6 +2906,13 @@ extern "C" PyUnicodeObject* _PyUnicode_New(Py_ssize_t length) noexcept {
     if (!str)
         return (PyUnicodeObject*)PyErr_NoMemory();
 
+#if STAT_ALLOCATIONS
+    {
+        size_t size = sizeof(PyUnicodeObject);
+        ALLOC_STATS(unicode_cls);
+    }
+#endif
+
     // Do a bunch of inlining + constant folding of this line of CPython's:
     // unicode = PyObject_New(PyUnicodeObject, &PyUnicode_Type);
     assert(PyUnicode_Type.tp_basicsize == sizeof(PyUnicodeObject)); // use the compile-time constant


### PR DESCRIPTION
by introducing some new calling conventions that we are able to jit to.  helps those functions a lot but maybe this isn't a huge deal overall (or maybe I need to add it to more places):
```
       django_template.py             3.6s (2)             3.6s (2)  -0.4%
            pyxl_bench.py             3.4s (2)             3.4s (2)  +0.1%
sqlalchemy_imperative2.py             4.3s (2)             4.3s (2)  +0.5%
         django_lexing.py             1.8s (2)             1.7s (2)  -6.4%
```