### PR TITLE
bjit: add support for most common missing nodes and don't JIT compile cold blocks

### DIFF
--- a/src/codegen/ast_interpreter.h
+++ b/src/codegen/ast_interpreter.h
@@ -41,12 +41,13 @@ struct ASTInterpreterJitInterface {
     static int getGeneratorOffset();
     static int getGlobalsOffset();
 
+    static void delNameHelper(void* _interpreter, InternedString name);
     static Box* derefHelper(void* interp, InternedString s);
     static Box* doOSRHelper(void* interp, AST_Jump* node);
     static Box* landingpadHelper(void* interp);
     static Box* setExcInfoHelper(void* interp, Box* type, Box* value, Box* traceback);
-    static Box* uncacheExcInfoHelper(void* interp);
     static void setLocalClosureHelper(void* interp, long vreg, InternedString id, Box* v);
+    static Box* uncacheExcInfoHelper(void* interp);
 };
 
 class RewriterVar;

--- a/src/codegen/baseline_jit.cpp
+++ b/src/codegen/baseline_jit.cpp
@@ -22,6 +22,7 @@
 #include "codegen/type_recording.h"
 #include "core/cfg.h"
 #include "runtime/generator.h"
+#include "runtime/import.h"
 #include "runtime/inline/list.h"
 #include "runtime/objmodel.h"
 #include "runtime/set.h"
