### PR TITLE
Templatize runtimeCall for different exception styles

### DIFF
--- a/src/codegen/codegen.cpp
+++ b/src/codegen/codegen.cpp
@@ -43,7 +43,8 @@ CLFunction::CLFunction(int num_args, int num_defaults, bool takes_varargs, bool 
       param_names(this->source->ast, this->source->getInternedStrings()),
       always_use_version(NULL),
       code_obj(NULL),
-      times_interpreted(0) {
+      times_interpreted(0),
+      internal_callable(NULL, NULL) {
     assert(num_args >= num_defaults);
 }
 CLFunction::CLFunction(int num_args, int num_defaults, bool takes_varargs, bool takes_kwargs,
@@ -53,7 +54,8 @@ CLFunction::CLFunction(int num_args, int num_defaults, bool takes_varargs, bool 
       param_names(param_names),
       always_use_version(NULL),
       code_obj(NULL),
-      times_interpreted(0) {
+      times_interpreted(0),
+      internal_callable(NULL, NULL) {
     assert(num_args >= num_defaults);
 }
 

--- a/src/codegen/irgen.cpp
+++ b/src/codegen/irgen.cpp
@@ -1016,7 +1016,7 @@ CompiledFunction* doCompile(CLFunction* clfunc, SourceInfo* source, ParamNames* 
     }
 
 
-    CompiledFunction* cf = new CompiledFunction(NULL, spec, NULL, effort, entry_descriptor);
+    CompiledFunction* cf = new CompiledFunction(NULL, spec, NULL, effort, ExceptionStyle::CXX, entry_descriptor);
 
     // Make sure that the instruction memory keeps the module object alive.
     // TODO: implement this for real

--- a/src/runtime/builtin_modules/builtins.cpp
+++ b/src/runtime/builtin_modules/builtins.cpp
@@ -1382,7 +1382,7 @@ void setupBuiltins() {
     builtins_module->giveAttr("repr", repr_obj);
 
     auto len_func = boxRTFunction((void*)len, UNKNOWN, 1);
-    len_func->internal_callable = lenCallInternal;
+    len_func->internal_callable.cxx_ptr = lenCallInternal;
     len_obj = new BoxedBuiltinFunctionOrMethod(len_func, "len");
     builtins_module->giveAttr("len", len_obj);
 

--- a/src/runtime/capi.cpp
+++ b/src/runtime/capi.cpp
@@ -578,15 +578,12 @@ extern "C" int PyObject_Not(PyObject* o) noexcept {
 }
 
 extern "C" PyObject* PyObject_Call(PyObject* callable_object, PyObject* args, PyObject* kw) noexcept {
-    try {
-        if (kw)
-            return runtimeCall(callable_object, ArgPassSpec(0, 0, true, true), args, kw, NULL, NULL, NULL);
-        else
-            return runtimeCall(callable_object, ArgPassSpec(0, 0, true, false), args, NULL, NULL, NULL, NULL);
-    } catch (ExcInfo e) {
-        setCAPIException(e);
-        return NULL;
-    }
+    if (kw)
+        return runtimeCallInternal<ExceptionStyle::CAPI>(callable_object, NULL, ArgPassSpec(0, 0, true, true), args, kw,
+                                                         NULL, NULL, NULL);
+    else
+        return runtimeCallInternal<ExceptionStyle::CAPI>(callable_object, NULL, ArgPassSpec(0, 0, true, false), args,
+                                                         NULL, NULL, NULL, NULL);
 }
 
 extern "C" int PyObject_GetBuffer(PyObject* obj, Py_buffer* view, int flags) noexcept {

--- a/src/runtime/generator.cpp
+++ b/src/runtime/generator.cpp
@@ -98,8 +98,8 @@ void generatorEntry(BoxedGenerator* g) {
             BoxedFunctionBase* func = g->function;
 
             Box** args = g->args ? &g->args->elts[0] : nullptr;
-            callCLFunc(func->f, nullptr, func->f->numReceivedArgs(), func->closure, g, func->globals, g->arg1, g->arg2,
-                       g->arg3, args);
+            callCLFunc<ExceptionStyle::CXX>(func->f, nullptr, func->f->numReceivedArgs(), func->closure, g,
+                                            func->globals, g->arg1, g->arg2, g->arg3, args);
         } catch (ExcInfo e) {
             // unhandled exception: propagate the exception to the caller
             g->exception = e;

--- a/src/runtime/list.cpp
+++ b/src/runtime/list.cpp
@@ -704,7 +704,7 @@ private:
 public:
     PyCmpComparer(Box* cmp) : cmp(cmp) {}
     bool operator()(Box* lhs, Box* rhs) {
-        Box* r = runtimeCallInternal(cmp, NULL, ArgPassSpec(2), lhs, rhs, NULL, NULL, NULL);
+        Box* r = runtimeCallInternal<ExceptionStyle::CXX>(cmp, NULL, ArgPassSpec(2), lhs, rhs, NULL, NULL, NULL);
         if (!isSubclass(r->cls, int_cls))
             raiseExcHelper(TypeError, "comparison function must return int, not %.200s", r->cls->tp_name);
         return static_cast<BoxedInt*>(r)->n < 0;
@@ -1169,7 +1169,10 @@ void setupList() {
     list_iterator_cls->giveAttr("__hasnext__", new BoxedFunction(hasnext));
     list_iterator_cls->giveAttr(
         "__iter__", new BoxedFunction(boxRTFunction((void*)listIterIter, typeFromClass(list_iterator_cls), 1)));
-    list_iterator_cls->giveAttr("next", new BoxedFunction(boxRTFunction((void*)listiterNext, UNKNOWN, 1)));
+
+    CLFunction* listiter_next = boxRTFunction((void*)listiterNext<ExceptionStyle::CXX>, UNKNOWN, 1);
+    addRTFunction(listiter_next, (void*)listiterNext<ExceptionStyle::CAPI>, UNKNOWN, ExceptionStyle::CAPI);
+    list_iterator_cls->giveAttr("next", new BoxedFunction(listiter_next));
 
     list_iterator_cls->freeze();
     list_iterator_cls->tpp_hasnext = listiterHasnextUnboxed;

--- a/src/runtime/list.h
+++ b/src/runtime/list.h
@@ -35,7 +35,7 @@ Box* listIter(Box* self);
 Box* listIterIter(Box* self);
 Box* listiterHasnext(Box* self);
 i1 listiterHasnextUnboxed(Box* self);
-Box* listiterNext(Box* self);
+template <ExceptionStyle::ExceptionStyle S> Box* listiterNext(Box* self) noexcept(S == ExceptionStyle::CAPI);
 Box* listReversed(Box* self);
 Box* listreviterHasnext(Box* self);
 i1 listreviterHasnextUnboxed(Box* self);

--- a/src/runtime/objmodel.h
+++ b/src/runtime/objmodel.h
@@ -111,8 +111,10 @@ struct BinopRewriteArgs;
 extern "C" Box* binopInternal(Box* lhs, Box* rhs, int op_type, bool inplace, BinopRewriteArgs* rewrite_args);
 
 struct CallRewriteArgs;
+template <ExceptionStyle::ExceptionStyle S>
 Box* runtimeCallInternal(Box* obj, CallRewriteArgs* rewrite_args, ArgPassSpec argspec, Box* arg1, Box* arg2, Box* arg3,
-                         Box** args, const std::vector<BoxedString*>* keyword_names);
+                         Box** args,
+                         const std::vector<BoxedString*>* keyword_names) noexcept(S == ExceptionStyle::CAPI);
 
 struct GetitemRewriteArgs;
 template <ExceptionStyle::ExceptionStyle S>
@@ -124,8 +126,10 @@ BoxedInt* lenInternal(Box* obj, LenRewriteArgs* rewrite_args) noexcept(S == Exce
 Box* lenCallInternal(BoxedFunctionBase* f, CallRewriteArgs* rewrite_args, ArgPassSpec argspec, Box* arg1, Box* arg2,
                      Box* arg3, Box** args, const std::vector<BoxedString*>* keyword_names);
 
+template <ExceptionStyle::ExceptionStyle S>
 Box* callFunc(BoxedFunctionBase* func, CallRewriteArgs* rewrite_args, ArgPassSpec argspec, Box* arg1, Box* arg2,
-              Box* arg3, Box** args, const std::vector<BoxedString*>* keyword_names);
+              Box* arg3, Box** args,
+              const std::vector<BoxedString*>* keyword_names) noexcept(S == ExceptionStyle::CAPI);
 
 enum LookupScope {
     CLASS_ONLY = 1,
@@ -169,8 +173,10 @@ bool isUserDefined(BoxedClass* cls);
 Box* processDescriptor(Box* obj, Box* inst, Box* owner);
 Box* processDescriptorOrNull(Box* obj, Box* inst, Box* owner);
 
+template <ExceptionStyle::ExceptionStyle S>
 Box* callCLFunc(CLFunction* f, CallRewriteArgs* rewrite_args, int num_output_args, BoxedClosure* closure,
-                BoxedGenerator* generator, Box* globals, Box* oarg1, Box* oarg2, Box* oarg3, Box** oargs);
+                BoxedGenerator* generator, Box* globals, Box* oarg1, Box* oarg2, Box* oarg3,
+                Box** oargs) noexcept(S == ExceptionStyle::CAPI);
 
 static const char* objectNewParameterTypeErrorMsg() {
     if (PYTHON_VERSION_HEX >= version_hex(2, 7, 4)) {


### PR DESCRIPTION
Which also involves templatizing most of the things that it
calls as well.

CompiledFunction's now have an additional parameter "exception_style",
and we will try to call a version of the function with the requested
style.  All of our runtime functions are written to the CXX style,
and there's not a whole lot of benefit until we templatize the runtime
functions individually.

Sorry for all the mess (duplication+churn) that this is creating.