### PR TITLE
start templatizing the runtime to be able to choose exception styles

### DIFF
--- a/src/capi/abstract.cpp
+++ b/src/capi/abstract.cpp
@@ -732,12 +732,10 @@ exit:
 }
 
 extern "C" Py_ssize_t PyObject_Size(PyObject* o) noexcept {
-    try {
-        return len(o)->n;
-    } catch (ExcInfo e) {
-        setCAPIException(e);
+    BoxedInt* r = lenInternal<ExceptionStyle::CAPI>(o, NULL);
+    if (!r)
         return -1;
-    }
+    return r->n;
 }
 
 extern "C" PyObject* PyObject_GetIter(PyObject* o) noexcept {

--- a/src/capi/object.cpp
+++ b/src/capi/object.cpp
@@ -534,7 +534,7 @@ extern "C" int PyObject_SetAttrString(PyObject* v, const char* name, PyObject* w
 
 extern "C" PyObject* PyObject_GetAttrString(PyObject* o, const char* attr) noexcept {
     try {
-        Box* r = getattrInternal(o, internStringMortal(attr), NULL);
+        Box* r = getattrInternal<ExceptionStyle::CXX>(o, internStringMortal(attr), NULL);
         if (!r)
             PyErr_Format(PyExc_AttributeError, "'%.50s' object has no attribute '%.400s'", o->cls->tp_name, attr);
         return r;

--- a/src/capi/typeobject.cpp
+++ b/src/capi/typeobject.cpp
@@ -532,8 +532,14 @@ static PyObject* lookup_maybe(PyObject* self, const char* attrstr, PyObject** at
     }
 
     Box* obj = typeLookup(self->cls, (BoxedString*)*attrobj, NULL);
-    if (obj)
-        return processDescriptor(obj, self, self->cls);
+    if (obj) {
+        try {
+            return processDescriptor(obj, self, self->cls);
+        } catch (ExcInfo e) {
+            setCAPIException(e);
+            return NULL;
+        }
+    }
     return obj;
 }
 

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -68,6 +68,13 @@ enum class EffortLevel {
     MAXIMAL = 3,
 };
 
+namespace ExceptionStyle {
+enum ExceptionStyle {
+    CAPI,
+    CXX,
+};
+};
+
 class CompilerType;
 template <class V> class ValuedCompilerType;
 typedef ValuedCompilerType<llvm::Value*> ConcreteCompilerType;

--- a/src/runtime/capi.cpp
+++ b/src/runtime/capi.cpp
@@ -457,12 +457,7 @@ done:
 
 
 extern "C" PyObject* PyObject_GetItem(PyObject* o, PyObject* key) noexcept {
-    try {
-        return getitem(o, key);
-    } catch (ExcInfo e) {
-        setCAPIException(e);
-        return NULL;
-    }
+    return getitemInternal<ExceptionStyle::CAPI>(o, key, NULL);
 }
 
 extern "C" int PyObject_SetItem(PyObject* o, PyObject* key, PyObject* v) noexcept {

--- a/src/runtime/capi.cpp
+++ b/src/runtime/capi.cpp
@@ -204,13 +204,29 @@ done:
 }
 
 
-extern "C" PyObject* PyObject_GetAttr(PyObject* o, PyObject* attr_name) noexcept {
-    try {
-        return getattrMaybeNonstring(o, attr_name);
-    } catch (ExcInfo e) {
-        setCAPIException(e);
-        return NULL;
+extern "C" PyObject* PyObject_GetAttr(PyObject* o, PyObject* attr) noexcept {
+    if (!PyString_Check(attr)) {
+        if (PyUnicode_Check(attr)) {
+            attr = _PyUnicode_AsDefaultEncodedString(attr, NULL);
+            if (attr == NULL)
+                return NULL;
+        } else {
+            PyErr_Format(TypeError, "attribute name must be string, not '%.200s'", Py_TYPE(attr)->tp_name);
+            return NULL;
+        }
     }
+
+    BoxedString* s = static_cast<BoxedString*>(attr);
+    internStringMortalInplace(s);
+
+    Box* r = getattrInternal<ExceptionStyle::CAPI>(o, s, NULL);
+
+    if (!r && !PyErr_Occurred()) {
+        PyErr_Format(PyExc_AttributeError, "'%.50s' object has no attribute '%.400s'", o->cls->tp_name,
+                     PyString_AS_STRING(attr));
+    }
+
+    return r;
 }
 
 extern "C" PyObject* PyObject_GenericGetAttr(PyObject* o, PyObject* name) noexcept {

--- a/src/runtime/descr.cpp
+++ b/src/runtime/descr.cpp
@@ -46,7 +46,7 @@ static void propertyDocCopy(BoxedProperty* prop, Box* fget) {
 
     static BoxedString* doc_str = internStringImmortal("__doc__");
     try {
-        get_doc = getattrInternal(fget, doc_str, NULL);
+        get_doc = getattrInternal<ExceptionStyle::CXX>(fget, doc_str, NULL);
     } catch (ExcInfo e) {
         if (!e.matches(Exception)) {
             throw e;

--- a/src/runtime/dict.cpp
+++ b/src/runtime/dict.cpp
@@ -588,7 +588,7 @@ Box* dictUpdate(BoxedDict* self, BoxedTuple* args, BoxedDict* kwargs) {
     if (args->size()) {
         Box* arg = args->elts[0];
         static BoxedString* keys_str = internStringImmortal("keys");
-        if (getattrInternal(arg, keys_str, NULL)) {
+        if (getattrInternal<ExceptionStyle::CXX>(arg, keys_str, NULL)) {
             dictMerge(self, arg);
         } else {
             dictMergeFromSeq2(self, arg);

--- a/src/runtime/dict.cpp
+++ b/src/runtime/dict.cpp
@@ -27,6 +27,9 @@
 
 namespace pyston {
 
+using namespace pyston::ExceptionStyle;
+using pyston::ExceptionStyle::ExceptionStyle;
+
 Box* dictRepr(BoxedDict* self) {
     std::vector<char> chars;
     chars.push_back('{');
@@ -183,23 +186,54 @@ extern "C" int PyDict_Update(PyObject* a, PyObject* b) noexcept {
     return PyDict_Merge(a, b, 1);
 }
 
-Box* dictGetitem(BoxedDict* self, Box* k) {
-    if (!isSubclass(self->cls, dict_cls))
-        raiseExcHelper(TypeError, "descriptor '__getitem__' requires a 'dict' object but received a '%s'",
-                       getTypeName(self));
+template <enum ExceptionStyle S> Box* dictGetitem(BoxedDict* self, Box* k) noexcept(S == CAPI) {
+    if (!isSubclass(self->cls, dict_cls)) {
+        if (S == CAPI) {
+            PyErr_Format(TypeError, "descriptor '__getitem__' requires a 'dict' object but received a '%s'",
+                         getTypeName(self));
+            return NULL;
+        } else {
+            raiseExcHelper(TypeError, "descriptor '__getitem__' requires a 'dict' object but received a '%s'",
+                           getTypeName(self));
+        }
+    }
 
-    auto it = self->d.find(k);
+    BoxedDict::DictMap::iterator it;
+    try {
+        it = self->d.find(k);
+    } catch (ExcInfo e) {
+        if (S == CAPI) {
+            setCAPIException(e);
+            return NULL;
+        } else {
+            throw e;
+        }
+    }
+
     if (it == self->d.end()) {
         // Try calling __missing__ if this is a subclass
         if (self->cls != dict_cls) {
             static BoxedString* missing_str = internStringImmortal("__missing__");
             CallattrFlags callattr_flags{.cls_only = true, .null_on_nonexistent = true, .argspec = ArgPassSpec(1) };
-            Box* r = callattr(self, missing_str, callattr_flags, k, NULL, NULL, NULL, NULL);
+            Box* r;
+            try {
+                r = callattr(self, missing_str, callattr_flags, k, NULL, NULL, NULL, NULL);
+            } catch (ExcInfo e) {
+                if (S == CAPI) {
+                    setCAPIException(e);
+                    return NULL;
+                } else
+                    throw e;
+            }
             if (r)
                 return r;
         }
 
-        raiseExcHelper(KeyError, k);
+        if (S == CAPI) {
+            PyErr_SetObject(KeyError, k);
+            return NULL;
+        } else
+            raiseExcHelper(KeyError, k);
     }
     return it->second;
 }
@@ -715,7 +749,7 @@ void setupDict() {
     dict_cls->giveAttr("setdefault",
                        new BoxedFunction(boxRTFunction((void*)dictSetdefault, UNKNOWN, 3, 1, false, false), { None }));
 
-    dict_cls->giveAttr("__getitem__", new BoxedFunction(boxRTFunction((void*)dictGetitem, UNKNOWN, 2)));
+    dict_cls->giveAttr("__getitem__", new BoxedFunction(boxRTFunction((void*)dictGetitem<CXX>, UNKNOWN, 2)));
     dict_cls->giveAttr("__setitem__", new BoxedFunction(boxRTFunction((void*)dictSetitem, NONE, 3)));
     dict_cls->giveAttr("__delitem__", new BoxedFunction(boxRTFunction((void*)dictDelitem, UNKNOWN, 2)));
     dict_cls->giveAttr("__contains__", new BoxedFunction(boxRTFunction((void*)dictContains, BOXED_BOOL, 2)));
@@ -746,6 +780,8 @@ void setupDict() {
     // subclass Python classes.
     dict_cls->tp_init = dict_init;
     dict_cls->tp_repr = dict_repr;
+
+    dict_cls->tp_as_mapping->mp_subscript = (binaryfunc)dictGetitem<CAPI>;
 
     dict_keys_cls->giveAttr(
         "__iter__", new BoxedFunction(boxRTFunction((void*)dictViewKeysIter, typeFromClass(dict_iterator_cls), 1)));

--- a/src/runtime/import.cpp
+++ b/src/runtime/import.cpp
@@ -382,7 +382,7 @@ static Box* importSub(const std::string& name, const std::string& full_name, Box
         path_list = NULL;
     } else {
         static BoxedString* path_str = internStringImmortal("__path__");
-        path_list = static_cast<BoxedList*>(getattrInternal(parent_module, path_str, NULL));
+        path_list = static_cast<BoxedList*>(getattrInternal<ExceptionStyle::CXX>(parent_module, path_str, NULL));
         if (path_list == NULL || path_list->cls != list_cls) {
             return None;
         }
@@ -562,7 +562,7 @@ static void ensureFromlist(Box* module, Box* fromlist, std::string& buf, bool re
     static BoxedString* path_str = internStringImmortal("__path__");
     Box* pathlist = NULL;
     try {
-        pathlist = getattrInternal(module, path_str, NULL);
+        pathlist = getattrInternal<ExceptionStyle::CXX>(module, path_str, NULL);
     } catch (ExcInfo e) {
         if (!e.matches(AttributeError))
             throw e;
@@ -584,14 +584,14 @@ static void ensureFromlist(Box* module, Box* fromlist, std::string& buf, bool re
                 continue;
 
             static BoxedString* all_str = internStringImmortal("__all__");
-            Box* all = getattrInternal(module, all_str, NULL);
+            Box* all = getattrInternal<ExceptionStyle::CXX>(module, all_str, NULL);
             if (all) {
                 ensureFromlist(module, all, buf, true);
             }
             continue;
         }
 
-        Box* attr = getattrInternal(module, s, NULL);
+        Box* attr = getattrInternal<ExceptionStyle::CXX>(module, s, NULL);
         if (attr != NULL)
             continue;
 

--- a/src/runtime/objmodel.cpp
+++ b/src/runtime/objmodel.cpp
@@ -1475,7 +1475,7 @@ Box* dataDescriptorInstanceSpecialCases(GetattrRewriteArgs* rewrite_args, BoxedS
 
 template <enum ExceptionStyle S>
 Box* getattrInternalEx(Box* obj, BoxedString* attr, GetattrRewriteArgs* rewrite_args, bool cls_only, bool for_call,
-                       Box** bind_obj_out, RewriterVar** r_bind_obj_out) {
+                       Box** bind_obj_out, RewriterVar** r_bind_obj_out) noexcept(S == ExceptionStyle::CAPI) {
     assert(gc::isValidGCObject(attr));
 
     if (S == CAPI) {
@@ -1979,7 +1979,9 @@ Box* getattrInternalGeneric(Box* obj, BoxedString* attr, GetattrRewriteArgs* rew
     return NULL;
 }
 
-template <enum ExceptionStyle S> Box* getattrInternal(Box* obj, BoxedString* attr, GetattrRewriteArgs* rewrite_args) {
+template <enum ExceptionStyle S>
+Box* getattrInternal(Box* obj, BoxedString* attr,
+                     GetattrRewriteArgs* rewrite_args) noexcept(S == ExceptionStyle::CAPI) {
     return getattrInternalEx<S>(obj, attr, rewrite_args,
                                 /* cls_only */ false,
                                 /* for_call */ false, NULL, NULL);
@@ -2592,7 +2594,8 @@ extern "C" BoxedInt* hash(Box* obj) {
     return new BoxedInt(r);
 }
 
-template <enum ExceptionStyle S> BoxedInt* lenInternal(Box* obj, LenRewriteArgs* rewrite_args) {
+template <enum ExceptionStyle S>
+BoxedInt* lenInternal(Box* obj, LenRewriteArgs* rewrite_args) noexcept(S == ExceptionStyle::CAPI) {
     static BoxedString* len_str = internStringImmortal("__len__");
 
     if (S == CAPI) {
@@ -4625,7 +4628,8 @@ Box* callItemOrSliceAttr(Box* target, BoxedString* item_str, BoxedString* slice_
     }
 }
 
-template <enum ExceptionStyle S> Box* getitemInternal(Box* target, Box* slice, GetitemRewriteArgs* rewrite_args) {
+template <enum ExceptionStyle S>
+Box* getitemInternal(Box* target, Box* slice, GetitemRewriteArgs* rewrite_args) noexcept(S == ExceptionStyle::CAPI) {
     if (S == CAPI) {
         assert(!rewrite_args && "implement me");
         rewrite_args = NULL;

--- a/src/runtime/objmodel.h
+++ b/src/runtime/objmodel.h
@@ -114,6 +114,8 @@ struct CallRewriteArgs;
 Box* runtimeCallInternal(Box* obj, CallRewriteArgs* rewrite_args, ArgPassSpec argspec, Box* arg1, Box* arg2, Box* arg3,
                          Box** args, const std::vector<BoxedString*>* keyword_names);
 
+struct LenRewriteArgs;
+template <ExceptionStyle::ExceptionStyle S> BoxedInt* lenInternal(Box* obj, LenRewriteArgs* rewrite_args);
 Box* lenCallInternal(BoxedFunctionBase* f, CallRewriteArgs* rewrite_args, ArgPassSpec argspec, Box* arg1, Box* arg2,
                      Box* arg3, Box** args, const std::vector<BoxedString*>* keyword_names);
 

--- a/src/runtime/objmodel.h
+++ b/src/runtime/objmodel.h
@@ -114,6 +114,10 @@ struct CallRewriteArgs;
 Box* runtimeCallInternal(Box* obj, CallRewriteArgs* rewrite_args, ArgPassSpec argspec, Box* arg1, Box* arg2, Box* arg3,
                          Box** args, const std::vector<BoxedString*>* keyword_names);
 
+struct GetitemRewriteArgs;
+template <ExceptionStyle::ExceptionStyle S>
+Box* getitemInternal(Box* target, Box* slice, GetitemRewriteArgs* rewrite_args);
+
 struct LenRewriteArgs;
 template <ExceptionStyle::ExceptionStyle S> BoxedInt* lenInternal(Box* obj, LenRewriteArgs* rewrite_args);
 Box* lenCallInternal(BoxedFunctionBase* f, CallRewriteArgs* rewrite_args, ArgPassSpec argspec, Box* arg1, Box* arg2,

--- a/src/runtime/objmodel.h
+++ b/src/runtime/objmodel.h
@@ -116,10 +116,11 @@ Box* runtimeCallInternal(Box* obj, CallRewriteArgs* rewrite_args, ArgPassSpec ar
 
 struct GetitemRewriteArgs;
 template <ExceptionStyle::ExceptionStyle S>
-Box* getitemInternal(Box* target, Box* slice, GetitemRewriteArgs* rewrite_args);
+Box* getitemInternal(Box* target, Box* slice, GetitemRewriteArgs* rewrite_args) noexcept(S == ExceptionStyle::CAPI);
 
 struct LenRewriteArgs;
-template <ExceptionStyle::ExceptionStyle S> BoxedInt* lenInternal(Box* obj, LenRewriteArgs* rewrite_args);
+template <ExceptionStyle::ExceptionStyle S>
+BoxedInt* lenInternal(Box* obj, LenRewriteArgs* rewrite_args) noexcept(S == ExceptionStyle::CAPI);
 Box* lenCallInternal(BoxedFunctionBase* f, CallRewriteArgs* rewrite_args, ArgPassSpec argspec, Box* arg1, Box* arg2,
                      Box* arg3, Box** args, const std::vector<BoxedString*>* keyword_names);
 
@@ -141,7 +142,7 @@ Box* compareInternal(Box* lhs, Box* rhs, int op_type, CompareRewriteArgs* rewrit
 // This is the equivalent of PyObject_GetAttr. Unlike getattrInternalGeneric, it checks for custom __getattr__ or
 // __getattribute__ methods.
 template <ExceptionStyle::ExceptionStyle S>
-Box* getattrInternal(Box* obj, BoxedString* attr, GetattrRewriteArgs* rewrite_args);
+Box* getattrInternal(Box* obj, BoxedString* attr, GetattrRewriteArgs* rewrite_args) noexcept(S == ExceptionStyle::CAPI);
 
 // This is the equivalent of PyObject_GenericGetAttr, which performs the default lookup rules for getattr() (check for
 // data descriptor, check for instance attribute, check for non-data descriptor). It does not check for __getattr__ or

--- a/src/runtime/objmodel.h
+++ b/src/runtime/objmodel.h
@@ -134,6 +134,7 @@ Box* compareInternal(Box* lhs, Box* rhs, int op_type, CompareRewriteArgs* rewrit
 
 // This is the equivalent of PyObject_GetAttr. Unlike getattrInternalGeneric, it checks for custom __getattr__ or
 // __getattribute__ methods.
+template <ExceptionStyle::ExceptionStyle S>
 Box* getattrInternal(Box* obj, BoxedString* attr, GetattrRewriteArgs* rewrite_args);
 
 // This is the equivalent of PyObject_GenericGetAttr, which performs the default lookup rules for getattr() (check for

--- a/src/runtime/rewrite_args.h
+++ b/src/runtime/rewrite_args.h
@@ -97,6 +97,24 @@ struct CallRewriteArgs {
           out_rtn(NULL) {}
 };
 
+struct GetitemRewriteArgs {
+    Rewriter* rewriter;
+    RewriterVar* target;
+    RewriterVar* slice;
+    Location destination;
+
+    bool out_success;
+    RewriterVar* out_rtn;
+
+    GetitemRewriteArgs(Rewriter* rewriter, RewriterVar* target, RewriterVar* slice, Location destination)
+        : rewriter(rewriter),
+          target(target),
+          slice(slice),
+          destination(destination),
+          out_success(false),
+          out_rtn(NULL) {}
+};
+
 struct BinopRewriteArgs {
     Rewriter* rewriter;
     RewriterVar* lhs;

--- a/src/runtime/types.cpp
+++ b/src/runtime/types.cpp
@@ -1654,7 +1654,7 @@ static Box* instancemethodRepr(Box* b) {
     const char* sfuncname = "?", * sklassname = "?";
 
     static BoxedString* name_str = internStringImmortal("__name__");
-    funcname = getattrInternal(func, name_str, NULL);
+    funcname = getattrInternal<ExceptionStyle::CXX>(func, name_str, NULL);
 
     if (funcname != NULL) {
         if (!PyString_Check(funcname)) {
@@ -1666,7 +1666,7 @@ static Box* instancemethodRepr(Box* b) {
     if (klass == NULL) {
         klassname = NULL;
     } else {
-        klassname = getattrInternal(klass, name_str, NULL);
+        klassname = getattrInternal<ExceptionStyle::CXX>(klass, name_str, NULL);
         if (klassname != NULL) {
             if (!PyString_Check(klassname)) {
                 klassname = NULL;


### PR DESCRIPTION
with the goal of making sure that most exceptions we throw are CAPI exceptions rather that C++ exceptions.  This is just some easy things for now: getattr, getitem, and len().  The plan is then to add runtimeCall, callattr, and then finally add support from the interpreter and/or jit to call the capi-style versions (ideally with some sort of profiling guidance).

For django_template3, these changes cut the number of calls to __cxa_throw from 44k to 27k, and the number of C frames we unwind from 395k to 240k.

Not sure why there's a fairly consistent regression in pyxl_bench; I tried looking into it and it seems dwarfed by variability so I'm punting on that for now.
```
      django_template3.py             3.8s (2)             3.7s (2)  -2.6%
            pyxl_bench.py             3.0s (2)             3.1s (2)  +1.3%
sqlalchemy_imperative2.py             3.3s (2)             3.3s (2)  +0.5%
                  geomean                 3.4s                 3.4s  -0.3%
```