### PR TITLE
Allow passing NULL for empty kwargs

### DIFF
--- a/src/capi/typeobject.cpp
+++ b/src/capi/typeobject.cpp
@@ -1977,7 +1977,7 @@ static PyObject* tp_new_wrapper(PyTypeObject* self, BoxedTuple* args, Box* kwds)
     // ASSERT(self->tp_new != Py_CallPythonNew, "going to get in an infinite loop");
 
     RELEASE_ASSERT(args->cls == tuple_cls, "");
-    RELEASE_ASSERT(kwds->cls == dict_cls, "");
+    RELEASE_ASSERT(!kwds || kwds->cls == dict_cls, "");
     RELEASE_ASSERT(args->size() >= 1, "");
 
     BoxedClass* subtype = static_cast<BoxedClass*>(args->elts[0]);

--- a/src/codegen/ast_interpreter.cpp
+++ b/src/codegen/ast_interpreter.cpp
@@ -315,8 +315,12 @@ void ASTInterpreter::initArguments(int nargs, BoxedClosure* _closure, BoxedGener
     if (param_names.vararg_name)
         doStore(param_names.vararg_name, Value(getArg(i++, arg1, arg2, arg3, args), 0));
 
-    if (param_names.kwarg_name)
-        doStore(param_names.kwarg_name, Value(getArg(i++, arg1, arg2, arg3, args), 0));
+    if (param_names.kwarg_name) {
+        Box* val = getArg(i++, arg1, arg2, arg3, args);
+        if (!val)
+            val = createDict();
+        doStore(param_names.kwarg_name, Value(val, 0));
+    }
 
     assert(nargs == i);
 }
