### PR TITLE
bjit: inline trivial helper functions

### DIFF
--- a/src/codegen/ast_interpreter.cpp
+++ b/src/codegen/ast_interpreter.cpp
@@ -1570,12 +1570,24 @@ Value ASTInterpreter::visit_attribute(AST_Attribute* node) {
 }
 
 
+int ASTInterpreterJitInterface::getBoxedLocalsOffset() {
+    return offsetof(ASTInterpreter, frame_info.boxedLocals);
+}
+
 int ASTInterpreterJitInterface::getCurrentBlockOffset() {
     return offsetof(ASTInterpreter, current_block);
 }
 
 int ASTInterpreterJitInterface::getCurrentInstOffset() {
     return offsetof(ASTInterpreter, current_inst);
+}
+
+int ASTInterpreterJitInterface::getGeneratorOffset() {
+    return offsetof(ASTInterpreter, generator);
+}
+
+int ASTInterpreterJitInterface::getGlobalsOffset() {
+    return offsetof(ASTInterpreter, globals);
 }
 
 Box* ASTInterpreterJitInterface::derefHelper(void* _interpreter, InternedString s) {
@@ -1599,16 +1611,6 @@ Box* ASTInterpreterJitInterface::doOSRHelper(void* _interpreter, AST_Jump* node)
     if (interpreter->edgecount >= OSR_THRESHOLD_BASELINE)
         return interpreter->doOSR(node);
     return NULL;
-}
-
-Box* ASTInterpreterJitInterface::getBoxedLocalHelper(void* _interpreter, BoxedString* s) {
-    ASTInterpreter* interpreter = (ASTInterpreter*)_interpreter;
-    return boxedLocalsGet(interpreter->frame_info.boxedLocals, s, interpreter->globals);
-}
-
-Box* ASTInterpreterJitInterface::getBoxedLocalsHelper(void* _interpreter) {
-    ASTInterpreter* interpreter = (ASTInterpreter*)_interpreter;
-    return interpreter->frame_info.boxedLocals;
 }
 
 Box* ASTInterpreterJitInterface::getLocalHelper(void* _interpreter, InternedString id) {
@@ -1646,17 +1648,6 @@ Box* ASTInterpreterJitInterface::uncacheExcInfoHelper(void* _interpreter) {
     ASTInterpreter* interpreter = (ASTInterpreter*)_interpreter;
     interpreter->getFrameInfo()->exc = ExcInfo(NULL, NULL, NULL);
     return None;
-}
-
-Box* ASTInterpreterJitInterface::yieldHelper(void* _interpreter, Box* val) {
-    ASTInterpreter* interpreter = (ASTInterpreter*)_interpreter;
-    return yield(interpreter->generator, val);
-}
-
-void ASTInterpreterJitInterface::setItemNameHelper(void* _interpreter, Box* str, Box* val) {
-    ASTInterpreter* interpreter = (ASTInterpreter*)_interpreter;
-    assert(interpreter->frame_info.boxedLocals != NULL);
-    setitem(interpreter->frame_info.boxedLocals, str, val);
 }
 
 void ASTInterpreterJitInterface::setLocalClosureHelper(void* _interpreter, InternedString id, Box* v) {

--- a/src/codegen/ast_interpreter.h
+++ b/src/codegen/ast_interpreter.h
@@ -35,19 +35,18 @@ struct LineInfo;
 extern const void* interpreter_instr_addr;
 
 struct ASTInterpreterJitInterface {
+    static int getBoxedLocalsOffset();
     static int getCurrentBlockOffset();
     static int getCurrentInstOffset();
+    static int getGeneratorOffset();
+    static int getGlobalsOffset();
 
     static Box* derefHelper(void* interp, InternedString s);
     static Box* doOSRHelper(void* interp, AST_Jump* node);
-    static Box* getBoxedLocalHelper(void* interp, BoxedString* s);
-    static Box* getBoxedLocalsHelper(void* interp);
     static Box* getLocalHelper(void* interp, InternedString id);
     static Box* landingpadHelper(void* interp);
     static Box* setExcInfoHelper(void* interp, Box* type, Box* value, Box* traceback);
     static Box* uncacheExcInfoHelper(void* interp);
-    static Box* yieldHelper(void* interp, Box* val);
-    static void setItemNameHelper(void* interp, Box* str, Box* val);
     static void setLocalClosureHelper(void* interp, InternedString id, Box* v);
     static void setLocalHelper(void* interp, InternedString id, Box* v);
 };


### PR DESCRIPTION
This doen't show any perf improvement at the moment, but I think it's still nice and it may improve perf after #736. 
Having to call less external functions helps register allocation.