### PR TITLE
Fix parsing caching

### DIFF
--- a/src/codegen/parser.cpp
+++ b/src/codegen/parser.cpp
@@ -1135,7 +1135,7 @@ AST_Module* caching_parse_file(const char* fn) {
     assert(code == 0);
     code = stat(cache_fn.c_str(), &cache_stat);
     std::vector<char> file_data;
-    if (code != 0 && (cache_stat.st_mtime > source_stat.st_mtime
+    if (code == 0 && (cache_stat.st_mtime > source_stat.st_mtime
                       || (cache_stat.st_mtime == source_stat.st_mtime
                           && cache_stat.st_mtim.tv_nsec > source_stat.st_mtim.tv_nsec))) {
         oss << "reading pyc file\n";


### PR DESCRIPTION
Flipped conditional meant that we were never caching the parse results :(

perf results are pretty nice!
```
      django_template2.py             7.1s (2)             5.3s (2)  -25.3%
            pyxl_bench.py             3.7s (2)             3.4s (2)  -8.5%
sqlalchemy_imperative2.py             5.3s (2)             4.2s (2)  -21.2%
                  geomean                 5.2s                 4.2s  -18.6%
```
(only because the bug caused an equal regression earlier...)