### PR TITLE
reenable PyList macros

### DIFF
--- a/from_cpython/Include/listobject.h
+++ b/from_cpython/Include/listobject.h
@@ -20,8 +20,6 @@ returned item's reference count.
 extern "C" {
 #endif
 
-// Pyston change: comment this out since this is not the format we're using
-#if 0
 typedef struct {
     PyObject_VAR_HEAD
     /* Vector of pointers to list elements.  list[0] is ob_item[0], etc. */
@@ -40,9 +38,6 @@ typedef struct {
      */
     Py_ssize_t allocated;
 } PyListObject;
-#endif
-struct _PyListObject;
-typedef struct _PyListObject PyListObject;
 
 // Pyston change: this is no longer a static object
 PyAPI_DATA(PyTypeObject*) list_cls;
@@ -69,13 +64,9 @@ PyAPI_FUNC(PyObject *) _PyList_Extend(PyListObject *, PyObject *) PYSTON_NOEXCEP
 PyAPI_FUNC(PyObject **) PyList_Items(PyObject *) PYSTON_NOEXCEPT;
 
 /* Macro, trading safety for speed */
-// Pyston changes: these aren't direct macros any more [they potentially could be though]
-#define PyList_GET_ITEM(op, i) PyList_GetItem((PyObject*)(op), (i))
-#define PyList_SET_ITEM(op, i, v) PyList_SetItem((PyObject*)(op), (i), (v))
-#define PyList_GET_SIZE(op)    PyList_Size((PyObject*)(op))
-//#define PyList_GET_ITEM(op, i) (((PyListObject *)(op))->ob_item[i])
-//#define PyList_SET_ITEM(op, i, v) (((PyListObject *)(op))->ob_item[i] = (v))
-//#define PyList_GET_SIZE(op)    Py_SIZE(op)
+#define PyList_GET_ITEM(op, i) (((PyListObject *)(op))->ob_item[i])
+#define PyList_SET_ITEM(op, i, v) (((PyListObject *)(op))->ob_item[i] = (v))
+#define PyList_GET_SIZE(op)    Py_SIZE(op)
 
 #ifdef __cplusplus
 }

--- a/src/runtime/inline/list.cpp
+++ b/src/runtime/inline/list.cpp
@@ -115,8 +115,6 @@ void BoxedList::shrink() {
 
 
 extern "C" void listAppendArrayInternal(Box* s, Box** v, int nelts) {
-    // Lock must be held!
-
     assert(isSubclass(s->cls, list_cls));
     BoxedList* self = static_cast<BoxedList*>(s);
 
@@ -133,8 +131,6 @@ extern "C" void listAppendArrayInternal(Box* s, Box** v, int nelts) {
 extern "C" Box* listAppend(Box* s, Box* v) {
     assert(isSubclass(s->cls, list_cls));
     BoxedList* self = static_cast<BoxedList*>(s);
-
-    LOCK_REGION(self->lock.asWrite());
 
     listAppendInternal(self, v);
 

--- a/src/runtime/list.cpp
+++ b/src/runtime/list.cpp
@@ -63,8 +63,6 @@ extern "C" PyObject* PyList_AsTuple(PyObject* v) noexcept {
 }
 
 extern "C" Box* listRepr(BoxedList* self) {
-    LOCK_REGION(self->lock.asRead());
-
     // TODO highly inefficient with all the string copying
 
     std::string O("");
@@ -89,8 +87,6 @@ extern "C" Box* listNonzero(BoxedList* self) {
 }
 
 extern "C" Box* listPop(BoxedList* self, Box* idx) {
-    LOCK_REGION(self->lock.asWrite());
-
     if (idx == None) {
         if (self->size == 0) {
             raiseExcHelper(IndexError, "pop from empty list");
@@ -190,8 +186,6 @@ static Box* list_slice(Box* o, Py_ssize_t ilow, Py_ssize_t ihigh) noexcept {
 }
 
 extern "C" Box* listGetitemUnboxed(BoxedList* self, int64_t n) {
-    LOCK_REGION(self->lock.asRead());
-
     assert(isSubclass(self->cls, list_cls));
     if (n < 0)
         n = self->size + n;
@@ -219,8 +213,6 @@ extern "C" PyObject* PyList_GetItem(PyObject* op, Py_ssize_t i) noexcept {
 }
 
 extern "C" Box* listGetitemSlice(BoxedList* self, BoxedSlice* slice) {
-    LOCK_REGION(self->lock.asRead());
-
     assert(isSubclass(self->cls, list_cls));
     assert(slice->cls == slice_cls);
     i64 start, stop, step, length;
@@ -254,8 +246,6 @@ static void _listSetitem(BoxedList* self, int64_t n, Box* v) {
 }
 
 extern "C" Box* listSetitemUnboxed(BoxedList* self, int64_t n, Box* v) {
-    // I think r lock is ok here, since we don't change the list structure:
-    LOCK_REGION(self->lock.asRead());
     assert(isSubclass(self->cls, list_cls));
     _listSetitem(self, n, v);
     return None;
@@ -420,8 +410,6 @@ int list_ass_ext_slice(BoxedList* self, PyObject* item, PyObject* value) {
 }
 
 extern "C" Box* listSetitemSlice(BoxedList* self, BoxedSlice* slice, Box* v) {
-    LOCK_REGION(self->lock.asWrite());
-
     assert(isSubclass(self->cls, list_cls));
     assert(slice->cls == slice_cls);
 
@@ -516,8 +504,6 @@ extern "C" Box* listSetitem(BoxedList* self, Box* slice, Box* v) {
 }
 
 extern "C" Box* listDelitemInt(BoxedList* self, BoxedInt* slice) {
-    LOCK_REGION(self->lock.asWrite());
-
     int64_t n = slice->n;
     if (n < 0)
         n = self->size + n;
@@ -535,8 +521,6 @@ extern "C" Box* listDelitemSlice(BoxedList* self, BoxedSlice* slice) {
 }
 
 extern "C" Box* listDelitem(BoxedList* self, Box* slice) {
-    LOCK_REGION(self->lock.asWrite());
-
     Box* rtn;
     if (PyIndex_Check(slice)) {
         Py_ssize_t i = PyNumber_AsSsize_t(slice, PyExc_IndexError);
@@ -556,8 +540,6 @@ extern "C" Box* listInsert(BoxedList* self, Box* idx, Box* v) {
     if (idx->cls != int_cls) {
         raiseExcHelper(TypeError, "an integer is required");
     }
-
-    LOCK_REGION(self->lock.asWrite());
 
     int64_t n = static_cast<BoxedInt*>(idx)->n;
     if (n < 0)
@@ -603,8 +585,6 @@ Box* listMul(BoxedList* self, Box* rhs) {
         raiseExcHelper(TypeError, "can't multiply sequence by non-int of type '%s'", getTypeName(rhs));
     }
 
-    LOCK_REGION(self->lock.asRead());
-
     int n = static_cast<BoxedInt*>(rhs)->n;
     int s = self->size;
 
@@ -624,8 +604,6 @@ Box* listMul(BoxedList* self, Box* rhs) {
 }
 
 Box* listIAdd(BoxedList* self, Box* _rhs) {
-    LOCK_REGION(self->lock.asWrite());
-
     if (_rhs->cls == list_cls) {
         // This branch is safe if self==rhs:
         BoxedList* rhs = static_cast<BoxedList*>(_rhs);
@@ -656,8 +634,6 @@ Box* listAdd(BoxedList* self, Box* _rhs) {
         raiseExcHelper(TypeError, "can only concatenate list (not \"%s\") to list", getTypeName(_rhs));
     }
 
-    LOCK_REGION(self->lock.asRead());
-
     BoxedList* rhs = static_cast<BoxedList*>(_rhs);
 
     BoxedList* rtn = new BoxedList();
@@ -673,8 +649,6 @@ Box* listAdd(BoxedList* self, Box* _rhs) {
 }
 
 Box* listReverse(BoxedList* self) {
-    LOCK_REGION(self->lock.asWrite());
-
     assert(isSubclass(self->cls, list_cls));
     for (int i = 0, j = self->size - 1; i < j; i++, j--) {
         Box* e = self->elts->elts[i];
@@ -715,7 +689,6 @@ public:
 };
 
 void listSort(BoxedList* self, Box* cmp, Box* key, Box* reverse) {
-    LOCK_REGION(self->lock.asWrite());
     assert(isSubclass(self->cls, list_cls));
 
     if (cmp == None)
@@ -813,8 +786,6 @@ extern "C" Box* PyList_GetSlice(PyObject* a, Py_ssize_t ilow, Py_ssize_t ihigh) 
 }
 
 Box* listContains(BoxedList* self, Box* elt) {
-    LOCK_REGION(self->lock.asRead());
-
     int size = self->size;
     for (int i = 0; i < size; i++) {
         Box* e = self->elts->elts[i];
@@ -834,8 +805,6 @@ Box* listContains(BoxedList* self, Box* elt) {
 }
 
 Box* listCount(BoxedList* self, Box* elt) {
-    LOCK_REGION(self->lock.asRead());
-
     int size = self->size;
     int count = 0;
 
@@ -853,8 +822,6 @@ Box* listCount(BoxedList* self, Box* elt) {
 }
 
 Box* listIndex(BoxedList* self, Box* elt, BoxedInt* _start, Box** args) {
-    LOCK_REGION(self->lock.asRead());
-
     BoxedInt* _stop = (BoxedInt*)args[0];
     RELEASE_ASSERT(!_start || _start->cls == int_cls, "");
     RELEASE_ASSERT(!_stop || _stop->cls == int_cls, "");
@@ -890,8 +857,6 @@ Box* listIndex(BoxedList* self, Box* elt, BoxedInt* _start, Box** args) {
 }
 
 Box* listRemove(BoxedList* self, Box* elt) {
-    LOCK_REGION(self->lock.asWrite());
-
     assert(isSubclass(self->cls, list_cls));
 
     for (int i = 0; i < self->size; i++) {
@@ -1017,8 +982,6 @@ Box* listEq(BoxedList* self, Box* rhs) {
         return NotImplemented;
     }
 
-    LOCK_REGION(self->lock.asRead());
-
     return _listCmp(self, static_cast<BoxedList*>(rhs), AST_TYPE::Eq);
 }
 
@@ -1026,8 +989,6 @@ Box* listNe(BoxedList* self, Box* rhs) {
     if (!isSubclass(rhs->cls, list_cls)) {
         return NotImplemented;
     }
-
-    LOCK_REGION(self->lock.asRead());
 
     return _listCmp(self, static_cast<BoxedList*>(rhs), AST_TYPE::NotEq);
 }
@@ -1037,8 +998,6 @@ Box* listLt(BoxedList* self, Box* rhs) {
         return NotImplemented;
     }
 
-    LOCK_REGION(self->lock.asRead());
-
     return _listCmp(self, static_cast<BoxedList*>(rhs), AST_TYPE::Lt);
 }
 
@@ -1046,8 +1005,6 @@ Box* listLe(BoxedList* self, Box* rhs) {
     if (!isSubclass(rhs->cls, list_cls)) {
         return NotImplemented;
     }
-
-    LOCK_REGION(self->lock.asRead());
 
     return _listCmp(self, static_cast<BoxedList*>(rhs), AST_TYPE::LtE);
 }
@@ -1057,8 +1014,6 @@ Box* listGt(BoxedList* self, Box* rhs) {
         return NotImplemented;
     }
 
-    LOCK_REGION(self->lock.asRead());
-
     return _listCmp(self, static_cast<BoxedList*>(rhs), AST_TYPE::Gt);
 }
 
@@ -1066,8 +1021,6 @@ Box* listGe(BoxedList* self, Box* rhs) {
     if (!isSubclass(rhs->cls, list_cls)) {
         return NotImplemented;
     }
-
-    LOCK_REGION(self->lock.asRead());
 
     return _listCmp(self, static_cast<BoxedList*>(rhs), AST_TYPE::GtE);
 }

--- a/src/runtime/types.h
+++ b/src/runtime/types.h
@@ -602,6 +602,12 @@ public:
 
     DEFAULT_CLASS_SIMPLE(list_cls);
 };
+static_assert(sizeof(BoxedList) <= sizeof(PyListObject), "");
+static_assert(sizeof(BoxedList) >= sizeof(PyListObject), "");
+static_assert(offsetof(BoxedList, size) == offsetof(PyListObject, ob_size), "");
+static_assert(offsetof(BoxedList, elts) == offsetof(PyListObject, ob_item), "");
+static_assert(offsetof(GCdArray, elts) == 0, "");
+static_assert(offsetof(BoxedList, capacity) == offsetof(PyListObject, allocated), "");
 
 class BoxedTuple : public BoxVar {
 public:

--- a/src/runtime/types.h
+++ b/src/runtime/types.h
@@ -590,10 +590,9 @@ private:
     void grow(int min_free);
 
 public:
-    int64_t size, capacity;
+    Py_ssize_t size;
     GCdArray* elts;
-
-    DS_DEFINE_MUTEX(lock);
+    Py_ssize_t capacity;
 
     BoxedList() __attribute__((visibility("default"))) : size(0), capacity(0) {}
 


### PR DESCRIPTION
Our list object format was pretty close to CPython's -- we had two fields flipped, and I guess some extra padding from an empty structure.  Fixing that allows C API code to use the PyList macros for direct field access, which can significantly speed up list-heavy benchmarks.  which apparently none of ours are:
```
       django_template.py             3.6s (2)             3.7s (2)  +0.6%
            pyxl_bench.py             3.4s (2)             3.4s (4)  +0.2%
sqlalchemy_imperative2.py             4.3s (2)             4.3s (2)  -0.6%
                  geomean                 3.8s                 3.8s  +0.1%
```

So no win, but I think it's an improvement so I'm going to merge it in.