### PR TITLE
bjit: fix problems when setting bjit thresholds to 1

### DIFF
--- a/src/asm_writing/rewriter.cpp
+++ b/src/asm_writing/rewriter.cpp
@@ -819,7 +819,7 @@ RewriterVar* Rewriter::call(bool has_side_effects, void* func_addr, const Rewrit
     return result;
 }
 
-void Rewriter::_setupCall(RewriterVar* result, bool has_side_effects, const RewriterVar::SmallVector& args,
+void Rewriter::_setupCall(bool has_side_effects, const RewriterVar::SmallVector& args,
                           const RewriterVar::SmallVector& args_xmm) {
     if (has_side_effects)
         assert(done_guarding);
@@ -972,7 +972,7 @@ void Rewriter::_call(RewriterVar* result, bool has_side_effects, void* func_addr
     // RewriterVarUsage scratch = createNewVar(Location::any());
     assembler::Register r = allocReg(assembler::R11);
 
-    _setupCall(result, has_side_effects, args, args_xmm);
+    _setupCall(has_side_effects, args, args_xmm);
 
     for (RewriterVar* arg : args) {
         arg->bumpUse();

--- a/src/asm_writing/rewriter.h
+++ b/src/asm_writing/rewriter.h
@@ -422,7 +422,7 @@ protected:
 
     void _trap();
     void _loadConst(RewriterVar* result, int64_t val);
-    void _setupCall(RewriterVar* result, bool has_side_effects, const RewriterVar::SmallVector& args,
+    void _setupCall(bool has_side_effects, const RewriterVar::SmallVector& args,
                     const RewriterVar::SmallVector& args_xmm);
     void _call(RewriterVar* result, bool has_side_effects, void* func_addr, const RewriterVar::SmallVector& args,
                const RewriterVar::SmallVector& args_xmm);

--- a/src/codegen/baseline_jit.cpp
+++ b/src/codegen/baseline_jit.cpp
@@ -803,9 +803,12 @@ void JitFragmentWriter::_emitPPCall(RewriterVar* result, void* func_addr, const 
         }
         RewriterVar::SmallVector reg_args(args.begin(), args.begin() + 6);
         assert(reg_args.size() == 6);
-        _setupCall(result, false, reg_args, RewriterVar::SmallVector());
+        _setupCall(false, reg_args, RewriterVar::SmallVector());
     } else
-        _setupCall(result, false, args, RewriterVar::SmallVector());
+        _setupCall(false, args, RewriterVar::SmallVector());
+
+    if (failed)
+        return;
 
     // make sure setupCall doesn't use R11
     assert(vars_by_location.count(assembler::R11) == 0);

--- a/src/runtime/classobj.cpp
+++ b/src/runtime/classobj.cpp
@@ -203,7 +203,7 @@ static const char* set_bases(PyClassObject* c, PyObject* v) {
     return "";
 }
 
-static void classobjSetattr(Box* _cls, Box* _attr, Box* _value) {
+static Box* classobjSetattr(Box* _cls, Box* _attr, Box* _value) {
     RELEASE_ASSERT(_cls->cls == classobj_cls, "");
     BoxedClassobj* cls = static_cast<BoxedClassobj*>(_cls);
 
@@ -216,10 +216,11 @@ static void classobjSetattr(Box* _cls, Box* _attr, Box* _value) {
             raiseExcHelper(TypeError, "%s", error_str);
         static BoxedString* bases_str = internStringImmortal("__bases__");
         cls->setattr(bases_str, _value, NULL);
-        return;
+        return None;
     }
     PyObject_GenericSetAttr(cls, _attr, _value);
     checkAndThrowCAPIException();
+    return None;
 }
 
 static int classobj_setattro(Box* cls, Box* attr, Box* value) noexcept {

--- a/src/runtime/dict.cpp
+++ b/src/runtime/dict.cpp
@@ -696,8 +696,8 @@ static Box* dict_repr(PyObject* self) noexcept {
 }
 
 void setupDict() {
-    dict_iterator_cls = BoxedHeapClass::create(type_cls, object_cls, &dictIteratorGCHandler, 0, 0, sizeof(BoxedDict),
-                                               false, "dictionary-itemiterator");
+    dict_iterator_cls = BoxedHeapClass::create(type_cls, object_cls, &dictIteratorGCHandler, 0, 0,
+                                               sizeof(BoxedDictIterator), false, "dictionary-itemiterator");
 
     dict_keys_cls = BoxedHeapClass::create(type_cls, object_cls, &dictViewGCHandler, 0, 0, sizeof(BoxedDictView), false,
                                            "dict_keys");

--- a/src/runtime/list.cpp
+++ b/src/runtime/list.cpp
@@ -1083,8 +1083,8 @@ extern "C" int PyList_SetSlice(PyObject* a, Py_ssize_t ilow, Py_ssize_t ihigh, P
 }
 
 void setupList() {
-    list_iterator_cls = BoxedHeapClass::create(type_cls, object_cls, &listIteratorGCHandler, 0, 0, sizeof(BoxedList),
-                                               false, "listiterator");
+    list_iterator_cls = BoxedHeapClass::create(type_cls, object_cls, &listIteratorGCHandler, 0, 0,
+                                               sizeof(BoxedListIterator), false, "listiterator");
     list_reverse_iterator_cls = BoxedHeapClass::create(type_cls, object_cls, &listIteratorGCHandler, 0, 0,
                                                        sizeof(BoxedListIterator), false, "listreverseiterator");
 

--- a/src/runtime/set.cpp
+++ b/src/runtime/set.cpp
@@ -488,8 +488,8 @@ extern "C" PyObject* PyFrozenSet_New(PyObject* iterable) noexcept {
 using namespace pyston::set;
 
 void setupSet() {
-    set_iterator_cls = BoxedHeapClass::create(type_cls, object_cls, &setIteratorGCHandler, 0, 0, sizeof(BoxedSet),
-                                              false, "setiterator");
+    set_iterator_cls = BoxedHeapClass::create(type_cls, object_cls, &setIteratorGCHandler, 0, 0,
+                                              sizeof(BoxedSetIterator), false, "setiterator");
     set_iterator_cls->giveAttr(
         "__iter__", new BoxedFunction(boxRTFunction((void*)setiteratorIter, typeFromClass(set_iterator_cls), 1)));
     set_iterator_cls->giveAttr("__hasnext__",


### PR DESCRIPTION
- we hit an assert when we ran out of scratch space
- 'classobjSetattr' returned void but all runtime funcs must return a Box* object.
- sneak in a change which removes a unused arg from '_setupCall'
- skip retrying to jit very large blocks
- register iterator types with the correct size
 - I checked all calls to ```BoxedHeapClass::create```

We may want to add a test run which forces to use the baseline JIT like we do for the other tiers...

This shows a perf change with our default thresholds which surprises me:
```
                           75e203a2dfac5578fc:  dbc4b9d2ff6f1b31a2:
      django_template3.py             3.6s (4)             3.3s (4)  -7.2%
            pyxl_bench.py             2.9s (4)             2.9s (4)  +1.4%
sqlalchemy_imperative2.py             3.3s (4)             3.2s (4)  -0.4%
                  geomean                 3.2s                 3.2s  -2.1%
```