### PR TITLE
Revert #708 in order to check if this caused the build failures

### DIFF
--- a/src/asm_writing/rewriter.h
+++ b/src/asm_writing/rewriter.h
@@ -243,16 +243,13 @@ private:
     void bumpUse();
     void releaseIfNoUses();
     bool isDoneUsing() { return next_use == uses.size(); }
-    bool hasScratchAllocation() const { return scratch_allocation.second > 0; }
-    void resetHasScratchAllocation() { scratch_allocation = std::make_pair(0, 0); }
 
     // Indicates if this variable is an arg, and if so, what location the arg is from.
     bool is_arg;
-    bool is_constant;
-
-    uint64_t constant_value;
     Location arg_loc;
-    std::pair<int /*offset*/, int /*size*/> scratch_allocation;
+
+    bool is_constant;
+    uint64_t constant_value;
 
     llvm::SmallSet<std::tuple<int, uint64_t, bool>, 4> attr_guards; // used to detect duplicate guards
 

--- a/src/codegen/baseline_jit.cpp
+++ b/src/codegen/baseline_jit.cpp
@@ -712,6 +712,7 @@ void JitFragmentWriter::_emitPPCall(RewriterVar* result, void* func_addr, const 
         for (int i = 6; i < args.size(); ++i) {
             assembler::Register reg = args[i]->getInReg(Location::any(), true);
             assembler->mov(reg, assembler::Indirect(assembler::RSP, sizeof(void*) * (i - 6)));
+            args[i]->bumpUse();
         }
         RewriterVar::SmallVector reg_args(args.begin(), args.begin() + 6);
         assert(reg_args.size() == 6);
@@ -745,12 +746,6 @@ void JitFragmentWriter::_emitPPCall(RewriterVar* result, void* func_addr, const 
         pp_scratch_size += 8;
         pp_scratch_location -= 8;
     }
-
-    for (RewriterVar* arg : args) {
-        arg->bumpUse();
-    }
-
-    assertConsistent();
 
     StackInfo stack_info(pp_scratch_size, pp_scratch_location);
     pp_infos.emplace_back(PPInfo{ func_addr, pp_start, pp_end, std::move(setup_info), stack_info });


### PR DESCRIPTION
Revert "rewriter: release allocated scratch space after last use" #708
This reverts commit 9bbc7eb7a21e06dd7543741d211c59fa31478678.