### PR TITLE
Fix gc visiting code for running generators

### DIFF
--- a/src/runtime/generator.cpp
+++ b/src/runtime/generator.cpp
@@ -406,8 +406,8 @@ extern "C" void generatorGCHandler(GCVisitor* v, Box* b) {
         v->visit(g->exception.traceback);
 
     if (g->running) {
-        v->visitPotentialRange((void**)&g->returnContext,
-                               ((void**)&g->returnContext) + sizeof(*g->returnContext) / sizeof(void*));
+        v->visitPotentialRange((void**)g->returnContext,
+                               ((void**)g->returnContext) + sizeof(*g->returnContext) / sizeof(void*));
     } else {
         // g->context is always set for a running generator, but we can trigger a GC while constructing
         // a generator in which case we can see a NULL context


### PR DESCRIPTION
I verified with gdb that this now really visits all entries of the return context struct
