### PR TITLE
make attributes interned BoxedStrings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,8 +81,8 @@ else
 endif
 
 TOOLS_DIR := ./tools
-TEST_DIR := ./test
-TESTS_DIR := ./test/tests
+TEST_DIR := $(abspath ./test)
+TESTS_DIR := $(abspath ./test/tests)
 
 GPP := $(GCC_DIR)/bin/g++
 GCC := $(GCC_DIR)/bin/gcc

--- a/src/analysis/type_analysis.cpp
+++ b/src/analysis/type_analysis.cpp
@@ -222,7 +222,7 @@ private:
 
         // TODO this isn't the exact behavior
         BoxedString* name = getInplaceOpName(node->op_type);
-        CompilerType* attr_type = left->getattrType(name->s(), true);
+        CompilerType* attr_type = left->getattrType(name, true);
 
         if (attr_type == UNDEF)
             attr_type = UNKNOWN;
@@ -251,7 +251,7 @@ private:
 
         // TODO this isn't the exact behavior
         BoxedString* name = getOpName(node->op_type);
-        CompilerType* attr_type = left->getattrType(name->s(), true);
+        CompilerType* attr_type = left->getattrType(name, true);
 
         if (attr_type == UNDEF)
             attr_type = UNKNOWN;
@@ -336,7 +336,7 @@ private:
             }
 
             BoxedString* name = getOpName(node->ops[0]);
-            CompilerType* attr_type = left->getattrType(name->s(), true);
+            CompilerType* attr_type = left->getattrType(name, true);
 
             if (attr_type == UNDEF)
                 attr_type = UNKNOWN;
@@ -474,7 +474,7 @@ private:
     void* visit_subscript(AST_Subscript* node) override {
         CompilerType* val = getType(node->value);
         CompilerType* slice = getType(node->slice);
-        static std::string name("__getitem__");
+        static BoxedString* name = internStringImmortal("__getitem__");
         CompilerType* getitem_type = val->getattrType(name, true);
         std::vector<CompilerType*> args;
         args.push_back(slice);
@@ -494,7 +494,7 @@ private:
 
         // TODO this isn't the exact behavior
         BoxedString* name = getOpName(node->op_type);
-        CompilerType* attr_type = operand->getattrType(name->s(), true);
+        CompilerType* attr_type = operand->getattrType(name, true);
         std::vector<CompilerType*> arg_types;
         return attr_type->callType(ArgPassSpec(0), arg_types, NULL);
     }

--- a/src/capi/modsupport.cpp
+++ b/src/capi/modsupport.cpp
@@ -444,7 +444,7 @@ extern "C" int PyModule_AddObject(PyObject* _m, const char* name, PyObject* valu
     BoxedModule* m = static_cast<BoxedModule*>(_m);
     assert(m->cls == module_cls);
 
-    m->setattr(name, value, NULL);
+    m->setattr(internStringMortal(name), value, NULL);
     return 0;
 }
 

