### PR TITLE
Reenable attr interning

### DIFF
--- a/src/analysis/type_analysis.cpp
+++ b/src/analysis/type_analysis.cpp
@@ -222,7 +222,7 @@ private:
 
         // TODO this isn't the exact behavior
         BoxedString* name = getInplaceOpName(node->op_type);
-        CompilerType* attr_type = left->getattrType(name->s(), true);
+        CompilerType* attr_type = left->getattrType(name, true);
 
         if (attr_type == UNDEF)
             attr_type = UNKNOWN;
@@ -251,7 +251,7 @@ private:
 
         // TODO this isn't the exact behavior
         BoxedString* name = getOpName(node->op_type);
-        CompilerType* attr_type = left->getattrType(name->s(), true);
+        CompilerType* attr_type = left->getattrType(name, true);
 
         if (attr_type == UNDEF)
             attr_type = UNKNOWN;
@@ -336,7 +336,7 @@ private:
             }
 
             BoxedString* name = getOpName(node->ops[0]);
-            CompilerType* attr_type = left->getattrType(name->s(), true);
+            CompilerType* attr_type = left->getattrType(name, true);
 
             if (attr_type == UNDEF)
                 attr_type = UNKNOWN;
@@ -474,7 +474,7 @@ private:
     void* visit_subscript(AST_Subscript* node) override {
         CompilerType* val = getType(node->value);
         CompilerType* slice = getType(node->slice);
-        static std::string name("__getitem__");
+        static BoxedString* name = internStringImmortal("__getitem__");
         CompilerType* getitem_type = val->getattrType(name, true);
         std::vector<CompilerType*> args;
         args.push_back(slice);
@@ -494,7 +494,7 @@ private:
 
         // TODO this isn't the exact behavior
         BoxedString* name = getOpName(node->op_type);
-        CompilerType* attr_type = operand->getattrType(name->s(), true);
+        CompilerType* attr_type = operand->getattrType(name, true);
         std::vector<CompilerType*> arg_types;
         return attr_type->callType(ArgPassSpec(0), arg_types, NULL);
     }

--- a/src/capi/modsupport.cpp
+++ b/src/capi/modsupport.cpp
@@ -444,7 +444,7 @@ extern "C" int PyModule_AddObject(PyObject* _m, const char* name, PyObject* valu
     BoxedModule* m = static_cast<BoxedModule*>(_m);
     assert(m->cls == module_cls);
 
-    m->setattr(name, value, NULL);
+    m->setattr(internStringMortal(name), value, NULL);
     return 0;
 }
 

