### PR TITLE
object.__str__ use capi slot in order to increase compatibility with cpython

### DIFF
--- a/src/runtime/objmodel.cpp
+++ b/src/runtime/objmodel.cpp
@@ -1118,12 +1118,12 @@ Box* nondataDescriptorInstanceSpecialCases(GetattrRewriteArgs* rewrite_args, Box
         Box* inst = obj;
         Box* owner = obj->cls;
 
-        Box* r = BoxedWrapperDescriptor::__get__(self, inst, owner);
+        Box* r = BoxedWrapperDescriptor::descr_get(self, inst, owner);
 
         if (rewrite_args) {
             // TODO: inline this?
             RewriterVar* r_rtn = rewrite_args->rewriter->call(
-                /* has_side_effects= */ false, (void*)&BoxedWrapperDescriptor::__get__, r_descr, rewrite_args->obj,
+                /* has_side_effects= */ false, (void*)&BoxedWrapperDescriptor::descr_get, r_descr, rewrite_args->obj,
                 r_descr->getAttr(offsetof(Box, cls), Location::forArg(2)));
 
             rewrite_args->out_success = true;

--- a/src/runtime/types.h
+++ b/src/runtime/types.h
@@ -945,7 +945,6 @@ public:
 
     DEFAULT_CLASS(wrapperdescr_cls);
 
-    static Box* __get__(BoxedWrapperDescriptor* self, Box* inst, Box* owner);
     static Box* descr_get(Box* self, Box* inst, Box* owner) noexcept;
     static Box* __call__(BoxedWrapperDescriptor* descr, PyObject* self, BoxedTuple* args, Box** _args);
 

--- a/test/tests/thread_test.py
+++ b/test/tests/thread_test.py
@@ -30,9 +30,13 @@ while not done:
     time.sleep(0)
 
 l = allocate_lock()
+print "locked:", l.locked()
 print l.acquire()
+print "locked:", l.locked()
 print l.acquire(0)
+print "locked:", l.locked()
 print l.release()
+print "locked:", l.locked()
 print l.acquire(0)
 
 

--- a/test/tests/wrapperdesc.py
+++ b/test/tests/wrapperdesc.py
@@ -1,0 +1,8 @@
+class C(object):
+    pass
+print C.__str__ is object.__str__
+print type(C).__str__ is object.__str__
+print type(None).__str__ is object.__str__
+print type(None).__str__ is None.__str__
+print type(None.__str__)
+print type(type(None).__str__.__get__(None, type(None)))


### PR DESCRIPTION
With this change we print True for:
```
class C(object):
    pass
print C.__str__ is object.__str__
```
Cheetah depends on this behavior (see https://bitbucket.org/pypy/compatibility/wiki/cheetah)