### PR TITLE
Add integration test for installing NumPy

### DIFF
--- a/test/integration/Cython_0001-Pyston-change-we-don-t-support-custom-traceback-entr.patch
+++ b/test/integration/Cython_0001-Pyston-change-we-don-t-support-custom-traceback-entr.patch
@@ -1,0 +1,125 @@
+From 0d1aaa649bd47a3f78e573eb4e5b9e35f9aa02d3 Mon Sep 17 00:00:00 2001
+From: Marius Wachtler <undingen@gmail.com>
+Date: Tue, 9 Jun 2015 19:26:44 +0200
+Subject: [PATCH] Pyston change: we don't support custom traceback entries yet
+
+---
+ Cython/Compiler/ModuleNode.py |  8 ++++++--
+ Cython/Utility/Exceptions.c   |  7 ++++++-
+ Cython/Utility/Generator.c    | 31 +++++++++++++++++++++----------
+ 3 files changed, 33 insertions(+), 13 deletions(-)
+
+diff --git a/Cython/Compiler/ModuleNode.py b/Cython/Compiler/ModuleNode.py
+index 4785858..699cd15 100644
+--- a/Cython/Compiler/ModuleNode.py
++++ b/Cython/Compiler/ModuleNode.py
+@@ -1399,9 +1399,13 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
+         code.putln("{")
+         code.putln("PyObject *etype, *eval, *etb;")
+         code.putln("PyErr_Fetch(&etype, &eval, &etb);")
+-        code.putln("++Py_REFCNT(o);")
++        # Pyston change:
++        # code.putln("++Py_REFCNT(o);")
++        code.putln("Py_INCREF(o);")
+         code.putln("%s(o);" % entry.func_cname)
+-        code.putln("--Py_REFCNT(o);")
++        # Pyston change:
++        # code.putln("--Py_REFCNT(o);")
++        code.putln("Py_DECREF(o);")
+         code.putln("PyErr_Restore(etype, eval, etb);")
+         code.putln("}")
+ 
+diff --git a/Cython/Utility/Exceptions.c b/Cython/Utility/Exceptions.c
+index 354a776..8af3cb7 100644
+--- a/Cython/Utility/Exceptions.c
++++ b/Cython/Utility/Exceptions.c
+@@ -450,7 +450,8 @@ static void __Pyx_AddTraceback(const char *funcname, int c_line,
+ /////////////// AddTraceback ///////////////
+ //@requires: ModuleSetupCode.c::CodeObjectCache
+ //@substitute: naming
+-
++// Pyston change: We don't support custom traceback entries currently
++#if 0
+ #include "compile.h"
+ #include "frameobject.h"
+ #include "traceback.h"
+@@ -534,3 +535,7 @@ bad:
+     Py_XDECREF(py_code);
+     Py_XDECREF(py_frame);
+ }
++#else
++static void __Pyx_AddTraceback(const char *funcname, int c_line, int py_line, const char *filename) {
++}
++#endif
+diff --git a/Cython/Utility/Generator.c b/Cython/Utility/Generator.c
+index 0310570..bcd0eb2 100644
+--- a/Cython/Utility/Generator.c
++++ b/Cython/Utility/Generator.c
+@@ -43,7 +43,9 @@ static void __Pyx_Generator_Replace_StopIteration(void) {
+ //////////////////// Generator.proto ////////////////////
+ #define __Pyx_Generator_USED
+ #include <structmember.h>
+-#include <frameobject.h>
++
++// Pyston change:
++// #include <frameobject.h>
+ 
+ typedef PyObject *(*__pyx_generator_body_t)(PyObject *, PyObject *);
+ 
+@@ -487,7 +489,8 @@ static void __Pyx_Generator_dealloc(PyObject *self) {
+         if (PyObject_CallFinalizerFromDealloc(self))
+ #else
+         Py_TYPE(gen)->tp_del(self);
+-        if (self->ob_refcnt > 0)
++        // Pyston change:
++        // if (self->ob_refcnt > 0)
+ #endif
+         {
+             // resurrected.  :(
+@@ -509,9 +512,10 @@ static void __Pyx_Generator_del(PyObject *self) {
+         return ;
+ 
+ #if PY_VERSION_HEX < 0x030400a1
+-    // Temporarily resurrect the object.
+-    assert(self->ob_refcnt == 0);
+-    self->ob_refcnt = 1;
++    // Pyston change:
++    // // Temporarily resurrect the object.
++    // assert(self->ob_refcnt == 0);
++    // self->ob_refcnt = 1;
+ #endif
+ 
+     // Save the current exception, if any.
+@@ -530,18 +534,25 @@ static void __Pyx_Generator_del(PyObject *self) {
+ #if PY_VERSION_HEX < 0x030400a1
+     // Undo the temporary resurrection; can't use DECREF here, it would
+     // cause a recursive call.
+-    assert(self->ob_refcnt > 0);
+-    if (--self->ob_refcnt == 0) {
+-        // this is the normal path out
+-        return;
+-    }
++
++    // Pyston change:
++    // assert(self->ob_refcnt > 0);
++    // if (--self->ob_refcnt == 0) {
++    //     // this is the normal path out
++    //     return;
++    // }
+ 
+     // close() resurrected it!  Make it look like the original Py_DECREF
+     // never happened.
+     {
++// Pyston change:
++#if 0
+         Py_ssize_t refcnt = self->ob_refcnt;
+         _Py_NewReference(self);
+         self->ob_refcnt = refcnt;
++#else
++        _Py_NewReference(self);
++#endif
+     }
+ #if CYTHON_COMPILING_IN_CPYTHON
+     assert(PyType_IS_GC(self->ob_type) &&
+-- 
+2.1.4

--- a/test/integration/numpy_test.py
+++ b/test/integration/numpy_test.py
@@ -1,0 +1,59 @@
+# skip-if: True
+# script expects to find the numpy directory at the same level as the Pyston directory
+import os
+import sys
+import subprocess
+import shutil
+
+ENV_NAME = "numpy_test_env_" + os.path.basename(sys.executable)
+
+if not os.path.exists(ENV_NAME) or os.stat(sys.executable).st_mtime > os.stat(ENV_NAME + "/bin/python").st_mtime:
+    print "Creating virtualenv to install testing dependencies..."
+    VIRTUALENV_SCRIPT = os.path.dirname(__file__) + "/virtualenv/virtualenv.py"
+
+    try:
+        args = [sys.executable, VIRTUALENV_SCRIPT, "-p", sys.executable, ENV_NAME]
+        print "Running", args
+        subprocess.check_call(args)
+    except:
+        print "Error occurred; trying to remove partially-created directory"
+        ei = sys.exc_info()
+        try:
+            subprocess.check_call(["rm", "-rf", ENV_NAME])
+        except Exception as e:
+            print e
+        raise ei[0], ei[1], ei[2]
+
+SRC_DIR = ENV_NAME
+PYTHON_EXE = os.path.abspath(ENV_NAME + "/bin/python")
+CYTHON_DIR = os.path.abspath(os.path.join(SRC_DIR, "Cython-0.22"))
+NUMPY_DIR = ENV_NAME + "/../../numpy"
+
+print "\n>>>"
+print ">>> Setting up Cython..."
+if not os.path.exists(CYTHON_DIR):
+    print ">>>"
+
+    url = "http://cython.org/release/Cython-0.22.tar.gz"
+    subprocess.check_call(["wget", url], cwd=SRC_DIR)
+    subprocess.check_call(["tar", "-zxf", "Cython-0.22.tar.gz"], cwd=SRC_DIR)
+
+    PATCH_FILE = os.path.abspath(os.path.join(os.path.dirname(__file__), "Cython_0001-Pyston-change-we-don-t-support-custom-traceback-entr.patch"))
+    subprocess.check_call(["patch", "-p1", "--input=" + PATCH_FILE], cwd=CYTHON_DIR)
+    print "Applied Cython patch"
+
+
+    subprocess.check_call([PYTHON_EXE, "setup.py", "install"], cwd=CYTHON_DIR)
+    subprocess.check_call([PYTHON_EXE, "-c", "import Cython"], cwd=CYTHON_DIR)
+else:
+    print ">>> Cython already installed."
+    print ">>>"
+
+print "\n>>>"
+print ">>> Setting up NumPy..."
+print ">>>"
+subprocess.check_call([PYTHON_EXE, "setup.py", "build"], cwd=NUMPY_DIR)
+subprocess.check_call([PYTHON_EXE, "setup.py", "install"], cwd=NUMPY_DIR)
+
+print
+print "PASSED"


### PR DESCRIPTION
Since we're not able to install NumPy yet, I just added `skip-if: True` and a comment saying that the script expects to find `NumPy` at the same directory level as `pyston` (to avoid having yet another submodule to clone).

This uses @undingen's patch for CPython.