### PR TITLE
Release leftover chunk in the TraceStack.

### DIFF
--- a/src/gc/collector.cpp
+++ b/src/gc/collector.cpp
@@ -120,6 +120,13 @@ public:
             push(p);
         }
     }
+    ~TraceStack() {
+        RELEASE_ASSERT(end - cur == CHUNK_SIZE, "destroying non-empty TraceStack");
+
+        // We always have a block available in case we want to push items onto the TraceStack,
+        // but that chunk needs to be released after use to avoid a memory leak.
+        release_chunk(start);
+    }
 
     void push(void* p) {
         GC_TRACE_LOG("Pushing %p\n", p);


### PR DESCRIPTION
This also makes the implementation of TraceStack more correct. Though in practice we always a non-zero number of elements to the TraceStack before using it, the old TraceStack would leak memory if it was created but never used.

Addresses https://github.com/dropbox/pyston/issues/749