@@ -328,6 +329,20 @@ RewriterVar* JitFragmentWriter::emitGetPystonIter(RewriterVar* v) {
 
 RewriterVar* JitFragmentWriter::emitHasnext(RewriterVar* v) {
     return call(false, (void*)hasnextHelper, v);
+}
+
+RewriterVar* JitFragmentWriter::emitImportFrom(RewriterVar* module, BoxedString* name) {
+    return call(false, (void*)importFrom, module, imm(name));
+}
+
+RewriterVar* JitFragmentWriter::emitImportName(int level, RewriterVar* from_imports, llvm::StringRef module_name) {
+    return call(false, (void*)import, imm(level), from_imports, imm(const_cast<char*>(module_name.data())),
+                imm(module_name.size()));
+}
+
+RewriterVar* JitFragmentWriter::emitImportStar(RewriterVar* module) {
+    RewriterVar* globals = getInterp()->getAttr(ASTInterpreterJitInterface::getGlobalsOffset());
+    return call(false, (void*)importStar, module, globals);
 }
 
 RewriterVar* JitFragmentWriter::emitLandingpad() {

--- a/src/codegen/baseline_jit.cpp
+++ b/src/codegen/baseline_jit.cpp
@@ -423,6 +423,27 @@ RewriterVar* JitFragmentWriter::emitYield(RewriterVar* v) {
     return call(false, (void*)yield, generator, v);
 }
 
+void JitFragmentWriter::emitDelAttr(RewriterVar* target, BoxedString* attr) {
+    emitPPCall((void*)delattr, { target, imm(attr) }, 1, 512);
+}
+
+void JitFragmentWriter::emitDelGlobal(BoxedString* name) {
+    RewriterVar* globals = getInterp()->getAttr(ASTInterpreterJitInterface::getGlobalsOffset());
+    emitPPCall((void*)delGlobal, { globals, imm(name) }, 1, 512);
+}
+
+void JitFragmentWriter::emitDelItem(RewriterVar* target, RewriterVar* slice) {
+    emitPPCall((void*)delitem, { target, slice }, 1, 512);
+}
+
+void JitFragmentWriter::emitDelName(InternedString name) {
+    call(false, (void*)ASTInterpreterJitInterface::delNameHelper, getInterp(),
+#ifndef NDEBUG
+         imm(asUInt(name).first), imm(asUInt(name).second));
+#else
+         imm(asUInt(name)));
+#endif
+}
 
 void JitFragmentWriter::emitExec(RewriterVar* code, RewriterVar* globals, RewriterVar* locals, FutureFlags flags) {
     if (!globals)

--- a/src/codegen/baseline_jit.cpp
+++ b/src/codegen/baseline_jit.cpp
@@ -149,6 +149,10 @@ JitFragmentWriter::JitFragmentWriter(CFGBlock* block, std::unique_ptr<ICInfo> ic
     addAction([=]() { vregs_array->bumpUse(); }, vregs_array, ActionType::NORMAL);
 }
 
+RewriterVar* JitFragmentWriter::getInterp() {
+    return interp;
+}
+
 RewriterVar* JitFragmentWriter::imm(uint64_t val) {
     return loadConst(val);
 }
@@ -641,10 +645,6 @@ uint64_t JitFragmentWriter::asUInt(InternedString s) {
     return u.u;
 }
 #endif
-
-RewriterVar* JitFragmentWriter::getInterp() {
-    return interp;
-}
 
 RewriterVar* JitFragmentWriter::emitPPCall(void* func_addr, llvm::ArrayRef<RewriterVar*> args, int num_slots,
                                            int slot_size, TypeRecorder* type_recorder) {

--- a/src/codegen/baseline_jit.h
+++ b/src/codegen/baseline_jit.h
@@ -200,9 +200,9 @@ public:
     JitFragmentWriter(CFGBlock* block, std::unique_ptr<ICInfo> ic_info, std::unique_ptr<ICSlotRewrite> rewrite,
                       int code_offset, int num_bytes_overlapping, void* entry_code, JitCodeBlock& code_block);
 
+    RewriterVar* getInterp();
     RewriterVar* imm(uint64_t val);
     RewriterVar* imm(void* val);
-
 
     RewriterVar* emitAugbinop(RewriterVar* lhs, RewriterVar* rhs, int op_type);
     RewriterVar* emitBinop(RewriterVar* lhs, RewriterVar* rhs, int op_type);
@@ -273,7 +273,6 @@ private:
 #else
     uint64_t asUInt(InternedString s);
 #endif
-    RewriterVar* getInterp();
 
     RewriterVar* emitPPCall(void* func_addr, llvm::ArrayRef<RewriterVar*> args, int num_slots, int slot_size,
                             TypeRecorder* type_recorder = NULL);

--- a/src/codegen/baseline_jit.h
+++ b/src/codegen/baseline_jit.h
@@ -226,6 +226,9 @@ public:
     RewriterVar* emitGetLocal(InternedString s, int vreg);
     RewriterVar* emitGetPystonIter(RewriterVar* v);
     RewriterVar* emitHasnext(RewriterVar* v);
+    RewriterVar* emitImportFrom(RewriterVar* module, BoxedString* name);
+    RewriterVar* emitImportName(int level, RewriterVar* from_imports, llvm::StringRef module_name);
+    RewriterVar* emitImportStar(RewriterVar* module);
     RewriterVar* emitLandingpad();
     RewriterVar* emitNonzero(RewriterVar* v);
     RewriterVar* emitNotNonzero(RewriterVar* v);

--- a/src/codegen/baseline_jit.h
+++ b/src/codegen/baseline_jit.h
@@ -239,6 +239,10 @@ public:
     RewriterVar* emitUnpackIntoArray(RewriterVar* v, uint64_t num);
     RewriterVar* emitYield(RewriterVar* v);
 
+    void emitDelAttr(RewriterVar* target, BoxedString* attr);
+    void emitDelGlobal(BoxedString* name);
+    void emitDelItem(RewriterVar* target, RewriterVar* slice);
+    void emitDelName(InternedString name);
     void emitExec(RewriterVar* code, RewriterVar* globals, RewriterVar* locals, FutureFlags flags);
     void emitJump(CFGBlock* b);
     void emitOSRPoint(AST_Jump* node);


### PR DESCRIPTION
- don't jit cold blocks after doing a OSR JIT compilation
 - previously after doing a OSR JIT compilation we continued to JIT every block outside of the loop.
This doesn't show up as a perf change but reduces the number of JITed code / makes it slightly smaller.
- add the most common missing AST nodes to the baseline JIT
 - with this PR I'm seeing only 6 aborts for ```django_template.py```, 1 abort for ```pyxl_bench.py``` and none for ```sqlalchemy_imperative.py``` 