### PR TITLE
Reduce number of optimization passes we run

### DIFF
--- a/src/codegen/entry.cpp
+++ b/src/codegen/entry.cpp
@@ -513,6 +513,8 @@ void initCodegen() {
 // llvm_args.push_back("--debug-only=stackmaps");
 #endif
 
+    // llvm_args.push_back("--time-passes");
+
     // llvm_args.push_back("--print-after-all");
     // llvm_args.push_back("--print-machineinstrs");
     if (USE_REGALLOC_BASIC)

--- a/src/codegen/irgen.cpp
+++ b/src/codegen/irgen.cpp
@@ -108,20 +108,27 @@ static void optimizeIR(llvm::Function* f, EffortLevel effort) {
     if (ENABLE_PYSTON_PASSES)
         fpm.add(createMallocsNonNullPass());
 
-    // TODO Find the right place for this pass (and ideally not duplicate it)
-    if (ENABLE_PYSTON_PASSES) {
-        fpm.add(llvm::createGVNPass());
-        fpm.add(createConstClassesPass());
-    }
-
     // TODO: find the right set of passes
-    if (0) {
-        // My original set of passes, that seem to get about 90% of the benefit:
+    if (1) {
+        // Small set of passes:
         fpm.add(llvm::createInstructionCombiningPass());
         fpm.add(llvm::createReassociatePass());
         fpm.add(llvm::createGVNPass());
         fpm.add(llvm::createCFGSimplificationPass());
+
+        if (ENABLE_PYSTON_PASSES) {
+            fpm.add(createConstClassesPass());
+            fpm.add(createDeadAllocsPass());
+            fpm.add(llvm::createInstructionCombiningPass());
+            fpm.add(llvm::createCFGSimplificationPass());
+        }
     } else {
+        // TODO Find the right place for this pass (and ideally not duplicate it)
+        if (ENABLE_PYSTON_PASSES) {
+            fpm.add(llvm::createGVNPass());
+            fpm.add(createConstClassesPass());
+        }
+
         // copied + slightly modified from llvm/lib/Transforms/IPO/PassManagerBuilder.cpp::populateModulePassManager
         fpm.add(llvm::createEarlyCSEPass());                   // Catch trivial redundancies
         fpm.add(llvm::createJumpThreadingPass());              // Thread jumps.
@@ -165,19 +172,19 @@ static void optimizeIR(llvm::Function* f, EffortLevel effort) {
         // fpm.add(llvm::createLoopVectorizePass(DisableUnrollLoops, LoopVectorize));
         fpm.add(llvm::createInstructionCombiningPass());
         fpm.add(llvm::createCFGSimplificationPass());
-    }
 
-    // TODO Find the right place for this pass (and ideally not duplicate it)
-    if (ENABLE_PYSTON_PASSES) {
-        fpm.add(createConstClassesPass());
-        fpm.add(llvm::createInstructionCombiningPass());
-        fpm.add(llvm::createCFGSimplificationPass());
-        fpm.add(createConstClassesPass());
-        fpm.add(createDeadAllocsPass());
-        // fpm.add(llvm::createSCCPPass());                  // Constant prop with SCCP
-        // fpm.add(llvm::createEarlyCSEPass());              // Catch trivial redundancies
-        // fpm.add(llvm::createInstructionCombiningPass());
-        // fpm.add(llvm::createCFGSimplificationPass());
+        // TODO Find the right place for this pass (and ideally not duplicate it)
+        if (ENABLE_PYSTON_PASSES) {
+            fpm.add(createConstClassesPass());
+            fpm.add(llvm::createInstructionCombiningPass());
+            fpm.add(llvm::createCFGSimplificationPass());
+            fpm.add(createConstClassesPass());
+            fpm.add(createDeadAllocsPass());
+            // fpm.add(llvm::createSCCPPass());                  // Constant prop with SCCP
+            // fpm.add(llvm::createEarlyCSEPass());              // Catch trivial redundancies
+            // fpm.add(llvm::createInstructionCombiningPass());
+            // fpm.add(llvm::createCFGSimplificationPass());
+        }
     }
 
     fpm.doInitialization();


### PR DESCRIPTION
The previous set was based on trying to get the absolute
best results on microbenchmarks; go back to the small set.

We'll want to revisit this later, but for now we're not getting much benefit from these (especially with type speculation not firing), so turning them off is an easy win:
```
      django_template2.py             5.2s (2)             5.1s (2)  -2.3%
            pyxl_bench.py             3.4s (2)             3.3s (2)  -2.1%
sqlalchemy_imperative2.py             4.0s (2)             3.9s (2)  -1.2%
                  geomean                 4.1s                 4.0s  -1.9%
```