--- a/src/capi/object.cpp
+++ b/src/capi/object.cpp
@@ -419,11 +419,13 @@ extern "C" PyObject* PyObject_SelfIter(PyObject* obj) noexcept {
 
 extern "C" int PyObject_GenericSetAttr(PyObject* obj, PyObject* name, PyObject* value) noexcept {
     RELEASE_ASSERT(PyString_Check(name), "");
+    BoxedString* str = static_cast<BoxedString*>(name);
+    internStringMortalInplace(str);
     try {
         if (value == NULL)
-            delattrGeneric(obj, static_cast<BoxedString*>(name), NULL);
+            delattrGeneric(obj, str, NULL);
         else
-            setattrGeneric(obj, static_cast<BoxedString*>(name), value, NULL);
+            setattrGeneric(obj, str, value, NULL);
     } catch (ExcInfo e) {
         setCAPIException(e);
         return -1;
@@ -458,7 +460,7 @@ extern "C" int PyObject_SetAttr(PyObject* obj, PyObject* name, PyObject* value) 
 
 extern "C" int PyObject_SetAttrString(PyObject* v, const char* name, PyObject* w) noexcept {
     try {
-        setattr(v, boxString(name), w);
+        setattr(v, internStringMortal(name), w);
     } catch (ExcInfo e) {
         setCAPIException(e);
         return -1;
@@ -468,7 +470,7 @@ extern "C" int PyObject_SetAttrString(PyObject* v, const char* name, PyObject* w
 
 extern "C" PyObject* PyObject_GetAttrString(PyObject* o, const char* attr) noexcept {
     try {
-        return getattr(o, boxString(attr));
+        return getattr(o, internStringMortal(attr));
     } catch (ExcInfo e) {
         setCAPIException(e);
         return NULL;

--- a/src/codegen/ast_interpreter.cpp
+++ b/src/codegen/ast_interpreter.cpp
@@ -855,7 +855,7 @@ Value ASTInterpreter::visit_langPrimitive(AST_LangPrimitive* node) {
         const std::string& name = ast_str->str_data;
         assert(name.size());
         // TODO: shouldn't have to rebox here
-        v.o = importFrom(module.o, boxString(name));
+        v.o = importFrom(module.o, internStringMortal(name));
     } else if (node->opcode == AST_LangPrimitive::IMPORT_NAME) {
         abortJITing();
         assert(node->args.size() == 3);
@@ -1139,7 +1139,7 @@ Value ASTInterpreter::visit_assert(AST_Assert* node) {
     assert(v.o->cls == int_cls && static_cast<BoxedInt*>(v.o)->n == 0);
 #endif
 
-    static BoxedString* AssertionError_str = static_cast<BoxedString*>(PyString_InternFromString("AssertionError"));
+    static BoxedString* AssertionError_str = internStringImmortal("AssertionError");
     Box* assertion_type = getGlobal(globals, AssertionError_str);
     assertFail(assertion_type, node->msg ? visit_expr(node->msg).o : 0);
 

--- a/src/codegen/compvars.cpp
+++ b/src/codegen/compvars.cpp
@@ -34,10 +34,9 @@
 
 namespace pyston {
 
-static const std::string iter_str = "__iter__";
-static const std::string hasnext_str = "__hasnext__";
-
 CompilerType* CompilerType::getPystonIterType() {
+    static BoxedString* iter_str = internStringImmortal("__iter__");
+    static BoxedString* hasnext_str = internStringImmortal("__hasnext__");
     if (hasattr(iter_str) == Yes) {
         CompilerType* iter_type = getattrType(iter_str, true)->callType(ArgPassSpec(0), {}, NULL);
         if (iter_type->hasattr(hasnext_str) == Yes)
@@ -48,7 +47,7 @@ CompilerType* CompilerType::getPystonIterType() {
     return UNKNOWN;
 }
 
-CompilerType::Result CompilerType::hasattr(llvm::StringRef attr) {
+CompilerType::Result CompilerType::hasattr(BoxedString* attr) {
     CompilerType* type = getattrType(attr, true);
     if (type == UNKNOWN)
         return Result::Maybe;
@@ -299,7 +298,7 @@ public:
         return rtn;
     }
 
-    CompilerType* getattrType(llvm::StringRef attr, bool cls_only) override { return UNKNOWN; }
+    CompilerType* getattrType(BoxedString* attr, bool cls_only) override { return UNKNOWN; }
     CompilerType* callType(ArgPassSpec argspec, const std::vector<CompilerType*>& arg_types,
                            const std::vector<llvm::StringRef>* keyword_names) override {
         return UNKNOWN;
@@ -357,7 +356,7 @@ public:
     }
 
     CompilerVariable* getPystonIter(IREmitter& emitter, const OpInfo& info, ConcreteCompilerVariable* var) override {
-        static BoxedString* iter_box = static_cast<BoxedString*>(PyString_InternFromString("__iter__"));
+        static BoxedString* iter_box = internStringImmortal("__iter__");
 
         CallattrFlags flags = {.cls_only = true, .null_on_nonexistent = true, .argspec = ArgPassSpec(0) };
         CompilerVariable* iter_call = var->callattr(emitter, info, iter_box, flags, {}, 0);
@@ -780,7 +779,7 @@ public:
 
     bool canConvertTo(ConcreteCompilerType* other_type) override { return other_type == UNKNOWN; }
 
-    CompilerType* getattrType(llvm::StringRef attr, bool cls_only) override { return UNDEF; }
+    CompilerType* getattrType(BoxedString* attr, bool cls_only) override { return UNDEF; }
 
     CompilerType* callType(ArgPassSpec argspec, const std::vector<CompilerType*>& arg_types,
                            const std::vector<llvm::StringRef>* keyword_names) override {
@@ -861,7 +860,7 @@ public:
         // pass
     }
 
-    CompilerType* getattrType(llvm::StringRef attr, bool cls_only) override {
+    CompilerType* getattrType(BoxedString* attr, bool cls_only) override {
         /*
         static std::vector<AbstractFunctionType::Sig*> sigs;
         if (sigs.size() == 0) {
@@ -903,8 +902,9 @@ public:
         }
 
         // we can handle those operations when the rhs is a float
-        if (attr == "__add__" || attr == "__sub__" || attr == "__mul__" || attr == "__div__" || attr == "__pow__"
-            || attr == "__floordiv__" || attr == "__mod__" || attr == "__pow__") {
+        if (attr->s() == "__add__" || attr->s() == "__sub__" || attr->s() == "__mul__" || attr->s() == "__div__"
+            || attr->s() == "__pow__" || attr->s() == "__floordiv__" || attr->s() == "__mod__"
+            || attr->s() == "__pow__") {
             return AbstractFunctionType::get(sigs);
         }
         return BOXED_INT->getattrType(attr, cls_only);
@@ -1118,7 +1118,7 @@ public:
         // pass
     }
 
-    CompilerType* getattrType(llvm::StringRef attr, bool cls_only) override {
+    CompilerType* getattrType(BoxedString* attr, bool cls_only) override {
         static std::vector<AbstractFunctionType::Sig*> sigs;
         if (sigs.size() == 0) {
             AbstractFunctionType::Sig* float_sig = new AbstractFunctionType::Sig();
@@ -1137,13 +1137,15 @@ public:
             sigs.push_back(unknown_sig);
         }
 
-        if (attr == "__add__" || attr == "__sub__" || attr == "__mul__" || attr == "__div__" || attr == "__pow__"
-            || attr == "__floordiv__" || attr == "__mod__" || attr == "__pow__") {
+        if (attr->s() == "__add__" || attr->s() == "__sub__" || attr->s() == "__mul__" || attr->s() == "__div__"
+            || attr->s() == "__pow__" || attr->s() == "__floordiv__" || attr->s() == "__mod__"
+            || attr->s() == "__pow__") {
             return AbstractFunctionType::get(sigs);
         }
 
-        if (attr == "__iadd__" || attr == "__isub__" || attr == "__imul__" || attr == "__idiv__" || attr == "__ipow__"
-            || attr == "__ifloordiv__" || attr == "__imod__" || attr == "__ipow__") {
+        if (attr->s() == "__iadd__" || attr->s() == "__isub__" || attr->s() == "__imul__" || attr->s() == "__idiv__"
+            || attr->s() == "__ipow__" || attr->s() == "__ifloordiv__" || attr->s() == "__imod__"
+            || attr->s() == "__ipow__") {
             return AbstractFunctionType::get(sigs);
         }
 
@@ -1446,7 +1448,7 @@ public:
                 && cls->hasGenericGetattr());
     }
 
-    CompilerType* getattrType(llvm::StringRef attr, bool cls_only) override {
+    CompilerType* getattrType(BoxedString* attr, bool cls_only) override {
         // Any changes here need to be mirrored in getattr()
         if (canStaticallyResolveGetattrs()) {
             Box* rtattr = typeLookup(cls, attr, nullptr);
@@ -1474,7 +1476,7 @@ public:
                               bool cls_only) override {
         // Any changes here need to be mirrored in getattrType()
         if (canStaticallyResolveGetattrs()) {
-            Box* rtattr = typeLookup(cls, attr->s(), nullptr);
+            Box* rtattr = typeLookup(cls, attr, nullptr);
             if (rtattr == NULL) {
                 llvm::CallSite call = emitter.createCall3(
                     info.unw_info, g.funcs.raiseAttributeErrorStr, embedRelocatablePtr(cls->tp_name, g.i8_ptr),
@@ -1524,7 +1526,7 @@ public:
         if (!canStaticallyResolveGetattrs())
             return NULL;
 
-        Box* rtattr = cls->getattr(attr->s());
+        Box* rtattr = cls->getattr(attr);
         if (rtattr == NULL) {
             if (no_attribute) {
                 *no_attribute = true;
@@ -1705,7 +1707,7 @@ public:
     }
 
     CompilerVariable* getitem(IREmitter& emitter, const OpInfo& info, VAR* var, CompilerVariable* slice) override {
-        static BoxedString* attr = static_cast<BoxedString*>(PyString_InternFromString("__getitem__"));
+        static BoxedString* attr = internStringImmortal("__getitem__");
         bool no_attribute = false;
         ConcreteCompilerVariable* called_constant = tryCallattrConstant(
             emitter, info, var, attr, true, ArgPassSpec(1, 0, 0, 0), { slice }, NULL, &no_attribute);
@@ -1731,7 +1733,7 @@ public:
     }
 
     ConcreteCompilerVariable* len(IREmitter& emitter, const OpInfo& info, VAR* var) override {
-        static BoxedString* attr = static_cast<BoxedString*>(PyString_InternFromString("__len__"));
+        static BoxedString* attr = internStringImmortal("__len__");
         ConcreteCompilerVariable* called_constant
             = tryCallattrConstant(emitter, info, var, attr, true, ArgPassSpec(0, 0, 0, 0), {}, NULL);
         if (called_constant)
@@ -1741,7 +1743,7 @@ public:
     }
 
     ConcreteCompilerVariable* nonzero(IREmitter& emitter, const OpInfo& info, ConcreteCompilerVariable* var) override {
-        static BoxedString* attr = static_cast<BoxedString*>(PyString_InternFromString("__nonzero__"));
+        static BoxedString* attr = internStringImmortal("__nonzero__");
 
         bool no_attribute = false;
         ConcreteCompilerVariable* called_constant
@@ -1765,7 +1767,7 @@ public:
     }
 
     ConcreteCompilerVariable* hasnext(IREmitter& emitter, const OpInfo& info, ConcreteCompilerVariable* var) override {
-        static BoxedString* attr = static_cast<BoxedString*>(PyString_InternFromString("__hasnext__"));
+        static BoxedString* attr = internStringImmortal("__hasnext__");
 
         ConcreteCompilerVariable* called_constant
             = tryCallattrConstant(emitter, info, var, attr, true, ArgPassSpec(0, 0, 0, 0), {}, NULL, NULL);
@@ -2027,7 +2029,7 @@ public:
         return new ConcreteCompilerVariable(other_type, boxed, true);
     }
 
-    CompilerType* getattrType(llvm::StringRef attr, bool cls_only) override {
+    CompilerType* getattrType(BoxedString* attr, bool cls_only) override {
         return BOXED_BOOL->getattrType(attr, cls_only);
     }
 
@@ -2228,7 +2230,7 @@ public:
         return new ConcreteCompilerVariable(INT, getConstantInt(var->getValue()->size(), g.i64), true);
     }
 
-    CompilerType* getattrType(llvm::StringRef attr, bool cls_only) override {
+    CompilerType* getattrType(BoxedString* attr, bool cls_only) override {
         return BOXED_TUPLE->getattrType(attr, cls_only);
     }
 
@@ -2429,7 +2431,7 @@ public:
 
     ConcreteCompilerType* getConcreteType() override { return this; }
 
-    CompilerType* getattrType(llvm::StringRef attr, bool cls_only) override { return UNDEF; }
+    CompilerType* getattrType(BoxedString* attr, bool cls_only) override { return UNDEF; }
 
     bool canConvertTo(ConcreteCompilerType* other_type) override { return true; }
 

--- a/src/codegen/compvars.h
+++ b/src/codegen/compvars.h
@@ -35,6 +35,7 @@ class IREmitter;
 class BoxedInt;
 class BoxedFloat;
 class BoxedLong;
+class BoxedString;
 
 typedef llvm::SmallVector<uint64_t, 1> FrameVals;
 
@@ -47,9 +48,9 @@ public:
     virtual ConcreteCompilerType* getConcreteType() = 0;
     virtual ConcreteCompilerType* getBoxType() = 0;
     virtual bool canConvertTo(ConcreteCompilerType* other_type) = 0;
-    virtual CompilerType* getattrType(llvm::StringRef attr, bool cls_only) = 0;
+    virtual CompilerType* getattrType(BoxedString* attr, bool cls_only) = 0;
     virtual CompilerType* getPystonIterType();
-    virtual Result hasattr(llvm::StringRef attr);
+    virtual Result hasattr(BoxedString* attr);
     virtual CompilerType* callType(ArgPassSpec argspec, const std::vector<CompilerType*>& arg_types,
                                    const std::vector<llvm::StringRef>* keyword_names) = 0;
 
@@ -157,7 +158,7 @@ public:
         printf("makeClassCheck not defined for %s\n", debugName().c_str());
         abort();
     }
-    CompilerType* getattrType(llvm::StringRef attr, bool cls_only) override {
+    CompilerType* getattrType(BoxedString* attr, bool cls_only) override {
         printf("getattrType not defined for %s\n", debugName().c_str());
         abort();
     }

--- a/src/codegen/irgen/irgenerator.cpp
+++ b/src/codegen/irgen/irgenerator.cpp
@@ -642,8 +642,9 @@ private:
                 const std::string& name = ast_str->str_data;
                 assert(name.size());
 
-                llvm::Value* name_arg = embedRelocatablePtr(
-                    irstate->getSourceInfo()->parent_module->getStringConstant(name), g.llvm_boxedstring_type_ptr);
+                llvm::Value* name_arg
+                    = embedRelocatablePtr(irstate->getSourceInfo()->parent_module->getStringConstant(name, true),
+                                          g.llvm_boxedstring_type_ptr);
                 llvm::Value* r
                     = emitter.createCall2(unw_info, g.funcs.importFrom, converted_module->getValue(), name_arg);
 
@@ -894,7 +895,7 @@ private:
         llvm::Value* v = emitter.getBuilder()->CreateCall(g.funcs.createDict);
         ConcreteCompilerVariable* rtn = new ConcreteCompilerVariable(DICT, v, true);
         if (node->keys.size()) {
-            static BoxedString* setitem_str = static_cast<BoxedString*>(PyString_InternFromString("__setitem__"));
+            static BoxedString* setitem_str = internStringImmortal("__setitem__");
             CompilerVariable* setitem = rtn->getattr(emitter, getEmptyOpInfo(unw_info), setitem_str, true);
             for (int i = 0; i < node->keys.size(); i++) {
                 CompilerVariable* key = evalExpr(node->keys[i], unw_info);
@@ -1136,7 +1137,7 @@ private:
         llvm::Value* v = emitter.getBuilder()->CreateCall(g.funcs.createSet);
         ConcreteCompilerVariable* rtn = new ConcreteCompilerVariable(SET, v, true);
 
-        static BoxedString* add_str = static_cast<BoxedString*>(PyString_InternFromString("add"));
+        static BoxedString* add_str = internStringImmortal("add");
 
         for (int i = 0; i < node->elts.size(); i++) {
             CompilerVariable* elt = elts[i];
@@ -1722,7 +1723,7 @@ private:
 
         // We could patchpoint this or try to avoid the overhead, but this should only
         // happen when the assertion is actually thrown so I don't think it will be necessary.
-        static BoxedString* AssertionError_str = static_cast<BoxedString*>(PyString_InternFromString("AssertionError"));
+        static BoxedString* AssertionError_str = internStringImmortal("AssertionError");
         llvm_args.push_back(emitter.createCall2(unw_info, g.funcs.getGlobal, embedParentModulePtr(),
                                                 embedRelocatablePtr(AssertionError_str, g.llvm_boxedstring_type_ptr)));
 
@@ -1885,9 +1886,9 @@ private:
         }
         assert(dest);
 
-        static BoxedString* write_str = static_cast<BoxedString*>(PyString_InternFromString("write"));
-        static BoxedString* newline_str = static_cast<BoxedString*>(PyString_InternFromString("\n"));
-        static BoxedString* space_str = static_cast<BoxedString*>(PyString_InternFromString(" "));
+        static BoxedString* write_str = internStringImmortal("write");
+        static BoxedString* newline_str = internStringImmortal("\n");
+        static BoxedString* space_str = internStringImmortal(" ");
 
         // TODO: why are we inline-generating all this code instead of just emitting a call to some runtime function?
         // (=printHelper())

--- a/src/core/ast.cpp
+++ b/src/core/ast.cpp
@@ -114,31 +114,31 @@ BoxedString* getOpName(int op_type) {
 
     static bool initialized = false;
     if (!initialized) {
-        strAdd = static_cast<BoxedString*>(PyString_InternFromString("__add__"));
-        strBitAnd = static_cast<BoxedString*>(PyString_InternFromString("__and__"));
-        strBitOr = static_cast<BoxedString*>(PyString_InternFromString("__or__"));
-        strBitXor = static_cast<BoxedString*>(PyString_InternFromString("__xor__"));
-        strDiv = static_cast<BoxedString*>(PyString_InternFromString("__div__"));
-        strTrueDiv = static_cast<BoxedString*>(PyString_InternFromString("__truediv__"));
-        strDivMod = static_cast<BoxedString*>(PyString_InternFromString("__divmod__"));
-        strEq = static_cast<BoxedString*>(PyString_InternFromString("__eq__"));
-        strFloorDiv = static_cast<BoxedString*>(PyString_InternFromString("__floordiv__"));
-        strLShift = static_cast<BoxedString*>(PyString_InternFromString("__lshift__"));
-        strLt = static_cast<BoxedString*>(PyString_InternFromString("__lt__"));
-        strLtE = static_cast<BoxedString*>(PyString_InternFromString("__le__"));
-        strGt = static_cast<BoxedString*>(PyString_InternFromString("__gt__"));
-        strGtE = static_cast<BoxedString*>(PyString_InternFromString("__ge__"));
-        strIn = static_cast<BoxedString*>(PyString_InternFromString("__contains__"));
-        strInvert = static_cast<BoxedString*>(PyString_InternFromString("__invert__"));
-        strMod = static_cast<BoxedString*>(PyString_InternFromString("__mod__"));
-        strMult = static_cast<BoxedString*>(PyString_InternFromString("__mul__"));
-        strNot = static_cast<BoxedString*>(PyString_InternFromString("__nonzero__"));
-        strNotEq = static_cast<BoxedString*>(PyString_InternFromString("__ne__"));
-        strPow = static_cast<BoxedString*>(PyString_InternFromString("__pow__"));
-        strRShift = static_cast<BoxedString*>(PyString_InternFromString("__rshift__"));
-        strSub = static_cast<BoxedString*>(PyString_InternFromString("__sub__"));
-        strUAdd = static_cast<BoxedString*>(PyString_InternFromString("__pos__"));
-        strUSub = static_cast<BoxedString*>(PyString_InternFromString("__neg__"));
+        strAdd = internStringImmortal("__add__");
+        strBitAnd = internStringImmortal("__and__");
+        strBitOr = internStringImmortal("__or__");
+        strBitXor = internStringImmortal("__xor__");
+        strDiv = internStringImmortal("__div__");
+        strTrueDiv = internStringImmortal("__truediv__");
+        strDivMod = internStringImmortal("__divmod__");
+        strEq = internStringImmortal("__eq__");
+        strFloorDiv = internStringImmortal("__floordiv__");
+        strLShift = internStringImmortal("__lshift__");
+        strLt = internStringImmortal("__lt__");
+        strLtE = internStringImmortal("__le__");
+        strGt = internStringImmortal("__gt__");
+        strGtE = internStringImmortal("__ge__");
+        strIn = internStringImmortal("__contains__");
+        strInvert = internStringImmortal("__invert__");
+        strMod = internStringImmortal("__mod__");
+        strMult = internStringImmortal("__mul__");
+        strNot = internStringImmortal("__nonzero__");
+        strNotEq = internStringImmortal("__ne__");
+        strPow = internStringImmortal("__pow__");
+        strRShift = internStringImmortal("__rshift__");
+        strSub = internStringImmortal("__sub__");
+        strUAdd = internStringImmortal("__pos__");
+        strUSub = internStringImmortal("__neg__");
 
         initialized = true;
     }
@@ -203,7 +203,7 @@ BoxedString* getOpName(int op_type) {
 BoxedString* getInplaceOpName(int op_type) {
     BoxedString* normal_name = getOpName(op_type);
     // TODO inefficient
-    return static_cast<BoxedString*>(PyString_InternFromString(("__i" + normal_name->s().substr(2).str()).c_str()));
+    return internStringImmortal(("__i" + normal_name->s().substr(2).str()).c_str());
 }
 
 // Maybe better name is "swapped" -- it's what the runtime will try if the normal op
@@ -234,7 +234,7 @@ BoxedString* getReverseOpName(int op_type) {
         return getOpName(op_type);
     BoxedString* normal_name = getOpName(op_type);
     // TODO inefficient
-    return static_cast<BoxedString*>(PyString_InternFromString(("__r" + normal_name->s().substr(2).str()).c_str()));
+    return internStringImmortal(("__r" + normal_name->s().substr(2).str()).c_str());
 }
 
 template <class T> static void visitVector(const std::vector<T*>& vec, ASTVisitor* v) {

--- a/src/core/cfg.cpp
+++ b/src/core/cfg.cpp
@@ -2489,7 +2489,8 @@ CFG* computeCFG(SourceInfo* source, std::vector<AST_stmt*> body) {
             new AST_Name(source->getInternedStrings().get("__module__"), AST_TYPE::Store, source->ast->lineno));
 
         if (source->scoping->areGlobalsFromModule()) {
-            Box* module_name = source->parent_module->getattr("__name__", NULL);
+            static BoxedString* name_str = internStringImmortal("__name__");
+            Box* module_name = source->parent_module->getattr(name_str, NULL);
             assert(module_name->cls == str_cls);
             module_assign->value = new AST_Str(static_cast<BoxedString*>(module_name)->s());
         } else {

--- a/src/core/contiguous_map.h
+++ b/src/core/contiguous_map.h
@@ -43,12 +43,11 @@ public:
     const_iterator begin() const noexcept { return map.begin(); }
     const_iterator end() const noexcept { return map.end(); }
 
-    iterator erase(const_iterator position) {
+    void erase(const_iterator position) {
         int idx = map[position->first];
         free_list.push_back(idx);
         vec[idx] = TVal();
         map.erase(position->first);
-        return begin(); // this is broken...
     }
 
     size_type erase(const TKey& key) {
@@ -73,9 +72,9 @@ public:
                 free_list.pop_back();
             } else {
                 idx = vec.size();
+                vec.push_back(TVal());
             }
             map[key] = idx;
-            vec.push_back(TVal());
             return vec[idx];
         } else {
             return vec[it->second];
@@ -91,9 +90,9 @@ public:
                 free_list.pop_back();
             } else {
                 idx = vec.size();
+                vec.push_back(TVal());
             }
             map[key] = idx;
-            vec.push_back(TVal());
             return vec[idx];
         } else {
             return vec[it->second];
@@ -102,7 +101,8 @@ public:
 
     TVal getMapped(int idx) const { return vec[idx]; }
 
-    size_type size() const { return vec.size(); }
+    size_type size() const { return map.size(); }
+    bool empty() const { return map.empty(); }
     const vec_type& vector() { return vec; }
 };
 }

--- a/src/core/stringpool.cpp
+++ b/src/core/stringpool.cpp
@@ -19,20 +19,8 @@
 namespace pyston {
 
 InternedString InternedStringPool::get(llvm::StringRef arg) {
-    auto it = interned.find(arg);
-
-    BoxedString* s;
-    if (it != interned.end()) {
-        s = it->second;
-    } else {
-        s = boxString(arg);
-        // HACK: should properly track this liveness:
-        PyString_InternInPlace(reinterpret_cast<Box**>(&s));
-
-        // Note: make sure the key points to the value we just created, not the
-        // argument string:
-        interned[s->s()] = s;
-    }
+    // HACK: should properly track this liveness:
+    BoxedString* s = internStringImmortal(arg);
 
 #ifndef NDEBUG
     return InternedString(s, this);

--- a/src/core/stringpool.h
+++ b/src/core/stringpool.h
@@ -80,6 +80,7 @@ public:
 
     llvm::StringRef s() const;
     operator llvm::StringRef() const { return s(); }
+    operator BoxedString*() const { return getBox(); }
 
     friend class InternedStringPool;
     friend struct std::hash<InternedString>;
@@ -88,12 +89,6 @@ public:
 };
 
 class InternedStringPool {
-private:
-    // We probably don't need to pull in llvm::StringRef as the key, but it's better than std::string
-    // which I assume forces extra allocations.
-    // (We could define a custom string-pointer container but is it worth it?)
-    std::unordered_map<llvm::StringRef, BoxedString*> interned;
-
 public:
     void gcHandler(gc::GCVisitor* v);
     InternedString get(llvm::StringRef s);

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -456,6 +456,26 @@ struct SetattrRewriteArgs;
 struct GetattrRewriteArgs;
 struct DelattrRewriteArgs;
 
+// Helper function around PyString_InternFromString:
+BoxedString* internStringImmortal(llvm::StringRef s);
+
+// Callers should use this function if they can accept mortal string objects.
+// FIXME For now it just returns immortal strings, but at least we can use it
+// to start documenting the places that can take mortal strings.
+inline BoxedString* internStringMortal(const char* s) {
+    return internStringImmortal(s);
+}
+
+inline BoxedString* internStringMortal(llvm::StringRef s) {
+    assert(s.data()[s.size()] == '\0');
+    return internStringMortal(s.data());
+}
+
+// TODO this is an immortal intern for now
+inline void internStringMortalInplace(BoxedString*& s) {
+    PyString_InternInPlace((PyObject**)&s);
+}
+
 struct HCAttrs {
 public:
     struct AttrList {
@@ -502,18 +522,19 @@ public:
     BoxedDict* getDict();
 
 
-    void setattr(llvm::StringRef attr, Box* val, SetattrRewriteArgs* rewrite_args);
-    void giveAttr(llvm::StringRef attr, Box* val) {
+    void setattr(BoxedString* attr, Box* val, SetattrRewriteArgs* rewrite_args);
+    void giveAttr(const char* attr, Box* val) { giveAttr(internStringMortal(attr), val); }
+    void giveAttr(BoxedString* attr, Box* val) {
         assert(!this->hasattr(attr));
         this->setattr(attr, val, NULL);
     }
 
     // getattr() does the equivalent of PyDict_GetItem(obj->dict, attr): it looks up the attribute's value on the
     // object's attribute storage. it doesn't look at other objects or do any descriptor logic.
-    Box* getattr(llvm::StringRef attr, GetattrRewriteArgs* rewrite_args);
-    Box* getattr(llvm::StringRef attr) { return getattr(attr, NULL); }
-    bool hasattr(llvm::StringRef attr) { return getattr(attr) != NULL; }
-    void delattr(llvm::StringRef attr, DelattrRewriteArgs* rewrite_args);
+    Box* getattr(BoxedString* attr, GetattrRewriteArgs* rewrite_args);
+    Box* getattr(BoxedString* attr) { return getattr(attr, NULL); }
+    bool hasattr(BoxedString* attr) { return getattr(attr) != NULL; }
+    void delattr(BoxedString* attr, DelattrRewriteArgs* rewrite_args);
 
     // Only valid for hc-backed instances:
     Box* getAttrWrapper();

--- a/src/gc/heap.cpp
+++ b/src/gc/heap.cpp
@@ -456,6 +456,7 @@ SmallArena::Block** SmallArena::_freeChain(Block** head, std::vector<Box*>& weak
                 clearMark(al);
             } else {
                 if (_doFree(al, &weakly_referenced)) {
+                    GC_TRACE_LOG("freeing %p\n", al->user_data);
                     b->isfree.set(atom_idx);
 #ifndef NDEBUG
                     memset(al->user_data, 0xbb, b->size - sizeof(GCAllocation));

--- a/src/runtime/bool.cpp
+++ b/src/runtime/bool.cpp
@@ -31,8 +31,8 @@ extern "C" Box* boolNonzero(BoxedBool* v) {
 }
 
 extern "C" Box* boolRepr(BoxedBool* v) {
-    static BoxedString* true_str = static_cast<BoxedString*>(PyString_InternFromString("True"));
-    static BoxedString* false_str = static_cast<BoxedString*>(PyString_InternFromString("False"));
+    static BoxedString* true_str = internStringImmortal("True");
+    static BoxedString* false_str = internStringImmortal("False");
 
     if (v == True)
         return true_str;

--- a/src/runtime/builtin_modules/builtins.cpp
+++ b/src/runtime/builtin_modules/builtins.cpp
@@ -95,14 +95,14 @@ extern "C" Box* abs_(Box* x) {
     } else if (x->cls == long_cls) {
         return longAbs(static_cast<BoxedLong*>(x));
     } else {
-        static BoxedString* abs_str = static_cast<BoxedString*>(PyString_InternFromString("__abs__"));
+        static BoxedString* abs_str = internStringImmortal("__abs__");
         CallattrFlags callattr_flags{.cls_only = true, .null_on_nonexistent = false, .argspec = ArgPassSpec(0) };
         return callattr(x, abs_str, callattr_flags, NULL, NULL, NULL, NULL, NULL);
     }
 }
 
 extern "C" Box* hexFunc(Box* x) {
-    static BoxedString* hex_str = static_cast<BoxedString*>(PyString_InternFromString("__hex__"));
+    static BoxedString* hex_str = internStringImmortal("__hex__");
     CallattrFlags callattr_flags{.cls_only = true, .null_on_nonexistent = true, .argspec = ArgPassSpec(0) };
     Box* r = callattr(x, hex_str, callattr_flags, NULL, NULL, NULL, NULL, NULL);
     if (!r)
@@ -115,7 +115,7 @@ extern "C" Box* hexFunc(Box* x) {
 }
 
 extern "C" Box* octFunc(Box* x) {
-    static BoxedString* oct_str = static_cast<BoxedString*>(PyString_InternFromString("__oct__"));
+    static BoxedString* oct_str = internStringImmortal("__oct__");
     CallattrFlags callattr_flags{.cls_only = true, .null_on_nonexistent = true, .argspec = ArgPassSpec(0) };
     Box* r = callattr(x, oct_str, callattr_flags, NULL, NULL, NULL, NULL, NULL);
     if (!r)
@@ -209,7 +209,7 @@ extern "C" Box* max(Box* arg0, BoxedTuple* args) {
 
 extern "C" Box* next(Box* iterator, Box* _default) {
     try {
-        static BoxedString* next_str = static_cast<BoxedString*>(PyString_InternFromString("next"));
+        static BoxedString* next_str = internStringImmortal("next");
         CallattrFlags callattr_flags{.cls_only = true, .null_on_nonexistent = false, .argspec = ArgPassSpec(0) };
         return callattr(iterator, next_str, callattr_flags, NULL, NULL, NULL, NULL, NULL);
     } catch (ExcInfo e) {
@@ -412,6 +412,8 @@ Box* delattrFunc(Box* obj, Box* _str) {
     if (_str->cls != str_cls)
         raiseExcHelper(TypeError, "attribute name must be string, not '%s'", getTypeName(_str));
     BoxedString* str = static_cast<BoxedString*>(_str);
+    internStringMortalInplace(str);
+
     delattr(obj, str);
     return None;
 }
@@ -424,6 +426,7 @@ Box* getattrFunc(Box* obj, Box* _str, Box* default_value) {
     }
 
     BoxedString* str = static_cast<BoxedString*>(_str);
+    internStringMortalInplace(str);
 
     Box* rtn = NULL;
     try {
@@ -451,6 +454,8 @@ Box* setattrFunc(Box* obj, Box* _str, Box* value) {
     }
 
     BoxedString* str = static_cast<BoxedString*>(_str);
+    internStringMortalInplace(str);
+
     setattr(obj, str, value);
     return None;
 }
@@ -463,6 +468,8 @@ Box* hasattr(Box* obj, Box* _str) {
     }
 
     BoxedString* str = static_cast<BoxedString*>(_str);
+    internStringMortalInplace(str);
+
     Box* attr;
     try {
         attr = getattrInternal(obj, str, NULL);
@@ -656,7 +663,8 @@ Box* exceptionNew(BoxedClass* cls, BoxedTuple* args) {
 
 Box* exceptionStr(Box* b) {
     // TODO In CPython __str__ and __repr__ pull from an internalized message field, but for now do this:
-    Box* message = b->getattr("message");
+    static BoxedString* message_str = internStringImmortal("message");
+    Box* message = b->getattr(message_str);
     assert(message);
     message = str(message);
     assert(message->cls == str_cls);
@@ -666,7 +674,8 @@ Box* exceptionStr(Box* b) {
 
 Box* exceptionRepr(Box* b) {
     // TODO In CPython __str__ and __repr__ pull from an internalized message field, but for now do this:
-    Box* message = b->getattr("message");
+    static BoxedString* message_str = internStringImmortal("message");
+    Box* message = b->getattr(message_str);
     assert(message);
     message = repr(message);
     assert(message->cls == str_cls);
@@ -862,9 +871,9 @@ Box* print(BoxedTuple* args, BoxedDict* kwargs) {
 
     Box* dest, *end;
 
-    static BoxedString* file_str = static_cast<BoxedString*>(PyString_InternFromString("file"));
-    static BoxedString* end_str = static_cast<BoxedString*>(PyString_InternFromString("end"));
-    static BoxedString* space_str = static_cast<BoxedString*>(PyString_InternFromString(" "));
+    static BoxedString* file_str = internStringImmortal("file");
+    static BoxedString* end_str = internStringImmortal("end");
+    static BoxedString* space_str = internStringImmortal(" ");
 
     auto it = kwargs->d.find(file_str);
     if (it != kwargs->d.end()) {
@@ -884,7 +893,7 @@ Box* print(BoxedTuple* args, BoxedDict* kwargs) {
 
     RELEASE_ASSERT(kwargs->d.size() == 0, "print() got unexpected keyword arguments");
 
-    static BoxedString* write_str = static_cast<BoxedString*>(PyString_InternFromString("write"));
+    static BoxedString* write_str = internStringImmortal("write");
     CallattrFlags callattr_flags{.cls_only = false, .null_on_nonexistent = false, .argspec = ArgPassSpec(1) };
 
     // TODO softspace handling?
@@ -908,7 +917,7 @@ Box* print(BoxedTuple* args, BoxedDict* kwargs) {
 }
 
 Box* getreversed(Box* o) {
-    static BoxedString* reversed_str = static_cast<BoxedString*>(PyString_InternFromString("__reversed__"));
+    static BoxedString* reversed_str = internStringImmortal("__reversed__");
 
     // TODO add rewriting to this?  probably want to try to avoid this path though
     CallattrFlags callattr_flags{.cls_only = true, .null_on_nonexistent = true, .argspec = ArgPassSpec(0) };
@@ -916,7 +925,8 @@ Box* getreversed(Box* o) {
     if (r)
         return r;
 
-    if (!typeLookup(o->cls, "__getitem__", NULL)) {
+    static BoxedString* getitem_str = internStringImmortal("__getitem__");
+    if (!typeLookup(o->cls, getitem_str, NULL)) {
         raiseExcHelper(TypeError, "'%s' object is not iterable", getTypeName(o));
     }
     int64_t len = unboxedLen(o); // this will throw an exception if __len__ isn't there

--- a/src/runtime/builtin_modules/sys.cpp
+++ b/src/runtime/builtin_modules/sys.cpp
@@ -84,7 +84,7 @@ BoxedDict* getSysModulesDict() {
 
 BoxedList* getSysPath() {
     // Unlike sys.modules, CPython handles sys.path by fetching it each time:
-    Box* _sys_path = sys_module->getattr("path");
+    Box* _sys_path = sys_module->getattr(internStringMortal("path"));
     assert(_sys_path);
 
     if (_sys_path->cls != list_cls) {
@@ -97,7 +97,7 @@ BoxedList* getSysPath() {
 }
 
 Box* getSysStdout() {
-    Box* sys_stdout = sys_module->getattr("stdout");
+    Box* sys_stdout = sys_module->getattr(internStringMortal("stdout"));
     RELEASE_ASSERT(sys_stdout, "lost sys.stdout??");
     return sys_stdout;
 }
@@ -135,10 +135,10 @@ Box* sysGetRecursionLimit() {
 extern "C" int PySys_SetObject(const char* name, PyObject* v) noexcept {
     try {
         if (!v) {
-            if (sys_module->getattr(name))
-                sys_module->delattr(name, NULL);
+            if (sys_module->getattr(internStringMortal(name)))
+                sys_module->delattr(internStringMortal(name), NULL);
         } else
-            sys_module->setattr(name, v, NULL);
+            sys_module->setattr(internStringMortal(name), v, NULL);
     } catch (ExcInfo e) {
         abort();
     }
@@ -146,7 +146,7 @@ extern "C" int PySys_SetObject(const char* name, PyObject* v) noexcept {
 }
 
 extern "C" PyObject* PySys_GetObject(const char* name) noexcept {
-    return sys_module->getattr(name);
+    return sys_module->getattr(internStringMortal(name));
 }
 
 static void mywrite(const char* name, FILE* fp, const char* format, va_list va) noexcept {
@@ -192,7 +192,7 @@ extern "C" void PySys_WriteStderr(const char* format, ...) noexcept {
 }
 
 void addToSysArgv(const char* str) {
-    Box* sys_argv = sys_module->getattr("argv");
+    Box* sys_argv = sys_module->getattr(internStringMortal("argv"));
     assert(sys_argv);
     assert(sys_argv->cls == list_cls);
     listAppendInternal(sys_argv, boxString(str));
@@ -205,7 +205,7 @@ void appendToSysPath(llvm::StringRef path) {
 
 void prependToSysPath(llvm::StringRef path) {
     BoxedList* sys_path = getSysPath();
-    static BoxedString* insert_str = static_cast<BoxedString*>(PyString_InternFromString("insert"));
+    static BoxedString* insert_str = internStringImmortal("insert");
     CallattrFlags callattr_flags{.cls_only = false, .null_on_nonexistent = false, .argspec = ArgPassSpec(2) };
     callattr(sys_path, insert_str, callattr_flags, boxInt(0), boxString(path), NULL, NULL, NULL);
 }
@@ -422,9 +422,9 @@ void setupSys() {
     sys_module->giveAttr("stdout", new BoxedFile(stdout, "<stdout>", "w"));
     sys_module->giveAttr("stdin", new BoxedFile(stdin, "<stdin>", "r"));
     sys_module->giveAttr("stderr", new BoxedFile(stderr, "<stderr>", "w"));
-    sys_module->giveAttr("__stdout__", sys_module->getattr("stdout"));
-    sys_module->giveAttr("__stdin__", sys_module->getattr("stdin"));
-    sys_module->giveAttr("__stderr__", sys_module->getattr("stderr"));
+    sys_module->giveAttr("__stdout__", sys_module->getattr(internStringMortal("stdout")));
+    sys_module->giveAttr("__stdin__", sys_module->getattr(internStringMortal("stdin")));
+    sys_module->giveAttr("__stderr__", sys_module->getattr(internStringMortal("stderr")));
 
     sys_module->giveAttr(
         "exc_info", new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)sysExcInfo, BOXED_TUPLE, 0), "exc_info"));

--- a/src/runtime/builtin_modules/thread.cpp
+++ b/src/runtime/builtin_modules/thread.cpp
@@ -201,9 +201,9 @@ void setupThread() {
         "acquire", new BoxedFunction(boxRTFunction((void*)BoxedThreadLock::acquire, BOXED_BOOL, 2, 1, false, false),
                                      { boxInt(1) }));
     thread_lock_cls->giveAttr("release", new BoxedFunction(boxRTFunction((void*)BoxedThreadLock::release, NONE, 1)));
-    thread_lock_cls->giveAttr("acquire_lock", thread_lock_cls->getattr("acquire"));
-    thread_lock_cls->giveAttr("release_lock", thread_lock_cls->getattr("release"));
-    thread_lock_cls->giveAttr("__enter__", thread_lock_cls->getattr("acquire"));
+    thread_lock_cls->giveAttr("acquire_lock", thread_lock_cls->getattr(internStringMortal("acquire")));
+    thread_lock_cls->giveAttr("release_lock", thread_lock_cls->getattr(internStringMortal("release")));
+    thread_lock_cls->giveAttr("__enter__", thread_lock_cls->getattr(internStringMortal("acquire")));
     thread_lock_cls->giveAttr("__exit__", new BoxedFunction(boxRTFunction((void*)BoxedThreadLock::exit, NONE, 4)));
     thread_lock_cls->freeze();
 

--- a/src/runtime/capi.cpp
+++ b/src/runtime/capi.cpp
@@ -215,7 +215,9 @@ extern "C" PyObject* PyObject_GetAttr(PyObject* o, PyObject* attr_name) noexcept
 
 extern "C" PyObject* PyObject_GenericGetAttr(PyObject* o, PyObject* name) noexcept {
     try {
-        Box* r = getattrInternalGeneric(o, static_cast<BoxedString*>(name)->data(), NULL, false, false, NULL, NULL);
+        BoxedString* s = static_cast<BoxedString*>(name);
+        internStringMortalInplace(s);
+        Box* r = getattrInternalGeneric(o, s, NULL, false, false, NULL, NULL);
         if (!r)
             PyErr_Format(PyExc_AttributeError, "'%.50s' object has no attribute '%.400s'", o->cls->tp_name,
                          PyString_AS_STRING(name));
@@ -637,7 +639,7 @@ extern "C" int PyCallable_Check(PyObject* x) noexcept {
     if (x == NULL)
         return 0;
 
-    static const std::string call_attr("__call__");
+    static BoxedString* call_attr = internStringImmortal("__call__");
     return typeLookup(x->cls, call_attr, NULL) != NULL;
 }
 
@@ -1417,7 +1419,8 @@ extern "C" char* PyModule_GetName(PyObject* m) noexcept {
         PyErr_BadArgument();
         return NULL;
     }
-    if ((nameobj = m->getattr("__name__")) == NULL || !PyString_Check(nameobj)) {
+    static BoxedString* name_str = internStringImmortal("__name__");
+    if ((nameobj = m->getattr(name_str)) == NULL || !PyString_Check(nameobj)) {
         PyErr_SetString(PyExc_SystemError, "nameless module");
         return NULL;
     }
@@ -1431,7 +1434,8 @@ extern "C" char* PyModule_GetFilename(PyObject* m) noexcept {
         PyErr_BadArgument();
         return NULL;
     }
-    if ((fileobj = m->getattr("__file__")) == NULL || !PyString_Check(fileobj)) {
+    static BoxedString* file_str = internStringImmortal("__file__");
+    if ((fileobj = m->getattr(file_str)) == NULL || !PyString_Check(fileobj)) {
         PyErr_SetString(PyExc_SystemError, "module filename missing");
         return NULL;
     }

--- a/src/runtime/descr.cpp
+++ b/src/runtime/descr.cpp
@@ -44,7 +44,7 @@ static void propertyDocCopy(BoxedProperty* prop, Box* fget) {
     assert(fget);
     Box* get_doc;
 
-    static BoxedString* doc_str = static_cast<BoxedString*>(PyString_InternFromString("__doc__"));
+    static BoxedString* doc_str = internStringImmortal("__doc__");
     try {
         get_doc = getattrInternal(fget, doc_str, NULL);
     } catch (ExcInfo e) {

--- a/src/runtime/dict.cpp
+++ b/src/runtime/dict.cpp
@@ -192,7 +192,7 @@ Box* dictGetitem(BoxedDict* self, Box* k) {
     if (it == self->d.end()) {
         // Try calling __missing__ if this is a subclass
         if (self->cls != dict_cls) {
-            static BoxedString* missing_str = static_cast<BoxedString*>(PyString_InternFromString("__missing__"));
+            static BoxedString* missing_str = internStringImmortal("__missing__");
             CallattrFlags callattr_flags{.cls_only = true, .null_on_nonexistent = true, .argspec = ArgPassSpec(1) };
             Box* r = callattr(self, missing_str, callattr_flags, k, NULL, NULL, NULL, NULL);
             if (r)
@@ -308,7 +308,7 @@ extern "C" int PyDict_Next(PyObject* op, Py_ssize_t* ppos, PyObject** pkey, PyOb
 
 extern "C" PyObject* PyDict_GetItemString(PyObject* dict, const char* key) noexcept {
     if (dict->cls == attrwrapper_cls)
-        return unwrapAttrWrapper(dict)->getattr(key);
+        return unwrapAttrWrapper(dict)->getattr(internStringMortal(key));
 
     Box* key_s;
     try {
@@ -524,7 +524,7 @@ void dictMerge(BoxedDict* self, Box* other) {
         return;
     }
 
-    static BoxedString* keys_str = static_cast<BoxedString*>(PyString_InternFromString("keys"));
+    static BoxedString* keys_str = internStringImmortal("keys");
     CallattrFlags callattr_flags{.cls_only = false, .null_on_nonexistent = true, .argspec = ArgPassSpec(0) };
     Box* keys = callattr(other, keys_str, callattr_flags, NULL, NULL, NULL, NULL, NULL);
     assert(keys);
@@ -588,7 +588,7 @@ Box* dictUpdate(BoxedDict* self, BoxedTuple* args, BoxedDict* kwargs) {
     RELEASE_ASSERT(args->size() <= 1, ""); // should throw a TypeError
     if (args->size()) {
         Box* arg = args->elts[0];
-        static BoxedString* keys_str = static_cast<BoxedString*>(PyString_InternFromString("keys"));
+        static BoxedString* keys_str = internStringImmortal("keys");
         if (getattrInternal(arg, keys_str, NULL)) {
             dictMerge(self, arg);
         } else {
@@ -697,7 +697,7 @@ void setupDict() {
                        new BoxedFunction(boxRTFunction((void*)dictIterValues, typeFromClass(dict_iterator_cls), 1)));
 
     dict_cls->giveAttr("keys", new BoxedFunction(boxRTFunction((void*)dictKeys, LIST, 1)));
-    dict_cls->giveAttr("iterkeys", dict_cls->getattr("__iter__"));
+    dict_cls->giveAttr("iterkeys", dict_cls->getattr(internStringMortal("__iter__")));
 
     dict_cls->giveAttr("pop", new BoxedFunction(boxRTFunction((void*)dictPop, UNKNOWN, 3, 1, false, false), { NULL }));
     dict_cls->giveAttr("popitem", new BoxedFunction(boxRTFunction((void*)dictPopitem, BOXED_TUPLE, 1)));

--- a/src/runtime/file.cpp
+++ b/src/runtime/file.cpp
@@ -1776,7 +1776,7 @@ void setupFile() {
     file_cls->giveAttr("__enter__", new BoxedFunction(boxRTFunction((void*)fileEnter, typeFromClass(file_cls), 1)));
     file_cls->giveAttr("__exit__", new BoxedFunction(boxRTFunction((void*)fileExit, UNKNOWN, 4)));
 
-    file_cls->giveAttr("__iter__", file_cls->getattr("__enter__"));
+    file_cls->giveAttr("__iter__", file_cls->getattr(internStringMortal("__enter__")));
     file_cls->giveAttr("__hasnext__", new BoxedFunction(boxRTFunction((void*)fileIterHasNext, BOXED_BOOL, 1)));
     file_cls->giveAttr("next", new BoxedFunction(boxRTFunction((void*)fileIterNext, STR, 1)));
 

--- a/src/runtime/float.cpp
+++ b/src/runtime/float.cpp
@@ -651,7 +651,7 @@ BoxedFloat* _floatNew(Box* a) {
             raiseExcHelper(ValueError, "could not convert string to float: %s", s.data());
         return new BoxedFloat(r);
     } else {
-        static BoxedString* float_str = static_cast<BoxedString*>(PyString_InternFromString("__float__"));
+        static BoxedString* float_str = internStringImmortal("__float__");
         CallattrFlags callattr_flags{.cls_only = true, .null_on_nonexistent = true, .argspec = ArgPassSpec(0) };
         Box* r = callattr(a, float_str, callattr_flags, NULL, NULL, NULL, NULL, NULL);
 
@@ -1447,7 +1447,7 @@ static PyMethodDef float_methods[] = { { "hex", (PyCFunction)float_hex, METH_NOA
 
 void setupFloat() {
     _addFunc("__add__", BOXED_FLOAT, (void*)floatAddFloat, (void*)floatAddInt, (void*)floatAdd);
-    float_cls->giveAttr("__radd__", float_cls->getattr("__add__"));
+    float_cls->giveAttr("__radd__", float_cls->getattr(internStringMortal("__add__")));
 
     _addFunc("__div__", BOXED_FLOAT, (void*)floatDivFloat, (void*)floatDivInt, (void*)floatDiv);
     _addFunc("__rdiv__", BOXED_FLOAT, (void*)floatRDivFloat, (void*)floatRDivInt, (void*)floatRDiv);
@@ -1464,7 +1464,7 @@ void setupFloat() {
     _addFunc("__mod__", BOXED_FLOAT, (void*)floatModFloat, (void*)floatModInt, (void*)floatMod);
     _addFunc("__rmod__", BOXED_FLOAT, (void*)floatRModFloat, (void*)floatRModInt, (void*)floatRMod);
     _addFunc("__mul__", BOXED_FLOAT, (void*)floatMulFloat, (void*)floatMulInt, (void*)floatMul);
-    float_cls->giveAttr("__rmul__", float_cls->getattr("__mul__"));
+    float_cls->giveAttr("__rmul__", float_cls->getattr(internStringMortal("__mul__")));
 
     _addFuncPow("__pow__", BOXED_FLOAT, (void*)floatPowFloat, (void*)floatPowInt, (void*)floatPow);
     _addFunc("__sub__", BOXED_FLOAT, (void*)floatSubFloat, (void*)floatSubInt, (void*)floatSub);

--- a/src/runtime/int.cpp
+++ b/src/runtime/int.cpp
@@ -931,7 +931,7 @@ static Box* _intNew(Box* val, Box* base) {
         return PyLong_FromDouble(wholepart);
     } else {
         RELEASE_ASSERT(!base, "");
-        static BoxedString* int_str = static_cast<BoxedString*>(PyString_InternFromString("__int__"));
+        static BoxedString* int_str = internStringImmortal("__int__");
         CallattrFlags callattr_flags{.cls_only = true, .null_on_nonexistent = true, .argspec = ArgPassSpec(0) };
         Box* r = callattr(val, int_str, callattr_flags, NULL, NULL, NULL, NULL, NULL);
 

--- a/src/runtime/iterators.cpp
+++ b/src/runtime/iterators.cpp
@@ -42,9 +42,10 @@ public:
         STAT_TIMER(t0, "us_timer_iteratorgeneric_next", 0);
 
         Box* next = PyIter_Next(iterator);
-        if (next)
+        if (next) {
+            assert(gc::isValidGCObject(next));
             value = next;
-        else {
+        } else {
             checkAndThrowCAPIException();
             *this = *end();
         }
@@ -91,7 +92,11 @@ public:
         }
     }
 
-    Box* getValue() override { return getValue(obj, index); }
+    Box* getValue() override {
+        Box* r = getValue(obj, index);
+        assert(gc::isValidGCObject(r));
+        return r;
+    }
 
     bool isSame(const BoxIteratorImpl* _rhs) override {
         const auto rhs = (const BoxIteratorIndex*)_rhs;

--- a/src/runtime/long.cpp
+++ b/src/runtime/long.cpp
@@ -642,7 +642,7 @@ BoxedLong* _longNew(Box* val, Box* _base) {
         } else if (val->cls == float_cls) {
             mpz_init_set_si(rtn->n, static_cast<BoxedFloat*>(val)->d);
         } else {
-            static BoxedString* long_str = static_cast<BoxedString*>(PyString_InternFromString("__long__"));
+            static BoxedString* long_str = internStringImmortal("__long__");
             CallattrFlags callattr_flags{.cls_only = true, .null_on_nonexistent = true, .argspec = ArgPassSpec(0) };
             Box* r = callattr(val, long_str, callattr_flags, NULL, NULL, NULL, NULL, NULL);
 
@@ -1373,7 +1373,7 @@ void setupLong() {
         "__new__", new BoxedFunction(boxRTFunction((void*)longNew, UNKNOWN, 3, 2, false, false), { boxInt(0), NULL }));
 
     long_cls->giveAttr("__mul__", new BoxedFunction(boxRTFunction((void*)longMul, UNKNOWN, 2)));
-    long_cls->giveAttr("__rmul__", long_cls->getattr("__mul__"));
+    long_cls->giveAttr("__rmul__", long_cls->getattr(internStringMortal("__mul__")));
 
     long_cls->giveAttr("__div__", new BoxedFunction(boxRTFunction((void*)longDiv, UNKNOWN, 2)));
     long_cls->giveAttr("__rdiv__", new BoxedFunction(boxRTFunction((void*)longRdiv, UNKNOWN, 2)));
@@ -1390,17 +1390,17 @@ void setupLong() {
     long_cls->giveAttr("__rsub__", new BoxedFunction(boxRTFunction((void*)longRsub, UNKNOWN, 2)));
 
     long_cls->giveAttr("__add__", new BoxedFunction(boxRTFunction((void*)longAdd, UNKNOWN, 2)));
-    long_cls->giveAttr("__radd__", long_cls->getattr("__add__"));
+    long_cls->giveAttr("__radd__", long_cls->getattr(internStringMortal("__add__")));
 
     long_cls->giveAttr("__pow__",
                        new BoxedFunction(boxRTFunction((void*)longPow, UNKNOWN, 3, 1, false, false), { None }));
 
     long_cls->giveAttr("__and__", new BoxedFunction(boxRTFunction((void*)longAnd, UNKNOWN, 2)));
-    long_cls->giveAttr("__rand__", long_cls->getattr("__and__"));
+    long_cls->giveAttr("__rand__", long_cls->getattr(internStringMortal("__and__")));
     long_cls->giveAttr("__or__", new BoxedFunction(boxRTFunction((void*)longOr, UNKNOWN, 2)));
-    long_cls->giveAttr("__ror__", long_cls->getattr("__or__"));
+    long_cls->giveAttr("__ror__", long_cls->getattr(internStringMortal("__or__")));
     long_cls->giveAttr("__xor__", new BoxedFunction(boxRTFunction((void*)longXor, UNKNOWN, 2)));
-    long_cls->giveAttr("__rxor__", long_cls->getattr("__xor__"));
+    long_cls->giveAttr("__rxor__", long_cls->getattr(internStringMortal("__xor__")));
 
     // Note: CPython implements long comparisons using tp_compare
     long_cls->tp_richcompare = long_richcompare;

--- a/src/runtime/objmodel.cpp
+++ b/src/runtime/objmodel.cpp
@@ -59,24 +59,15 @@
 
 namespace pyston {
 
-static const std::string all_str("__all__");
-static const std::string call_str("__call__");
-static const std::string delattr_str("__delattr__");
-static const std::string delete_str("__delete__");
 static const std::string delitem_str("__delitem__");
 static const std::string getattribute_str("__getattribute__");
 static const std::string getattr_str("__getattr__");
-static const std::string getitem_str("__getitem__");
-static const std::string get_str("__get__");
-static const std::string hasnext_str("__hasnext__");
 static const std::string init_str("__init__");
 static const std::string iter_str("__iter__");
 static const std::string new_str("__new__");
 static const std::string none_str("None");
 static const std::string repr_str("__repr__");
-static const std::string setattr_str("__setattr__");
 static const std::string setitem_str("__setitem__");
-static const std::string set_str("__set__");
 static const std::string str_str("__str__");
 
 #if 0
@@ -200,7 +191,7 @@ extern "C" bool softspace(Box* b, bool newval) {
         return (bool)r;
     }
 
-    static BoxedString* softspace_str = static_cast<BoxedString*>(PyString_InternFromString("softspace"));
+    static BoxedString* softspace_str = internStringImmortal("softspace");
 
     bool r;
     Box* gotten = NULL;
@@ -225,9 +216,9 @@ extern "C" bool softspace(Box* b, bool newval) {
 }
 
 extern "C" void printHelper(Box* dest, Box* var, bool nl) {
-    static BoxedString* write_str = static_cast<BoxedString*>(PyString_InternFromString("write"));
-    static BoxedString* newline_str = static_cast<BoxedString*>(PyString_InternFromString("\n"));
-    static BoxedString* space_str = static_cast<BoxedString*>(PyString_InternFromString(" "));
+    static BoxedString* write_str = internStringImmortal("write");
+    static BoxedString* newline_str = internStringImmortal("\n");
+    static BoxedString* space_str = internStringImmortal(" ");
 
     if (var) {
         // begin code for handling of softspace
@@ -358,7 +349,7 @@ void BoxedClass::freeze() {
 
     if (instancesHaveDictAttrs() || instancesHaveHCAttrs())
         ASSERT(this == closure_cls || this == classobj_cls || this == instance_cls
-                   || typeLookup(this, "__dict__", NULL),
+                   || typeLookup(this, internStringMortal("__dict__"), NULL),
                "%s", tp_name);
 
     is_constant = true;
@@ -500,7 +491,8 @@ BoxedHeapClass* BoxedHeapClass::create(BoxedClass* metaclass, BoxedClass* base, 
 }
 
 std::string getFullNameOfClass(BoxedClass* cls) {
-    Box* b = cls->getattr("__module__");
+    static BoxedString* module_str = internStringImmortal("__module__");
+    Box* b = cls->getattr(module_str);
     if (!b)
         return cls->tp_name;
     assert(b);
@@ -524,7 +516,8 @@ const char* getNameOfClass(BoxedClass* cls) {
     return cls->tp_name;
 }
 
-void HiddenClass::appendAttribute(llvm::StringRef attr) {
+void HiddenClass::appendAttribute(BoxedString* attr) {
+    assert(attr->interned_state != SSTATE_NOT_INTERNED);
     assert(type == SINGLETON);
     dependent_getattrs.invalidateAll();
     assert(attr_offsets.count(attr) == 0);
@@ -539,7 +532,8 @@ void HiddenClass::appendAttrwrapper() {
     attrwrapper_offset = this->attributeArraySize();
 }
 
-void HiddenClass::delAttribute(llvm::StringRef attr) {
+void HiddenClass::delAttribute(BoxedString* attr) {
+    assert(attr->interned_state != SSTATE_NOT_INTERNED);
     assert(type == SINGLETON);
     dependent_getattrs.invalidateAll();
     assert(attr_offsets.count(attr));
@@ -561,8 +555,10 @@ void HiddenClass::addDependence(Rewriter* rewriter) {
     rewriter->addDependenceOn(dependent_getattrs);
 }
 
-HiddenClass* HiddenClass::getOrMakeChild(llvm::StringRef attr) {
+HiddenClass* HiddenClass::getOrMakeChild(BoxedString* attr) {
     STAT_TIMER(t0, "us_timer_hiddenclass_getOrMakeChild", 0);
+
+    assert(attr->interned_state != SSTATE_NOT_INTERNED);
     assert(type == NORMAL);
 
     auto it = children.find(attr);
@@ -595,19 +591,20 @@ HiddenClass* HiddenClass::getAttrwrapperChild() {
 /**
  * del attr from current HiddenClass, maintaining the order of the remaining attrs
  */
-HiddenClass* HiddenClass::delAttrToMakeHC(llvm::StringRef attr) {
+HiddenClass* HiddenClass::delAttrToMakeHC(BoxedString* attr) {
     STAT_TIMER(t0, "us_timer_hiddenclass_delAttrToMakeHC", 0);
 
+    assert(attr->interned_state != SSTATE_NOT_INTERNED);
     assert(type == NORMAL);
     int idx = getOffset(attr);
     assert(idx >= 0);
 
-    std::vector<std::string> new_attrs(attributeArraySize() - 1);
+    std::vector<BoxedString*> new_attrs(attributeArraySize() - 1);
     for (auto it = attr_offsets.begin(); it != attr_offsets.end(); ++it) {
         if (it->second < idx)
-            new_attrs[it->second] = it->first();
+            new_attrs[it->second] = it->first;
         else if (it->second > idx) {
-            new_attrs[it->second - 1] = it->first();
+            new_attrs[it->second - 1] = it->first;
         }
     }
 
@@ -684,7 +681,8 @@ BoxedDict* Box::getDict() {
 }
 
 static StatCounter box_getattr_slowpath("slowpath_box_getattr");
-Box* Box::getattr(llvm::StringRef attr, GetattrRewriteArgs* rewrite_args) {
+Box* Box::getattr(BoxedString* attr, GetattrRewriteArgs* rewrite_args) {
+    assert(attr->interned_state != SSTATE_NOT_INTERNED);
 
     if (rewrite_args && !rewrite_args->obj_cls_guarded)
         rewrite_args->obj->addAttrGuard(offsetof(Box, cls), (intptr_t)cls);
@@ -722,8 +720,8 @@ Box* Box::getattr(llvm::StringRef attr, GetattrRewriteArgs* rewrite_args) {
             rewrite_args = NULL;
             Box* d = attrs->attr_list->attrs[0];
             assert(d);
-            assert(attr.data()[attr.size()] == '\0');
-            Box* r = PyDict_GetItemString(d, attr.data());
+            assert(attr->data()[attr->size()] == '\0');
+            Box* r = PyDict_GetItem(d, attr);
             // r can be NULL if the item didn't exist
             return r;
         }
@@ -780,8 +778,7 @@ Box* Box::getattr(llvm::StringRef attr, GetattrRewriteArgs* rewrite_args) {
 
         BoxedDict* d = getDict();
 
-        Box* key = boxString(attr);
-        auto it = d->d.find(key);
+        auto it = d->d.find(attr);
         if (it == d->d.end()) {
             return NULL;
         }
@@ -837,8 +834,9 @@ void Box::appendNewHCAttr(Box* new_attr, SetattrRewriteArgs* rewrite_args) {
     attrs->attr_list->attrs[numattrs] = new_attr;
 }
 
-void Box::setattr(llvm::StringRef attr, Box* val, SetattrRewriteArgs* rewrite_args) {
+void Box::setattr(BoxedString* attr, Box* val, SetattrRewriteArgs* rewrite_args) {
     assert(gc::isValidGCObject(val));
+    assert(attr->interned_state != SSTATE_NOT_INTERNED);
 
     // Have to guard on the memory layout of this object.
     // Right now, guard on the specific Python-class, which in turn
@@ -852,7 +850,7 @@ void Box::setattr(llvm::StringRef attr, Box* val, SetattrRewriteArgs* rewrite_ar
     if (rewrite_args)
         rewrite_args->obj->addAttrGuard(offsetof(Box, cls), (intptr_t)cls);
 
-    RELEASE_ASSERT(attr != none_str || this == builtins_module, "can't assign to None");
+    RELEASE_ASSERT(attr->s() != none_str || this == builtins_module, "can't assign to None");
 
     if (cls->instancesHaveHCAttrs()) {
         HCAttrs* attrs = getHCAttrsPtr();
@@ -864,8 +862,8 @@ void Box::setattr(llvm::StringRef attr, Box* val, SetattrRewriteArgs* rewrite_ar
             rewrite_args = NULL;
             Box* d = attrs->attr_list->attrs[0];
             assert(d);
-            assert(attr.data()[attr.size()] == '\0');
-            PyDict_SetItemString(d, attr.data(), val);
+            assert(attr->data()[attr->size()] == '\0');
+            PyDict_SetItem(d, attr, val);
             checkAndThrowCAPIException();
             return;
         }
@@ -943,7 +941,7 @@ void Box::setattr(llvm::StringRef attr, Box* val, SetattrRewriteArgs* rewrite_ar
 
     if (cls->instancesHaveDictAttrs()) {
         BoxedDict* d = getDict();
-        d->d[boxString(attr)] = val;
+        d->d[attr] = val;
         return;
     }
 
@@ -954,14 +952,14 @@ void Box::setattr(llvm::StringRef attr, Box* val, SetattrRewriteArgs* rewrite_ar
 extern "C" PyObject* _PyType_Lookup(PyTypeObject* type, PyObject* name) noexcept {
     RELEASE_ASSERT(name->cls == str_cls, "");
     try {
-        return typeLookup(type, static_cast<BoxedString*>(name)->s(), NULL);
+        return typeLookup(type, static_cast<BoxedString*>(name), NULL);
     } catch (ExcInfo e) {
         setCAPIException(e);
         return NULL;
     }
 }
 
-Box* typeLookup(BoxedClass* cls, llvm::StringRef attr, GetattrRewriteArgs* rewrite_args) {
+Box* typeLookup(BoxedClass* cls, BoxedString* attr, GetattrRewriteArgs* rewrite_args) {
     Box* val;
 
     if (rewrite_args) {
@@ -1003,13 +1001,15 @@ Box* typeLookup(BoxedClass* cls, llvm::StringRef attr, GetattrRewriteArgs* rewri
 
         return NULL;
     } else {
+        assert(attr->interned_state != SSTATE_NOT_INTERNED);
+
         assert(cls->tp_mro);
         assert(cls->tp_mro->cls == tuple_cls);
         for (auto b : *static_cast<BoxedTuple*>(cls->tp_mro)) {
             // object_cls will get checked very often, but it only
             // has attributes that start with an underscore.
             if (b == object_cls) {
-                if (attr.data()[0] != '_') {
+                if (attr->data()[0] != '_') {
                     assert(!b->getattr(attr, NULL));
                     continue;
                 }
@@ -1215,8 +1215,8 @@ static Box* boxStringFromCharPtr(const char* s) {
     return boxString(s);
 }
 
-Box* dataDescriptorInstanceSpecialCases(GetattrRewriteArgs* rewrite_args, llvm::StringRef attr_name, Box* obj,
-                                        Box* descr, RewriterVar* r_descr, bool for_call, Box** bind_obj_out,
+Box* dataDescriptorInstanceSpecialCases(GetattrRewriteArgs* rewrite_args, BoxedString* attr_name, Box* obj, Box* descr,
+                                        RewriterVar* r_descr, bool for_call, Box** bind_obj_out,
                                         RewriterVar** r_bind_obj_out) {
     // Special case: data descriptor: member descriptor
     if (descr->cls == member_descriptor_cls) {
@@ -1250,7 +1250,7 @@ Box* dataDescriptorInstanceSpecialCases(GetattrRewriteArgs* rewrite_args, llvm::
 
                 Box* rtn = *reinterpret_cast<Box**>((char*)obj + member_desc->offset);
                 if (rtn == NULL) {
-                    raiseExcHelper(AttributeError, "%.*s", attr_name.size(), attr_name.data());
+                    raiseExcHelper(AttributeError, "%.*s", attr_name->size(), attr_name->data());
                 }
                 return rtn;
             }
@@ -1369,8 +1369,8 @@ Box* dataDescriptorInstanceSpecialCases(GetattrRewriteArgs* rewrite_args, llvm::
         // is of that type.
 
         if (getset_descr->get == NULL) {
-            raiseExcHelper(AttributeError, "attribute '%.*s' of '%s' object is not readable", attr_name.size(),
-                           attr_name.data(), getTypeName(getset_descr));
+            raiseExcHelper(AttributeError, "attribute '%.*s' of '%s' object is not readable", attr_name->size(),
+                           attr_name->data(), getTypeName(getset_descr));
         }
 
         // Abort because right now we can't call twice in a rewrite
@@ -1449,7 +1449,7 @@ Box* getattrInternalEx(Box* obj, BoxedString* attr, GetattrRewriteArgs* rewrite_
         }
     }
 
-    return getattrInternalGeneric(obj, attr->s(), rewrite_args, cls_only, for_call, bind_obj_out, r_bind_obj_out);
+    return getattrInternalGeneric(obj, attr, rewrite_args, cls_only, for_call, bind_obj_out, r_bind_obj_out);
 }
 
 inline Box* getclsattrInternal(Box* obj, BoxedString* attr, GetattrRewriteArgs* rewrite_args) {
@@ -1512,8 +1512,10 @@ return gotten;
 // this function is useful for custom getattribute implementations that already know whether the descriptor
 // came from the class or not.
 Box* processDescriptorOrNull(Box* obj, Box* inst, Box* owner) {
-    if (DEBUG >= 2)
+    if (DEBUG >= 2) {
+        static BoxedString* get_str = internStringImmortal("__get__");
         assert((obj->cls->tp_descr_get == NULL) == (typeLookup(obj->cls, get_str, NULL) == NULL));
+    }
     if (obj->cls->tp_descr_get) {
         Box* r = obj->cls->tp_descr_get(obj, inst, owner);
         if (!r)
@@ -1531,13 +1533,16 @@ Box* processDescriptor(Box* obj, Box* inst, Box* owner) {
 }
 
 
-Box* getattrInternalGeneric(Box* obj, llvm::StringRef attr, GetattrRewriteArgs* rewrite_args, bool cls_only,
-                            bool for_call, Box** bind_obj_out, RewriterVar** r_bind_obj_out) {
+Box* getattrInternalGeneric(Box* obj, BoxedString* attr, GetattrRewriteArgs* rewrite_args, bool cls_only, bool for_call,
+                            Box** bind_obj_out, RewriterVar** r_bind_obj_out) {
     if (for_call) {
         *bind_obj_out = NULL;
     }
 
     assert(obj->cls != closure_cls);
+
+    static BoxedString* get_str = internStringImmortal("__get__");
+    static BoxedString* set_str = internStringImmortal("__set__");
 
     // Handle descriptor logic here.
     // A descriptor is either a data descriptor or a non-data descriptor.
@@ -1855,8 +1860,8 @@ Box* getattrInternalGeneric(Box* obj, llvm::StringRef attr, GetattrRewriteArgs* 
     // TODO this shouldn't go here; it should be in instancemethod_cls->tp_getattr[o]
     if (obj->cls == instancemethod_cls) {
         assert(!rewrite_args || !rewrite_args->out_success);
-        return getattrInternalEx(static_cast<BoxedInstanceMethod*>(obj)->func, boxString(attr), NULL, cls_only,
-                                 for_call, bind_obj_out, NULL);
+        return getattrInternalEx(static_cast<BoxedInstanceMethod*>(obj)->func, attr, NULL, cls_only, for_call,
+                                 bind_obj_out, NULL);
     }
 
     if (rewrite_args) {
@@ -1882,7 +1887,9 @@ Box* getattrMaybeNonstring(Box* obj, Box* attr) {
         }
     }
 
-    return getattr(obj, static_cast<BoxedString*>(attr));
+    BoxedString* s = static_cast<BoxedString*>(attr);
+    internStringMortalInplace(s);
+    return getattr(obj, s);
 }
 
 extern "C" Box* getattr(Box* obj, BoxedString* attr) {
@@ -1969,7 +1976,7 @@ extern "C" Box* getattr(Box* obj, BoxedString* attr) {
 }
 
 bool dataDescriptorSetSpecialCases(Box* obj, Box* val, Box* descr, SetattrRewriteArgs* rewrite_args,
-                                   RewriterVar* r_descr, llvm::StringRef attr_name) {
+                                   RewriterVar* r_descr, BoxedString* attr_name) {
 
     // Special case: getset descriptor
     if (descr->cls == pyston_getset_cls || descr->cls == capi_getset_cls) {
@@ -1977,8 +1984,8 @@ bool dataDescriptorSetSpecialCases(Box* obj, Box* val, Box* descr, SetattrRewrit
 
         // TODO type checking goes here
         if (getset_descr->set == NULL) {
-            raiseExcHelper(AttributeError, "attribute '%.*s' of '%s' objects is not writable", attr_name.size(),
-                           attr_name.data(), getTypeName(obj));
+            raiseExcHelper(AttributeError, "attribute '%.*s' of '%s' objects is not writable", attr_name->size(),
+                           attr_name->data(), getTypeName(obj));
         }
 
         if (rewrite_args) {
@@ -2024,6 +2031,8 @@ void setattrGeneric(Box* obj, BoxedString* attr, Box* val, SetattrRewriteArgs* r
     assert(val);
     assert(gc::isValidGCObject(val));
 
+    static BoxedString* set_str = internStringImmortal("__set__");
+
     // TODO this should be in type_setattro
     if (obj->cls == type_cls) {
         BoxedClass* cobj = static_cast<BoxedClass*>(obj);
@@ -2041,7 +2050,7 @@ void setattrGeneric(Box* obj, BoxedString* attr, Box* val, SetattrRewriteArgs* r
     if (rewrite_args) {
         RewriterVar* r_cls = rewrite_args->obj->getAttr(offsetof(Box, cls), Location::any());
         GetattrRewriteArgs crewrite_args(rewrite_args->rewriter, r_cls, rewrite_args->rewriter->getReturnDestination());
-        descr = typeLookup(obj->cls, attr->s(), &crewrite_args);
+        descr = typeLookup(obj->cls, attr, &crewrite_args);
 
         if (!crewrite_args.out_success) {
             rewrite_args = NULL;
@@ -2049,13 +2058,13 @@ void setattrGeneric(Box* obj, BoxedString* attr, Box* val, SetattrRewriteArgs* r
             r_descr = crewrite_args.out_rtn;
         }
     } else {
-        descr = typeLookup(obj->cls, attr->s(), NULL);
+        descr = typeLookup(obj->cls, attr, NULL);
     }
 
     Box* _set_ = NULL;
     RewriterVar* r_set = NULL;
     if (descr) {
-        bool special_case_worked = dataDescriptorSetSpecialCases(obj, val, descr, rewrite_args, r_descr, attr->s());
+        bool special_case_worked = dataDescriptorSetSpecialCases(obj, val, descr, rewrite_args, r_descr, attr);
         if (special_case_worked) {
             // We don't need to to the invalidation stuff in this case.
             return;
@@ -2098,14 +2107,15 @@ void setattrGeneric(Box* obj, BoxedString* attr, Box* val, SetattrRewriteArgs* r
             raiseAttributeError(obj, attr->s());
         }
 
-        obj->setattr(attr->s(), val, rewrite_args);
+        obj->setattr(attr, val, rewrite_args);
     }
 
     // TODO this should be in type_setattro
     if (isSubclass(obj->cls, type_cls)) {
         BoxedClass* self = static_cast<BoxedClass*>(obj);
 
-        if (attr->s() == "__base__" && self->getattr("__base__"))
+        static BoxedString* base_str = internStringImmortal("__base__");
+        if (attr->s() == "__base__" && self->getattr(base_str))
             raiseExcHelper(TypeError, "readonly attribute");
 
         bool touched_slot = update_slot(self, attr->s());
@@ -2153,6 +2163,7 @@ extern "C" void setattr(Box* obj, BoxedString* attr, Box* attr_val) {
     Box* setattr = NULL;
     RewriterVar* r_setattr;
     if (tp_setattro != PyObject_GenericSetAttr) {
+        static BoxedString* setattr_str = internStringImmortal("__setattr__");
         if (rewriter.get()) {
             GetattrRewriteArgs rewrite_args(rewriter.get(), rewriter->getArg(0)->getAttr(offsetof(Box, cls)),
                                             Location::any());
@@ -2173,7 +2184,7 @@ extern "C" void setattr(Box* obj, BoxedString* attr, Box* attr_val) {
 
     // We should probably add this as a GC root, but we can cheat a little bit since
     // we know it's not going to get deallocated:
-    static Box* object_setattr = object_cls->getattr("__setattr__");
+    static Box* object_setattr = object_cls->getattr(internStringImmortal("__setattr__"));
     assert(object_setattr);
 
     // I guess this check makes it ok for us to just rely on having guarded on the value of setattr without
@@ -2311,8 +2322,8 @@ extern "C" bool nonzero(Box* obj) {
     }
 
     // TODO: rewrite these.
-    static BoxedString* nonzero_str = static_cast<BoxedString*>(PyString_InternFromString("__nonzero__"));
-    static BoxedString* len_str = static_cast<BoxedString*>(PyString_InternFromString("__len__"));
+    static BoxedString* nonzero_str = internStringImmortal("__nonzero__");
+    static BoxedString* len_str = internStringImmortal("__len__");
     // go through descriptor logic
     Box* func = getclsattrInternal(obj, nonzero_str, NULL);
     if (!func)
@@ -2350,7 +2361,7 @@ extern "C" BoxedString* str(Box* obj) {
     static StatCounter slowpath_str("slowpath_str");
     slowpath_str.log();
 
-    static BoxedString* str_box = static_cast<BoxedString*>(PyString_InternFromString(str_str.c_str()));
+    static BoxedString* str_box = internStringImmortal(str_str.c_str());
     if (obj->cls != str_cls) {
         // TODO could do an IC optimization here (once we do rewrites here at all):
         // if __str__ is objectStr, just guard on that and call repr directly.
@@ -2382,7 +2393,7 @@ extern "C" BoxedString* repr(Box* obj) {
     static StatCounter slowpath_repr("slowpath_repr");
     slowpath_repr.log();
 
-    static BoxedString* repr_box = static_cast<BoxedString*>(PyString_InternFromString(repr_str.c_str()));
+    static BoxedString* repr_box = internStringImmortal(repr_str.c_str());
     obj = callattrInternal(obj, repr_box, CLASS_ONLY, NULL, ArgPassSpec(0), NULL, NULL, NULL, NULL, NULL);
 
     if (isSubclass(obj->cls, unicode_cls)) {
@@ -2464,7 +2475,7 @@ extern "C" BoxedInt* hash(Box* obj) {
 }
 
 extern "C" BoxedInt* lenInternal(Box* obj, LenRewriteArgs* rewrite_args) {
-    static BoxedString* len_str = static_cast<BoxedString*>(PyString_InternFromString("__len__"));
+    static BoxedString* len_str = internStringImmortal("__len__");
 
     // Corresponds to the first part of PyObject_Size:
     PySequenceMethods* m = obj->cls->tp_as_sequence;
@@ -3645,17 +3656,17 @@ Box* runtimeCallInternal(Box* obj, CallRewriteArgs* rewrite_args, ArgPassSpec ar
 
         Box* rtn;
 
+        static BoxedString* call_str = internStringImmortal("__call__");
+
         if (DEBUG >= 2) {
             assert((obj->cls->tp_call == NULL) == (typeLookup(obj->cls, call_str, NULL) == NULL));
         }
 
-        static BoxedString* call_box = static_cast<BoxedString*>(PyString_InternFromString(call_str.c_str()));
-
         if (rewrite_args) {
-            rtn = callattrInternal(obj, call_box, CLASS_ONLY, rewrite_args, argspec, arg1, arg2, arg3, args,
+            rtn = callattrInternal(obj, call_str, CLASS_ONLY, rewrite_args, argspec, arg1, arg2, arg3, args,
                                    keyword_names);
         } else {
-            rtn = callattrInternal(obj, call_box, CLASS_ONLY, NULL, argspec, arg1, arg2, arg3, args, keyword_names);
+            rtn = callattrInternal(obj, call_str, CLASS_ONLY, NULL, argspec, arg1, arg2, arg3, args, keyword_names);
         }
         if (!rtn)
             raiseExcHelper(TypeError, "'%s' object is not callable", getTypeName(obj));
@@ -4065,7 +4076,7 @@ Box* compareInternal(Box* lhs, Box* rhs, int op_type, CompareRewriteArgs* rewrit
     }
 
     if (op_type == AST_TYPE::In || op_type == AST_TYPE::NotIn) {
-        static BoxedString* contains_str = static_cast<BoxedString*>(PyString_InternFromString("__contains__"));
+        static BoxedString* contains_str = internStringImmortal("__contains__");
 
         // The checks for this branch are taken from CPython's PySequence_Contains
         if (PyType_HasFeature(rhs->cls, Py_TPFLAGS_HAVE_SEQUENCE_IN)) {
@@ -4249,7 +4260,7 @@ Box* compareInternal(Box* lhs, Box* rhs, int op_type, CompareRewriteArgs* rewrit
     if (rrtn != NULL && rrtn != NotImplemented)
         return rrtn;
 
-    static BoxedString* cmp_str = static_cast<BoxedString*>(PyString_InternFromString("__cmp__"));
+    static BoxedString* cmp_str = internStringImmortal("__cmp__");
     lrtn = callattrInternal1(lhs, cmp_str, CLASS_ONLY, NULL, ArgPassSpec(1), rhs);
     if (lrtn && lrtn != NotImplemented) {
         return boxBool(convert3wayCompareResultToBool(lrtn, op_type));
@@ -4399,7 +4410,7 @@ extern "C" Box* getitem(Box* value, Box* slice) {
         return r;
     }
 
-    static BoxedString* getitem_str = static_cast<BoxedString*>(PyString_InternFromString("__getitem__"));
+    static BoxedString* getitem_str = internStringImmortal("__getitem__");
     Box* rtn;
     if (rewriter.get()) {
         CallRewriteArgs rewrite_args(rewriter.get(), rewriter->getArg(0), rewriter->getReturnDestination());
@@ -4441,7 +4452,7 @@ extern "C" void setitem(Box* target, Box* slice, Box* value) {
     std::unique_ptr<Rewriter> rewriter(
         Rewriter::createRewriter(__builtin_extract_return_addr(__builtin_return_address(0)), 3, "setitem"));
 
-    static BoxedString* setitem_str = static_cast<BoxedString*>(PyString_InternFromString("__setitem__"));
+    static BoxedString* setitem_str = internStringImmortal("__setitem__");
 
     Box* rtn;
     if (rewriter.get()) {
@@ -4477,7 +4488,7 @@ extern "C" void delitem(Box* target, Box* slice) {
     std::unique_ptr<Rewriter> rewriter(
         Rewriter::createRewriter(__builtin_extract_return_addr(__builtin_return_address(0)), 2, "delitem"));
 
-    static BoxedString* delitem_str = static_cast<BoxedString*>(PyString_InternFromString("__delitem__"));
+    static BoxedString* delitem_str = internStringImmortal("__delitem__");
 
     Box* rtn;
     if (rewriter.get()) {
@@ -4503,7 +4514,8 @@ extern "C" void delitem(Box* target, Box* slice) {
     }
 }
 
-void Box::delattr(llvm::StringRef attr, DelattrRewriteArgs* rewrite_args) {
+void Box::delattr(BoxedString* attr, DelattrRewriteArgs* rewrite_args) {
+    assert(attr->interned_state != SSTATE_NOT_INTERNED);
     if (cls->instancesHaveHCAttrs()) {
         // as soon as the hcls changes, the guard on hidden class won't pass.
         HCAttrs* attrs = getHCAttrsPtr();
@@ -4515,8 +4527,8 @@ void Box::delattr(llvm::StringRef attr, DelattrRewriteArgs* rewrite_args) {
             rewrite_args = NULL;
             Box* d = attrs->attr_list->attrs[0];
             assert(d);
-            assert(attr.data()[attr.size()] == '\0');
-            PyDict_DelItemString(d, attr.data());
+            assert(attr->data()[attr->size()] == '\0');
+            PyDict_DelItem(d, attr);
             checkAndThrowCAPIException();
             return;
         }
@@ -4555,8 +4567,9 @@ void Box::delattr(llvm::StringRef attr, DelattrRewriteArgs* rewrite_args) {
 
 extern "C" void delattrGeneric(Box* obj, BoxedString* attr, DelattrRewriteArgs* rewrite_args) {
     // first check whether the deleting attribute is a descriptor
-    Box* clsAttr = typeLookup(obj->cls, attr->s(), NULL);
+    Box* clsAttr = typeLookup(obj->cls, attr, NULL);
     if (clsAttr != NULL) {
+        static BoxedString* delete_str = internStringImmortal("__delete__");
         Box* delAttr = typeLookup(static_cast<BoxedClass*>(clsAttr->cls), delete_str, NULL);
 
         if (delAttr != NULL) {
@@ -4566,9 +4579,9 @@ extern "C" void delattrGeneric(Box* obj, BoxedString* attr, DelattrRewriteArgs* 
     }
 
     // check if the attribute is in the instance's __dict__
-    Box* attrVal = obj->getattr(attr->s(), NULL);
+    Box* attrVal = obj->getattr(attr, NULL);
     if (attrVal != NULL) {
-        obj->delattr(attr->s(), NULL);
+        obj->delattr(attr, NULL);
     } else {
         // the exception cpthon throws is different when the class contains the attribute
         if (clsAttr != NULL) {
@@ -4584,7 +4597,8 @@ extern "C" void delattrGeneric(Box* obj, BoxedString* attr, DelattrRewriteArgs* 
     if (isSubclass(obj->cls, type_cls)) {
         BoxedClass* self = static_cast<BoxedClass*>(obj);
 
-        if (attr->s() == "__base__" && self->getattr("__base__"))
+        static BoxedString* base_str = internStringImmortal("__base__");
+        if (attr->s() == "__base__" && self->getattr(base_str))
             raiseExcHelper(TypeError, "readonly attribute");
 
         assert(attr->data()[attr->size()] == '\0');
@@ -4600,6 +4614,7 @@ extern "C" void delattrGeneric(Box* obj, BoxedString* attr, DelattrRewriteArgs* 
 }
 
 extern "C" void delattrInternal(Box* obj, BoxedString* attr, DelattrRewriteArgs* rewrite_args) {
+    static BoxedString* delattr_str = internStringImmortal("__delattr__");
     Box* delAttr = typeLookup(obj->cls, delattr_str, NULL);
     if (delAttr != NULL) {
         Box* rtn = runtimeCallInternal(delAttr, NULL, ArgPassSpec(2), obj, attr, NULL, NULL, NULL);
@@ -4636,6 +4651,8 @@ extern "C" Box* createBoxedIterWrapperIfNeeded(Box* o) {
 
     std::unique_ptr<Rewriter> rewriter(Rewriter::createRewriter(
         __builtin_extract_return_addr(__builtin_return_address(0)), 1, "createBoxedIterWrapperIfNeeded"));
+
+    static BoxedString* hasnext_str = internStringImmortal("__hasnext__");
 
     if (rewriter.get()) {
         RewriterVar* r_o = rewriter->getArg(0);
@@ -4676,6 +4693,7 @@ extern "C" Box* getPystonIter(Box* o) {
 }
 
 extern "C" Box* getiterHelper(Box* o) {
+    static BoxedString* getitem_str = internStringImmortal("__getitem__");
     if (typeLookup(o->cls, getitem_str, NULL))
         return new BoxedSeqIter(o, 0);
     raiseExcHelper(TypeError, "'%s' object is not iterable", getTypeName(o));
@@ -4683,7 +4701,7 @@ extern "C" Box* getiterHelper(Box* o) {
 
 Box* getiter(Box* o) {
     // TODO add rewriting to this?  probably want to try to avoid this path though
-    static BoxedString* iter_str = static_cast<BoxedString*>(PyString_InternFromString("__iter__"));
+    static BoxedString* iter_str = internStringImmortal("__iter__");
     Box* r = callattrInternal0(o, iter_str, LookupScope::CLASS_ONLY, NULL, ArgPassSpec(0));
     if (r)
         return r;
@@ -4772,7 +4790,7 @@ Box* typeNew(Box* _cls, Box* arg1, Box* arg2, Box** _args) {
                                   "of the metaclasses of all its bases");
     }
 
-    static BoxedString* new_box = static_cast<BoxedString*>(PyString_InternFromString(new_str.c_str()));
+    static BoxedString* new_box = internStringImmortal(new_str.c_str());
     if (winner != metatype) {
         if (getattr(winner, new_box) != getattr(type_cls, new_box)) {
             CallattrFlags callattr_flags
@@ -4790,7 +4808,8 @@ Box* typeNew(Box* _cls, Box* arg1, Box* arg2, Box** _args) {
     assert(isSubclass(base->cls, type_cls));
 
     // Handle slots
-    Box* boxedSlots = PyDict_GetItemString(attr_dict, "__slots__");
+    static BoxedString* slots_str = internStringImmortal("__slots__");
+    Box* boxedSlots = PyDict_GetItem(attr_dict, slots_str);
     int add_dict = 0;
     int add_weak = 0;
     bool may_add_dict = base->tp_dictoffset == 0 && base->attrs_offset == 0;
@@ -4950,24 +4969,32 @@ Box* typeNew(Box* _cls, Box* arg1, Box* arg2, Box** _args) {
                base_heap_cls->nslots() * sizeof(BoxedHeapClass::SlotOffset));
     }
 
-    if (made->instancesHaveHCAttrs() || made->instancesHaveDictAttrs())
-        made->setattr("__dict__", dict_descr, NULL);
+    if (made->instancesHaveHCAttrs() || made->instancesHaveDictAttrs()) {
+        static BoxedString* dict_str = internStringImmortal("__dict__");
+        made->setattr(dict_str, dict_descr, NULL);
+    }
 
     for (const auto& p : attr_dict->d) {
         auto k = coerceUnicodeToStr(p.first);
 
         RELEASE_ASSERT(k->cls == str_cls, "");
-        made->setattr(static_cast<BoxedString*>(k)->s(), p.second, NULL);
+        BoxedString* s = static_cast<BoxedString*>(k);
+        internStringMortalInplace(s);
+        made->setattr(s, p.second, NULL);
     }
 
-    if (!made->hasattr("__module__")) {
+    static BoxedString* module_str = internStringImmortal("__module__");
+    if (!made->hasattr(module_str)) {
         Box* gl = getGlobalsDict();
-        Box* attr = PyDict_GetItemString(gl, "__name__");
+        static BoxedString* name_str = internStringImmortal("__name__");
+        Box* attr = PyDict_GetItem(gl, name_str);
         if (attr)
-            made->giveAttr("__module__", attr);
+            made->giveAttr(module_str, attr);
     }
-    if (!made->hasattr("__doc__"))
-        made->giveAttr("__doc__", None);
+
+    static BoxedString* doc_str = internStringImmortal("__doc__");
+    if (!made->hasattr(doc_str))
+        made->giveAttr(doc_str, None);
 
     made->tp_new = base->tp_new;
 
@@ -4996,11 +5023,11 @@ Box* typeNew(Box* _cls, Box* arg1, Box* arg2, Box** _args) {
 extern "C" void delGlobal(Box* globals, BoxedString* name) {
     if (globals->cls == module_cls) {
         BoxedModule* m = static_cast<BoxedModule*>(globals);
-        if (!m->getattr(name->s())) {
+        if (!m->getattr(name)) {
             assert(name->data()[name->size()] == '\0');
             raiseExcHelper(NameError, "name '%s' is not defined", name->data());
         }
-        m->delattr(name->s(), NULL);
+        m->delattr(name, NULL);
     } else {
         assert(globals->cls == dict_cls);
         BoxedDict* d = static_cast<BoxedDict*>(globals);
@@ -5045,7 +5072,7 @@ extern "C" Box* getGlobal(Box* globals, BoxedString* name) {
                 r_mod->addAttrGuard(offsetof(Box, cls), (intptr_t)module_cls);
 
                 GetattrRewriteArgs rewrite_args(rewriter.get(), r_mod, rewriter->getReturnDestination());
-                r = m->getattr(name->s(), &rewrite_args);
+                r = m->getattr(name, &rewrite_args);
                 if (!rewrite_args.out_success) {
                     rewriter.reset(NULL);
                 }
@@ -5056,7 +5083,7 @@ extern "C" Box* getGlobal(Box* globals, BoxedString* name) {
                     return r;
                 }
             } else {
-                r = m->getattr(name->s(), NULL);
+                r = m->getattr(name, NULL);
                 nopatch_getglobal.log();
                 if (r) {
                     return r;
@@ -5083,7 +5110,7 @@ extern "C" Box* getGlobal(Box* globals, BoxedString* name) {
             RewriterVar* builtins = rewriter->loadConst((intptr_t)builtins_module, Location::any());
             GetattrRewriteArgs rewrite_args(rewriter.get(), builtins, rewriter->getReturnDestination());
             rewrite_args.obj_cls_guarded = true; // always builtin module
-            rtn = builtins_module->getattr(name->s(), &rewrite_args);
+            rtn = builtins_module->getattr(name, &rewrite_args);
 
             if (!rtn || !rewrite_args.out_success) {
                 rewriter.reset(NULL);
@@ -5093,7 +5120,7 @@ extern "C" Box* getGlobal(Box* globals, BoxedString* name) {
                 rewriter->commitReturning(rewrite_args.out_rtn);
             }
         } else {
-            rtn = builtins_module->getattr(name->s(), NULL);
+            rtn = builtins_module->getattr(name, NULL);
         }
 
         if (rtn)
@@ -5111,7 +5138,7 @@ Box* getFromGlobals(Box* globals, BoxedString* name) {
     }
 
     if (globals->cls == module_cls) {
-        return globals->getattr(name->s());
+        return globals->getattr(name);
     } else if (globals->cls == dict_cls) {
         auto d = static_cast<BoxedDict*>(globals)->d;
         auto it = d.find(name);
@@ -5153,9 +5180,11 @@ extern "C" Box* importStar(Box* _from_module, Box* to_globals) {
     RELEASE_ASSERT(isSubclass(_from_module->cls, module_cls), "%s", _from_module->cls->tp_name);
     BoxedModule* from_module = static_cast<BoxedModule*>(_from_module);
 
+    static BoxedString* all_str = internStringImmortal("__all__");
     Box* all = from_module->getattr(all_str);
 
     if (all) {
+        static BoxedString* getitem_str = internStringImmortal("__getitem__");
         Box* all_getitem = typeLookup(all->cls, getitem_str, NULL);
         if (!all_getitem)
             raiseExcHelper(TypeError, "'%s' object does not support indexing", getTypeName(all));
@@ -5178,7 +5207,8 @@ extern "C" Box* importStar(Box* _from_module, Box* to_globals) {
                 raiseExcHelper(TypeError, "attribute name must be string, not '%s'", getTypeName(attr_name));
 
             BoxedString* casted_attr_name = static_cast<BoxedString*>(attr_name);
-            Box* attr_value = from_module->getattr(casted_attr_name->s());
+            internStringMortalInplace(casted_attr_name);
+            Box* attr_value = from_module->getattr(casted_attr_name);
 
             if (!attr_value)
                 raiseExcHelper(AttributeError, "'module' object has no attribute '%s'", casted_attr_name->data());
@@ -5189,10 +5219,10 @@ extern "C" Box* importStar(Box* _from_module, Box* to_globals) {
 
     HCAttrs* module_attrs = from_module->getHCAttrsPtr();
     for (auto& p : module_attrs->hcls->getStrAttrOffsets()) {
-        if (p.first()[0] == '_')
+        if (p.first->data()[0] == '_')
             continue;
 
-        setGlobal(to_globals, boxString(p.first()), module_attrs->attr_list->attrs[p.second]);
+        setGlobal(to_globals, p.first, module_attrs->attr_list->attrs[p.second]);
     }
 
     return None;

--- a/src/runtime/objmodel.cpp
+++ b/src/runtime/objmodel.cpp
@@ -569,8 +569,8 @@ HiddenClass* HiddenClass::getOrMakeChild(BoxedString* attr) {
     num_hclses.log();
 
     HiddenClass* rtn = new HiddenClass(this);
-    this->children[attr] = rtn;
     rtn->attr_offsets[attr] = this->attributeArraySize();
+    this->children[attr] = rtn;
     assert(rtn->attributeArraySize() == this->attributeArraySize() + 1);
     return rtn;
 }
@@ -580,9 +580,10 @@ HiddenClass* HiddenClass::getAttrwrapperChild() {
     assert(attrwrapper_offset == -1);
 
     if (!attrwrapper_child) {
-        attrwrapper_child = new HiddenClass(this);
-        attrwrapper_child->attrwrapper_offset = this->attributeArraySize();
-        assert(attrwrapper_child->attributeArraySize() == this->attributeArraySize() + 1);
+        HiddenClass* made = new HiddenClass(this);
+        made->attrwrapper_offset = this->attributeArraySize();
+        this->attrwrapper_child = made;
+        assert(made->attributeArraySize() == this->attributeArraySize() + 1);
     }
 
     return attrwrapper_child;

--- a/src/runtime/objmodel.h
+++ b/src/runtime/objmodel.h
@@ -128,7 +128,7 @@ enum LookupScope {
 extern "C" Box* callattrInternal(Box* obj, BoxedString* attr, LookupScope, CallRewriteArgs* rewrite_args,
                                  ArgPassSpec argspec, Box* arg1, Box* arg2, Box* arg3, Box** args,
                                  const std::vector<BoxedString*>* keyword_names);
-extern "C" void delattr_internal(Box* obj, llvm::StringRef attr, bool allow_custom, DelattrRewriteArgs* rewrite_args);
+extern "C" void delattr_internal(Box* obj, BoxedString* attr, bool allow_custom, DelattrRewriteArgs* rewrite_args);
 struct CompareRewriteArgs;
 Box* compareInternal(Box* lhs, Box* rhs, int op_type, CompareRewriteArgs* rewrite_args);
 
@@ -139,12 +139,12 @@ Box* getattrInternal(Box* obj, BoxedString* attr, GetattrRewriteArgs* rewrite_ar
 // This is the equivalent of PyObject_GenericGetAttr, which performs the default lookup rules for getattr() (check for
 // data descriptor, check for instance attribute, check for non-data descriptor). It does not check for __getattr__ or
 // __getattribute__.
-Box* getattrInternalGeneric(Box* obj, llvm::StringRef attr, GetattrRewriteArgs* rewrite_args, bool cls_only,
-                            bool for_call, Box** bind_obj_out, RewriterVar** r_bind_obj_out);
+Box* getattrInternalGeneric(Box* obj, BoxedString* attr, GetattrRewriteArgs* rewrite_args, bool cls_only, bool for_call,
+                            Box** bind_obj_out, RewriterVar** r_bind_obj_out);
 
 // This is the equivalent of _PyType_Lookup(), which calls Box::getattr() on each item in the object's MRO in the
 // appropriate order. It does not do any descriptor logic.
-Box* typeLookup(BoxedClass* cls, llvm::StringRef attr, GetattrRewriteArgs* rewrite_args);
+Box* typeLookup(BoxedClass* cls, BoxedString* attr, GetattrRewriteArgs* rewrite_args);
 
 extern "C" void raiseAttributeErrorStr(const char* typeName, llvm::StringRef attr) __attribute__((__noreturn__));
 extern "C" void raiseAttributeError(Box* obj, llvm::StringRef attr) __attribute__((__noreturn__));

--- a/src/runtime/set.cpp
+++ b/src/runtime/set.cpp
@@ -490,7 +490,7 @@ void setupSet() {
 
     set_cls->giveAttr("__new__",
                       new BoxedFunction(boxRTFunction((void*)setNew, UNKNOWN, 2, 1, false, false), { None }));
-    frozenset_cls->giveAttr("__new__", set_cls->getattr("__new__"));
+    frozenset_cls->giveAttr("__new__", set_cls->getattr(internStringMortal("__new__")));
 
     Box* set_repr = new BoxedFunction(boxRTFunction((void*)setRepr, STR, 1));
     set_cls->giveAttr("__repr__", set_repr);
@@ -515,14 +515,14 @@ void setupSet() {
     v_fu.push_back(FROZENSET);
     v_fu.push_back(UNKNOWN);
 
-    auto add = [&](llvm::StringRef name, void* func) {
+    auto add = [&](const char* name, void* func) {
         CLFunction* func_obj = createRTFunction(2, 0, false, false);
         addRTFunction(func_obj, (void*)func, SET, v_ss);
         addRTFunction(func_obj, (void*)func, SET, v_sf);
         addRTFunction(func_obj, (void*)func, FROZENSET, v_fs);
         addRTFunction(func_obj, (void*)func, FROZENSET, v_ff);
         set_cls->giveAttr(name, new BoxedFunction(func_obj));
-        frozenset_cls->giveAttr(name, set_cls->getattr(name));
+        frozenset_cls->giveAttr(name, set_cls->getattr(internStringMortal(name)));
     };
 
     add("__or__", (void*)setOrSet);
@@ -531,21 +531,21 @@ void setupSet() {
     add("__and__", (void*)setAndSet);
 
     set_cls->giveAttr("__iter__", new BoxedFunction(boxRTFunction((void*)setIter, typeFromClass(set_iterator_cls), 1)));
-    frozenset_cls->giveAttr("__iter__", set_cls->getattr("__iter__"));
+    frozenset_cls->giveAttr("__iter__", set_cls->getattr(internStringMortal("__iter__")));
 
     set_cls->giveAttr("__len__", new BoxedFunction(boxRTFunction((void*)setLen, BOXED_INT, 1)));
-    frozenset_cls->giveAttr("__len__", set_cls->getattr("__len__"));
+    frozenset_cls->giveAttr("__len__", set_cls->getattr(internStringMortal("__len__")));
 
     set_cls->giveAttr("__contains__", new BoxedFunction(boxRTFunction((void*)setContains, BOXED_BOOL, 2)));
-    frozenset_cls->giveAttr("__contains__", set_cls->getattr("__contains__"));
+    frozenset_cls->giveAttr("__contains__", set_cls->getattr(internStringMortal("__contains__")));
 
     set_cls->giveAttr("__eq__", new BoxedFunction(boxRTFunction((void*)setEq, UNKNOWN, 2)));
-    frozenset_cls->giveAttr("__eq__", set_cls->getattr("__eq__"));
+    frozenset_cls->giveAttr("__eq__", set_cls->getattr(internStringMortal("__eq__")));
     set_cls->giveAttr("__ne__", new BoxedFunction(boxRTFunction((void*)setNe, UNKNOWN, 2)));
-    frozenset_cls->giveAttr("__ne__", set_cls->getattr("__ne__"));
+    frozenset_cls->giveAttr("__ne__", set_cls->getattr(internStringMortal("__ne__")));
 
     set_cls->giveAttr("__nonzero__", new BoxedFunction(boxRTFunction((void*)setNonzero, BOXED_BOOL, 1)));
-    frozenset_cls->giveAttr("__nonzero__", set_cls->getattr("__nonzero__"));
+    frozenset_cls->giveAttr("__nonzero__", set_cls->getattr(internStringMortal("__nonzero__")));
 
     frozenset_cls->giveAttr("__hash__", new BoxedFunction(boxRTFunction((void*)setHash, BOXED_INT, 1)));
 
@@ -556,12 +556,12 @@ void setupSet() {
     set_cls->giveAttr("clear", new BoxedFunction(boxRTFunction((void*)setClear, NONE, 1)));
     set_cls->giveAttr("update", new BoxedFunction(boxRTFunction((void*)setUpdate, NONE, 1, 0, true, false)));
     set_cls->giveAttr("union", new BoxedFunction(boxRTFunction((void*)setUnion, UNKNOWN, 1, 0, true, false)));
-    frozenset_cls->giveAttr("union", set_cls->getattr("union"));
+    frozenset_cls->giveAttr("union", set_cls->getattr(internStringMortal("union")));
     set_cls->giveAttr("intersection",
                       new BoxedFunction(boxRTFunction((void*)setIntersection, UNKNOWN, 1, 0, true, false)));
-    frozenset_cls->giveAttr("intersection", set_cls->getattr("intersection"));
+    frozenset_cls->giveAttr("intersection", set_cls->getattr(internStringMortal("intersection")));
     set_cls->giveAttr("difference", new BoxedFunction(boxRTFunction((void*)setDifference, UNKNOWN, 1, 0, true, false)));
-    frozenset_cls->giveAttr("difference", set_cls->getattr("difference"));
+    frozenset_cls->giveAttr("difference", set_cls->getattr(internStringMortal("difference")));
     set_cls->giveAttr("difference_update",
                       new BoxedFunction(boxRTFunction((void*)setDifferenceUpdate, UNKNOWN, 1, 0, true, false)));
     set_cls->giveAttr("issubset", new BoxedFunction(boxRTFunction((void*)setIssubset, UNKNOWN, 2)));

--- a/src/runtime/stacktrace.cpp
+++ b/src/runtime/stacktrace.cpp
@@ -135,7 +135,16 @@ extern "C" void abort() {
     }
 
     if (PAUSE_AT_ABORT) {
-        printf("PID %d about to call libc abort; pausing for a debugger...\n", getpid());
+        fprintf(stderr, "PID %d about to call libc abort; pausing for a debugger...\n", getpid());
+
+        // Sometimes stderr isn't available (or doesn't immediately appear), so write out a file
+        // just in case:
+        FILE* f = fopen("pausing.txt", "w");
+        if (f) {
+            fprintf(f, "PID %d about to call libc abort; pausing for a debugger...\n", getpid());
+            fclose(f);
+        }
+
         while (true) {
             sleep(1);
         }

--- a/src/runtime/super.cpp
+++ b/src/runtime/super.cpp
@@ -101,7 +101,7 @@ Box* superGetattribute(Box* _s, Box* _attr) {
                 continue;
             res = PyDict_GetItem(dict, name);
 #endif
-            res = tmp->getattr(std::string(attr->s()));
+            res = tmp->getattr(attr);
 
             if (res != NULL) {
 // Pyston change:
@@ -128,7 +128,7 @@ Box* superGetattribute(Box* _s, Box* _attr) {
         }
     }
 
-    Box* r = typeLookup(s->cls, attr->s(), NULL);
+    Box* r = typeLookup(s->cls, attr, NULL);
     // TODO implement this
     RELEASE_ASSERT(r, "should call the equivalent of objectGetattr here");
     return processDescriptor(r, s, s->cls);
@@ -166,6 +166,7 @@ BoxedClass* supercheck(BoxedClass* type, Box* obj) {
         return obj->cls;
     }
 
+    static BoxedString* class_str = internStringImmortal("__class__");
     Box* class_attr = obj->getattr(class_str);
     if (class_attr && isSubclass(class_attr->cls, type_cls) && class_attr != obj->cls) {
         Py_FatalError("warning: this path never tested"); // blindly copied from CPython

--- a/src/runtime/tuple.cpp
+++ b/src/runtime/tuple.cpp
@@ -31,6 +31,8 @@
 namespace pyston {
 
 extern "C" Box* createTuple(int64_t nelts, Box** elts) {
+    for (int i = 0; i < nelts; i++)
+        assert(gc::isValidGCObject(elts[i]));
     return BoxedTuple::create(nelts, elts);
 }
 

--- a/src/runtime/types.h
+++ b/src/runtime/types.h
@@ -879,6 +879,8 @@ private:
     ContiguousMap<int64_t, BoxedFloat*, std::unordered_map<int64_t, int>> float_constants;
     ContiguousMap<int64_t, Box*, std::unordered_map<int64_t, int>> imaginary_constants;
     ContiguousMap<llvm::StringRef, Box*, llvm::StringMap<int>> long_constants;
+    // Other objects that this module needs to keep alive; see getStringConstant.
+    llvm::SmallVector<Box*, 8> keep_alive;
 
 public:
     DEFAULT_CLASS(module_cls);

--- a/src/runtime/types.h
+++ b/src/runtime/types.h
@@ -624,18 +624,24 @@ public:
     }
     static BoxedTuple* create(int64_t nelts, Box** elts) {
         BoxedTuple* rtn = new (nelts) BoxedTuple();
+        for (int i = 0; i < nelts; i++)
+            assert(gc::isValidGCObject(elts[i]));
         memmove(&rtn->elts[0], elts, sizeof(Box*) * nelts);
         return rtn;
     }
     static BoxedTuple* create1(Box* elt0) {
         BoxedTuple* rtn = new (1) BoxedTuple();
         rtn->elts[0] = elt0;
+        for (int i = 0; i < rtn->size(); i++)
+            assert(gc::isValidGCObject(rtn->elts[i]));
         return rtn;
     }
     static BoxedTuple* create2(Box* elt0, Box* elt1) {
         BoxedTuple* rtn = new (2) BoxedTuple();
         rtn->elts[0] = elt0;
         rtn->elts[1] = elt1;
+        for (int i = 0; i < rtn->size(); i++)
+            assert(gc::isValidGCObject(rtn->elts[i]));
         return rtn;
     }
     static BoxedTuple* create3(Box* elt0, Box* elt1, Box* elt2) {
@@ -643,6 +649,8 @@ public:
         rtn->elts[0] = elt0;
         rtn->elts[1] = elt1;
         rtn->elts[2] = elt2;
+        for (int i = 0; i < rtn->size(); i++)
+            assert(gc::isValidGCObject(rtn->elts[i]));
         return rtn;
     }
     static BoxedTuple* create4(Box* elt0, Box* elt1, Box* elt2, Box* elt3) {
@@ -651,6 +659,8 @@ public:
         rtn->elts[1] = elt1;
         rtn->elts[2] = elt2;
         rtn->elts[3] = elt3;
+        for (int i = 0; i < rtn->size(); i++)
+            assert(gc::isValidGCObject(rtn->elts[i]));
         return rtn;
     }
     static BoxedTuple* create5(Box* elt0, Box* elt1, Box* elt2, Box* elt3, Box* elt4) {
@@ -660,9 +670,17 @@ public:
         rtn->elts[2] = elt2;
         rtn->elts[3] = elt3;
         rtn->elts[4] = elt4;
+        for (int i = 0; i < rtn->size(); i++)
+            assert(gc::isValidGCObject(rtn->elts[i]));
         return rtn;
     }
-    static BoxedTuple* create(std::initializer_list<Box*> members) { return new (members.size()) BoxedTuple(members); }
+    static BoxedTuple* create(std::initializer_list<Box*> members) {
+        auto rtn = new (members.size()) BoxedTuple(members);
+
+        for (int i = 0; i < rtn->size(); i++)
+            assert(gc::isValidGCObject(rtn->elts[i]));
+        return rtn;
+    }
 
     static BoxedTuple* create(int64_t size, BoxedClass* cls) {
         BoxedTuple* rtn;
@@ -731,6 +749,7 @@ private:
         Box** p = &elts[0];
         for (auto b : members) {
             *p++ = b;
+            assert(gc::isValidGCObject(b));
         }
     }
 


### PR DESCRIPTION
We would potentially lose a gc reference if a function contained both a string literal and a variable or attribute with the same name.  This actually happens somewhat frequently due to our representation of import statements -- in `from a import b`, "b" is both a string literal and a variable name.