### PR TITLE
Cache floats based on their bits, not their value

### DIFF
--- a/src/core/ast.cpp
+++ b/src/core/ast.cpp
@@ -1860,7 +1860,9 @@ bool PrintVisitor::visit_unaryop(AST_UnaryOp* node) {
             RELEASE_ASSERT(0, "%s", getOpName(node->op_type)->c_str());
             break;
     }
+    printf("(");
     node->operand->accept(this);
+    printf(")");
     return true;
 }
 

--- a/src/runtime/types.cpp
+++ b/src/runtime/types.cpp
@@ -495,15 +495,22 @@ BoxedInt* BoxedModule::getIntConstant(int64_t n) {
     return r;
 }
 
+static int64_t getDoubleBits(double d) {
+    int64_t rtn;
+    static_assert(sizeof(rtn) == sizeof(d), "");
+    memcpy(&rtn, &d, sizeof(d));
+    return rtn;
+}
+
 BoxedFloat* BoxedModule::getFloatConstant(double d) {
-    BoxedFloat*& r = float_constants[d];
+    BoxedFloat*& r = float_constants[getDoubleBits(d)];
     if (!r)
         r = static_cast<BoxedFloat*>(boxFloat(d));
     return r;
 }
 
 Box* BoxedModule::getPureImaginaryConstant(double d) {
-    Box*& r = imaginary_constants[d];
+    Box*& r = imaginary_constants[getDoubleBits(d)];
     if (!r)
         r = createPureImaginary(d);
     return r;

--- a/src/runtime/types.h
+++ b/src/runtime/types.h
@@ -856,8 +856,8 @@ private:
     ContiguousMap<int64_t, BoxedInt*, std::unordered_map<int64_t, int>> int_constants;
     // I'm not sure how well it works to use doubles as hashtable keys; thankfully
     // it's not a big deal if we get misses.
-    ContiguousMap<double, BoxedFloat*, std::unordered_map<double, int>> float_constants;
-    ContiguousMap<double, Box*, std::unordered_map<double, int>> imaginary_constants;
+    ContiguousMap<int64_t, BoxedFloat*, std::unordered_map<int64_t, int>> float_constants;
+    ContiguousMap<int64_t, Box*, std::unordered_map<int64_t, int>> imaginary_constants;
     ContiguousMap<llvm::StringRef, Box*, llvm::StringMap<int>> long_constants;
 
 public:

--- a/test/tests/float.py
+++ b/test/tests/float.py
@@ -88,3 +88,8 @@ try:
     float(-l)
 except OverflowError as e:
     print e.message
+
+print 0.0
+print -0.0
+print -(0.0)
+print -(-0.0)


### PR DESCRIPTION
We were using a C 'double' as the hashmap key, which meant
that 0.0 and -0.0 would end up caching to the same thing.
Instead, extract the bits of the double, and use that as the
cache key instead.

Should fix #724