@@ -1695,7 +1699,8 @@ Box* astInterpretFunction(CLFunction* clfunc, int nargs, Box* closure, Box* gene
         std::vector<ConcreteCompilerType*> arg_types;
         for (int i = 0; i < nargs; i++) {
             Box* arg = getArg(i, arg1, arg2, arg3, args);
-            assert(arg); // only builtin functions can pass NULL args
+
+            assert(arg || i == clfunc->param_names.kwargsIndex()); // only builtin functions can pass NULL args
 
             // TODO: reenable argument-type specialization
             arg_types.push_back(UNKNOWN);

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -133,6 +133,11 @@ struct ArgPassSpec {
 
     int totalPassed() { return num_args + num_keywords + (has_starargs ? 1 : 0) + (has_kwargs ? 1 : 0); }
 
+    int kwargsIndex() const {
+        assert(has_kwargs);
+        return num_args + num_keywords + (has_starargs ? 1 : 0);
+    }
+
     uint32_t asInt() const { return *reinterpret_cast<const uint32_t*>(this); }
 
     void dump() {
@@ -160,6 +165,11 @@ struct ParamNames {
 
     int totalParameters() const {
         return args.size() + (vararg.str().size() == 0 ? 0 : 1) + (kwarg.str().size() == 0 ? 0 : 1);
+    }
+
+    int kwargsIndex() const {
+        assert(kwarg.str().size());
+        return args.size() + (vararg.str().size() == 0 ? 0 : 1);
     }
 
 private:

--- a/src/gc/collector.cpp
+++ b/src/gc/collector.cpp
@@ -555,7 +555,7 @@ static void callPendingFinalizers() {
         Box* box = pending_finalization_list.front();
         pending_finalization_list.pop_front();
 
-        RELEASE_ASSERT(isValidGCObject(box), "objects to be finalized should still be alive");
+        ASSERT(isValidGCObject(box), "objects to be finalized should still be alive");
 
         if (isWeaklyReferenced(box)) {
             // Callbacks for weakly-referenced objects with finalizers (if any), followed by call to finalizers.
@@ -572,7 +572,7 @@ static void callPendingFinalizers() {
         }
 
         finalize(box);
-        RELEASE_ASSERT(isValidGCObject(box), "finalizing an object should not free the object");
+        ASSERT(isValidGCObject(box), "finalizing an object should not free the object");
     }
 
     if (!initially_empty) {

--- a/src/gc/heap.cpp
+++ b/src/gc/heap.cpp
@@ -128,7 +128,7 @@ void _bytesAllocatedTripped() {
 
 bool hasOrderedFinalizer(BoxedClass* cls) {
     if (cls->has_safe_tp_dealloc) {
-        assert(!cls->tp_del);
+        ASSERT(!cls->tp_del, "class \"%s\" with safe tp_dealloc also has tp_del?", cls->tp_name);
         return false;
     } else if (cls->hasNonDefaultTpDealloc()) {
         return true;

--- a/src/runtime/builtin_modules/builtins.cpp
+++ b/src/runtime/builtin_modules/builtins.cpp
@@ -865,7 +865,7 @@ Box* execfile(Box* _fn) {
 
 Box* print(BoxedTuple* args, BoxedDict* kwargs) {
     assert(args->cls == tuple_cls);
-    assert(kwargs->cls == dict_cls);
+    assert(!kwargs || kwargs->cls == dict_cls);
 
     Box* dest, *end;
 
@@ -873,23 +873,22 @@ Box* print(BoxedTuple* args, BoxedDict* kwargs) {
     static BoxedString* end_str = internStringImmortal("end");
     static BoxedString* space_str = internStringImmortal(" ");
 
-    auto it = kwargs->d.find(file_str);
-    if (it != kwargs->d.end()) {
+    BoxedDict::DictMap::iterator it;
+    if (kwargs && ((it = kwargs->d.find(file_str)) != kwargs->d.end())) {
         dest = it->second;
         kwargs->d.erase(it);
     } else {
         dest = getSysStdout();
     }
 
-    it = kwargs->d.find(end_str);
-    if (it != kwargs->d.end()) {
+    if (kwargs && ((it = kwargs->d.find(end_str)) != kwargs->d.end())) {
         end = it->second;
         kwargs->d.erase(it);
     } else {
         end = boxString("\n");
     }
 
-    RELEASE_ASSERT(kwargs->d.size() == 0, "print() got unexpected keyword arguments");
+    RELEASE_ASSERT(!kwargs || kwargs->d.size() == 0, "print() got unexpected keyword arguments");
 
     static BoxedString* write_str = internStringImmortal("write");
     CallattrFlags callattr_flags{.cls_only = false, .null_on_nonexistent = false, .argspec = ArgPassSpec(1) };

--- a/src/runtime/capi.cpp
+++ b/src/runtime/capi.cpp
@@ -1448,7 +1448,7 @@ Box* BoxedCApiFunction::__call__(BoxedCApiFunction* self, BoxedTuple* varargs, B
     STAT_TIMER(t0, "us_timer_boxedcapifunction__call__", (self->cls->is_user_defined ? 10 : 20));
     assert(self->cls == capifunc_cls);
     assert(varargs->cls == tuple_cls);
-    assert(kwargs->cls == dict_cls);
+    assert(!kwargs || kwargs->cls == dict_cls);
 
     // Kind of silly to have asked callFunc to rearrange the arguments for us, just to pass things
     // off to tppCall, but this case should be very uncommon (people explicitly asking for __call__)

--- a/src/runtime/classobj.cpp
+++ b/src/runtime/classobj.cpp
@@ -125,7 +125,7 @@ Box* classobjCall(Box* _cls, Box* _args, Box* _kwargs) {
     assert(_args->cls == tuple_cls);
     BoxedTuple* args = static_cast<BoxedTuple*>(_args);
 
-    assert(_kwargs->cls == dict_cls);
+    assert(!_kwargs || _kwargs->cls == dict_cls);
     BoxedDict* kwargs = static_cast<BoxedDict*>(_kwargs);
 
     BoxedInstance* made = new BoxedInstance(cls);
@@ -138,7 +138,7 @@ Box* classobjCall(Box* _cls, Box* _args, Box* _kwargs) {
         if (init_rtn != None)
             raiseExcHelper(TypeError, "__init__() should return None");
     } else {
-        if (args->size() || kwargs->d.size())
+        if (args->size() || (kwargs && kwargs->d.size()))
             raiseExcHelper(TypeError, "this constructor takes no arguments");
     }
     return made;

--- a/src/runtime/descr.cpp
+++ b/src/runtime/descr.cpp
@@ -480,7 +480,7 @@ Box* BoxedWrapperObject::__call__(BoxedWrapperObject* self, Box* args, Box* kwds
 
     assert(self->cls == wrapperobject_cls);
     assert(args->cls == tuple_cls);
-    assert(kwds->cls == dict_cls);
+    assert(!kwds || kwds->cls == dict_cls);
 
     int flags = self->descr->wrapper->flags;
     wrapperfunc wrapper = self->descr->wrapper->wrapper;

--- a/src/runtime/str.cpp
+++ b/src/runtime/str.cpp
@@ -1827,7 +1827,7 @@ extern "C" PyObject* _do_string_format(PyObject* self, PyObject* args, PyObject*
 
 Box* strFormat(BoxedString* self, BoxedTuple* args, BoxedDict* kwargs) {
     assert(args->cls == tuple_cls);
-    assert(kwargs->cls == dict_cls);
+    assert(!kwargs || kwargs->cls == dict_cls);
 
     Box* rtn = _do_string_format(self, args, kwargs);
     checkAndThrowCAPIException();

--- a/src/runtime/tuple.cpp
+++ b/src/runtime/tuple.cpp
@@ -262,7 +262,7 @@ extern "C" Box* tupleNew(Box* _cls, BoxedTuple* args, BoxedDict* kwargs) {
                        getNameOfClass(cls));
 
     int args_sz = args->size();
-    int kwargs_sz = kwargs->d.size();
+    int kwargs_sz = kwargs ? kwargs->d.size() : 0;
 
     if (args_sz + kwargs_sz > 1)
         raiseExcHelper(TypeError, "tuple() takes at most 1 argument (%d given)", args_sz + kwargs_sz);

--- a/src/runtime/types.cpp
+++ b/src/runtime/types.cpp
@@ -1358,7 +1358,7 @@ static Box* functionCall(BoxedFunction* self, Box* args, Box* kwargs) {
     // disallow it but it's good to know.
 
     assert(args->cls == tuple_cls);
-    assert(kwargs->cls == dict_cls);
+    assert(!kwargs || kwargs->cls == dict_cls);
     return runtimeCall(self, ArgPassSpec(0, 0, true, true), args, kwargs, NULL, NULL, NULL);
 }
 
@@ -2156,8 +2156,7 @@ public:
         AttrWrapper* self = static_cast<AttrWrapper*>(_self);
 
         assert(args->cls == tuple_cls);
-        assert(kwargs);
-        assert(kwargs->cls == dict_cls);
+        assert(!kwargs || kwargs->cls == dict_cls);
 
         RELEASE_ASSERT(args->size() <= 1, ""); // should throw a TypeError
 
@@ -2192,7 +2191,8 @@ public:
         for (auto e : *args) {
             handle(e);
         }
-        handle(kwargs);
+        if (kwargs)
+            handle(kwargs);
 
         return None;
     }

--- a/test/tests/print_function.py
+++ b/test/tests/print_function.py
@@ -50,3 +50,5 @@ try:
 except TypeError:
     pass
 
+for i in xrange(10):
+    print()


### PR DESCRIPTION
This is an optimization that cpython uses.  It's helpful because we can't have an EmptyDict singleton like we do for EmptyTuple, and we are currently creating a dict for every call to a function that takes kwargs (many c api functions).

```
      django_template2.py             5.0s (2)             5.0s (2)  -1.2%
            pyxl_bench.py             3.3s (2)             3.2s (2)  -2.0%
sqlalchemy_imperative2.py             3.6s (2)             3.6s (2)  +0.5%
                  geomean                 3.9s                 3.9s  -0.9%
```