--- a/src/capi/object.cpp
+++ b/src/capi/object.cpp
@@ -419,11 +419,13 @@ extern "C" PyObject* PyObject_SelfIter(PyObject* obj) noexcept {
 
 extern "C" int PyObject_GenericSetAttr(PyObject* obj, PyObject* name, PyObject* value) noexcept {
     RELEASE_ASSERT(PyString_Check(name), "");
+    BoxedString* str = static_cast<BoxedString*>(name);
+    internStringMortalInplace(str);
     try {
         if (value == NULL)
-            delattrGeneric(obj, static_cast<BoxedString*>(name), NULL);
+            delattrGeneric(obj, str, NULL);
         else
-            setattrGeneric(obj, static_cast<BoxedString*>(name), value, NULL);
+            setattrGeneric(obj, str, value, NULL);
     } catch (ExcInfo e) {
         setCAPIException(e);
         return -1;
@@ -458,7 +460,7 @@ extern "C" int PyObject_SetAttr(PyObject* obj, PyObject* name, PyObject* value) 
 
 extern "C" int PyObject_SetAttrString(PyObject* v, const char* name, PyObject* w) noexcept {
     try {
-        setattr(v, boxString(name), w);
+        setattr(v, internStringMortal(name), w);
     } catch (ExcInfo e) {
         setCAPIException(e);
         return -1;
@@ -468,7 +470,7 @@ extern "C" int PyObject_SetAttrString(PyObject* v, const char* name, PyObject* w
 
 extern "C" PyObject* PyObject_GetAttrString(PyObject* o, const char* attr) noexcept {
     try {
-        return getattr(o, boxString(attr));
+        return getattr(o, internStringMortal(attr));
     } catch (ExcInfo e) {
         setCAPIException(e);
         return NULL;

--- a/src/codegen/ast_interpreter.cpp
+++ b/src/codegen/ast_interpreter.cpp
@@ -849,7 +849,7 @@ Value ASTInterpreter::visit_langPrimitive(AST_LangPrimitive* node) {
         const std::string& name = ast_str->str_data;
         assert(name.size());
         // TODO: shouldn't have to rebox here
-        v.o = importFrom(module.o, boxString(name));
+        v.o = importFrom(module.o, internStringMortal(name));
     } else if (node->opcode == AST_LangPrimitive::IMPORT_NAME) {
         abortJITing();
         assert(node->args.size() == 3);

--- a/src/codegen/ast_interpreter.cpp
+++ b/src/codegen/ast_interpreter.cpp
@@ -1133,7 +1133,7 @@ Value ASTInterpreter::visit_assert(AST_Assert* node) {
     assert(v.o->cls == int_cls && static_cast<BoxedInt*>(v.o)->n == 0);
 #endif
 
-    static BoxedString* AssertionError_str = static_cast<BoxedString*>(PyString_InternFromString("AssertionError"));
+    static BoxedString* AssertionError_str = internStringImmortal("AssertionError");
     Box* assertion_type = getGlobal(globals, AssertionError_str);
     assertFail(assertion_type, node->msg ? visit_expr(node->msg).o : 0);
 

--- a/src/codegen/compvars.cpp
+++ b/src/codegen/compvars.cpp
@@ -357,7 +357,7 @@ public:
     }
 
     CompilerVariable* getPystonIter(IREmitter& emitter, const OpInfo& info, ConcreteCompilerVariable* var) override {
-        static BoxedString* iter_box = static_cast<BoxedString*>(PyString_InternFromString("__iter__"));
+        static BoxedString* iter_box = internStringImmortal("__iter__");
 
         CallattrFlags flags = {.cls_only = true, .null_on_nonexistent = true, .argspec = ArgPassSpec(0) };
         CompilerVariable* iter_call = var->callattr(emitter, info, iter_box, flags, {}, 0);
@@ -1705,7 +1705,7 @@ public:
     }
 
     CompilerVariable* getitem(IREmitter& emitter, const OpInfo& info, VAR* var, CompilerVariable* slice) override {
-        static BoxedString* attr = static_cast<BoxedString*>(PyString_InternFromString("__getitem__"));
+        static BoxedString* attr = internStringImmortal("__getitem__");
         bool no_attribute = false;
         ConcreteCompilerVariable* called_constant = tryCallattrConstant(
             emitter, info, var, attr, true, ArgPassSpec(1, 0, 0, 0), { slice }, NULL, &no_attribute);
@@ -1731,7 +1731,7 @@ public:
     }
 
     ConcreteCompilerVariable* len(IREmitter& emitter, const OpInfo& info, VAR* var) override {
-        static BoxedString* attr = static_cast<BoxedString*>(PyString_InternFromString("__len__"));
+        static BoxedString* attr = internStringImmortal("__len__");
         ConcreteCompilerVariable* called_constant
             = tryCallattrConstant(emitter, info, var, attr, true, ArgPassSpec(0, 0, 0, 0), {}, NULL);
         if (called_constant)
@@ -1741,7 +1741,7 @@ public:
     }
 
     ConcreteCompilerVariable* nonzero(IREmitter& emitter, const OpInfo& info, ConcreteCompilerVariable* var) override {
-        static BoxedString* attr = static_cast<BoxedString*>(PyString_InternFromString("__nonzero__"));
+        static BoxedString* attr = internStringImmortal("__nonzero__");
 
         bool no_attribute = false;
         ConcreteCompilerVariable* called_constant
@@ -1765,7 +1765,7 @@ public:
     }
 
     ConcreteCompilerVariable* hasnext(IREmitter& emitter, const OpInfo& info, ConcreteCompilerVariable* var) override {
-        static BoxedString* attr = static_cast<BoxedString*>(PyString_InternFromString("__hasnext__"));
+        static BoxedString* attr = internStringImmortal("__hasnext__");
 
         ConcreteCompilerVariable* called_constant
             = tryCallattrConstant(emitter, info, var, attr, true, ArgPassSpec(0, 0, 0, 0), {}, NULL, NULL);

--- a/src/codegen/compvars.h
+++ b/src/codegen/compvars.h
@@ -35,6 +35,7 @@ class IREmitter;
 class BoxedInt;
 class BoxedFloat;
 class BoxedLong;
+class BoxedString;
 
 typedef llvm::SmallVector<uint64_t, 1> FrameVals;
 
@@ -47,9 +48,9 @@ public:
     virtual ConcreteCompilerType* getConcreteType() = 0;
     virtual ConcreteCompilerType* getBoxType() = 0;
     virtual bool canConvertTo(ConcreteCompilerType* other_type) = 0;
-    virtual CompilerType* getattrType(llvm::StringRef attr, bool cls_only) = 0;
+    virtual CompilerType* getattrType(BoxedString* attr, bool cls_only) = 0;
     virtual CompilerType* getPystonIterType();
-    virtual Result hasattr(llvm::StringRef attr);
+    virtual Result hasattr(BoxedString* attr);
     virtual CompilerType* callType(ArgPassSpec argspec, const std::vector<CompilerType*>& arg_types,
                                    const std::vector<llvm::StringRef>* keyword_names) = 0;
 
@@ -157,7 +158,7 @@ public:
         printf("makeClassCheck not defined for %s\n", debugName().c_str());
         abort();
     }
-    CompilerType* getattrType(llvm::StringRef attr, bool cls_only) override {
+    CompilerType* getattrType(BoxedString* attr, bool cls_only) override {
         printf("getattrType not defined for %s\n", debugName().c_str());
         abort();
     }

--- a/src/codegen/irgen/hooks.cpp
+++ b/src/codegen/irgen/hooks.cpp
@@ -283,9 +283,13 @@ void compileAndRunModule(AST_Module* m, BoxedModule* bm) {
         ScopingAnalysis* scoping = new ScopingAnalysis(m, true);
 
         std::unique_ptr<SourceInfo> si(new SourceInfo(bm, scoping, future_flags, m, m->body, fn));
-        bm->setattr("__doc__", si->getDocString(), NULL);
-        if (!bm->hasattr("__builtins__"))
-            bm->giveAttr("__builtins__", PyModule_GetDict(builtins_module));
+
+        static BoxedString* doc_str = internStringImmortal("__doc__");
+        bm->setattr(doc_str, si->getDocString(), NULL);
+
+        static BoxedString* builtins_str = internStringImmortal("__builtins__");
+        if (!bm->hasattr(builtins_str))
+            bm->giveAttr(builtins_str, PyModule_GetDict(builtins_module));
 
         clfunc = new CLFunction(0, 0, false, false, std::move(si));
     }

--- a/src/codegen/irgen/hooks.cpp
+++ b/src/codegen/irgen/hooks.cpp
@@ -302,7 +302,7 @@ Box* evalOrExec(CLFunction* cl, Box* globals, Box* boxedLocals) {
 
     Box* doc_string = cl->source->getDocString();
     if (doc_string != None) {
-        static BoxedString* doc_box = static_cast<BoxedString*>(PyString_InternFromString("__doc__"));
+        static BoxedString* doc_box = internStringImmortal("__doc__");
         setGlobal(boxedLocals, doc_box, doc_string);
     }
 

--- a/src/codegen/irgen/irgenerator.cpp
+++ b/src/codegen/irgen/irgenerator.cpp
@@ -894,7 +894,7 @@ private:
         llvm::Value* v = emitter.getBuilder()->CreateCall(g.funcs.createDict);
         ConcreteCompilerVariable* rtn = new ConcreteCompilerVariable(DICT, v, true);
         if (node->keys.size()) {
-            static BoxedString* setitem_str = static_cast<BoxedString*>(PyString_InternFromString("__setitem__"));
+            static BoxedString* setitem_str = internStringImmortal("__setitem__");
             CompilerVariable* setitem = rtn->getattr(emitter, getEmptyOpInfo(unw_info), setitem_str, true);
             for (int i = 0; i < node->keys.size(); i++) {
                 CompilerVariable* key = evalExpr(node->keys[i], unw_info);
@@ -1136,7 +1136,7 @@ private:
         llvm::Value* v = emitter.getBuilder()->CreateCall(g.funcs.createSet);
         ConcreteCompilerVariable* rtn = new ConcreteCompilerVariable(SET, v, true);
 
-        static BoxedString* add_str = static_cast<BoxedString*>(PyString_InternFromString("add"));
+        static BoxedString* add_str = internStringImmortal("add");
 
         for (int i = 0; i < node->elts.size(); i++) {
             CompilerVariable* elt = elts[i];
@@ -1722,7 +1722,7 @@ private:
 
         // We could patchpoint this or try to avoid the overhead, but this should only
         // happen when the assertion is actually thrown so I don't think it will be necessary.
-        static BoxedString* AssertionError_str = static_cast<BoxedString*>(PyString_InternFromString("AssertionError"));
+        static BoxedString* AssertionError_str = internStringImmortal("AssertionError");
         llvm_args.push_back(emitter.createCall2(unw_info, g.funcs.getGlobal, embedParentModulePtr(),
                                                 embedRelocatablePtr(AssertionError_str, g.llvm_boxedstring_type_ptr)));
 
@@ -1885,9 +1885,9 @@ private:
         }
         assert(dest);
 
-        static BoxedString* write_str = static_cast<BoxedString*>(PyString_InternFromString("write"));
-        static BoxedString* newline_str = static_cast<BoxedString*>(PyString_InternFromString("\n"));
-        static BoxedString* space_str = static_cast<BoxedString*>(PyString_InternFromString(" "));
+        static BoxedString* write_str = internStringImmortal("write");
+        static BoxedString* newline_str = internStringImmortal("\n");
+        static BoxedString* space_str = internStringImmortal(" ");
 
         // TODO: why are we inline-generating all this code instead of just emitting a call to some runtime function?
         // (=printHelper())

--- a/src/codegen/irgen/irgenerator.cpp
+++ b/src/codegen/irgen/irgenerator.cpp
@@ -642,8 +642,9 @@ private:
                 const std::string& name = ast_str->str_data;
                 assert(name.size());
 
-                llvm::Value* name_arg = embedRelocatablePtr(
-                    irstate->getSourceInfo()->parent_module->getStringConstant(name), g.llvm_boxedstring_type_ptr);
+                llvm::Value* name_arg
+                    = embedRelocatablePtr(irstate->getSourceInfo()->parent_module->getStringConstant(name, true),
+                                          g.llvm_boxedstring_type_ptr);
                 llvm::Value* r
                     = emitter.createCall2(unw_info, g.funcs.importFrom, converted_module->getValue(), name_arg);
 

--- a/src/core/ast.cpp
+++ b/src/core/ast.cpp
@@ -114,31 +114,31 @@ BoxedString* getOpName(int op_type) {
 
     static bool initialized = false;
     if (!initialized) {
-        strAdd = static_cast<BoxedString*>(PyString_InternFromString("__add__"));
-        strBitAnd = static_cast<BoxedString*>(PyString_InternFromString("__and__"));
-        strBitOr = static_cast<BoxedString*>(PyString_InternFromString("__or__"));
-        strBitXor = static_cast<BoxedString*>(PyString_InternFromString("__xor__"));
-        strDiv = static_cast<BoxedString*>(PyString_InternFromString("__div__"));
-        strTrueDiv = static_cast<BoxedString*>(PyString_InternFromString("__truediv__"));
-        strDivMod = static_cast<BoxedString*>(PyString_InternFromString("__divmod__"));
-        strEq = static_cast<BoxedString*>(PyString_InternFromString("__eq__"));
-        strFloorDiv = static_cast<BoxedString*>(PyString_InternFromString("__floordiv__"));
-        strLShift = static_cast<BoxedString*>(PyString_InternFromString("__lshift__"));
-        strLt = static_cast<BoxedString*>(PyString_InternFromString("__lt__"));
-        strLtE = static_cast<BoxedString*>(PyString_InternFromString("__le__"));
-        strGt = static_cast<BoxedString*>(PyString_InternFromString("__gt__"));
-        strGtE = static_cast<BoxedString*>(PyString_InternFromString("__ge__"));
-        strIn = static_cast<BoxedString*>(PyString_InternFromString("__contains__"));
-        strInvert = static_cast<BoxedString*>(PyString_InternFromString("__invert__"));
-        strMod = static_cast<BoxedString*>(PyString_InternFromString("__mod__"));
-        strMult = static_cast<BoxedString*>(PyString_InternFromString("__mul__"));
-        strNot = static_cast<BoxedString*>(PyString_InternFromString("__nonzero__"));
-        strNotEq = static_cast<BoxedString*>(PyString_InternFromString("__ne__"));
-        strPow = static_cast<BoxedString*>(PyString_InternFromString("__pow__"));
-        strRShift = static_cast<BoxedString*>(PyString_InternFromString("__rshift__"));
-        strSub = static_cast<BoxedString*>(PyString_InternFromString("__sub__"));
-        strUAdd = static_cast<BoxedString*>(PyString_InternFromString("__pos__"));
-        strUSub = static_cast<BoxedString*>(PyString_InternFromString("__neg__"));
+        strAdd = internStringImmortal("__add__");
+        strBitAnd = internStringImmortal("__and__");
+        strBitOr = internStringImmortal("__or__");
+        strBitXor = internStringImmortal("__xor__");
+        strDiv = internStringImmortal("__div__");
+        strTrueDiv = internStringImmortal("__truediv__");
+        strDivMod = internStringImmortal("__divmod__");
+        strEq = internStringImmortal("__eq__");
+        strFloorDiv = internStringImmortal("__floordiv__");
+        strLShift = internStringImmortal("__lshift__");
+        strLt = internStringImmortal("__lt__");
+        strLtE = internStringImmortal("__le__");
+        strGt = internStringImmortal("__gt__");
+        strGtE = internStringImmortal("__ge__");
+        strIn = internStringImmortal("__contains__");
+        strInvert = internStringImmortal("__invert__");
+        strMod = internStringImmortal("__mod__");
+        strMult = internStringImmortal("__mul__");
+        strNot = internStringImmortal("__nonzero__");
+        strNotEq = internStringImmortal("__ne__");
+        strPow = internStringImmortal("__pow__");
+        strRShift = internStringImmortal("__rshift__");
+        strSub = internStringImmortal("__sub__");
+        strUAdd = internStringImmortal("__pos__");
+        strUSub = internStringImmortal("__neg__");
 
         initialized = true;
     }
@@ -203,7 +203,7 @@ BoxedString* getOpName(int op_type) {
 BoxedString* getInplaceOpName(int op_type) {
     BoxedString* normal_name = getOpName(op_type);
     // TODO inefficient
-    return static_cast<BoxedString*>(PyString_InternFromString(("__i" + normal_name->s().substr(2).str()).c_str()));
+    return internStringImmortal(("__i" + normal_name->s().substr(2).str()).c_str());
 }
 
 // Maybe better name is "swapped" -- it's what the runtime will try if the normal op
@@ -234,7 +234,7 @@ BoxedString* getReverseOpName(int op_type) {
         return getOpName(op_type);
     BoxedString* normal_name = getOpName(op_type);
     // TODO inefficient
-    return static_cast<BoxedString*>(PyString_InternFromString(("__r" + normal_name->s().substr(2).str()).c_str()));
+    return internStringImmortal(("__r" + normal_name->s().substr(2).str()).c_str());
 }
 
 template <class T> static void visitVector(const std::vector<T*>& vec, ASTVisitor* v) {

--- a/src/core/cfg.cpp
+++ b/src/core/cfg.cpp
@@ -2489,7 +2489,8 @@ CFG* computeCFG(SourceInfo* source, std::vector<AST_stmt*> body) {
             new AST_Name(source->getInternedStrings().get("__module__"), AST_TYPE::Store, source->ast->lineno));
 
         if (source->scoping->areGlobalsFromModule()) {
-            Box* module_name = source->parent_module->getattr("__name__", NULL);
+            static BoxedString* name_str = internStringImmortal("__name__");
+            Box* module_name = source->parent_module->getattr(name_str, NULL);
             assert(module_name->cls == str_cls);
             module_assign->value = new AST_Str(static_cast<BoxedString*>(module_name)->s());
         } else {

--- a/src/core/contiguous_map.h
+++ b/src/core/contiguous_map.h
@@ -43,12 +43,11 @@ public:
     const_iterator begin() const noexcept { return map.begin(); }
     const_iterator end() const noexcept { return map.end(); }
 
-    iterator erase(const_iterator position) {
+    void erase(const_iterator position) {
         int idx = map[position->first];
         free_list.push_back(idx);
         vec[idx] = TVal();
         map.erase(position->first);
-        return begin(); // this is broken...
     }
 
     size_type erase(const TKey& key) {
@@ -73,9 +72,9 @@ public:
                 free_list.pop_back();
             } else {
                 idx = vec.size();
+                vec.push_back(TVal());
             }
             map[key] = idx;
-            vec.push_back(TVal());
             return vec[idx];
         } else {
             return vec[it->second];
@@ -91,9 +90,9 @@ public:
                 free_list.pop_back();
             } else {
                 idx = vec.size();
+                vec.push_back(TVal());
             }
             map[key] = idx;
-            vec.push_back(TVal());
             return vec[idx];
         } else {
             return vec[it->second];
@@ -102,7 +101,8 @@ public:
 
     TVal getMapped(int idx) const { return vec[idx]; }
 
-    size_type size() const { return vec.size(); }
+    size_type size() const { return map.size(); }
+    bool empty() const { return map.empty(); }
     const vec_type& vector() { return vec; }
 };
 }

--- a/src/core/stringpool.cpp
+++ b/src/core/stringpool.cpp
@@ -25,9 +25,8 @@ InternedString InternedStringPool::get(llvm::StringRef arg) {
     if (it != interned.end()) {
         s = it->second;
     } else {
-        s = boxString(arg);
         // HACK: should properly track this liveness:
-        PyString_InternInPlace(reinterpret_cast<Box**>(&s));
+        s = internStringImmortal(arg);
 
         // Note: make sure the key points to the value we just created, not the
         // argument string:

--- a/src/core/stringpool.h
+++ b/src/core/stringpool.h
@@ -80,6 +80,7 @@ public:
 
     llvm::StringRef s() const;
     operator llvm::StringRef() const { return s(); }
+    operator BoxedString*() const { return getBox(); }
 
     friend class InternedStringPool;
     friend struct std::hash<InternedString>;

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -456,6 +456,13 @@ struct SetattrRewriteArgs;
 struct GetattrRewriteArgs;
 struct DelattrRewriteArgs;
 
+// Helper function around PyString_InternFromString:
+inline BoxedString* internStringImmortal(const char* s) {
+    BoxedString* r = (BoxedString*)PyString_InternFromString(s);
+    assert(r);
+    return r;
+}
+
 struct HCAttrs {
 public:
     struct AttrList {

--- a/src/runtime/bool.cpp
+++ b/src/runtime/bool.cpp
@@ -31,8 +31,8 @@ extern "C" Box* boolNonzero(BoxedBool* v) {
 }
 
 extern "C" Box* boolRepr(BoxedBool* v) {
-    static BoxedString* true_str = static_cast<BoxedString*>(PyString_InternFromString("True"));
-    static BoxedString* false_str = static_cast<BoxedString*>(PyString_InternFromString("False"));
+    static BoxedString* true_str = internStringImmortal("True");
+    static BoxedString* false_str = internStringImmortal("False");
 
     if (v == True)
         return true_str;

--- a/src/runtime/builtin_modules/builtins.cpp
+++ b/src/runtime/builtin_modules/builtins.cpp
@@ -95,14 +95,14 @@ extern "C" Box* abs_(Box* x) {
     } else if (x->cls == long_cls) {
         return longAbs(static_cast<BoxedLong*>(x));
     } else {
-        static BoxedString* abs_str = static_cast<BoxedString*>(PyString_InternFromString("__abs__"));
+        static BoxedString* abs_str = internStringImmortal("__abs__");
         CallattrFlags callattr_flags{.cls_only = true, .null_on_nonexistent = false, .argspec = ArgPassSpec(0) };
         return callattr(x, abs_str, callattr_flags, NULL, NULL, NULL, NULL, NULL);
     }
 }
 
 extern "C" Box* hexFunc(Box* x) {
-    static BoxedString* hex_str = static_cast<BoxedString*>(PyString_InternFromString("__hex__"));
+    static BoxedString* hex_str = internStringImmortal("__hex__");
     CallattrFlags callattr_flags{.cls_only = true, .null_on_nonexistent = true, .argspec = ArgPassSpec(0) };
     Box* r = callattr(x, hex_str, callattr_flags, NULL, NULL, NULL, NULL, NULL);
     if (!r)
@@ -115,7 +115,7 @@ extern "C" Box* hexFunc(Box* x) {
 }
 
 extern "C" Box* octFunc(Box* x) {
-    static BoxedString* oct_str = static_cast<BoxedString*>(PyString_InternFromString("__oct__"));
+    static BoxedString* oct_str = internStringImmortal("__oct__");
     CallattrFlags callattr_flags{.cls_only = true, .null_on_nonexistent = true, .argspec = ArgPassSpec(0) };
     Box* r = callattr(x, oct_str, callattr_flags, NULL, NULL, NULL, NULL, NULL);
     if (!r)
@@ -209,7 +209,7 @@ extern "C" Box* max(Box* arg0, BoxedTuple* args) {
 
 extern "C" Box* next(Box* iterator, Box* _default) {
     try {
-        static BoxedString* next_str = static_cast<BoxedString*>(PyString_InternFromString("next"));
+        static BoxedString* next_str = internStringImmortal("next");
         CallattrFlags callattr_flags{.cls_only = true, .null_on_nonexistent = false, .argspec = ArgPassSpec(0) };
         return callattr(iterator, next_str, callattr_flags, NULL, NULL, NULL, NULL, NULL);
     } catch (ExcInfo e) {
@@ -862,9 +862,9 @@ Box* print(BoxedTuple* args, BoxedDict* kwargs) {
 
     Box* dest, *end;
 
-    static BoxedString* file_str = static_cast<BoxedString*>(PyString_InternFromString("file"));
-    static BoxedString* end_str = static_cast<BoxedString*>(PyString_InternFromString("end"));
-    static BoxedString* space_str = static_cast<BoxedString*>(PyString_InternFromString(" "));
+    static BoxedString* file_str = internStringImmortal("file");
+    static BoxedString* end_str = internStringImmortal("end");
+    static BoxedString* space_str = internStringImmortal(" ");
 
     auto it = kwargs->d.find(file_str);
     if (it != kwargs->d.end()) {
@@ -884,7 +884,7 @@ Box* print(BoxedTuple* args, BoxedDict* kwargs) {
 
     RELEASE_ASSERT(kwargs->d.size() == 0, "print() got unexpected keyword arguments");
 
-    static BoxedString* write_str = static_cast<BoxedString*>(PyString_InternFromString("write"));
+    static BoxedString* write_str = internStringImmortal("write");
     CallattrFlags callattr_flags{.cls_only = false, .null_on_nonexistent = false, .argspec = ArgPassSpec(1) };
 
     // TODO softspace handling?
@@ -908,7 +908,7 @@ Box* print(BoxedTuple* args, BoxedDict* kwargs) {
 }
 
 Box* getreversed(Box* o) {
-    static BoxedString* reversed_str = static_cast<BoxedString*>(PyString_InternFromString("__reversed__"));
+    static BoxedString* reversed_str = internStringImmortal("__reversed__");
 
     // TODO add rewriting to this?  probably want to try to avoid this path though
     CallattrFlags callattr_flags{.cls_only = true, .null_on_nonexistent = true, .argspec = ArgPassSpec(0) };

--- a/src/runtime/builtin_modules/sys.cpp
+++ b/src/runtime/builtin_modules/sys.cpp
@@ -84,7 +84,7 @@ BoxedDict* getSysModulesDict() {
 
 BoxedList* getSysPath() {
     // Unlike sys.modules, CPython handles sys.path by fetching it each time:
-    Box* _sys_path = sys_module->getattr("path");
+    Box* _sys_path = sys_module->getattr(internStringMortal("path"));
     assert(_sys_path);
 
     if (_sys_path->cls != list_cls) {
@@ -97,7 +97,7 @@ BoxedList* getSysPath() {
 }
 
 Box* getSysStdout() {
-    Box* sys_stdout = sys_module->getattr("stdout");
+    Box* sys_stdout = sys_module->getattr(internStringMortal("stdout"));
     RELEASE_ASSERT(sys_stdout, "lost sys.stdout??");
     return sys_stdout;
 }
@@ -135,10 +135,10 @@ Box* sysGetRecursionLimit() {
 extern "C" int PySys_SetObject(const char* name, PyObject* v) noexcept {
     try {
         if (!v) {
-            if (sys_module->getattr(name))
-                sys_module->delattr(name, NULL);
+            if (sys_module->getattr(internStringMortal(name)))
+                sys_module->delattr(internStringMortal(name), NULL);
         } else
-            sys_module->setattr(name, v, NULL);
+            sys_module->setattr(internStringMortal(name), v, NULL);
     } catch (ExcInfo e) {
         abort();
     }
@@ -146,7 +146,7 @@ extern "C" int PySys_SetObject(const char* name, PyObject* v) noexcept {
 }
 
 extern "C" PyObject* PySys_GetObject(const char* name) noexcept {
-    return sys_module->getattr(name);
+    return sys_module->getattr(internStringMortal(name));
 }
 
 static void mywrite(const char* name, FILE* fp, const char* format, va_list va) noexcept {
@@ -192,7 +192,7 @@ extern "C" void PySys_WriteStderr(const char* format, ...) noexcept {
 }
 
 void addToSysArgv(const char* str) {
-    Box* sys_argv = sys_module->getattr("argv");
+    Box* sys_argv = sys_module->getattr(internStringMortal("argv"));
     assert(sys_argv);
     assert(sys_argv->cls == list_cls);
     listAppendInternal(sys_argv, boxString(str));
@@ -422,9 +422,9 @@ void setupSys() {
     sys_module->giveAttr("stdout", new BoxedFile(stdout, "<stdout>", "w"));
     sys_module->giveAttr("stdin", new BoxedFile(stdin, "<stdin>", "r"));
     sys_module->giveAttr("stderr", new BoxedFile(stderr, "<stderr>", "w"));
-    sys_module->giveAttr("__stdout__", sys_module->getattr("stdout"));
-    sys_module->giveAttr("__stdin__", sys_module->getattr("stdin"));
-    sys_module->giveAttr("__stderr__", sys_module->getattr("stderr"));
+    sys_module->giveAttr("__stdout__", sys_module->getattr(internStringMortal("stdout")));
+    sys_module->giveAttr("__stdin__", sys_module->getattr(internStringMortal("stdin")));
+    sys_module->giveAttr("__stderr__", sys_module->getattr(internStringMortal("stderr")));
 
     sys_module->giveAttr(
         "exc_info", new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)sysExcInfo, BOXED_TUPLE, 0), "exc_info"));

--- a/src/runtime/builtin_modules/sys.cpp
+++ b/src/runtime/builtin_modules/sys.cpp
@@ -205,7 +205,7 @@ void appendToSysPath(llvm::StringRef path) {
 
 void prependToSysPath(llvm::StringRef path) {
     BoxedList* sys_path = getSysPath();
-    static BoxedString* insert_str = static_cast<BoxedString*>(PyString_InternFromString("insert"));
+    static BoxedString* insert_str = internStringImmortal("insert");
     CallattrFlags callattr_flags{.cls_only = false, .null_on_nonexistent = false, .argspec = ArgPassSpec(2) };
     callattr(sys_path, insert_str, callattr_flags, boxInt(0), boxString(path), NULL, NULL, NULL);
 }

--- a/src/runtime/builtin_modules/thread.cpp
+++ b/src/runtime/builtin_modules/thread.cpp
@@ -201,9 +201,9 @@ void setupThread() {
         "acquire", new BoxedFunction(boxRTFunction((void*)BoxedThreadLock::acquire, BOXED_BOOL, 2, 1, false, false),
                                      { boxInt(1) }));
     thread_lock_cls->giveAttr("release", new BoxedFunction(boxRTFunction((void*)BoxedThreadLock::release, NONE, 1)));
-    thread_lock_cls->giveAttr("acquire_lock", thread_lock_cls->getattr("acquire"));
-    thread_lock_cls->giveAttr("release_lock", thread_lock_cls->getattr("release"));
-    thread_lock_cls->giveAttr("__enter__", thread_lock_cls->getattr("acquire"));
+    thread_lock_cls->giveAttr("acquire_lock", thread_lock_cls->getattr(internStringMortal("acquire")));
+    thread_lock_cls->giveAttr("release_lock", thread_lock_cls->getattr(internStringMortal("release")));
+    thread_lock_cls->giveAttr("__enter__", thread_lock_cls->getattr(internStringMortal("acquire")));
     thread_lock_cls->giveAttr("__exit__", new BoxedFunction(boxRTFunction((void*)BoxedThreadLock::exit, NONE, 4)));
     thread_lock_cls->freeze();
 

--- a/src/runtime/capi.cpp
+++ b/src/runtime/capi.cpp
@@ -215,7 +215,9 @@ extern "C" PyObject* PyObject_GetAttr(PyObject* o, PyObject* attr_name) noexcept
 
 extern "C" PyObject* PyObject_GenericGetAttr(PyObject* o, PyObject* name) noexcept {
     try {
-        Box* r = getattrInternalGeneric(o, static_cast<BoxedString*>(name)->data(), NULL, false, false, NULL, NULL);
+        BoxedString* s = static_cast<BoxedString*>(name);
+        internStringMortalInplace(s);
+        Box* r = getattrInternalGeneric(o, s, NULL, false, false, NULL, NULL);
         if (!r)
             PyErr_Format(PyExc_AttributeError, "'%.50s' object has no attribute '%.400s'", o->cls->tp_name,
                          PyString_AS_STRING(name));
@@ -637,7 +639,7 @@ extern "C" int PyCallable_Check(PyObject* x) noexcept {
     if (x == NULL)
         return 0;
 
-    static const std::string call_attr("__call__");
+    static BoxedString* call_attr = internStringImmortal("__call__");
     return typeLookup(x->cls, call_attr, NULL) != NULL;
 }
 
@@ -1417,7 +1419,8 @@ extern "C" char* PyModule_GetName(PyObject* m) noexcept {
         PyErr_BadArgument();
         return NULL;
     }
-    if ((nameobj = m->getattr("__name__")) == NULL || !PyString_Check(nameobj)) {
+    static BoxedString* name_str = internStringImmortal("__name__");
+    if ((nameobj = m->getattr(name_str)) == NULL || !PyString_Check(nameobj)) {
         PyErr_SetString(PyExc_SystemError, "nameless module");
         return NULL;
     }
@@ -1431,7 +1434,8 @@ extern "C" char* PyModule_GetFilename(PyObject* m) noexcept {
         PyErr_BadArgument();
         return NULL;
     }
-    if ((fileobj = m->getattr("__file__")) == NULL || !PyString_Check(fileobj)) {
+    static BoxedString* file_str = internStringImmortal("__file__");
+    if ((fileobj = m->getattr(file_str)) == NULL || !PyString_Check(fileobj)) {
         PyErr_SetString(PyExc_SystemError, "module filename missing");
         return NULL;
     }

--- a/src/runtime/classobj.cpp
+++ b/src/runtime/classobj.cpp
@@ -28,7 +28,7 @@ extern "C" {
 BoxedClass* classobj_cls, *instance_cls;
 }
 
-static Box* classLookup(BoxedClassobj* cls, llvm::StringRef attr) {
+static Box* classLookup(BoxedClassobj* cls, BoxedString* attr) {
     Box* r = cls->getattr(attr);
     if (r)
         return r;
@@ -104,12 +104,14 @@ Box* classobjNew(Box* _cls, Box* _name, Box* _bases, Box** _args) {
 
     for (auto& p : dict->d) {
         RELEASE_ASSERT(p.first->cls == str_cls, "");
-        made->setattr(std::string(static_cast<BoxedString*>(p.first)->s()), p.second, NULL);
+        BoxedString* s = (BoxedString*)p.first;
+        internStringMortalInplace(s);
+        made->setattr(s, p.second, NULL);
     }
 
     // Note: make sure to do this after assigning the attrs, since it will overwrite any defined __name__
-    made->setattr("__name__", name, NULL);
-    made->setattr("__bases__", bases, NULL);
+    made->setattr(internStringMortal("__name__"), name, NULL);
+    made->setattr(internStringMortal("__bases__"), bases, NULL);
 
     return made;
 }
@@ -126,7 +128,7 @@ Box* classobjCall(Box* _cls, Box* _args, Box* _kwargs) {
 
     BoxedInstance* made = new BoxedInstance(cls);
 
-    static const std::string init_str("__init__");
+    static BoxedString* init_str = internStringImmortal("__init__");
     Box* init_func = classLookup(cls, init_str);
 
     if (init_func) {
@@ -162,7 +164,7 @@ static Box* classobjGetattribute(Box* _cls, Box* _attr) {
         }
     }
 
-    Box* r = classLookup(cls, attr->s());
+    Box* r = classLookup(cls, attr);
     if (!r)
         raiseExcHelper(AttributeError, "class %s has no attribute '%s'", cls->name->data(), attr->data());
 
@@ -210,7 +212,8 @@ static void classobjSetattr(Box* _cls, Box* _attr, Box* _value) {
         const char* error_str = set_bases((PyClassObject*)cls, _value);
         if (error_str && error_str[0] != '\0')
             raiseExcHelper(TypeError, "%s", error_str);
-        cls->setattr("__bases__", _value, NULL);
+        static BoxedString* bases_str = internStringImmortal("__bases__");
+        cls->setattr(bases_str, _value, NULL);
         return;
     }
     PyObject_GenericSetAttr(cls, _attr, _value);
@@ -239,7 +242,8 @@ Box* classobjStr(Box* _obj) {
 
     BoxedClassobj* cls = static_cast<BoxedClassobj*>(_obj);
 
-    Box* _mod = cls->getattr("__module__");
+    static BoxedString* module_str = internStringImmortal("__module__");
+    Box* _mod = cls->getattr(module_str);
     RELEASE_ASSERT(_mod, "");
     RELEASE_ASSERT(_mod->cls == str_cls, "");
     return boxStringTwine(llvm::Twine(static_cast<BoxedString*>(_mod)->s()) + "." + cls->name->s());
@@ -263,17 +267,17 @@ static Box* _instanceGetattribute(Box* _inst, Box* _attr, bool raise_on_missing)
             return inst->inst_cls;
     }
 
-    Box* r = inst->getattr(attr->s());
+    Box* r = inst->getattr(attr);
     if (r)
         return r;
 
-    r = classLookup(inst->inst_cls, attr->s());
+    r = classLookup(inst->inst_cls, attr);
     if (r) {
         return processDescriptor(r, inst, inst->inst_cls);
     }
     RELEASE_ASSERT(!r, "");
 
-    static const std::string getattr_str("__getattr__");
+    static BoxedString* getattr_str = internStringImmortal("__getattr__");
     Box* getattr = classLookup(inst->inst_cls, getattr_str);
 
     if (getattr) {
@@ -323,7 +327,7 @@ Box* instanceSetattr(Box* _inst, Box* _attr, Box* value) {
         }
     }
 
-    static const std::string setattr_str("__setattr__");
+    static BoxedString* setattr_str = internStringImmortal("__setattr__");
     Box* setattr = classLookup(inst->inst_cls, setattr_str);
 
     if (setattr) {
@@ -331,7 +335,7 @@ Box* instanceSetattr(Box* _inst, Box* _attr, Box* value) {
         return runtimeCall(setattr, ArgPassSpec(2), _attr, value, NULL, NULL, NULL);
     }
 
-    _inst->setattr(attr->s(), value, NULL);
+    _inst->setattr(attr, value, NULL);
     return None;
 }
 
@@ -351,7 +355,7 @@ Box* instanceDelattr(Box* _inst, Box* _attr) {
             raiseExcHelper(TypeError, "__class__ must be set to a class");
     }
 
-    static const std::string delattr_str("__delattr__");
+    static BoxedString* delattr_str = internStringImmortal("__delattr__");
     Box* delattr = classLookup(inst->inst_cls, delattr_str);
 
     if (delattr) {
@@ -359,7 +363,7 @@ Box* instanceDelattr(Box* _inst, Box* _attr) {
         return runtimeCall(delattr, ArgPassSpec(1), _attr, NULL, NULL, NULL, NULL);
     }
 
-    _inst->delattr(attr->s(), NULL);
+    _inst->delattr(attr, NULL);
     return None;
 }
 
@@ -731,38 +735,44 @@ static PyObject* instance_index(PyObject* self) noexcept {
     return res;
 }
 
-Box* _instanceBinary(Box* _inst, Box* other, const char* attr) {
+static Box* _instanceBinary(Box* _inst, Box* other, BoxedString* attr) {
     RELEASE_ASSERT(_inst->cls == instance_cls, "");
     BoxedInstance* inst = static_cast<BoxedInstance*>(_inst);
 
-    Box* func = _instanceGetattribute(inst, boxString(attr), false);
+    Box* func = _instanceGetattribute(inst, attr, false);
     if (!func)
         return NotImplemented;
     return runtimeCall(func, ArgPassSpec(1), other, NULL, NULL, NULL, NULL);
 }
 
 Box* instanceGt(Box* _inst, Box* other) {
-    return _instanceBinary(_inst, other, "__gt__");
+    static BoxedString* attr_str = internStringImmortal("__gt__");
+    return _instanceBinary(_inst, other, attr_str);
 }
 
 Box* instanceGe(Box* _inst, Box* other) {
-    return _instanceBinary(_inst, other, "__ge__");
+    static BoxedString* attr_str = internStringImmortal("__ge__");
+    return _instanceBinary(_inst, other, attr_str);
 }
 
 Box* instanceLt(Box* _inst, Box* other) {
-    return _instanceBinary(_inst, other, "__lt__");
+    static BoxedString* attr_str = internStringImmortal("__lt__");
+    return _instanceBinary(_inst, other, attr_str);
 }
 
 Box* instanceLe(Box* _inst, Box* other) {
-    return _instanceBinary(_inst, other, "__le__");
+    static BoxedString* attr_str = internStringImmortal("__le__");
+    return _instanceBinary(_inst, other, attr_str);
 }
 
 Box* instanceEq(Box* _inst, Box* other) {
-    return _instanceBinary(_inst, other, "__eq__");
+    static BoxedString* attr_str = internStringImmortal("__eq__");
+    return _instanceBinary(_inst, other, attr_str);
 }
 
 Box* instanceNe(Box* _inst, Box* other) {
-    return _instanceBinary(_inst, other, "__ne__");
+    static BoxedString* attr_str = internStringImmortal("__ne__");
+    return _instanceBinary(_inst, other, attr_str);
 }
 
 Box* instanceCall(Box* _inst, Box* _args, Box* _kwargs) {

--- a/src/runtime/classobj.cpp
+++ b/src/runtime/classobj.cpp
@@ -110,8 +110,10 @@ Box* classobjNew(Box* _cls, Box* _name, Box* _bases, Box** _args) {
     }
 
     // Note: make sure to do this after assigning the attrs, since it will overwrite any defined __name__
-    made->setattr(internStringMortal("__name__"), name, NULL);
-    made->setattr(internStringMortal("__bases__"), bases, NULL);
+    static BoxedString* name_str = internStringImmortal("__name__");
+    static BoxedString* bases_str = internStringImmortal("__bases__");
+    made->setattr(name_str, name, NULL);
+    made->setattr(bases_str, bases, NULL);
 
     return made;
 }

--- a/src/runtime/classobj.cpp
+++ b/src/runtime/classobj.cpp
@@ -381,7 +381,7 @@ Box* instanceRepr(Box* _inst) {
     RELEASE_ASSERT(_inst->cls == instance_cls, "");
     BoxedInstance* inst = static_cast<BoxedInstance*>(_inst);
 
-    static BoxedString* repr_str = static_cast<BoxedString*>(PyString_InternFromString("__repr__"));
+    static BoxedString* repr_str = internStringImmortal("__repr__");
     Box* repr_func = _instanceGetattribute(inst, repr_str, false);
 
     if (repr_func) {
@@ -400,7 +400,7 @@ Box* instanceStr(Box* _inst) {
     RELEASE_ASSERT(_inst->cls == instance_cls, "");
     BoxedInstance* inst = static_cast<BoxedInstance*>(_inst);
 
-    static BoxedString* str_str = static_cast<BoxedString*>(PyString_InternFromString("__str__"));
+    static BoxedString* str_str = internStringImmortal("__str__");
     Box* str_func = _instanceGetattribute(inst, str_str, false);
 
     if (str_func) {
@@ -415,7 +415,7 @@ Box* instanceNonzero(Box* _inst) {
     RELEASE_ASSERT(_inst->cls == instance_cls, "");
     BoxedInstance* inst = static_cast<BoxedInstance*>(_inst);
 
-    static BoxedString* nonzero_str = static_cast<BoxedString*>(PyString_InternFromString("__nonzero__"));
+    static BoxedString* nonzero_str = internStringImmortal("__nonzero__");
 
     Box* nonzero_func = NULL;
     try {
@@ -426,7 +426,7 @@ Box* instanceNonzero(Box* _inst) {
     }
 
     if (nonzero_func == NULL) {
-        static BoxedString* len_str = static_cast<BoxedString*>(PyString_InternFromString("__len__"));
+        static BoxedString* len_str = internStringImmortal("__len__");
         try {
             nonzero_func = _instanceGetattribute(inst, len_str, false);
         } catch (ExcInfo e) {
@@ -446,7 +446,7 @@ Box* instanceLen(Box* _inst) {
     RELEASE_ASSERT(_inst->cls == instance_cls, "");
     BoxedInstance* inst = static_cast<BoxedInstance*>(_inst);
 
-    static BoxedString* len_str = static_cast<BoxedString*>(PyString_InternFromString("__len__"));
+    static BoxedString* len_str = internStringImmortal("__len__");
     Box* len_func = _instanceGetattribute(inst, len_str, true);
     return runtimeCall(len_func, ArgPassSpec(0), NULL, NULL, NULL, NULL, NULL);
 }
@@ -455,7 +455,7 @@ Box* instanceGetitem(Box* _inst, Box* key) {
     RELEASE_ASSERT(_inst->cls == instance_cls, "");
     BoxedInstance* inst = static_cast<BoxedInstance*>(_inst);
 
-    static BoxedString* getitem_str = static_cast<BoxedString*>(PyString_InternFromString("__getitem__"));
+    static BoxedString* getitem_str = internStringImmortal("__getitem__");
     Box* getitem_func = _instanceGetattribute(inst, getitem_str, true);
     return runtimeCall(getitem_func, ArgPassSpec(1), key, NULL, NULL, NULL, NULL);
 }
@@ -464,7 +464,7 @@ Box* instanceSetitem(Box* _inst, Box* key, Box* value) {
     RELEASE_ASSERT(_inst->cls == instance_cls, "");
     BoxedInstance* inst = static_cast<BoxedInstance*>(_inst);
 
-    static BoxedString* setitem_str = static_cast<BoxedString*>(PyString_InternFromString("__setitem__"));
+    static BoxedString* setitem_str = internStringImmortal("__setitem__");
     Box* setitem_func = _instanceGetattribute(inst, setitem_str, true);
     return runtimeCall(setitem_func, ArgPassSpec(2), key, value, NULL, NULL, NULL);
 }
@@ -473,7 +473,7 @@ Box* instanceDelitem(Box* _inst, Box* key) {
     RELEASE_ASSERT(_inst->cls == instance_cls, "");
     BoxedInstance* inst = static_cast<BoxedInstance*>(_inst);
 
-    static BoxedString* delitem_str = static_cast<BoxedString*>(PyString_InternFromString("__delitem__"));
+    static BoxedString* delitem_str = internStringImmortal("__delitem__");
     Box* delitem_func = _instanceGetattribute(inst, delitem_str, true);
     return runtimeCall(delitem_func, ArgPassSpec(1), key, NULL, NULL, NULL, NULL);
 }
@@ -494,7 +494,7 @@ static int half_cmp(PyObject* v, PyObject* w) noexcept {
 
     assert(PyInstance_Check(v));
 
-    static BoxedString* cmp_str = static_cast<BoxedString*>(PyString_InternFromString("__cmp__"));
+    static BoxedString* cmp_str = internStringImmortal("__cmp__");
 // Pyston change:
 #if 0
         if (cmp_obj == NULL) {
@@ -617,7 +617,7 @@ Box* instanceContains(Box* _inst, Box* key) {
     RELEASE_ASSERT(_inst->cls == instance_cls, "");
     BoxedInstance* inst = static_cast<BoxedInstance*>(_inst);
 
-    static BoxedString* contains_str = static_cast<BoxedString*>(PyString_InternFromString("__contains__"));
+    static BoxedString* contains_str = internStringImmortal("__contains__");
     Box* contains_func = _instanceGetattribute(inst, contains_str, false);
 
     if (!contains_func) {
@@ -638,9 +638,9 @@ static Box* instanceHash(BoxedInstance* inst) {
     PyObject* func;
     PyObject* res;
 
-    static BoxedString* hash_str = static_cast<BoxedString*>(PyString_InternFromString("__hash__"));
-    static BoxedString* eq_str = static_cast<BoxedString*>(PyString_InternFromString("__eq__"));
-    static BoxedString* cmp_str = static_cast<BoxedString*>(PyString_InternFromString("__cmp__"));
+    static BoxedString* hash_str = internStringImmortal("__hash__");
+    static BoxedString* eq_str = internStringImmortal("__eq__");
+    static BoxedString* cmp_str = internStringImmortal("__cmp__");
 
     func = _instanceGetattribute(inst, hash_str, false);
     if (func == NULL) {
@@ -671,8 +671,8 @@ static Box* instanceIter(BoxedInstance* self) {
 
     PyObject* func;
 
-    static BoxedString* iter_str = static_cast<BoxedString*>(PyString_InternFromString("__iter__"));
-    static BoxedString* getitem_str = static_cast<BoxedString*>(PyString_InternFromString("__getitem__"));
+    static BoxedString* iter_str = internStringImmortal("__iter__");
+    static BoxedString* getitem_str = internStringImmortal("__getitem__");
     if ((func = _instanceGetattribute(self, iter_str, false)) != NULL) {
         PyObject* res = PyEval_CallObject(func, (PyObject*)NULL);
         if (!res)
@@ -696,7 +696,7 @@ static Box* instanceIter(BoxedInstance* self) {
 static Box* instanceNext(BoxedInstance* inst) {
     assert(inst->cls == instance_cls);
 
-    static BoxedString* next_str = static_cast<BoxedString*>(PyString_InternFromString("next"));
+    static BoxedString* next_str = internStringImmortal("next");
     Box* next_func = _instanceGetattribute(inst, next_str, false);
 
     if (!next_func) {
@@ -769,7 +769,7 @@ Box* instanceCall(Box* _inst, Box* _args, Box* _kwargs) {
     assert(_inst->cls == instance_cls);
     BoxedInstance* inst = static_cast<BoxedInstance*>(_inst);
 
-    static BoxedString* call_str = static_cast<BoxedString*>(PyString_InternFromString("__call__"));
+    static BoxedString* call_str = internStringImmortal("__call__");
     Box* call_func = _instanceGetattribute(inst, call_str, false);
     if (!call_func)
         raiseExcHelper(AttributeError, "%s instance has no __call__ method", inst->inst_cls->name->data());

--- a/src/runtime/descr.cpp
+++ b/src/runtime/descr.cpp
@@ -44,7 +44,7 @@ static void propertyDocCopy(BoxedProperty* prop, Box* fget) {
     assert(fget);
     Box* get_doc;
 
-    static BoxedString* doc_str = static_cast<BoxedString*>(PyString_InternFromString("__doc__"));
+    static BoxedString* doc_str = internStringImmortal("__doc__");
     try {
         get_doc = getattrInternal(fget, doc_str, NULL);
     } catch (ExcInfo e) {

--- a/src/runtime/dict.cpp
+++ b/src/runtime/dict.cpp
@@ -308,7 +308,7 @@ extern "C" int PyDict_Next(PyObject* op, Py_ssize_t* ppos, PyObject** pkey, PyOb
 
 extern "C" PyObject* PyDict_GetItemString(PyObject* dict, const char* key) noexcept {
     if (dict->cls == attrwrapper_cls)
-        return unwrapAttrWrapper(dict)->getattr(key);
+        return unwrapAttrWrapper(dict)->getattr(internStringMortal(key));
 
     Box* key_s;
     try {
@@ -697,7 +697,7 @@ void setupDict() {
                        new BoxedFunction(boxRTFunction((void*)dictIterValues, typeFromClass(dict_iterator_cls), 1)));
 
     dict_cls->giveAttr("keys", new BoxedFunction(boxRTFunction((void*)dictKeys, LIST, 1)));
-    dict_cls->giveAttr("iterkeys", dict_cls->getattr("__iter__"));
+    dict_cls->giveAttr("iterkeys", dict_cls->getattr(internStringMortal("__iter__")));
 
     dict_cls->giveAttr("pop", new BoxedFunction(boxRTFunction((void*)dictPop, UNKNOWN, 3, 1, false, false), { NULL }));
     dict_cls->giveAttr("popitem", new BoxedFunction(boxRTFunction((void*)dictPopitem, BOXED_TUPLE, 1)));

--- a/src/runtime/dict.cpp
+++ b/src/runtime/dict.cpp
@@ -192,7 +192,7 @@ Box* dictGetitem(BoxedDict* self, Box* k) {
     if (it == self->d.end()) {
         // Try calling __missing__ if this is a subclass
         if (self->cls != dict_cls) {
-            static BoxedString* missing_str = static_cast<BoxedString*>(PyString_InternFromString("__missing__"));
+            static BoxedString* missing_str = internStringImmortal("__missing__");
             CallattrFlags callattr_flags{.cls_only = true, .null_on_nonexistent = true, .argspec = ArgPassSpec(1) };
             Box* r = callattr(self, missing_str, callattr_flags, k, NULL, NULL, NULL, NULL);
             if (r)
@@ -524,7 +524,7 @@ void dictMerge(BoxedDict* self, Box* other) {
         return;
     }
 
-    static BoxedString* keys_str = static_cast<BoxedString*>(PyString_InternFromString("keys"));
+    static BoxedString* keys_str = internStringImmortal("keys");
     CallattrFlags callattr_flags{.cls_only = false, .null_on_nonexistent = true, .argspec = ArgPassSpec(0) };
     Box* keys = callattr(other, keys_str, callattr_flags, NULL, NULL, NULL, NULL, NULL);
     assert(keys);
@@ -588,7 +588,7 @@ Box* dictUpdate(BoxedDict* self, BoxedTuple* args, BoxedDict* kwargs) {
     RELEASE_ASSERT(args->size() <= 1, ""); // should throw a TypeError
     if (args->size()) {
         Box* arg = args->elts[0];
-        static BoxedString* keys_str = static_cast<BoxedString*>(PyString_InternFromString("keys"));
+        static BoxedString* keys_str = internStringImmortal("keys");
         if (getattrInternal(arg, keys_str, NULL)) {
             dictMerge(self, arg);
         } else {

--- a/src/runtime/file.cpp
+++ b/src/runtime/file.cpp
@@ -1776,7 +1776,7 @@ void setupFile() {
     file_cls->giveAttr("__enter__", new BoxedFunction(boxRTFunction((void*)fileEnter, typeFromClass(file_cls), 1)));
     file_cls->giveAttr("__exit__", new BoxedFunction(boxRTFunction((void*)fileExit, UNKNOWN, 4)));
 
-    file_cls->giveAttr("__iter__", file_cls->getattr("__enter__"));
+    file_cls->giveAttr("__iter__", file_cls->getattr(internStringMortal("__enter__")));
     file_cls->giveAttr("__hasnext__", new BoxedFunction(boxRTFunction((void*)fileIterHasNext, BOXED_BOOL, 1)));
     file_cls->giveAttr("next", new BoxedFunction(boxRTFunction((void*)fileIterNext, STR, 1)));
 

--- a/src/runtime/float.cpp
+++ b/src/runtime/float.cpp
@@ -1447,7 +1447,7 @@ static PyMethodDef float_methods[] = { { "hex", (PyCFunction)float_hex, METH_NOA
 
 void setupFloat() {
     _addFunc("__add__", BOXED_FLOAT, (void*)floatAddFloat, (void*)floatAddInt, (void*)floatAdd);
-    float_cls->giveAttr("__radd__", float_cls->getattr("__add__"));
+    float_cls->giveAttr("__radd__", float_cls->getattr(internStringMortal("__add__")));
 
     _addFunc("__div__", BOXED_FLOAT, (void*)floatDivFloat, (void*)floatDivInt, (void*)floatDiv);
     _addFunc("__rdiv__", BOXED_FLOAT, (void*)floatRDivFloat, (void*)floatRDivInt, (void*)floatRDiv);
@@ -1464,7 +1464,7 @@ void setupFloat() {
     _addFunc("__mod__", BOXED_FLOAT, (void*)floatModFloat, (void*)floatModInt, (void*)floatMod);
     _addFunc("__rmod__", BOXED_FLOAT, (void*)floatRModFloat, (void*)floatRModInt, (void*)floatRMod);
     _addFunc("__mul__", BOXED_FLOAT, (void*)floatMulFloat, (void*)floatMulInt, (void*)floatMul);
-    float_cls->giveAttr("__rmul__", float_cls->getattr("__mul__"));
+    float_cls->giveAttr("__rmul__", float_cls->getattr(internStringMortal("__mul__")));
 
     _addFuncPow("__pow__", BOXED_FLOAT, (void*)floatPowFloat, (void*)floatPowInt, (void*)floatPow);
     _addFunc("__sub__", BOXED_FLOAT, (void*)floatSubFloat, (void*)floatSubInt, (void*)floatSub);

--- a/src/runtime/float.cpp
+++ b/src/runtime/float.cpp
@@ -651,7 +651,7 @@ BoxedFloat* _floatNew(Box* a) {
             raiseExcHelper(ValueError, "could not convert string to float: %s", s.data());
         return new BoxedFloat(r);
     } else {
-        static BoxedString* float_str = static_cast<BoxedString*>(PyString_InternFromString("__float__"));
+        static BoxedString* float_str = internStringImmortal("__float__");
         CallattrFlags callattr_flags{.cls_only = true, .null_on_nonexistent = true, .argspec = ArgPassSpec(0) };
         Box* r = callattr(a, float_str, callattr_flags, NULL, NULL, NULL, NULL, NULL);
 

--- a/src/runtime/import.cpp
+++ b/src/runtime/import.cpp
@@ -188,7 +188,7 @@ SearchResult findModule(const std::string& name, const std::string& full_name, B
     if (!meta_path || meta_path->cls != list_cls)
         raiseExcHelper(RuntimeError, "sys.meta_path must be a list of import hooks");
 
-    static BoxedString* findmodule_str = static_cast<BoxedString*>(PyString_InternFromString("find_module"));
+    static BoxedString* findmodule_str = internStringImmortal("find_module");
     for (int i = 0; i < meta_path->size; i++) {
         Box* finder = meta_path->elts->elts[i];
 
@@ -279,7 +279,7 @@ static Box* getParent(Box* globals, int level, std::string& buf) {
     if (globals == NULL || globals == None || level == 0)
         return None;
 
-    static BoxedString* package_str = static_cast<BoxedString*>(PyString_InternFromString("__package__"));
+    static BoxedString* package_str = internStringImmortal("__package__");
     BoxedString* pkgname = static_cast<BoxedString*>(getFromGlobals(globals, package_str));
     if (pkgname != NULL && pkgname != None) {
         /* __package__ is set, so use it */
@@ -298,14 +298,14 @@ static Box* getParent(Box* globals, int level, std::string& buf) {
         }
         buf += pkgname->s();
     } else {
-        static BoxedString* name_str = static_cast<BoxedString*>(PyString_InternFromString("__name__"));
+        static BoxedString* name_str = internStringImmortal("__name__");
 
         /* __package__ not set, so figure it out and set it */
         BoxedString* modname = static_cast<BoxedString*>(getFromGlobals(globals, name_str));
         if (modname == NULL || modname->cls != str_cls)
             return None;
 
-        static BoxedString* path_str = static_cast<BoxedString*>(PyString_InternFromString("__path__"));
+        static BoxedString* path_str = internStringImmortal("__path__");
         Box* modpath = getFromGlobals(globals, path_str);
 
         if (modpath != NULL) {
@@ -378,7 +378,7 @@ static Box* importSub(const std::string& name, const std::string& full_name, Box
     if (parent_module == NULL || parent_module == None) {
         path_list = NULL;
     } else {
-        static BoxedString* path_str = static_cast<BoxedString*>(PyString_InternFromString("__path__"));
+        static BoxedString* path_str = internStringImmortal("__path__");
         path_list = static_cast<BoxedList*>(getattrInternal(parent_module, path_str, NULL));
         if (path_list == NULL || path_list->cls != list_cls) {
             return None;
@@ -398,8 +398,7 @@ static Box* importSub(const std::string& name, const std::string& full_name, Box
             else if (sr.type == SearchResult::C_EXTENSION)
                 module = importCExtension(full_name, name, sr.path);
             else if (sr.type == SearchResult::IMP_HOOK) {
-                static BoxedString* loadmodule_str
-                    = static_cast<BoxedString*>(PyString_InternFromString("load_module"));
+                static BoxedString* loadmodule_str = internStringImmortal("load_module");
                 CallattrFlags callattr_flags{.cls_only = false,
                                              .null_on_nonexistent = false,
                                              .argspec = ArgPassSpec(1) };
@@ -557,7 +556,7 @@ extern "C" PyObject* PyImport_ImportModuleLevel(const char* name, PyObject* glob
 }
 
 static void ensureFromlist(Box* module, Box* fromlist, std::string& buf, bool recursive) {
-    static BoxedString* path_str = static_cast<BoxedString*>(PyString_InternFromString("__path__"));
+    static BoxedString* path_str = internStringImmortal("__path__");
     Box* pathlist = NULL;
     try {
         pathlist = getattrInternal(module, path_str, NULL);
@@ -580,7 +579,7 @@ static void ensureFromlist(Box* module, Box* fromlist, std::string& buf, bool re
             if (recursive)
                 continue;
 
-            static BoxedString* all_str = static_cast<BoxedString*>(PyString_InternFromString("__all__"));
+            static BoxedString* all_str = internStringImmortal("__all__");
             Box* all = getattrInternal(module, all_str, NULL);
             if (all) {
                 ensureFromlist(module, all, buf, true);

--- a/src/runtime/import.cpp
+++ b/src/runtime/import.cpp
@@ -184,7 +184,8 @@ struct SearchResult {
 };
 
 SearchResult findModule(const std::string& name, const std::string& full_name, BoxedList* path_list) {
-    BoxedList* meta_path = static_cast<BoxedList*>(sys_module->getattr(internStringMortal("meta_path")));
+    static BoxedString* meta_path_str = internStringImmortal("meta_path");
+    BoxedList* meta_path = static_cast<BoxedList*>(sys_module->getattr(meta_path_str));
     if (!meta_path || meta_path->cls != list_cls)
         raiseExcHelper(RuntimeError, "sys.meta_path must be a list of import hooks");
 
@@ -208,12 +209,13 @@ SearchResult findModule(const std::string& name, const std::string& full_name, B
         raiseExcHelper(RuntimeError, "sys.path must be a list of directory names");
     }
 
-    BoxedList* path_hooks = static_cast<BoxedList*>(sys_module->getattr(internStringMortal("path_hooks")));
+    static BoxedString* path_hooks_str = internStringImmortal("path_hooks");
+    BoxedList* path_hooks = static_cast<BoxedList*>(sys_module->getattr(path_hooks_str));
     if (!path_hooks || path_hooks->cls != list_cls)
         raiseExcHelper(RuntimeError, "sys.path_hooks must be a list of import hooks");
 
-    BoxedDict* path_importer_cache
-        = static_cast<BoxedDict*>(sys_module->getattr(internStringMortal("path_importer_cache")));
+    static BoxedString* path_importer_cache_str = internStringImmortal("path_importer_cache");
+    BoxedDict* path_importer_cache = static_cast<BoxedDict*>(sys_module->getattr(path_importer_cache_str));
     if (!path_importer_cache || path_importer_cache->cls != dict_cls)
         raiseExcHelper(RuntimeError, "sys.path_importer_cache must be a dict");
 
@@ -865,7 +867,8 @@ Box* impIsBuiltin(Box* _name) {
     if (!PyString_Check(_name))
         raiseExcHelper(TypeError, "must be string, not %s", getTypeName(_name));
 
-    BoxedTuple* builtin_modules = (BoxedTuple*)sys_module->getattr(internStringMortal("builtin_module_names"));
+    static BoxedString* builtin_module_names_str = internStringImmortal("builtin_module_names");
+    BoxedTuple* builtin_modules = (BoxedTuple*)sys_module->getattr(builtin_module_names_str);
     RELEASE_ASSERT(PyTuple_Check(builtin_modules), "");
     for (Box* m : builtin_modules->pyElements()) {
         if (compare(m, _name, AST_TYPE::Eq) == True)

--- a/src/runtime/int.cpp
+++ b/src/runtime/int.cpp
@@ -931,7 +931,7 @@ static Box* _intNew(Box* val, Box* base) {
         return PyLong_FromDouble(wholepart);
     } else {
         RELEASE_ASSERT(!base, "");
-        static BoxedString* int_str = static_cast<BoxedString*>(PyString_InternFromString("__int__"));
+        static BoxedString* int_str = internStringImmortal("__int__");
         CallattrFlags callattr_flags{.cls_only = true, .null_on_nonexistent = true, .argspec = ArgPassSpec(0) };
         Box* r = callattr(val, int_str, callattr_flags, NULL, NULL, NULL, NULL, NULL);
 

--- a/src/runtime/long.cpp
+++ b/src/runtime/long.cpp
@@ -1373,7 +1373,7 @@ void setupLong() {
         "__new__", new BoxedFunction(boxRTFunction((void*)longNew, UNKNOWN, 3, 2, false, false), { boxInt(0), NULL }));
 
     long_cls->giveAttr("__mul__", new BoxedFunction(boxRTFunction((void*)longMul, UNKNOWN, 2)));
-    long_cls->giveAttr("__rmul__", long_cls->getattr("__mul__"));
+    long_cls->giveAttr("__rmul__", long_cls->getattr(internStringMortal("__mul__")));
 
     long_cls->giveAttr("__div__", new BoxedFunction(boxRTFunction((void*)longDiv, UNKNOWN, 2)));
     long_cls->giveAttr("__rdiv__", new BoxedFunction(boxRTFunction((void*)longRdiv, UNKNOWN, 2)));
@@ -1390,17 +1390,17 @@ void setupLong() {
     long_cls->giveAttr("__rsub__", new BoxedFunction(boxRTFunction((void*)longRsub, UNKNOWN, 2)));
 
     long_cls->giveAttr("__add__", new BoxedFunction(boxRTFunction((void*)longAdd, UNKNOWN, 2)));
-    long_cls->giveAttr("__radd__", long_cls->getattr("__add__"));
+    long_cls->giveAttr("__radd__", long_cls->getattr(internStringMortal("__add__")));
 
     long_cls->giveAttr("__pow__",
                        new BoxedFunction(boxRTFunction((void*)longPow, UNKNOWN, 3, 1, false, false), { None }));
 
     long_cls->giveAttr("__and__", new BoxedFunction(boxRTFunction((void*)longAnd, UNKNOWN, 2)));
-    long_cls->giveAttr("__rand__", long_cls->getattr("__and__"));
+    long_cls->giveAttr("__rand__", long_cls->getattr(internStringMortal("__and__")));
     long_cls->giveAttr("__or__", new BoxedFunction(boxRTFunction((void*)longOr, UNKNOWN, 2)));
-    long_cls->giveAttr("__ror__", long_cls->getattr("__or__"));
+    long_cls->giveAttr("__ror__", long_cls->getattr(internStringMortal("__or__")));
     long_cls->giveAttr("__xor__", new BoxedFunction(boxRTFunction((void*)longXor, UNKNOWN, 2)));
-    long_cls->giveAttr("__rxor__", long_cls->getattr("__xor__"));
+    long_cls->giveAttr("__rxor__", long_cls->getattr(internStringMortal("__xor__")));
 
     // Note: CPython implements long comparisons using tp_compare
     long_cls->tp_richcompare = long_richcompare;

--- a/src/runtime/long.cpp
+++ b/src/runtime/long.cpp
@@ -642,7 +642,7 @@ BoxedLong* _longNew(Box* val, Box* _base) {
         } else if (val->cls == float_cls) {
             mpz_init_set_si(rtn->n, static_cast<BoxedFloat*>(val)->d);
         } else {
-            static BoxedString* long_str = static_cast<BoxedString*>(PyString_InternFromString("__long__"));
+            static BoxedString* long_str = internStringImmortal("__long__");
             CallattrFlags callattr_flags{.cls_only = true, .null_on_nonexistent = true, .argspec = ArgPassSpec(0) };
             Box* r = callattr(val, long_str, callattr_flags, NULL, NULL, NULL, NULL, NULL);
 

--- a/src/runtime/objmodel.cpp
+++ b/src/runtime/objmodel.cpp
@@ -200,7 +200,7 @@ extern "C" bool softspace(Box* b, bool newval) {
         return (bool)r;
     }
 
-    static BoxedString* softspace_str = static_cast<BoxedString*>(PyString_InternFromString("softspace"));
+    static BoxedString* softspace_str = internStringImmortal("softspace");
 
     bool r;
     Box* gotten = NULL;
@@ -225,9 +225,9 @@ extern "C" bool softspace(Box* b, bool newval) {
 }
 
 extern "C" void printHelper(Box* dest, Box* var, bool nl) {
-    static BoxedString* write_str = static_cast<BoxedString*>(PyString_InternFromString("write"));
-    static BoxedString* newline_str = static_cast<BoxedString*>(PyString_InternFromString("\n"));
-    static BoxedString* space_str = static_cast<BoxedString*>(PyString_InternFromString(" "));
+    static BoxedString* write_str = internStringImmortal("write");
+    static BoxedString* newline_str = internStringImmortal("\n");
+    static BoxedString* space_str = internStringImmortal(" ");
 
     if (var) {
         // begin code for handling of softspace
@@ -2302,8 +2302,8 @@ extern "C" bool nonzero(Box* obj) {
     }
 
     // TODO: rewrite these.
-    static BoxedString* nonzero_str = static_cast<BoxedString*>(PyString_InternFromString("__nonzero__"));
-    static BoxedString* len_str = static_cast<BoxedString*>(PyString_InternFromString("__len__"));
+    static BoxedString* nonzero_str = internStringImmortal("__nonzero__");
+    static BoxedString* len_str = internStringImmortal("__len__");
     // go through descriptor logic
     Box* func = getclsattrInternal(obj, nonzero_str, NULL);
     if (!func)
@@ -2341,7 +2341,7 @@ extern "C" BoxedString* str(Box* obj) {
     static StatCounter slowpath_str("slowpath_str");
     slowpath_str.log();
 
-    static BoxedString* str_box = static_cast<BoxedString*>(PyString_InternFromString(str_str.c_str()));
+    static BoxedString* str_box = internStringImmortal(str_str.c_str());
     if (obj->cls != str_cls) {
         // TODO could do an IC optimization here (once we do rewrites here at all):
         // if __str__ is objectStr, just guard on that and call repr directly.
@@ -2373,7 +2373,7 @@ extern "C" BoxedString* repr(Box* obj) {
     static StatCounter slowpath_repr("slowpath_repr");
     slowpath_repr.log();
 
-    static BoxedString* repr_box = static_cast<BoxedString*>(PyString_InternFromString(repr_str.c_str()));
+    static BoxedString* repr_box = internStringImmortal(repr_str.c_str());
     obj = callattrInternal(obj, repr_box, CLASS_ONLY, NULL, ArgPassSpec(0), NULL, NULL, NULL, NULL, NULL);
 
     if (isSubclass(obj->cls, unicode_cls)) {
@@ -2455,7 +2455,7 @@ extern "C" BoxedInt* hash(Box* obj) {
 }
 
 extern "C" BoxedInt* lenInternal(Box* obj, LenRewriteArgs* rewrite_args) {
-    static BoxedString* len_str = static_cast<BoxedString*>(PyString_InternFromString("__len__"));
+    static BoxedString* len_str = internStringImmortal("__len__");
 
     // Corresponds to the first part of PyObject_Size:
     PySequenceMethods* m = obj->cls->tp_as_sequence;
@@ -3640,7 +3640,7 @@ Box* runtimeCallInternal(Box* obj, CallRewriteArgs* rewrite_args, ArgPassSpec ar
             assert((obj->cls->tp_call == NULL) == (typeLookup(obj->cls, call_str, NULL) == NULL));
         }
 
-        static BoxedString* call_box = static_cast<BoxedString*>(PyString_InternFromString(call_str.c_str()));
+        static BoxedString* call_box = internStringImmortal(call_str.c_str());
 
         if (rewrite_args) {
             rtn = callattrInternal(obj, call_box, CLASS_ONLY, rewrite_args, argspec, arg1, arg2, arg3, args,
@@ -4056,7 +4056,7 @@ Box* compareInternal(Box* lhs, Box* rhs, int op_type, CompareRewriteArgs* rewrit
     }
 
     if (op_type == AST_TYPE::In || op_type == AST_TYPE::NotIn) {
-        static BoxedString* contains_str = static_cast<BoxedString*>(PyString_InternFromString("__contains__"));
+        static BoxedString* contains_str = internStringImmortal("__contains__");
 
         // The checks for this branch are taken from CPython's PySequence_Contains
         if (PyType_HasFeature(rhs->cls, Py_TPFLAGS_HAVE_SEQUENCE_IN)) {
@@ -4240,7 +4240,7 @@ Box* compareInternal(Box* lhs, Box* rhs, int op_type, CompareRewriteArgs* rewrit
     if (rrtn != NULL && rrtn != NotImplemented)
         return rrtn;
 
-    static BoxedString* cmp_str = static_cast<BoxedString*>(PyString_InternFromString("__cmp__"));
+    static BoxedString* cmp_str = internStringImmortal("__cmp__");
     lrtn = callattrInternal1(lhs, cmp_str, CLASS_ONLY, NULL, ArgPassSpec(1), rhs);
     if (lrtn && lrtn != NotImplemented) {
         return boxBool(convert3wayCompareResultToBool(lrtn, op_type));
@@ -4390,7 +4390,7 @@ extern "C" Box* getitem(Box* value, Box* slice) {
         return r;
     }
 
-    static BoxedString* getitem_str = static_cast<BoxedString*>(PyString_InternFromString("__getitem__"));
+    static BoxedString* getitem_str = internStringImmortal("__getitem__");
     Box* rtn;
     if (rewriter.get()) {
         CallRewriteArgs rewrite_args(rewriter.get(), rewriter->getArg(0), rewriter->getReturnDestination());
@@ -4432,7 +4432,7 @@ extern "C" void setitem(Box* target, Box* slice, Box* value) {
     std::unique_ptr<Rewriter> rewriter(
         Rewriter::createRewriter(__builtin_extract_return_addr(__builtin_return_address(0)), 3, "setitem"));
 
-    static BoxedString* setitem_str = static_cast<BoxedString*>(PyString_InternFromString("__setitem__"));
+    static BoxedString* setitem_str = internStringImmortal("__setitem__");
 
     Box* rtn;
     if (rewriter.get()) {
@@ -4468,7 +4468,7 @@ extern "C" void delitem(Box* target, Box* slice) {
     std::unique_ptr<Rewriter> rewriter(
         Rewriter::createRewriter(__builtin_extract_return_addr(__builtin_return_address(0)), 2, "delitem"));
 
-    static BoxedString* delitem_str = static_cast<BoxedString*>(PyString_InternFromString("__delitem__"));
+    static BoxedString* delitem_str = internStringImmortal("__delitem__");
 
     Box* rtn;
     if (rewriter.get()) {
@@ -4674,7 +4674,7 @@ extern "C" Box* getiterHelper(Box* o) {
 
 Box* getiter(Box* o) {
     // TODO add rewriting to this?  probably want to try to avoid this path though
-    static BoxedString* iter_str = static_cast<BoxedString*>(PyString_InternFromString("__iter__"));
+    static BoxedString* iter_str = internStringImmortal("__iter__");
     Box* r = callattrInternal0(o, iter_str, LookupScope::CLASS_ONLY, NULL, ArgPassSpec(0));
     if (r)
         return r;
@@ -4763,7 +4763,7 @@ Box* typeNew(Box* _cls, Box* arg1, Box* arg2, Box** _args) {
                                   "of the metaclasses of all its bases");
     }
 
-    static BoxedString* new_box = static_cast<BoxedString*>(PyString_InternFromString(new_str.c_str()));
+    static BoxedString* new_box = internStringImmortal(new_str.c_str());
     if (winner != metatype) {
         if (getattr(winner, new_box) != getattr(type_cls, new_box)) {
             CallattrFlags callattr_flags

--- a/src/runtime/objmodel.h
+++ b/src/runtime/objmodel.h
@@ -128,7 +128,7 @@ enum LookupScope {
 extern "C" Box* callattrInternal(Box* obj, BoxedString* attr, LookupScope, CallRewriteArgs* rewrite_args,
                                  ArgPassSpec argspec, Box* arg1, Box* arg2, Box* arg3, Box** args,
                                  const std::vector<BoxedString*>* keyword_names);
-extern "C" void delattr_internal(Box* obj, llvm::StringRef attr, bool allow_custom, DelattrRewriteArgs* rewrite_args);
+extern "C" void delattr_internal(Box* obj, BoxedString* attr, bool allow_custom, DelattrRewriteArgs* rewrite_args);
 struct CompareRewriteArgs;
 Box* compareInternal(Box* lhs, Box* rhs, int op_type, CompareRewriteArgs* rewrite_args);
 
@@ -139,12 +139,12 @@ Box* getattrInternal(Box* obj, BoxedString* attr, GetattrRewriteArgs* rewrite_ar
 // This is the equivalent of PyObject_GenericGetAttr, which performs the default lookup rules for getattr() (check for
 // data descriptor, check for instance attribute, check for non-data descriptor). It does not check for __getattr__ or
 // __getattribute__.
-Box* getattrInternalGeneric(Box* obj, llvm::StringRef attr, GetattrRewriteArgs* rewrite_args, bool cls_only,
-                            bool for_call, Box** bind_obj_out, RewriterVar** r_bind_obj_out);
+Box* getattrInternalGeneric(Box* obj, BoxedString* attr, GetattrRewriteArgs* rewrite_args, bool cls_only, bool for_call,
+                            Box** bind_obj_out, RewriterVar** r_bind_obj_out);
 
 // This is the equivalent of _PyType_Lookup(), which calls Box::getattr() on each item in the object's MRO in the
 // appropriate order. It does not do any descriptor logic.
-Box* typeLookup(BoxedClass* cls, llvm::StringRef attr, GetattrRewriteArgs* rewrite_args);
+Box* typeLookup(BoxedClass* cls, BoxedString* attr, GetattrRewriteArgs* rewrite_args);
 
 extern "C" void raiseAttributeErrorStr(const char* typeName, llvm::StringRef attr) __attribute__((__noreturn__));
 extern "C" void raiseAttributeError(Box* obj, llvm::StringRef attr) __attribute__((__noreturn__));

--- a/src/runtime/set.cpp
+++ b/src/runtime/set.cpp
@@ -490,7 +490,7 @@ void setupSet() {
 
     set_cls->giveAttr("__new__",
                       new BoxedFunction(boxRTFunction((void*)setNew, UNKNOWN, 2, 1, false, false), { None }));
-    frozenset_cls->giveAttr("__new__", set_cls->getattr("__new__"));
+    frozenset_cls->giveAttr("__new__", set_cls->getattr(internStringMortal("__new__")));
 
     Box* set_repr = new BoxedFunction(boxRTFunction((void*)setRepr, STR, 1));
     set_cls->giveAttr("__repr__", set_repr);
@@ -515,14 +515,14 @@ void setupSet() {
     v_fu.push_back(FROZENSET);
     v_fu.push_back(UNKNOWN);
 
-    auto add = [&](llvm::StringRef name, void* func) {
+    auto add = [&](const char* name, void* func) {
         CLFunction* func_obj = createRTFunction(2, 0, false, false);
         addRTFunction(func_obj, (void*)func, SET, v_ss);
         addRTFunction(func_obj, (void*)func, SET, v_sf);
         addRTFunction(func_obj, (void*)func, FROZENSET, v_fs);
         addRTFunction(func_obj, (void*)func, FROZENSET, v_ff);
         set_cls->giveAttr(name, new BoxedFunction(func_obj));
-        frozenset_cls->giveAttr(name, set_cls->getattr(name));
+        frozenset_cls->giveAttr(name, set_cls->getattr(internStringMortal(name)));
     };
 
     add("__or__", (void*)setOrSet);
@@ -531,21 +531,21 @@ void setupSet() {
     add("__and__", (void*)setAndSet);
 
     set_cls->giveAttr("__iter__", new BoxedFunction(boxRTFunction((void*)setIter, typeFromClass(set_iterator_cls), 1)));
-    frozenset_cls->giveAttr("__iter__", set_cls->getattr("__iter__"));
+    frozenset_cls->giveAttr("__iter__", set_cls->getattr(internStringMortal("__iter__")));
 
     set_cls->giveAttr("__len__", new BoxedFunction(boxRTFunction((void*)setLen, BOXED_INT, 1)));
-    frozenset_cls->giveAttr("__len__", set_cls->getattr("__len__"));
+    frozenset_cls->giveAttr("__len__", set_cls->getattr(internStringMortal("__len__")));
 
     set_cls->giveAttr("__contains__", new BoxedFunction(boxRTFunction((void*)setContains, BOXED_BOOL, 2)));
-    frozenset_cls->giveAttr("__contains__", set_cls->getattr("__contains__"));
+    frozenset_cls->giveAttr("__contains__", set_cls->getattr(internStringMortal("__contains__")));
 
     set_cls->giveAttr("__eq__", new BoxedFunction(boxRTFunction((void*)setEq, UNKNOWN, 2)));
-    frozenset_cls->giveAttr("__eq__", set_cls->getattr("__eq__"));
+    frozenset_cls->giveAttr("__eq__", set_cls->getattr(internStringMortal("__eq__")));
     set_cls->giveAttr("__ne__", new BoxedFunction(boxRTFunction((void*)setNe, UNKNOWN, 2)));
-    frozenset_cls->giveAttr("__ne__", set_cls->getattr("__ne__"));
+    frozenset_cls->giveAttr("__ne__", set_cls->getattr(internStringMortal("__ne__")));
 
     set_cls->giveAttr("__nonzero__", new BoxedFunction(boxRTFunction((void*)setNonzero, BOXED_BOOL, 1)));
-    frozenset_cls->giveAttr("__nonzero__", set_cls->getattr("__nonzero__"));
+    frozenset_cls->giveAttr("__nonzero__", set_cls->getattr(internStringMortal("__nonzero__")));
 
     frozenset_cls->giveAttr("__hash__", new BoxedFunction(boxRTFunction((void*)setHash, BOXED_INT, 1)));
 
@@ -556,12 +556,12 @@ void setupSet() {
     set_cls->giveAttr("clear", new BoxedFunction(boxRTFunction((void*)setClear, NONE, 1)));
     set_cls->giveAttr("update", new BoxedFunction(boxRTFunction((void*)setUpdate, NONE, 1, 0, true, false)));
     set_cls->giveAttr("union", new BoxedFunction(boxRTFunction((void*)setUnion, UNKNOWN, 1, 0, true, false)));
-    frozenset_cls->giveAttr("union", set_cls->getattr("union"));
+    frozenset_cls->giveAttr("union", set_cls->getattr(internStringMortal("union")));
     set_cls->giveAttr("intersection",
                       new BoxedFunction(boxRTFunction((void*)setIntersection, UNKNOWN, 1, 0, true, false)));
-    frozenset_cls->giveAttr("intersection", set_cls->getattr("intersection"));
+    frozenset_cls->giveAttr("intersection", set_cls->getattr(internStringMortal("intersection")));
     set_cls->giveAttr("difference", new BoxedFunction(boxRTFunction((void*)setDifference, UNKNOWN, 1, 0, true, false)));
-    frozenset_cls->giveAttr("difference", set_cls->getattr("difference"));
+    frozenset_cls->giveAttr("difference", set_cls->getattr(internStringMortal("difference")));
     set_cls->giveAttr("difference_update",
                       new BoxedFunction(boxRTFunction((void*)setDifferenceUpdate, UNKNOWN, 1, 0, true, false)));
     set_cls->giveAttr("issubset", new BoxedFunction(boxRTFunction((void*)setIssubset, UNKNOWN, 2)));

--- a/src/runtime/super.cpp
+++ b/src/runtime/super.cpp
@@ -101,7 +101,7 @@ Box* superGetattribute(Box* _s, Box* _attr) {
                 continue;
             res = PyDict_GetItem(dict, name);
 #endif
-            res = tmp->getattr(std::string(attr->s()));
+            res = tmp->getattr(attr);
 
             if (res != NULL) {
 // Pyston change:
@@ -128,7 +128,7 @@ Box* superGetattribute(Box* _s, Box* _attr) {
         }
     }
 
-    Box* r = typeLookup(s->cls, attr->s(), NULL);
+    Box* r = typeLookup(s->cls, attr, NULL);
     // TODO implement this
     RELEASE_ASSERT(r, "should call the equivalent of objectGetattr here");
     return processDescriptor(r, s, s->cls);
@@ -166,6 +166,7 @@ BoxedClass* supercheck(BoxedClass* type, Box* obj) {
         return obj->cls;
     }
 
+    static BoxedString* class_str = internStringImmortal("__class__");
     Box* class_attr = obj->getattr(class_str);
     if (class_attr && isSubclass(class_attr->cls, type_cls) && class_attr != obj->cls) {
         Py_FatalError("warning: this path never tested"); // blindly copied from CPython

--- a/src/runtime/types.cpp
+++ b/src/runtime/types.cpp
@@ -232,7 +232,7 @@ Box* BoxedClass::callHasnextIC(Box* obj, bool null_on_nonexistent) {
         hasnext_ic.reset(ic);
     }
 
-    static BoxedString* hasnext_str = static_cast<BoxedString*>(PyString_InternFromString("__hasnext__"));
+    static BoxedString* hasnext_str = internStringImmortal("__hasnext__");
     CallattrFlags callattr_flags
         = {.cls_only = true, .null_on_nonexistent = null_on_nonexistent, .argspec = ArgPassSpec(0) };
     return ic->call(obj, hasnext_str, callattr_flags, nullptr, nullptr, nullptr, nullptr, nullptr);
@@ -276,7 +276,7 @@ Box* BoxedClass::callNextIC(Box* obj) {
         next_ic.reset(ic);
     }
 
-    static BoxedString* next_str = static_cast<BoxedString*>(PyString_InternFromString("next"));
+    static BoxedString* next_str = internStringImmortal("next");
     CallattrFlags callattr_flags{.cls_only = true, .null_on_nonexistent = false, .argspec = ArgPassSpec(0) };
     return ic->call(obj, next_str, callattr_flags, nullptr, nullptr, nullptr, nullptr, nullptr);
 }
@@ -290,7 +290,7 @@ Box* BoxedClass::callReprIC(Box* obj) {
         repr_ic.reset(ic);
     }
 
-    static BoxedString* repr_str = static_cast<BoxedString*>(PyString_InternFromString("__repr__"));
+    static BoxedString* repr_str = internStringImmortal("__repr__");
     CallattrFlags callattr_flags{.cls_only = true, .null_on_nonexistent = false, .argspec = ArgPassSpec(0) };
     return ic->call(obj, repr_str, callattr_flags, nullptr, nullptr, nullptr, nullptr, nullptr);
 }
@@ -1240,7 +1240,7 @@ extern "C" Box* createUserClass(BoxedString* name, Box* _bases, Box* _attr_dict)
         assert(msg);
         // TODO this is an extra Pyston check and I don't think we should have to do it:
         if (isSubclass(e.value->cls, BaseException)) {
-            static BoxedString* message_str = static_cast<BoxedString*>(PyString_InternFromString("message"));
+            static BoxedString* message_str = internStringImmortal("message");
             msg = getattr(e.value, message_str);
         }
 
@@ -1396,7 +1396,7 @@ static Box* functionGlobals(Box* self, void*) {
     assert(func->f->source);
     assert(func->f->source->scoping->areGlobalsFromModule());
 
-    static BoxedString* dict_str = static_cast<BoxedString*>(PyString_InternFromString("__dict__"));
+    static BoxedString* dict_str = internStringImmortal("__dict__");
     return getattr(func->f->source->parent_module, dict_str);
 }
 
@@ -1521,7 +1521,7 @@ static Box* instancemethodRepr(Box* b) {
     Box* funcname = NULL, * klassname = NULL, * result = NULL;
     const char* sfuncname = "?", * sklassname = "?";
 
-    static BoxedString* name_str = static_cast<BoxedString*>(PyString_InternFromString("__name__"));
+    static BoxedString* name_str = internStringImmortal("__name__");
     funcname = getattrInternal(func, name_str, NULL);
 
     if (funcname != NULL) {
@@ -2173,7 +2173,7 @@ public:
         // In order to not have to reimplement dict cmp: just create a real dict for now and us it.
         BoxedDict* dict = (BoxedDict*)AttrWrapper::copy(_self);
         assert(dict->cls == dict_cls);
-        static BoxedString* eq_str = static_cast<BoxedString*>(PyString_InternFromString("__eq__"));
+        static BoxedString* eq_str = internStringImmortal("__eq__");
         return callattrInternal(dict, eq_str, LookupScope::CLASS_ONLY, NULL, ArgPassSpec(1), _other, NULL, NULL, NULL,
                                 NULL);
     }

--- a/src/runtime/types.cpp
+++ b/src/runtime/types.cpp
@@ -3027,6 +3027,9 @@ void setupRuntime() {
     type_cls->tp_itemsize = sizeof(BoxedHeapClass::SlotOffset);
     PyObject_Init(object_cls, type_cls);
     PyObject_Init(type_cls, type_cls);
+    // XXX silly that we have to set this again
+    new (&object_cls->attrs) HCAttrs(HiddenClass::makeSingleton());
+    new (&type_cls->attrs) HCAttrs(HiddenClass::makeSingleton());
 
     none_cls = new (0) BoxedHeapClass(object_cls, NULL, 0, 0, sizeof(Box), false, NULL);
     None = new (none_cls) Box();

--- a/src/runtime/types.h
+++ b/src/runtime/types.h
@@ -368,12 +368,15 @@ public:
     void gc_visit(GCVisitor* visitor) {
         // Visit children even for the dict-backed case, since children will just be empty
         visitor->visitRange((void* const*)&children.vector()[0], (void* const*)&children.vector()[children.size()]);
-        if (attrwrapper_child)
-            visitor->visit(attrwrapper_child);
-        for (auto p : children)
-            visitor->visit(p.first);
-        for (auto p : attr_offsets)
-            visitor->visit(p.first);
+        visitor->visit(attrwrapper_child);
+
+        // We don't need to visit the keys of the 'children' map, since the children should have those as entries
+        // in the attr_offssets map.
+        // Also, if we have any children, we can skip scanning our attr_offsets map, since it will be a subset
+        // of our child's map.
+        if (!children.size())
+            for (auto p : attr_offsets)
+                visitor->visit(p.first);
     }
 
     // The total size of the attribute array.  The slots in the attribute array may not correspond 1:1 to Python

--- a/src/runtime/types.h
+++ b/src/runtime/types.h
@@ -326,11 +326,9 @@ public:
 
 private:
     HiddenClass(HCType type) : type(type) {}
-    HiddenClass(HiddenClass* parent) : type(NORMAL), attr_offsets(), attrwrapper_offset(parent->attrwrapper_offset) {
+    HiddenClass(HiddenClass* parent)
+        : type(NORMAL), attr_offsets(parent->attr_offsets), attrwrapper_offset(parent->attrwrapper_offset) {
         assert(parent->type == NORMAL);
-        for (auto& p : parent->attr_offsets) {
-            this->attr_offsets.insert(p);
-        }
     }
 
     // These fields only make sense for NORMAL or SINGLETON hidden classes:

--- a/src/runtime/types.h
+++ b/src/runtime/types.h
@@ -374,7 +374,7 @@ public:
         // in the attr_offssets map.
         // Also, if we have any children, we can skip scanning our attr_offsets map, since it will be a subset
         // of our child's map.
-        if (!children.size())
+        if (children.empty())
             for (auto p : attr_offsets)
                 visitor->visit(p.first);
     }


### PR DESCRIPTION
instead of using llvm::StringMaps.  I guess the downside is additional gc pressure (django_template accumulates 15k interned strings) -- but this is memory that would get allocated anyway, and we probably save overall by de-duplicating between hiddenclasses.  We also have the ability to un-intern them when they become garbage ("mortal" interned strings).

```
       django_template.py             3.6s (2)             3.6s (2)  -2.3%
            pyxl_bench.py             3.4s (2)             3.4s (2)  -2.0%
sqlalchemy_imperative2.py             4.3s (2)             4.1s (2)  -6.7%
                  geomean                 3.8s                 3.6s  -3.7%
```