### PR TITLE
have the llvm jit start emitting some capi-style calls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1229,7 +1229,7 @@ endif
 # depend on the first one.
 $(firstword $(TEST_EXT_MODULE_OBJS)): $(TEST_EXT_MODULE_SRCS) | $(BUILD_PY)
 	$(VERB) cd $(TEST_DIR)/test_extension; time ../../$(BUILD_PY) setup.py build
-	$(VERB) cd $(TEST_DIR)/test_extension; ln -sf $(TEST_EXT_MODULE_NAMES:%=build/lib.linux2-2.7/%.pyston.so) .
+	$(VERB) cd $(TEST_DIR)/test_extension; ln -sf $(TEST_EXT_MODULE_NAMES:%=build/lib.linux-x86_64-2.7/%.pyston.so) .
 	$(VERB) touch -c $(TEST_EXT_MODULE_OBJS)
 $(wordlist 2,9999,$(TEST_EXT_MODULE_OBJS)): $(firstword $(TEST_EXT_MODULE_OBJS))
 $(firstword $(SHAREDMODS_OBJS)): $(SHAREDMODS_SRCS) | $(BUILD_PY)

--- a/src/codegen/irgen/hooks.cpp
+++ b/src/codegen/irgen/hooks.cpp
@@ -716,8 +716,7 @@ void CompiledFunction::speculationFailed() {
 }
 
 CompiledFunction::CompiledFunction(llvm::Function* func, FunctionSpecialization* spec, void* code, EffortLevel effort,
-                                   ExceptionStyle::ExceptionStyle exception_style,
-                                   const OSREntryDescriptor* entry_descriptor)
+                                   ExceptionStyle exception_style, const OSREntryDescriptor* entry_descriptor)
     : clfunc(NULL),
       func(func),
       spec(spec),
@@ -834,7 +833,7 @@ CLFunction* createRTFunction(int num_args, int num_defaults, bool takes_varargs,
 }
 
 CLFunction* boxRTFunction(void* f, ConcreteCompilerType* rtn_type, int num_args, const ParamNames& param_names,
-                          ExceptionStyle::ExceptionStyle exception_style) {
+                          ExceptionStyle exception_style) {
     assert(!param_names.takes_param_names || num_args == param_names.args.size());
     assert(param_names.vararg.str() == "");
     assert(param_names.kwarg.str() == "");
@@ -843,8 +842,7 @@ CLFunction* boxRTFunction(void* f, ConcreteCompilerType* rtn_type, int num_args,
 }
 
 CLFunction* boxRTFunction(void* f, ConcreteCompilerType* rtn_type, int num_args, int num_defaults, bool takes_varargs,
-                          bool takes_kwargs, const ParamNames& param_names,
-                          ExceptionStyle::ExceptionStyle exception_style) {
+                          bool takes_kwargs, const ParamNames& param_names, ExceptionStyle exception_style) {
     assert(!param_names.takes_param_names || num_args == param_names.args.size());
     assert(takes_varargs || param_names.vararg.str() == "");
     assert(takes_kwargs || param_names.kwarg.str() == "");
@@ -855,8 +853,7 @@ CLFunction* boxRTFunction(void* f, ConcreteCompilerType* rtn_type, int num_args,
     return cl_f;
 }
 
-void addRTFunction(CLFunction* cl_f, void* f, ConcreteCompilerType* rtn_type,
-                   ExceptionStyle::ExceptionStyle exception_style) {
+void addRTFunction(CLFunction* cl_f, void* f, ConcreteCompilerType* rtn_type, ExceptionStyle exception_style) {
     std::vector<ConcreteCompilerType*> arg_types(cl_f->numReceivedArgs(), UNKNOWN);
     return addRTFunction(cl_f, f, rtn_type, arg_types, exception_style);
 }
@@ -867,8 +864,7 @@ static ConcreteCompilerType* processType(ConcreteCompilerType* type) {
 }
 
 void addRTFunction(CLFunction* cl_f, void* f, ConcreteCompilerType* rtn_type,
-                   const std::vector<ConcreteCompilerType*>& arg_types,
-                   ExceptionStyle::ExceptionStyle exception_style) {
+                   const std::vector<ConcreteCompilerType*>& arg_types, ExceptionStyle exception_style) {
     assert(arg_types.size() == cl_f->numReceivedArgs());
 #ifndef NDEBUG
     for (ConcreteCompilerType* t : arg_types)

--- a/src/codegen/irgen/hooks.h
+++ b/src/codegen/irgen/hooks.h
@@ -39,6 +39,8 @@ void compileAndRunModule(AST_Module* m, BoxedModule* bm);
 // will we always want to generate unique function names? (ie will this function always be reasonable?)
 CompiledFunction* cfForMachineFunctionName(const std::string&);
 
+extern "C" void capiExcCaughtInJit(AST_stmt* current_stmt, void* source_info);
+
 extern "C" Box* exec(Box* boxedCode, Box* globals, Box* locals, FutureFlags caller_future_flags);
 extern "C" Box* eval(Box* boxedCode, Box* globals, Box* locals);
 extern "C" Box* compile(Box* source, Box* filename, Box* mode, Box** _args /* flags, dont_inherit */);

--- a/src/codegen/irgen/irgenerator.cpp
+++ b/src/codegen/irgen/irgenerator.cpp
@@ -37,7 +37,8 @@
 
 namespace pyston {
 
-extern "C" void dumpLLVM(llvm::Value* v) {
+extern "C" void dumpLLVM(void* _v) {
+    llvm::Value* v = (llvm::Value*)_v;
     v->getType()->dump();
     v->dump();
 }
@@ -91,6 +92,26 @@ llvm::Value* IRGenState::getScratchSpace(int min_bytes) {
     scratch_space = new_scratch_space;
 
     return scratch_space;
+}
+
+// This function is where we decide whether to have a certain operation use CAPI or CXX exceptions.
+// FIXME It's a bit messy at the moment because this requires coordinating between a couple different
+// parts: we need to make sure that the associated landingpad will catch the right kind of exception,
+// and we need to make sure that we can actually emit this statement using capi-exceptions.
+// It doesn't really belong on the IRGenState, but it's here so that we can access this state from
+// separate basic blocks (the IRGenerator only exists for a single bb).
+ExceptionStyle IRGenState::getLandingpadStyle(AST_Invoke* invoke) {
+    assert(!landingpad_styles.count(invoke->exc_dest));
+    ExceptionStyle& r = landingpad_styles[invoke->exc_dest];
+    // printf("Added %d\n", invoke->exc_dest->idx);
+
+    r = CXX; // default
+    return r;
+}
+
+ExceptionStyle IRGenState::getLandingpadStyle(CFGBlock* block) {
+    ASSERT(landingpad_styles.count(block), "%d", block->idx);
+    return landingpad_styles[block];
 }
 
 static llvm::Value* getClosureParentGep(IREmitter& emitter, llvm::Value* closure) {
@@ -230,25 +251,64 @@ private:
     llvm::BasicBlock*& curblock;
     IRGenerator* irgenerator;
 
-    llvm::CallSite emitCall(UnwindInfo unw_info, llvm::Value* callee, const std::vector<llvm::Value*>& args) {
-        if (unw_info.needsInvoke()) {
+    llvm::CallSite emitCall(const UnwindInfo& unw_info, llvm::Value* callee, const std::vector<llvm::Value*>& args,
+                            ExceptionStyle target_exception_style) {
+        if (unw_info.hasHandler() && target_exception_style == CXX) {
+            assert(unw_info.cxx_exc_dest);
             llvm::BasicBlock* normal_dest
                 = llvm::BasicBlock::Create(g.context, curblock->getName(), irstate->getLLVMFunction());
             normal_dest->moveAfter(curblock);
 
-            llvm::InvokeInst* rtn = getBuilder()->CreateInvoke(callee, normal_dest, unw_info.exc_dest, args);
+            llvm::InvokeInst* rtn = getBuilder()->CreateInvoke(callee, normal_dest, unw_info.cxx_exc_dest, args);
             getBuilder()->SetInsertPoint(normal_dest);
             curblock = normal_dest;
             return rtn;
         } else {
-            return getBuilder()->CreateCall(callee, args);
+            llvm::CallInst* cs = getBuilder()->CreateCall(callee, args);
+            return cs;
         }
     }
 
+    void checkAndPropagateCapiException(const UnwindInfo& unw_info, llvm::Value* returned_val, llvm::Value* exc_val,
+                                        bool double_check) {
+        assert(!double_check); // need to call PyErr_Occurred
+
+        llvm::BasicBlock* normal_dest
+            = llvm::BasicBlock::Create(g.context, curblock->getName(), irstate->getLLVMFunction());
+        normal_dest->moveAfter(curblock);
+
+        llvm::BasicBlock* exc_dest;
+        bool exc_caught;
+        if (unw_info.hasHandler()) {
+            assert(unw_info.capi_exc_dest);
+            exc_dest = unw_info.capi_exc_dest;
+            exc_caught = true;
+        } else {
+            exc_dest = llvm::BasicBlock::Create(g.context, curblock->getName() + "_exc", irstate->getLLVMFunction());
+            exc_dest->moveAfter(curblock);
+            exc_caught = false;
+        }
+
+        assert(returned_val->getType() == exc_val->getType());
+        llvm::Value* check_val = getBuilder()->CreateICmpEQ(returned_val, exc_val);
+        llvm::BranchInst* nullcheck = getBuilder()->CreateCondBr(check_val, exc_dest, normal_dest);
+
+        setCurrentBasicBlock(exc_dest);
+        getBuilder()->CreateCall2(g.funcs.capiExcCaughtInJit,
+                                  embedRelocatablePtr(unw_info.current_stmt, g.llvm_aststmt_type_ptr),
+                                  embedRelocatablePtr(irstate->getSourceInfo(), g.i8_ptr));
+
+        if (!exc_caught) {
+            RELEASE_ASSERT(0, "need to implement this");
+        }
+
+        setCurrentBasicBlock(normal_dest);
+    }
 
     llvm::CallSite emitPatchpoint(llvm::Type* return_type, const ICSetupInfo* pp, llvm::Value* func,
                                   const std::vector<llvm::Value*>& args,
-                                  const std::vector<llvm::Value*>& ic_stackmap_args, UnwindInfo unw_info) {
+                                  const std::vector<llvm::Value*>& ic_stackmap_args, const UnwindInfo& unw_info,
+                                  ExceptionStyle target_exception_style) {
         if (pp == NULL)
             assert(ic_stackmap_args.size() == 0);
 
@@ -272,7 +332,7 @@ private:
         int pp_size = pp ? pp->totalSize() : CALL_ONLY_SIZE;
 
         std::vector<llvm::Value*> pp_args;
-        pp_args.push_back(getConstantInt(pp_id, g.i64)); // pp_id: will fill this in later
+        pp_args.push_back(getConstantInt(pp_id, g.i64));
         pp_args.push_back(getConstantInt(pp_size, g.i32));
         if (ENABLE_JIT_OBJECT_CACHE)
             // add fixed dummy dest pointer, we will replace it with the correct address during stackmap processing
@@ -304,7 +364,7 @@ private:
         }
         llvm::Function* patchpoint = this->getIntrinsic(intrinsic_id);
 
-        llvm::CallSite rtn = this->emitCall(unw_info, patchpoint, pp_args);
+        llvm::CallSite rtn = this->emitCall(unw_info, patchpoint, pp_args, target_exception_style);
         return rtn;
     }
 
@@ -343,7 +403,8 @@ public:
         return llvm::BasicBlock::Create(g.context, name, irstate->getLLVMFunction());
     }
 
-    llvm::Value* createCall(UnwindInfo unw_info, llvm::Value* callee, const std::vector<llvm::Value*>& args) override {
+    llvm::Value* createCall(const UnwindInfo& unw_info, llvm::Value* callee, const std::vector<llvm::Value*>& args,
+                            ExceptionStyle target_exception_style = CXX) override {
 #ifndef NDEBUG
         // Copied the argument-type-checking from CallInst::init, since the patchpoint arguments don't
         // get checked.
@@ -367,7 +428,7 @@ public:
                                                                       ->getElementType())->getReturnType();
 
             llvm::Value* bitcasted = getBuilder()->CreateBitCast(callee, g.i8->getPointerTo());
-            llvm::CallSite cs = emitPatchpoint(rtn_type, NULL, bitcasted, args, {}, unw_info);
+            llvm::CallSite cs = emitPatchpoint(rtn_type, NULL, bitcasted, args, {}, unw_info, target_exception_style);
 
             if (rtn_type == cs->getType()) {
                 return cs.getInstruction();
@@ -381,34 +442,37 @@ public:
                 RELEASE_ASSERT(0, "don't know how to convert those");
             }
         } else {
-            return emitCall(unw_info, callee, args).getInstruction();
+            return emitCall(unw_info, callee, args, target_exception_style).getInstruction();
         }
     }
 
-    llvm::Value* createCall(UnwindInfo unw_info, llvm::Value* callee) override {
-        return createCall(unw_info, callee, std::vector<llvm::Value*>());
+    llvm::Value* createCall(const UnwindInfo& unw_info, llvm::Value* callee,
+                            ExceptionStyle target_exception_style = CXX) override {
+        return createCall(unw_info, callee, std::vector<llvm::Value*>(), target_exception_style);
     }
 
-    llvm::Value* createCall(UnwindInfo unw_info, llvm::Value* callee, llvm::Value* arg1) override {
-        return createCall(unw_info, callee, std::vector<llvm::Value*>({ arg1 }));
+    llvm::Value* createCall(const UnwindInfo& unw_info, llvm::Value* callee, llvm::Value* arg1,
+                            ExceptionStyle target_exception_style = CXX) override {
+        return createCall(unw_info, callee, std::vector<llvm::Value*>({ arg1 }), target_exception_style);
     }
 
-    llvm::Value* createCall2(UnwindInfo unw_info, llvm::Value* callee, llvm::Value* arg1, llvm::Value* arg2) override {
-        return createCall(unw_info, callee, { arg1, arg2 });
+    llvm::Value* createCall2(const UnwindInfo& unw_info, llvm::Value* callee, llvm::Value* arg1, llvm::Value* arg2,
+                             ExceptionStyle target_exception_style = CXX) override {
+        return createCall(unw_info, callee, { arg1, arg2 }, target_exception_style);
     }
 
-    llvm::Value* createCall3(UnwindInfo unw_info, llvm::Value* callee, llvm::Value* arg1, llvm::Value* arg2,
-                             llvm::Value* arg3) override {
-        return createCall(unw_info, callee, { arg1, arg2, arg3 });
+    llvm::Value* createCall3(const UnwindInfo& unw_info, llvm::Value* callee, llvm::Value* arg1, llvm::Value* arg2,
+                             llvm::Value* arg3, ExceptionStyle target_exception_style = CXX) override {
+        return createCall(unw_info, callee, { arg1, arg2, arg3 }, target_exception_style);
     }
 
     llvm::Value* createIC(const ICSetupInfo* pp, void* func_addr, const std::vector<llvm::Value*>& args,
-                          UnwindInfo unw_info) override {
+                          const UnwindInfo& unw_info, ExceptionStyle target_exception_style = CXX) override {
         std::vector<llvm::Value*> stackmap_args;
 
-        llvm::CallSite rtn
-            = emitPatchpoint(pp->hasReturnValue() ? g.i64 : g.void_, pp,
-                             embedConstantPtr(func_addr, g.i8->getPointerTo()), args, stackmap_args, unw_info);
+        llvm::CallSite rtn = emitPatchpoint(pp->hasReturnValue() ? g.i64 : g.void_, pp,
+                                            embedConstantPtr(func_addr, g.i8->getPointerTo()), args, stackmap_args,
+                                            unw_info, target_exception_style);
 
         rtn.setCallingConv(pp->getCallingConvention());
         return rtn.getInstruction();
@@ -489,7 +553,7 @@ public:
     ~IRGeneratorImpl() { delete emitter.getBuilder(); }
 
 private:
-    OpInfo getOpInfoForNode(AST* ast, UnwindInfo unw_info) {
+    OpInfo getOpInfoForNode(AST* ast, const UnwindInfo& unw_info) {
         assert(ast);
 
         EffortLevel effort = irstate->getEffortLevel();
@@ -508,7 +572,7 @@ private:
         return OpInfo(irstate->getEffortLevel(), type_recorder, unw_info);
     }
 
-    OpInfo getEmptyOpInfo(UnwindInfo unw_info) { return OpInfo(irstate->getEffortLevel(), NULL, unw_info); }
+    OpInfo getEmptyOpInfo(const UnwindInfo& unw_info) { return OpInfo(irstate->getEffortLevel(), NULL, unw_info); }
 
     void createExprTypeGuard(llvm::Value* check_val, AST_expr* node, llvm::Value* node_value,
                              AST_stmt* current_statement) {
@@ -532,7 +596,7 @@ private:
 
         curblock = deopt_bb;
         emitter.getBuilder()->SetInsertPoint(curblock);
-        llvm::Value* v = emitter.createCall2(UnwindInfo(current_statement, NULL), g.funcs.deopt,
+        llvm::Value* v = emitter.createCall2(UnwindInfo(current_statement, NULL, NULL), g.funcs.deopt,
                                              embedRelocatablePtr(node, g.llvm_aststmt_type_ptr), node_value);
         emitter.getBuilder()->CreateRet(v);
 
@@ -548,7 +612,7 @@ private:
         return pyston::getIsDefinedName(name, irstate->getSourceInfo()->getInternedStrings());
     }
 
-    CompilerVariable* evalAttribute(AST_Attribute* node, UnwindInfo unw_info) {
+    CompilerVariable* evalAttribute(AST_Attribute* node, const UnwindInfo& unw_info) {
         CompilerVariable* value = evalExpr(node->value, unw_info);
 
         CompilerVariable* rtn = value->getattr(emitter, getOpInfoForNode(node, unw_info), node->attr.getBox(), false);
@@ -556,14 +620,14 @@ private:
         return rtn;
     }
 
-    CompilerVariable* evalClsAttribute(AST_ClsAttribute* node, UnwindInfo unw_info) {
+    CompilerVariable* evalClsAttribute(AST_ClsAttribute* node, const UnwindInfo& unw_info) {
         CompilerVariable* value = evalExpr(node->value, unw_info);
         CompilerVariable* rtn = value->getattr(emitter, getOpInfoForNode(node, unw_info), node->attr.getBox(), true);
         value->decvref(emitter);
         return rtn;
     }
 
-    CompilerVariable* evalLangPrimitive(AST_LangPrimitive* node, UnwindInfo unw_info) {
+    CompilerVariable* evalLangPrimitive(AST_LangPrimitive* node, const UnwindInfo& unw_info) {
         switch (node->opcode) {
             case AST_LangPrimitive::CHECK_EXC_MATCH: {
                 assert(node->args.size() == 2);
@@ -582,38 +646,59 @@ private:
                 return boolFromI1(emitter, v);
             }
             case AST_LangPrimitive::LANDINGPAD: {
-                // llvm::Function* _personality_func = g.stdlib_module->getFunction("__py_personality_v0");
-                llvm::Function* _personality_func = g.stdlib_module->getFunction("__gxx_personality_v0");
-                assert(_personality_func);
-                llvm::Value* personality_func = g.cur_module->getOrInsertFunction(_personality_func->getName(),
-                                                                                  _personality_func->getFunctionType());
-                assert(personality_func);
-                llvm::LandingPadInst* landing_pad = emitter.getBuilder()->CreateLandingPad(
-                    llvm::StructType::create(std::vector<llvm::Type*>{ g.i8_ptr, g.i64 }), personality_func, 1);
-                landing_pad->addClause(getNullPtr(g.i8_ptr));
+                llvm::Value* exc_type;
+                llvm::Value* exc_value;
+                llvm::Value* exc_traceback;
+                if (irstate->getLandingpadStyle(myblock) == CXX) {
+                    // llvm::Function* _personality_func = g.stdlib_module->getFunction("__py_personality_v0");
+                    llvm::Function* _personality_func = g.stdlib_module->getFunction("__gxx_personality_v0");
+                    assert(_personality_func);
+                    llvm::Value* personality_func = g.cur_module->getOrInsertFunction(
+                        _personality_func->getName(), _personality_func->getFunctionType());
+                    assert(personality_func);
+                    llvm::LandingPadInst* landing_pad = emitter.getBuilder()->CreateLandingPad(
+                        llvm::StructType::create(std::vector<llvm::Type*>{ g.i8_ptr, g.i64 }), personality_func, 1);
+                    landing_pad->addClause(getNullPtr(g.i8_ptr));
 
-                llvm::Value* cxaexc_pointer = emitter.getBuilder()->CreateExtractValue(landing_pad, { 0 });
+                    llvm::Value* cxaexc_pointer = emitter.getBuilder()->CreateExtractValue(landing_pad, { 0 });
 
-                llvm::Function* std_module_catch = g.stdlib_module->getFunction("__cxa_begin_catch");
-                auto begin_catch_func = g.cur_module->getOrInsertFunction(std_module_catch->getName(),
-                                                                          std_module_catch->getFunctionType());
-                assert(begin_catch_func);
+                    llvm::Function* std_module_catch = g.stdlib_module->getFunction("__cxa_begin_catch");
+                    auto begin_catch_func = g.cur_module->getOrInsertFunction(std_module_catch->getName(),
+                                                                              std_module_catch->getFunctionType());
+                    assert(begin_catch_func);
 
-                llvm::Value* excinfo_pointer = emitter.getBuilder()->CreateCall(begin_catch_func, cxaexc_pointer);
-                llvm::Value* excinfo_pointer_casted
-                    = emitter.getBuilder()->CreateBitCast(excinfo_pointer, g.llvm_excinfo_type->getPointerTo());
+                    llvm::Value* excinfo_pointer = emitter.getBuilder()->CreateCall(begin_catch_func, cxaexc_pointer);
+                    llvm::Value* excinfo_pointer_casted
+                        = emitter.getBuilder()->CreateBitCast(excinfo_pointer, g.llvm_excinfo_type->getPointerTo());
 
-                auto* builder = emitter.getBuilder();
-                llvm::Value* exc_type
-                    = builder->CreateLoad(builder->CreateConstInBoundsGEP2_32(excinfo_pointer_casted, 0, 0));
-                llvm::Value* exc_value
-                    = builder->CreateLoad(builder->CreateConstInBoundsGEP2_32(excinfo_pointer_casted, 0, 1));
-                llvm::Value* exc_traceback
-                    = builder->CreateLoad(builder->CreateConstInBoundsGEP2_32(excinfo_pointer_casted, 0, 2));
+                    auto* builder = emitter.getBuilder();
+                    exc_type = builder->CreateLoad(builder->CreateConstInBoundsGEP2_32(excinfo_pointer_casted, 0, 0));
+                    exc_value = builder->CreateLoad(builder->CreateConstInBoundsGEP2_32(excinfo_pointer_casted, 0, 1));
+                    exc_traceback
+                        = builder->CreateLoad(builder->CreateConstInBoundsGEP2_32(excinfo_pointer_casted, 0, 2));
+                } else {
+                    llvm::Value* exc_type_ptr
+                        = new llvm::AllocaInst(g.llvm_value_type_ptr, getConstantInt(1, g.i64), "exc_type",
+                                               irstate->getLLVMFunction()->getEntryBlock().getFirstInsertionPt());
+                    llvm::Value* exc_value_ptr
+                        = new llvm::AllocaInst(g.llvm_value_type_ptr, getConstantInt(1, g.i64), "exc_value",
+                                               irstate->getLLVMFunction()->getEntryBlock().getFirstInsertionPt());
+                    llvm::Value* exc_traceback_ptr
+                        = new llvm::AllocaInst(g.llvm_value_type_ptr, getConstantInt(1, g.i64), "exc_traceback",
+                                               irstate->getLLVMFunction()->getEntryBlock().getFirstInsertionPt());
+                    emitter.getBuilder()->CreateCall3(g.funcs.PyErr_Fetch, exc_type_ptr, exc_value_ptr,
+                                                      exc_traceback_ptr);
+                    // TODO: I think we should be doing this on a python raise() or when we enter a python catch:
+                    emitter.getBuilder()->CreateCall3(g.funcs.PyErr_NormalizeException, exc_type_ptr, exc_value_ptr,
+                                                      exc_traceback_ptr);
+                    exc_type = emitter.getBuilder()->CreateLoad(exc_type_ptr);
+                    exc_value = emitter.getBuilder()->CreateLoad(exc_value_ptr);
+                    exc_traceback = emitter.getBuilder()->CreateLoad(exc_traceback_ptr);
+                }
+
                 assert(exc_type->getType() == g.llvm_value_type_ptr);
                 assert(exc_value->getType() == g.llvm_value_type_ptr);
                 assert(exc_traceback->getType() == g.llvm_value_type_ptr);
-
                 return makeTuple({ new ConcreteCompilerVariable(UNKNOWN, exc_type, true),
                                    new ConcreteCompilerVariable(UNKNOWN, exc_value, true),
                                    new ConcreteCompilerVariable(UNKNOWN, exc_traceback, true) });
@@ -763,7 +848,7 @@ private:
     }
 
     CompilerVariable* _evalBinExp(AST* node, CompilerVariable* left, CompilerVariable* right, AST_TYPE::AST_TYPE type,
-                                  BinExpType exp_type, UnwindInfo unw_info) {
+                                  BinExpType exp_type, const UnwindInfo& unw_info) {
         assert(left);
         assert(right);
 
@@ -783,7 +868,7 @@ private:
         return left->binexp(emitter, getOpInfoForNode(node, unw_info), right, type, exp_type);
     }
 
-    CompilerVariable* evalBinOp(AST_BinOp* node, UnwindInfo unw_info) {
+    CompilerVariable* evalBinOp(AST_BinOp* node, const UnwindInfo& unw_info) {
         CompilerVariable* left = evalExpr(node->left, unw_info);
         CompilerVariable* right = evalExpr(node->right, unw_info);
 
@@ -795,7 +880,7 @@ private:
         return rtn;
     }
 
-    CompilerVariable* evalAugBinOp(AST_AugBinOp* node, UnwindInfo unw_info) {
+    CompilerVariable* evalAugBinOp(AST_AugBinOp* node, const UnwindInfo& unw_info) {
         CompilerVariable* left = evalExpr(node->left, unw_info);
         CompilerVariable* right = evalExpr(node->right, unw_info);
 
@@ -807,7 +892,7 @@ private:
         return rtn;
     }
 
-    CompilerVariable* evalCompare(AST_Compare* node, UnwindInfo unw_info) {
+    CompilerVariable* evalCompare(AST_Compare* node, const UnwindInfo& unw_info) {
         RELEASE_ASSERT(node->ops.size() == 1, "");
 
         CompilerVariable* left = evalExpr(node->left, unw_info);
@@ -826,7 +911,7 @@ private:
         return rtn;
     }
 
-    CompilerVariable* evalCall(AST_Call* node, UnwindInfo unw_info) {
+    CompilerVariable* evalCall(AST_Call* node, const UnwindInfo& unw_info) {
         bool is_callattr;
         bool callattr_clsonly = false;
         InternedString attr;
@@ -891,7 +976,7 @@ private:
         return rtn;
     }
 
-    CompilerVariable* evalDict(AST_Dict* node, UnwindInfo unw_info) {
+    CompilerVariable* evalDict(AST_Dict* node, const UnwindInfo& unw_info) {
         llvm::Value* v = emitter.getBuilder()->CreateCall(g.funcs.createDict);
         ConcreteCompilerVariable* rtn = new ConcreteCompilerVariable(DICT, v, true);
         if (node->keys.size()) {
@@ -926,9 +1011,9 @@ private:
         inst->setMetadata(message, mdnode);
     }
 
-    CompilerVariable* evalIndex(AST_Index* node, UnwindInfo unw_info) { return evalExpr(node->value, unw_info); }
+    CompilerVariable* evalIndex(AST_Index* node, const UnwindInfo& unw_info) { return evalExpr(node->value, unw_info); }
 
-    CompilerVariable* evalLambda(AST_Lambda* node, UnwindInfo unw_info) {
+    CompilerVariable* evalLambda(AST_Lambda* node, const UnwindInfo& unw_info) {
         AST_Return* expr = new AST_Return();
         expr->value = node->body;
 
@@ -941,7 +1026,7 @@ private:
     }
 
 
-    CompilerVariable* evalList(AST_List* node, UnwindInfo unw_info) {
+    CompilerVariable* evalList(AST_List* node, const UnwindInfo& unw_info) {
         std::vector<CompilerVariable*> elts;
         for (int i = 0; i < node->elts.size(); i++) {
             CompilerVariable* value = evalExpr(node->elts[i], unw_info);
@@ -977,7 +1062,7 @@ private:
         return embedRelocatablePtr(parent_module, g.llvm_value_type_ptr, "cParentModule");
     }
 
-    ConcreteCompilerVariable* _getGlobal(AST_Name* node, UnwindInfo unw_info) {
+    ConcreteCompilerVariable* _getGlobal(AST_Name* node, const UnwindInfo& unw_info) {
         if (node->id.s() == "None")
             return getNone();
 
@@ -999,7 +1084,7 @@ private:
         }
     }
 
-    CompilerVariable* evalName(AST_Name* node, UnwindInfo unw_info) {
+    CompilerVariable* evalName(AST_Name* node, const UnwindInfo& unw_info) {
         auto scope_info = irstate->getScopeInfo();
 
         bool is_kill = irstate->getLiveness()->isKill(node, myblock);
@@ -1100,7 +1185,7 @@ private:
         }
     }
 
-    CompilerVariable* evalNum(AST_Num* node, UnwindInfo unw_info) {
+    CompilerVariable* evalNum(AST_Num* node, const UnwindInfo& unw_info) {
         // We can operate on ints and floats unboxed, so don't box those at first;
         // complex and long's have to get boxed so box them immediately.
         if (node->num_type == AST_Num::INT) {
@@ -1114,7 +1199,7 @@ private:
         }
     }
 
-    CompilerVariable* evalRepr(AST_Repr* node, UnwindInfo unw_info) {
+    CompilerVariable* evalRepr(AST_Repr* node, const UnwindInfo& unw_info) {
         CompilerVariable* var = evalExpr(node->value, unw_info);
         ConcreteCompilerVariable* cvar = var->makeConverted(emitter, var->getBoxType());
         var->decvref(emitter);
@@ -1127,7 +1212,7 @@ private:
         return new ConcreteCompilerVariable(STR, rtn, true);
     }
 
-    CompilerVariable* evalSet(AST_Set* node, UnwindInfo unw_info) {
+    CompilerVariable* evalSet(AST_Set* node, const UnwindInfo& unw_info) {
         std::vector<CompilerVariable*> elts;
         for (int i = 0; i < node->elts.size(); i++) {
             CompilerVariable* value = evalExpr(node->elts[i], unw_info);
@@ -1151,7 +1236,7 @@ private:
         return rtn;
     }
 
-    CompilerVariable* evalSlice(AST_Slice* node, UnwindInfo unw_info) {
+    CompilerVariable* evalSlice(AST_Slice* node, const UnwindInfo& unw_info) {
         CompilerVariable* start, *stop, *step;
         start = node->lower ? evalExpr(node->lower, unw_info) : getNone();
         stop = node->upper ? evalExpr(node->upper, unw_info) : getNone();
@@ -1177,7 +1262,7 @@ private:
         return new ConcreteCompilerVariable(SLICE, rtn, true);
     }
 
-    CompilerVariable* evalExtSlice(AST_ExtSlice* node, UnwindInfo unw_info) {
+    CompilerVariable* evalExtSlice(AST_ExtSlice* node, const UnwindInfo& unw_info) {
         std::vector<CompilerVariable*> elts;
         for (auto* e : node->dims) {
             elts.push_back(evalExpr(e, unw_info));
@@ -1191,7 +1276,7 @@ private:
         return rtn;
     }
 
-    CompilerVariable* evalStr(AST_Str* node, UnwindInfo unw_info) {
+    CompilerVariable* evalStr(AST_Str* node, const UnwindInfo& unw_info) {
         if (node->str_type == AST_Str::STR) {
             llvm::Value* rtn = embedRelocatablePtr(
                 irstate->getSourceInfo()->parent_module->getStringConstant(node->str_data), g.llvm_value_type_ptr);
@@ -1207,7 +1292,7 @@ private:
         }
     }
 
-    CompilerVariable* evalSubscript(AST_Subscript* node, UnwindInfo unw_info) {
+    CompilerVariable* evalSubscript(AST_Subscript* node, const UnwindInfo& unw_info) {
         CompilerVariable* value = evalExpr(node->value, unw_info);
         CompilerVariable* slice = evalExpr(node->slice, unw_info);
 
@@ -1217,7 +1302,7 @@ private:
         return rtn;
     }
 
-    CompilerVariable* evalTuple(AST_Tuple* node, UnwindInfo unw_info) {
+    CompilerVariable* evalTuple(AST_Tuple* node, const UnwindInfo& unw_info) {
         std::vector<CompilerVariable*> elts;
         for (int i = 0; i < node->elts.size(); i++) {
             CompilerVariable* value = evalExpr(node->elts[i], unw_info);
@@ -1232,7 +1317,7 @@ private:
         return rtn;
     }
 
-    CompilerVariable* evalUnaryOp(AST_UnaryOp* node, UnwindInfo unw_info) {
+    CompilerVariable* evalUnaryOp(AST_UnaryOp* node, const UnwindInfo& unw_info) {
         CompilerVariable* operand = evalExpr(node->operand, unw_info);
 
         if (node->op_type == AST_TYPE::Not) {
@@ -1259,7 +1344,7 @@ private:
         }
     }
 
-    CompilerVariable* evalYield(AST_Yield* node, UnwindInfo unw_info) {
+    CompilerVariable* evalYield(AST_Yield* node, const UnwindInfo& unw_info) {
         CompilerVariable* generator = symbol_table[internString(PASSED_GENERATOR_NAME)];
         assert(generator);
         ConcreteCompilerVariable* convertedGenerator = generator->makeConverted(emitter, generator->getBoxType());
@@ -1277,7 +1362,7 @@ private:
         return new ConcreteCompilerVariable(UNKNOWN, rtn, true);
     }
 
-    CompilerVariable* evalMakeClass(AST_MakeClass* mkclass, UnwindInfo unw_info) {
+    CompilerVariable* evalMakeClass(AST_MakeClass* mkclass, const UnwindInfo& unw_info) {
         assert(mkclass->type == AST_TYPE::MakeClass && mkclass->class_def->type == AST_TYPE::ClassDef);
         AST_ClassDef* node = mkclass->class_def;
         ScopeInfo* scope_info = irstate->getScopeInfoForNode(node);
@@ -1346,7 +1431,7 @@ private:
         return cls;
     }
 
-    CompilerVariable* _createFunction(AST* node, UnwindInfo unw_info, AST_arguments* args,
+    CompilerVariable* _createFunction(AST* node, const UnwindInfo& unw_info, AST_arguments* args,
                                       const std::vector<AST_stmt*>& body) {
         CLFunction* cl = wrapFunction(node, args, body, irstate->getSourceInfo());
 
@@ -1394,7 +1479,7 @@ private:
         return func;
     }
 
-    CompilerVariable* evalMakeFunction(AST_MakeFunction* mkfn, UnwindInfo unw_info) {
+    CompilerVariable* evalMakeFunction(AST_MakeFunction* mkfn, const UnwindInfo& unw_info) {
         AST_FunctionDef* node = mkfn->function_def;
         std::vector<CompilerVariable*> decorators;
         for (auto d : node->decorator_list) {
@@ -1429,7 +1514,7 @@ private:
         return new ConcreteCompilerVariable(t, v, grabbed);
     }
 
-    CompilerVariable* evalExpr(AST_expr* node, UnwindInfo unw_info) {
+    CompilerVariable* evalExpr(AST_expr* node, const UnwindInfo& unw_info) {
         // printf("%d expr: %d\n", node->type, node->lineno);
         if (node->lineno) {
             emitter.getBuilder()->SetCurrentDebugLocation(
@@ -1584,7 +1669,7 @@ private:
     }
 
     // only updates symbol_table if we're *not* setting a global
-    void _doSet(InternedString name, CompilerVariable* val, UnwindInfo unw_info) {
+    void _doSet(InternedString name, CompilerVariable* val, const UnwindInfo& unw_info) {
         assert(name.s() != "None");
         assert(name.s() != FRAME_INFO_PTR_NAME);
 
@@ -1632,13 +1717,13 @@ private:
         }
     }
 
-    void _doSetattr(AST_Attribute* target, CompilerVariable* val, UnwindInfo unw_info) {
+    void _doSetattr(AST_Attribute* target, CompilerVariable* val, const UnwindInfo& unw_info) {
         CompilerVariable* t = evalExpr(target->value, unw_info);
         t->setattr(emitter, getEmptyOpInfo(unw_info), target->attr.getBox(), val);
         t->decvref(emitter);
     }
 
-    void _doSetitem(AST_Subscript* target, CompilerVariable* val, UnwindInfo unw_info) {
+    void _doSetitem(AST_Subscript* target, CompilerVariable* val, const UnwindInfo& unw_info) {
         CompilerVariable* tget = evalExpr(target->value, unw_info);
         CompilerVariable* slice = evalExpr(target->slice, unw_info);
 
@@ -1672,7 +1757,7 @@ private:
         converted_val->decvref(emitter);
     }
 
-    void _doUnpackTuple(AST_Tuple* target, CompilerVariable* val, UnwindInfo unw_info) {
+    void _doUnpackTuple(AST_Tuple* target, CompilerVariable* val, const UnwindInfo& unw_info) {
         int ntargets = target->elts.size();
 
         std::vector<CompilerVariable*> unpacked = val->unpack(emitter, getOpInfoForNode(target, unw_info), ntargets);
@@ -1691,7 +1776,7 @@ private:
         }
     }
 
-    void _doSet(AST* target, CompilerVariable* val, UnwindInfo unw_info) {
+    void _doSet(AST* target, CompilerVariable* val, const UnwindInfo& unw_info) {
         switch (target->type) {
             case AST_TYPE::Attribute:
                 _doSetattr(ast_cast<AST_Attribute>(target), val, unw_info);
@@ -1711,7 +1796,7 @@ private:
         }
     }
 
-    void doAssert(AST_Assert* node, UnwindInfo unw_info) {
+    void doAssert(AST_Assert* node, const UnwindInfo& unw_info) {
         // cfg translates all asserts into only 'assert 0' on the failing path.
         AST_expr* test = node->test;
         assert(test->type == AST_TYPE::Num);
@@ -1740,7 +1825,7 @@ private:
         call.setDoesNotReturn();
     }
 
-    void doAssign(AST_Assign* node, UnwindInfo unw_info) {
+    void doAssign(AST_Assign* node, const UnwindInfo& unw_info) {
         CompilerVariable* val = evalExpr(node->value, unw_info);
 
         for (int i = 0; i < node->targets.size(); i++) {
@@ -1749,7 +1834,7 @@ private:
         val->decvref(emitter);
     }
 
-    void doDelete(AST_Delete* node, UnwindInfo unw_info) {
+    void doDelete(AST_Delete* node, const UnwindInfo& unw_info) {
         for (AST_expr* target : node->targets) {
             switch (target->type) {
                 case AST_TYPE::Subscript:
@@ -1769,7 +1854,7 @@ private:
     }
 
     // invoke delitem in objmodel.cpp, which will invoke the listDelitem of list
-    void _doDelitem(AST_Subscript* target, UnwindInfo unw_info) {
+    void _doDelitem(AST_Subscript* target, const UnwindInfo& unw_info) {
         CompilerVariable* tget = evalExpr(target->value, unw_info);
         CompilerVariable* slice = evalExpr(target->slice, unw_info);
 
@@ -1795,12 +1880,12 @@ private:
         converted_slice->decvref(emitter);
     }
 
-    void _doDelAttr(AST_Attribute* node, UnwindInfo unw_info) {
+    void _doDelAttr(AST_Attribute* node, const UnwindInfo& unw_info) {
         CompilerVariable* value = evalExpr(node->value, unw_info);
         value->delattr(emitter, getEmptyOpInfo(unw_info), node->attr.getBox());
     }
 
-    void _doDelName(AST_Name* target, UnwindInfo unw_info) {
+    void _doDelName(AST_Name* target, const UnwindInfo& unw_info) {
         auto scope_info = irstate->getScopeInfo();
         ScopeInfo::VarScopeType vst = scope_info->getScopeTypeOfName(target->id);
         if (vst == ScopeInfo::VarScopeType::GLOBAL) {
@@ -1845,7 +1930,7 @@ private:
         symbol_table.erase(target->id);
     }
 
-    void doExec(AST_Exec* node, UnwindInfo unw_info) {
+    void doExec(AST_Exec* node, const UnwindInfo& unw_info) {
         CompilerVariable* body = evalExpr(node->body, unw_info);
         llvm::Value* vbody = body->makeConverted(emitter, body->getBoxType())->getValue();
         body->decvref(emitter);
@@ -1873,7 +1958,7 @@ private:
                            { vbody, vglobals, vlocals, getConstantInt(irstate->getSourceInfo()->future_flags, g.i32) });
     }
 
-    void doPrint(AST_Print* node, UnwindInfo unw_info) {
+    void doPrint(AST_Print* node, const UnwindInfo& unw_info) {
         ConcreteCompilerVariable* dest = NULL;
         if (node->dest) {
             auto d = evalExpr(node->dest, unw_info);
@@ -1945,8 +2030,8 @@ private:
         dest->decvref(emitter);
     }
 
-    void doReturn(AST_Return* node, UnwindInfo unw_info) {
-        assert(!unw_info.needsInvoke());
+    void doReturn(AST_Return* node, const UnwindInfo& unw_info) {
+        assert(!unw_info.hasHandler());
 
         CompilerVariable* val;
         if (node->value == NULL) {
@@ -1984,8 +2069,8 @@ private:
         emitter.getBuilder()->CreateRet(rtn->getValue());
     }
 
-    void doBranch(AST_Branch* node, UnwindInfo unw_info) {
-        assert(!unw_info.needsInvoke());
+    void doBranch(AST_Branch* node, const UnwindInfo& unw_info) {
+        assert(!unw_info.hasHandler());
 
         assert(node->iftrue->idx > myblock->idx);
         assert(node->iffalse->idx > myblock->idx);
@@ -2007,7 +2092,7 @@ private:
         emitter.getBuilder()->CreateCondBr(v, iftrue, iffalse);
     }
 
-    void doExpr(AST_Expr* node, UnwindInfo unw_info) {
+    void doExpr(AST_Expr* node, const UnwindInfo& unw_info) {
         CompilerVariable* var = evalExpr(node->value, unw_info);
 
         var->decvref(emitter);
@@ -2179,7 +2264,7 @@ private:
         emitter.getBuilder()->SetInsertPoint(starting_block);
     }
 
-    void doJump(AST_Jump* node, UnwindInfo unw_info) {
+    void doJump(AST_Jump* node, const UnwindInfo& unw_info) {
         endBlock(FINISHED);
 
         llvm::BasicBlock* target = entry_blocks[node->target];
@@ -2192,7 +2277,7 @@ private:
         }
     }
 
-    void doRaise(AST_Raise* node, UnwindInfo unw_info) {
+    void doRaise(AST_Raise* node, const UnwindInfo& unw_info) {
         // It looks like ommitting the second and third arguments are equivalent to passing None,
         // but ommitting the first argument is *not* the same as passing None.
 
@@ -2225,7 +2310,7 @@ private:
         endBlock(DEAD);
     }
 
-    void doStmt(AST_stmt* node, UnwindInfo unw_info) {
+    void doStmt(AST_stmt* node, const UnwindInfo& unw_info) {
         // printf("%d stmt: %d\n", node->type, node->lineno);
         if (node->lineno) {
             emitter.getBuilder()->SetCurrentDebugLocation(
@@ -2267,21 +2352,27 @@ private:
                 doPrint(ast_cast<AST_Print>(node), unw_info);
                 break;
             case AST_TYPE::Return:
-                assert(!unw_info.needsInvoke());
+                assert(!unw_info.hasHandler());
                 doReturn(ast_cast<AST_Return>(node), unw_info);
                 break;
             case AST_TYPE::Branch:
-                assert(!unw_info.needsInvoke());
+                assert(!unw_info.hasHandler());
                 doBranch(ast_cast<AST_Branch>(node), unw_info);
                 break;
             case AST_TYPE::Jump:
-                assert(!unw_info.needsInvoke());
+                assert(!unw_info.hasHandler());
                 doJump(ast_cast<AST_Jump>(node), unw_info);
                 break;
             case AST_TYPE::Invoke: {
-                assert(!unw_info.needsInvoke());
+                assert(!unw_info.hasHandler());
                 AST_Invoke* invoke = ast_cast<AST_Invoke>(node);
-                doStmt(invoke->stmt, UnwindInfo(node, entry_blocks[invoke->exc_dest]));
+
+                ExceptionStyle landingpad_style = irstate->getLandingpadStyle(invoke);
+
+                if (landingpad_style == CXX)
+                    doStmt(invoke->stmt, UnwindInfo(node, NULL, entry_blocks[invoke->exc_dest]));
+                else
+                    doStmt(invoke->stmt, UnwindInfo(node, entry_blocks[invoke->exc_dest], NULL));
 
                 assert(state == RUNNING || state == DEAD);
                 if (state == RUNNING) {
@@ -2300,14 +2391,14 @@ private:
         }
     }
 
-    void loadArgument(InternedString name, ConcreteCompilerType* t, llvm::Value* v, UnwindInfo unw_info) {
+    void loadArgument(InternedString name, ConcreteCompilerType* t, llvm::Value* v, const UnwindInfo& unw_info) {
         assert(name.s() != FRAME_INFO_PTR_NAME);
         ConcreteCompilerVariable* var = unboxVar(t, v, false);
         _doSet(name, var, unw_info);
         var->decvref(emitter);
     }
 
-    void loadArgument(AST_expr* name, ConcreteCompilerType* t, llvm::Value* v, UnwindInfo unw_info) {
+    void loadArgument(AST_expr* name, ConcreteCompilerType* t, llvm::Value* v, const UnwindInfo& unw_info) {
         ConcreteCompilerVariable* var = unboxVar(t, v, false);
         _doSet(name, var, unw_info);
         var->decvref(emitter);
@@ -2656,7 +2747,7 @@ public:
                 doSafePoint(block->body[i]);
 #endif
 
-            doStmt(block->body[i], UnwindInfo(block->body[i], NULL));
+            doStmt(block->body[i], UnwindInfo(block->body[i], NULL, NULL));
         }
         if (VERBOSITY("irgenerator") >= 2) { // print ending symbol table
             printf("  %d fini:", block->idx);
@@ -2669,7 +2760,7 @@ public:
     void doSafePoint(AST_stmt* next_statement) override {
         // Unwind info is always needed in allowGLReadPreemption if it has any chance of
         // running arbitrary code like finalizers.
-        emitter.createCall(UnwindInfo(next_statement, NULL), g.funcs.allowGLReadPreemption);
+        emitter.createCall(UnwindInfo(next_statement, NULL, NULL), g.funcs.allowGLReadPreemption);
     }
 };
 

--- a/src/codegen/irgen/irgenerator.cpp
+++ b/src/codegen/irgen/irgenerator.cpp
@@ -106,6 +106,35 @@ ExceptionStyle IRGenState::getLandingpadStyle(AST_Invoke* invoke) {
     // printf("Added %d\n", invoke->exc_dest->idx);
 
     r = CXX; // default
+
+    // print_ast(invoke);
+    // printf("\n");
+    AST_expr* expr = NULL;
+
+    if (invoke->stmt->type == AST_TYPE::Assign) {
+        expr = ast_cast<AST_Assign>(invoke->stmt)->value;
+    } else if (invoke->stmt->type == AST_TYPE::Expr) {
+        expr = ast_cast<AST_Expr>(invoke->stmt)->value;
+    }
+
+    if (!expr)
+        return r;
+
+    if (0 && expr->type == AST_TYPE::Call) {
+        AST_Call* call = ast_cast<AST_Call>(expr);
+        if (call->func->type != AST_TYPE::Attribute && call->func->type != AST_TYPE::ClsAttribute) {
+            r = CAPI;
+            // printf("Doing a capi exception to %d\n", invoke->exc_dest->idx);
+        }
+        return r;
+    }
+
+    if (expr->type == AST_TYPE::Attribute) {
+        r = CAPI;
+        // printf("Doing a capi exception to %d\n", invoke->exc_dest->idx);
+        return r;
+    }
+
     return r;
 }
 

--- a/src/codegen/irgen/irgenerator.h
+++ b/src/codegen/irgen/irgenerator.h
@@ -17,6 +17,7 @@
 
 #include <map>
 
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/iterator_range.h"
 #include "llvm/IR/Instructions.h"
 
@@ -33,6 +34,7 @@ class MDNode;
 
 namespace pyston {
 
+class AST_Invoke;
 class CFGBlock;
 class GCBuilder;
 struct PatchpointInfo;
@@ -70,6 +72,7 @@ private:
     llvm::Value* frame_info_arg;
     int scratch_size;
 
+    llvm::DenseMap<CFGBlock*, ExceptionStyle> landingpad_styles;
 
 public:
     IRGenState(CLFunction* clfunc, CompiledFunction* cf, SourceInfo* source_info, std::unique_ptr<PhiAnalysis> phis,
@@ -104,6 +107,9 @@ public:
     ParamNames* getParamNames() { return param_names; }
 
     void setFrameInfoArgument(llvm::Value* v) { frame_info_arg = v; }
+
+    ExceptionStyle getLandingpadStyle(AST_Invoke* invoke);
+    ExceptionStyle getLandingpadStyle(CFGBlock* block);
 };
 
 // turns CFGBlocks into LLVM IR

--- a/src/codegen/runtime_hooks.cpp
+++ b/src/codegen/runtime_hooks.cpp
@@ -195,6 +195,7 @@ void initGlobalFuncs(GlobalState& g) {
     GET(createSet);
 
     GET(getattr);
+    GET(getattr_capi);
     GET(setattr);
     GET(delattr);
     GET(getitem);
@@ -223,6 +224,8 @@ void initGlobalFuncs(GlobalState& g) {
     GET(unpackIntoArray);
     GET(raiseAttributeError);
     GET(raiseAttributeErrorStr);
+    GET(raiseAttributeErrorCapi);
+    GET(raiseAttributeErrorStrCapi);
     GET(raiseIndexErrorStr);
     GET(raiseNotIterableError);
     GET(assertNameDefined);

--- a/src/codegen/runtime_hooks.cpp
+++ b/src/codegen/runtime_hooks.cpp
@@ -270,6 +270,9 @@ void initGlobalFuncs(GlobalState& g) {
     g.funcs.__cxa_end_catch = addFunc((void*)__cxa_end_catch, g.void_);
     GET(raise0);
     GET(raise3);
+    GET(PyErr_Fetch);
+    GET(PyErr_NormalizeException);
+    GET(capiExcCaughtInJit);
     GET(deopt);
 
     GET(div_float_float);

--- a/src/codegen/runtime_hooks.h
+++ b/src/codegen/runtime_hooks.h
@@ -50,6 +50,7 @@ struct GlobalFuncs {
 
     llvm::Value* __cxa_end_catch;
     llvm::Value* raise0, *raise3;
+    llvm::Value* PyErr_Fetch, *PyErr_NormalizeException, *capiExcCaughtInJit;
     llvm::Value* deopt;
 
     llvm::Value* div_float_float, *floordiv_float_float, *mod_float_float, *pow_float_float;

--- a/src/codegen/runtime_hooks.h
+++ b/src/codegen/runtime_hooks.h
@@ -35,12 +35,13 @@ struct GlobalFuncs {
     llvm::Value* boxInt, *unboxInt, *boxFloat, *unboxFloat, *boxCLFunction, *unboxCLFunction, *boxInstanceMethod,
         *boxBool, *unboxBool, *createTuple, *createDict, *createList, *createSlice, *createUserClass, *createClosure,
         *createGenerator, *createSet;
-    llvm::Value* getattr, *setattr, *delattr, *delitem, *delGlobal, *nonzero, *binop, *compare, *augbinop, *unboxedLen,
-        *getitem, *getclsattr, *getGlobal, *setitem, *unaryop, *import, *importFrom, *importStar, *repr, *str,
-        *strOrUnicode, *exceptionMatches, *yield, *getiterHelper, *hasnext;
+    llvm::Value* getattr, *getattr_capi, *setattr, *delattr, *delitem, *delGlobal, *nonzero, *binop, *compare,
+        *augbinop, *unboxedLen, *getitem, *getclsattr, *getGlobal, *setitem, *unaryop, *import, *importFrom,
+        *importStar, *repr, *str, *strOrUnicode, *exceptionMatches, *yield, *getiterHelper, *hasnext;
 
-    llvm::Value* unpackIntoArray, *raiseAttributeError, *raiseAttributeErrorStr, *raiseNotIterableError,
-        *raiseIndexErrorStr, *assertNameDefined, *assertFail, *assertFailDerefNameDefined;
+    llvm::Value* unpackIntoArray, *raiseAttributeError, *raiseAttributeErrorStr, *raiseAttributeErrorCapi,
+        *raiseAttributeErrorStrCapi, *raiseNotIterableError, *raiseIndexErrorStr, *assertNameDefined, *assertFail,
+        *assertFailDerefNameDefined;
     llvm::Value* printFloat, *listAppendInternal, *getSysStdout;
     llvm::Value* runtimeCall0, *runtimeCall1, *runtimeCall2, *runtimeCall3, *runtimeCall, *runtimeCallN;
     llvm::Value* callattr0, *callattr1, *callattr2, *callattr3, *callattr, *callattrN;

--- a/src/codegen/unwinding.cpp
+++ b/src/codegen/unwinding.cpp
@@ -603,6 +603,14 @@ static const LineInfo lineInfoForFrame(PythonFrameIteratorImpl* frame_it) {
     return LineInfo(current_stmt->lineno, current_stmt->col_offset, source->fn, source->getName());
 }
 
+extern "C" void capiExcCaughtInJit(AST_stmt* stmt, void* _source_info) {
+    SourceInfo* source = static_cast<SourceInfo*>(_source_info);
+    // TODO: handle reraise (currently on the ExcInfo object)
+    PyThreadState* tstate = PyThreadState_GET();
+    BoxedTraceback::here(LineInfo(stmt->lineno, stmt->col_offset, source->fn, source->getName()),
+                         &tstate->curexc_traceback);
+}
+
 void exceptionCaughtInInterpreter(LineInfo line_info, ExcInfo* exc_info) {
     static StatCounter frames_unwound("num_frames_unwound_python");
     frames_unwound.log();

--- a/src/core/stats.cpp
+++ b/src/core/stats.cpp
@@ -104,9 +104,6 @@ void Stats::clear() {
 }
 
 void Stats::startEstimatingCPUFreq() {
-    if (!Stats::enabled)
-        return;
-
     clock_gettime(CLOCK_REALTIME, &Stats::start_ts);
     Stats::start_tick = getCPUTicks();
 }

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -68,11 +68,9 @@ enum class EffortLevel {
     MAXIMAL = 3,
 };
 
-namespace ExceptionStyle {
 enum ExceptionStyle {
     CAPI,
     CXX,
-};
 };
 
 template <typename R, typename... Args> struct ExceptionSwitchableFunction {
@@ -83,13 +81,13 @@ public:
 
     ExceptionSwitchableFunction(FTy capi_ptr, FTy cxx_ptr) : capi_ptr(capi_ptr), cxx_ptr(cxx_ptr) {}
 
-    template <ExceptionStyle::ExceptionStyle S> FTy get() {
-        if (S == ExceptionStyle::CAPI)
+    template <ExceptionStyle S> FTy get() {
+        if (S == CAPI)
             return capi_ptr;
         else
             return cxx_ptr;
     }
-    template <ExceptionStyle::ExceptionStyle S> R call(Args... args) noexcept(S == ExceptionStyle::CAPI) {
+    template <ExceptionStyle S> R call(Args... args) noexcept(S == ExceptionStyle::CAPI) {
         return get()(args...);
     }
 };
@@ -283,7 +281,7 @@ public:
     int code_size;
 
     EffortLevel effort;
-    ExceptionStyle::ExceptionStyle exception_style;
+    ExceptionStyle exception_style;
 
     int64_t times_called, times_speculation_failed;
     ICInvalidator dependent_callsites;
@@ -293,7 +291,7 @@ public:
     std::vector<ICInfo*> ics;
 
     CompiledFunction(llvm::Function* func, FunctionSpecialization* spec, void* code, EffortLevel effort,
-                     ExceptionStyle::ExceptionStyle exception_style, const OSREntryDescriptor* entry_descriptor);
+                     ExceptionStyle exception_style, const OSREntryDescriptor* entry_descriptor);
 
     ConcreteCompilerType* getReturnType();
 
@@ -414,15 +412,12 @@ CLFunction* createRTFunction(int num_args, int num_defaults, bool takes_varargs,
                              const ParamNames& param_names = ParamNames::empty());
 CLFunction* boxRTFunction(void* f, ConcreteCompilerType* rtn_type, int nargs, int num_defaults, bool takes_varargs,
                           bool takes_kwargs, const ParamNames& param_names = ParamNames::empty(),
-                          ExceptionStyle::ExceptionStyle exception_style = ExceptionStyle::CXX);
+                          ExceptionStyle exception_style = CXX);
 CLFunction* boxRTFunction(void* f, ConcreteCompilerType* rtn_type, int nargs,
-                          const ParamNames& param_names = ParamNames::empty(),
-                          ExceptionStyle::ExceptionStyle exception_style = ExceptionStyle::CXX);
+                          const ParamNames& param_names = ParamNames::empty(), ExceptionStyle exception_style = CXX);
+void addRTFunction(CLFunction* cf, void* f, ConcreteCompilerType* rtn_type, ExceptionStyle exception_style = CXX);
 void addRTFunction(CLFunction* cf, void* f, ConcreteCompilerType* rtn_type,
-                   ExceptionStyle::ExceptionStyle exception_style = ExceptionStyle::CXX);
-void addRTFunction(CLFunction* cf, void* f, ConcreteCompilerType* rtn_type,
-                   const std::vector<ConcreteCompilerType*>& arg_types,
-                   ExceptionStyle::ExceptionStyle exception_style = ExceptionStyle::CXX);
+                   const std::vector<ConcreteCompilerType*>& arg_types, ExceptionStyle exception_style = CXX);
 CLFunction* unboxRTFunction(Box*);
 
 // Compiles a new version of the function with the given signature and adds it to the list;

--- a/src/runtime/builtin_modules/builtins.cpp
+++ b/src/runtime/builtin_modules/builtins.cpp
@@ -1382,7 +1382,7 @@ void setupBuiltins() {
     builtins_module->giveAttr("repr", repr_obj);
 
     auto len_func = boxRTFunction((void*)len, UNKNOWN, 1);
-    len_func->internal_callable.cxx_ptr = lenCallInternal;
+    len_func->internal_callable.cxx_val = lenCallInternal;
     len_obj = new BoxedBuiltinFunctionOrMethod(len_func, "len");
     builtins_module->giveAttr("len", len_obj);
 

--- a/src/runtime/capi.cpp
+++ b/src/runtime/capi.cpp
@@ -786,6 +786,11 @@ void setCAPIException(const ExcInfo& e) {
     cur_thread_state.curexc_traceback = e.traceback;
 }
 
+void ensureCAPIExceptionSet() {
+    if (!cur_thread_state.curexc_type)
+        PyErr_SetString(SystemError, "error return without exception set");
+}
+
 void throwCAPIException() {
     checkAndThrowCAPIException();
     raiseExcHelper(SystemError, "error return without exception set");

--- a/src/runtime/dict.cpp
+++ b/src/runtime/dict.cpp
@@ -27,9 +27,6 @@
 
 namespace pyston {
 
-using namespace pyston::ExceptionStyle;
-using pyston::ExceptionStyle::ExceptionStyle;
-
 Box* dictRepr(BoxedDict* self) {
     std::vector<char> chars;
     chars.push_back('{');

--- a/src/runtime/inline/link_forcer.cpp
+++ b/src/runtime/inline/link_forcer.cpp
@@ -117,6 +117,9 @@ void force() {
 
     FORCE(raise0);
     FORCE(raise3);
+    FORCE(PyErr_Fetch);
+    FORCE(PyErr_NormalizeException);
+    FORCE(capiExcCaughtInJit);
     FORCE(deopt);
 
     FORCE(div_i64_i64);

--- a/src/runtime/inline/link_forcer.cpp
+++ b/src/runtime/inline/link_forcer.cpp
@@ -74,6 +74,7 @@ void force() {
     FORCE(decodeUTF8StringPtr);
 
     FORCE(getattr);
+    FORCE(getattr_capi);
     FORCE(setattr);
     FORCE(delattr);
     FORCE(nonzero);
@@ -101,6 +102,8 @@ void force() {
     FORCE(unpackIntoArray);
     FORCE(raiseAttributeError);
     FORCE(raiseAttributeErrorStr);
+    FORCE(raiseAttributeErrorCapi);
+    FORCE(raiseAttributeErrorStrCapi);
     FORCE(raiseIndexErrorStr);
     FORCE(raiseNotIterableError);
     FORCE(assertNameDefined);

--- a/src/runtime/inline/list.cpp
+++ b/src/runtime/inline/list.cpp
@@ -22,9 +22,6 @@
 
 namespace pyston {
 
-using namespace pyston::ExceptionStyle;
-using pyston::ExceptionStyle::ExceptionStyle;
-
 BoxedListIterator::BoxedListIterator(BoxedList* l, int start) : l(l), pos(start) {
 }
 
@@ -68,7 +65,7 @@ i1 listiterHasnextUnboxed(Box* s) {
     return ans;
 }
 
-template <enum ExceptionStyle S> Box* listiterNext(Box* s) noexcept(S == CAPI) {
+template <ExceptionStyle S> Box* listiterNext(Box* s) noexcept(S == CAPI) {
     assert(s->cls == list_iterator_cls);
     BoxedListIterator* self = static_cast<BoxedListIterator*>(s);
 

--- a/src/runtime/list.cpp
+++ b/src/runtime/list.cpp
@@ -704,7 +704,7 @@ private:
 public:
     PyCmpComparer(Box* cmp) : cmp(cmp) {}
     bool operator()(Box* lhs, Box* rhs) {
-        Box* r = runtimeCallInternal<ExceptionStyle::CXX>(cmp, NULL, ArgPassSpec(2), lhs, rhs, NULL, NULL, NULL);
+        Box* r = runtimeCallInternal<CXX>(cmp, NULL, ArgPassSpec(2), lhs, rhs, NULL, NULL, NULL);
         if (!isSubclass(r->cls, int_cls))
             raiseExcHelper(TypeError, "comparison function must return int, not %.200s", r->cls->tp_name);
         return static_cast<BoxedInt*>(r)->n < 0;
@@ -1170,8 +1170,8 @@ void setupList() {
     list_iterator_cls->giveAttr(
         "__iter__", new BoxedFunction(boxRTFunction((void*)listIterIter, typeFromClass(list_iterator_cls), 1)));
 
-    CLFunction* listiter_next = boxRTFunction((void*)listiterNext<ExceptionStyle::CXX>, UNKNOWN, 1);
-    addRTFunction(listiter_next, (void*)listiterNext<ExceptionStyle::CAPI>, UNKNOWN, ExceptionStyle::CAPI);
+    CLFunction* listiter_next = boxRTFunction((void*)listiterNext<CXX>, UNKNOWN, 1);
+    addRTFunction(listiter_next, (void*)listiterNext<CAPI>, UNKNOWN, CAPI);
     list_iterator_cls->giveAttr("next", new BoxedFunction(listiter_next));
 
     list_iterator_cls->freeze();

--- a/src/runtime/list.h
+++ b/src/runtime/list.h
@@ -35,7 +35,7 @@ Box* listIter(Box* self);
 Box* listIterIter(Box* self);
 Box* listiterHasnext(Box* self);
 i1 listiterHasnextUnboxed(Box* self);
-template <ExceptionStyle::ExceptionStyle S> Box* listiterNext(Box* self) noexcept(S == ExceptionStyle::CAPI);
+template <ExceptionStyle S> Box* listiterNext(Box* self) noexcept(S == CAPI);
 Box* listReversed(Box* self);
 Box* listreviterHasnext(Box* self);
 i1 listreviterHasnextUnboxed(Box* self);

--- a/src/runtime/objmodel.cpp
+++ b/src/runtime/objmodel.cpp
@@ -60,9 +60,6 @@
 
 namespace pyston {
 
-using namespace pyston::ExceptionStyle;
-using pyston::ExceptionStyle::ExceptionStyle;
-
 static const std::string iter_str("__iter__");
 static const std::string new_str("__new__");
 static const std::string none_str("None");
@@ -76,20 +73,20 @@ void REWRITE_ABORTED(const char* reason) {
 #define REWRITE_ABORTED(reason) ((void)(reason))
 #endif
 
-template <enum ExceptionStyle S>
+template <ExceptionStyle S>
 static inline Box* runtimeCallInternal0(Box* obj, CallRewriteArgs* rewrite_args, ArgPassSpec argspec) {
     return runtimeCallInternal<S>(obj, rewrite_args, argspec, NULL, NULL, NULL, NULL, NULL);
 }
-template <enum ExceptionStyle S>
+template <ExceptionStyle S>
 static inline Box* runtimeCallInternal1(Box* obj, CallRewriteArgs* rewrite_args, ArgPassSpec argspec, Box* arg1) {
     return runtimeCallInternal<S>(obj, rewrite_args, argspec, arg1, NULL, NULL, NULL, NULL);
 }
-template <enum ExceptionStyle S>
+template <ExceptionStyle S>
 static inline Box* runtimeCallInternal2(Box* obj, CallRewriteArgs* rewrite_args, ArgPassSpec argspec, Box* arg1,
                                         Box* arg2) {
     return runtimeCallInternal<S>(obj, rewrite_args, argspec, arg1, arg2, NULL, NULL, NULL);
 }
-template <enum ExceptionStyle S>
+template <ExceptionStyle S>
 static inline Box* runtimeCallInternal3(Box* obj, CallRewriteArgs* rewrite_args, ArgPassSpec argspec, Box* arg1,
                                         Box* arg2, Box* arg3) {
     return runtimeCallInternal<S>(obj, rewrite_args, argspec, arg1, arg2, arg3, NULL, NULL);
@@ -1342,9 +1339,9 @@ Box* dataDescriptorInstanceSpecialCases(GetattrRewriteArgs* rewrite_args, BoxedS
     return NULL;
 }
 
-template <enum ExceptionStyle S>
+template <ExceptionStyle S>
 Box* getattrInternalEx(Box* obj, BoxedString* attr, GetattrRewriteArgs* rewrite_args, bool cls_only, bool for_call,
-                       Box** bind_obj_out, RewriterVar** r_bind_obj_out) noexcept(S == ExceptionStyle::CAPI) {
+                       Box** bind_obj_out, RewriterVar** r_bind_obj_out) noexcept(S == CAPI) {
     assert(gc::isValidGCObject(attr));
 
     if (S == CAPI) {
@@ -1848,9 +1845,8 @@ Box* getattrInternalGeneric(Box* obj, BoxedString* attr, GetattrRewriteArgs* rew
     return NULL;
 }
 
-template <enum ExceptionStyle S>
-Box* getattrInternal(Box* obj, BoxedString* attr,
-                     GetattrRewriteArgs* rewrite_args) noexcept(S == ExceptionStyle::CAPI) {
+template <ExceptionStyle S>
+Box* getattrInternal(Box* obj, BoxedString* attr, GetattrRewriteArgs* rewrite_args) noexcept(S == CAPI) {
     return getattrInternalEx<S>(obj, attr, rewrite_args,
                                 /* cls_only */ false,
                                 /* for_call */ false, NULL, NULL);
@@ -2458,8 +2454,7 @@ extern "C" BoxedInt* hash(Box* obj) {
     return new BoxedInt(r);
 }
 
-template <enum ExceptionStyle S>
-BoxedInt* lenInternal(Box* obj, LenRewriteArgs* rewrite_args) noexcept(S == ExceptionStyle::CAPI) {
+template <ExceptionStyle S> BoxedInt* lenInternal(Box* obj, LenRewriteArgs* rewrite_args) noexcept(S == CAPI) {
     static BoxedString* len_str = internStringImmortal("__len__");
 
     if (S == CAPI) {
@@ -2793,7 +2788,7 @@ static inline RewriterVar* getArg(int idx, CallRewriteArgs* rewrite_args) {
 }
 
 static StatCounter slowpath_pickversion("slowpath_pickversion");
-static CompiledFunction* pickVersion(CLFunction* f, enum ExceptionStyle S, int num_output_args, Box* oarg1, Box* oarg2,
+static CompiledFunction* pickVersion(CLFunction* f, ExceptionStyle S, int num_output_args, Box* oarg1, Box* oarg2,
                                      Box* oarg3, Box** oargs) {
     LOCK_REGION(codegen_rwlock.asWrite());
 
@@ -3256,7 +3251,7 @@ void rearrangeArguments(ParamReceiveSpec paramspec, const ParamNames* param_name
 }
 
 static StatCounter slowpath_callfunc("slowpath_callfunc");
-template <enum ExceptionStyle S>
+template <ExceptionStyle S>
 Box* callFunc(BoxedFunctionBase* func, CallRewriteArgs* rewrite_args, ArgPassSpec argspec, Box* arg1, Box* arg2,
               Box* arg3, Box** args, const std::vector<BoxedString*>* keyword_names) noexcept(S == CAPI) {
 #if STAT_TIMERS
@@ -3389,7 +3384,7 @@ Box* callFunc(BoxedFunctionBase* func, CallRewriteArgs* rewrite_args, ArgPassSpe
     return res;
 }
 
-template <enum ExceptionStyle S>
+template <ExceptionStyle S>
 static Box* callChosenCF(CompiledFunction* chosen_cf, BoxedClosure* closure, BoxedGenerator* generator, Box* oarg1,
                          Box* oarg2, Box* oarg3, Box** oargs) noexcept(S == CAPI) {
     if (S != chosen_cf->exception_style) {
@@ -3431,7 +3426,7 @@ static Box* astInterpretHelper(CLFunction* f, int num_args, BoxedClosure* closur
     return astInterpretFunction(f, num_args, closure, generator, globals, arg1, arg2, arg3, (Box**)args);
 }
 
-template <enum ExceptionStyle S>
+template <ExceptionStyle S>
 Box* callCLFunc(CLFunction* f, CallRewriteArgs* rewrite_args, int num_output_args, BoxedClosure* closure,
                 BoxedGenerator* generator, Box* globals, Box* oarg1, Box* oarg2, Box* oarg3,
                 Box** oargs) noexcept(S == CAPI) {
@@ -3543,7 +3538,7 @@ template Box* callCLFunc<CAPI>(CLFunction* f, CallRewriteArgs* rewrite_args, int
 template Box* callCLFunc<CXX>(CLFunction* f, CallRewriteArgs* rewrite_args, int num_output_args, BoxedClosure* closure,
                               BoxedGenerator* generator, Box* globals, Box* oarg1, Box* oarg2, Box* oarg3, Box** oargs);
 
-template <enum ExceptionStyle S>
+template <ExceptionStyle S>
 Box* runtimeCallInternal(Box* obj, CallRewriteArgs* rewrite_args, ArgPassSpec argspec, Box* arg1, Box* arg2, Box* arg3,
                          Box** args, const std::vector<BoxedString*>* keyword_names) noexcept(S == CAPI) {
     int npassed_args = argspec.totalPassed();
@@ -4416,8 +4411,8 @@ Box* callItemOrSliceAttr(Box* target, BoxedString* item_str, BoxedString* slice_
     }
 }
 
-template <enum ExceptionStyle S>
-Box* getitemInternal(Box* target, Box* slice, GetitemRewriteArgs* rewrite_args) noexcept(S == ExceptionStyle::CAPI) {
+template <ExceptionStyle S>
+Box* getitemInternal(Box* target, Box* slice, GetitemRewriteArgs* rewrite_args) noexcept(S == CAPI) {
     if (S == CAPI) {
         assert(!rewrite_args && "implement me");
         rewrite_args = NULL;

--- a/src/runtime/objmodel.h
+++ b/src/runtime/objmodel.h
@@ -55,6 +55,7 @@ extern "C" bool softspace(Box* b, bool newval);
 extern "C" void printHelper(Box* dest, Box* var, bool nl);
 extern "C" void my_assert(bool b);
 extern "C" Box* getattr(Box* obj, BoxedString* attr);
+extern "C" Box* getattr_capi(Box* obj, BoxedString* attr) noexcept;
 extern "C" Box* getattrMaybeNonstring(Box* obj, Box* attr);
 extern "C" void setattr(Box* obj, BoxedString* attr, Box* attr_val);
 extern "C" void setattrMaybeNonstring(Box* obj, Box* attr, Box* attr_val);
@@ -153,6 +154,8 @@ Box* typeLookup(BoxedClass* cls, BoxedString* attr, GetattrRewriteArgs* rewrite_
 
 extern "C" void raiseAttributeErrorStr(const char* typeName, llvm::StringRef attr) __attribute__((__noreturn__));
 extern "C" void raiseAttributeError(Box* obj, llvm::StringRef attr) __attribute__((__noreturn__));
+extern "C" void raiseAttributeErrorStrCapi(const char* typeName, llvm::StringRef attr) noexcept;
+extern "C" void raiseAttributeErrorCapi(Box* obj, llvm::StringRef attr) noexcept;
 extern "C" void raiseNotIterableError(const char* typeName) __attribute__((__noreturn__));
 extern "C" void raiseIndexErrorStr(const char* typeName) __attribute__((__noreturn__));
 

--- a/src/runtime/objmodel.h
+++ b/src/runtime/objmodel.h
@@ -107,25 +107,22 @@ struct BinopRewriteArgs;
 extern "C" Box* binopInternal(Box* lhs, Box* rhs, int op_type, bool inplace, BinopRewriteArgs* rewrite_args);
 
 struct CallRewriteArgs;
-template <ExceptionStyle::ExceptionStyle S>
+template <ExceptionStyle S>
 Box* runtimeCallInternal(Box* obj, CallRewriteArgs* rewrite_args, ArgPassSpec argspec, Box* arg1, Box* arg2, Box* arg3,
-                         Box** args,
-                         const std::vector<BoxedString*>* keyword_names) noexcept(S == ExceptionStyle::CAPI);
+                         Box** args, const std::vector<BoxedString*>* keyword_names) noexcept(S == CAPI);
 
 struct GetitemRewriteArgs;
-template <ExceptionStyle::ExceptionStyle S>
-Box* getitemInternal(Box* target, Box* slice, GetitemRewriteArgs* rewrite_args) noexcept(S == ExceptionStyle::CAPI);
+template <ExceptionStyle S>
+Box* getitemInternal(Box* target, Box* slice, GetitemRewriteArgs* rewrite_args) noexcept(S == CAPI);
 
 struct LenRewriteArgs;
-template <ExceptionStyle::ExceptionStyle S>
-BoxedInt* lenInternal(Box* obj, LenRewriteArgs* rewrite_args) noexcept(S == ExceptionStyle::CAPI);
+template <ExceptionStyle S> BoxedInt* lenInternal(Box* obj, LenRewriteArgs* rewrite_args) noexcept(S == CAPI);
 Box* lenCallInternal(BoxedFunctionBase* f, CallRewriteArgs* rewrite_args, ArgPassSpec argspec, Box* arg1, Box* arg2,
                      Box* arg3, Box** args, const std::vector<BoxedString*>* keyword_names);
 
-template <ExceptionStyle::ExceptionStyle S>
+template <ExceptionStyle S>
 Box* callFunc(BoxedFunctionBase* func, CallRewriteArgs* rewrite_args, ArgPassSpec argspec, Box* arg1, Box* arg2,
-              Box* arg3, Box** args,
-              const std::vector<BoxedString*>* keyword_names) noexcept(S == ExceptionStyle::CAPI);
+              Box* arg3, Box** args, const std::vector<BoxedString*>* keyword_names) noexcept(S == CAPI);
 
 enum LookupScope {
     CLASS_ONLY = 1,
@@ -141,8 +138,8 @@ Box* compareInternal(Box* lhs, Box* rhs, int op_type, CompareRewriteArgs* rewrit
 
 // This is the equivalent of PyObject_GetAttr. Unlike getattrInternalGeneric, it checks for custom __getattr__ or
 // __getattribute__ methods.
-template <ExceptionStyle::ExceptionStyle S>
-Box* getattrInternal(Box* obj, BoxedString* attr, GetattrRewriteArgs* rewrite_args) noexcept(S == ExceptionStyle::CAPI);
+template <ExceptionStyle S>
+Box* getattrInternal(Box* obj, BoxedString* attr, GetattrRewriteArgs* rewrite_args) noexcept(S == CAPI);
 
 // This is the equivalent of PyObject_GenericGetAttr, which performs the default lookup rules for getattr() (check for
 // data descriptor, check for instance attribute, check for non-data descriptor). It does not check for __getattr__ or
@@ -168,10 +165,10 @@ Box* typeNew(Box* cls, Box* arg1, Box* arg2, Box** _args);
 Box* processDescriptor(Box* obj, Box* inst, Box* owner);
 Box* processDescriptorOrNull(Box* obj, Box* inst, Box* owner);
 
-template <ExceptionStyle::ExceptionStyle S>
+template <ExceptionStyle S>
 Box* callCLFunc(CLFunction* f, CallRewriteArgs* rewrite_args, int num_output_args, BoxedClosure* closure,
                 BoxedGenerator* generator, Box* globals, Box* oarg1, Box* oarg2, Box* oarg3,
-                Box** oargs) noexcept(S == ExceptionStyle::CAPI);
+                Box** oargs) noexcept(S == CAPI);
 
 static const char* objectNewParameterTypeErrorMsg() {
     if (PYTHON_VERSION_HEX >= version_hex(2, 7, 4)) {

--- a/src/runtime/types.cpp
+++ b/src/runtime/types.cpp
@@ -639,7 +639,7 @@ static Box* typeCallInternal(BoxedFunctionBase* f, CallRewriteArgs* rewrite_args
     if (argspec.has_starargs || argspec.num_args == 0) {
         // Get callFunc to expand the arguments.
         // TODO: update this to use rearrangeArguments instead.
-        return callFunc<ExceptionStyle::CXX>(f, rewrite_args, argspec, arg1, arg2, arg3, args, keyword_names);
+        return callFunc<CXX>(f, rewrite_args, argspec, arg1, arg2, arg3, args, keyword_names);
     }
 
     return typeCallInner(rewrite_args, argspec, arg1, arg2, arg3, args, keyword_names);
@@ -997,8 +997,8 @@ static Box* typeCallInner(CallRewriteArgs* rewrite_args, ArgPassSpec argspec, Bo
             if (new_npassed_args >= 4)
                 srewrite_args.args = rewrite_args->args;
 
-            made = runtimeCallInternal<ExceptionStyle::CXX>(new_attr, &srewrite_args, new_argspec, cls, arg2, arg3,
-                                                            args, keyword_names);
+            made
+                = runtimeCallInternal<CXX>(new_attr, &srewrite_args, new_argspec, cls, arg2, arg3, args, keyword_names);
 
             if (!srewrite_args.out_success) {
                 rewrite_args = NULL;
@@ -1015,8 +1015,7 @@ static Box* typeCallInner(CallRewriteArgs* rewrite_args, ArgPassSpec argspec, Bo
         if (cls->tp_new == object_cls->tp_new && cls->tp_init != object_cls->tp_init)
             made = objectNewNoArgs(cls);
         else
-            made = runtimeCallInternal<ExceptionStyle::CXX>(new_attr, NULL, new_argspec, cls, arg2, arg3, args,
-                                                            keyword_names);
+            made = runtimeCallInternal<CXX>(new_attr, NULL, new_argspec, cls, arg2, arg3, args, keyword_names);
     }
 
     assert(made);
@@ -1066,8 +1065,8 @@ static Box* typeCallInner(CallRewriteArgs* rewrite_args, ArgPassSpec argspec, Bo
 
             // initrtn = callattrInternal(cls, _init_str, INST_ONLY, &srewrite_args, argspec, made, arg2, arg3, args,
             // keyword_names);
-            initrtn = runtimeCallInternal<ExceptionStyle::CXX>(init_attr, &srewrite_args, argspec, made, arg2, arg3,
-                                                               args, keyword_names);
+            initrtn
+                = runtimeCallInternal<CXX>(init_attr, &srewrite_args, argspec, made, arg2, arg3, args, keyword_names);
 
             if (!srewrite_args.out_success) {
                 rewrite_args = NULL;
@@ -1086,11 +1085,11 @@ static Box* typeCallInner(CallRewriteArgs* rewrite_args, ArgPassSpec argspec, Bo
 
             // If we weren't passed the args array, it's not safe to index into it
             if (passed <= 2)
-                initrtn = runtimeCallInternal<ExceptionStyle::CXX>(init_attr, NULL, init_argspec, arg2, arg3, NULL,
-                                                                   NULL, keyword_names);
+                initrtn
+                    = runtimeCallInternal<CXX>(init_attr, NULL, init_argspec, arg2, arg3, NULL, NULL, keyword_names);
             else
-                initrtn = runtimeCallInternal<ExceptionStyle::CXX>(init_attr, NULL, init_argspec, arg2, arg3, args[0],
-                                                                   &args[1], keyword_names);
+                initrtn = runtimeCallInternal<CXX>(init_attr, NULL, init_argspec, arg2, arg3, args[0], &args[1],
+                                                   keyword_names);
         }
         assertInitNone(initrtn);
     } else {
@@ -1659,7 +1658,7 @@ static Box* instancemethodRepr(Box* b) {
     const char* sfuncname = "?", * sklassname = "?";
 
     static BoxedString* name_str = internStringImmortal("__name__");
-    funcname = getattrInternal<ExceptionStyle::CXX>(func, name_str, NULL);
+    funcname = getattrInternal<CXX>(func, name_str, NULL);
 
     if (funcname != NULL) {
         if (!PyString_Check(funcname)) {
@@ -1671,7 +1670,7 @@ static Box* instancemethodRepr(Box* b) {
     if (klass == NULL) {
         klassname = NULL;
     } else {
-        klassname = getattrInternal<ExceptionStyle::CXX>(klass, name_str, NULL);
+        klassname = getattrInternal<CXX>(klass, name_str, NULL);
         if (klassname != NULL) {
             if (!PyString_Check(klassname)) {
                 klassname = NULL;

--- a/src/runtime/types.cpp
+++ b/src/runtime/types.cpp
@@ -3418,7 +3418,7 @@ void setupRuntime() {
     // Punting on that until needed; hopefully by then we will have better Pyston slots support.
 
     auto typeCallObj = boxRTFunction((void*)typeCall, UNKNOWN, 1, 0, true, true);
-    typeCallObj->internal_callable.cxx_ptr = &typeCallInternal;
+    typeCallObj->internal_callable.cxx_val = &typeCallInternal;
 
     type_cls->giveAttr("__name__", new (pyston_getset_cls) BoxedGetsetDescriptor(typeName, typeSetName, NULL));
     type_cls->giveAttr("__bases__", new (pyston_getset_cls) BoxedGetsetDescriptor(typeBases, typeSetBases, NULL));

--- a/src/runtime/types.h
+++ b/src/runtime/types.h
@@ -1000,6 +1000,7 @@ extern "C" PyObject* PystonType_GenericAlloc(BoxedClass* cls, Py_ssize_t nitems)
 
 void checkAndThrowCAPIException();
 void throwCAPIException() __attribute__((noreturn));
+void ensureCAPIExceptionSet();
 struct ExcInfo;
 void setCAPIException(const ExcInfo& e);
 

--- a/test/tests/incremental_tb.py
+++ b/test/tests/incremental_tb.py
@@ -52,3 +52,18 @@ print "******** 2", ''.join(traceback.format_exception(et2, ev2, tb2))
 print et1 is et2
 print ev1 is ev2
 print tb1 is tb2
+
+class C(object):
+    def __getattr__(self, attr):
+        raise AttributeError()
+
+def f4():
+    try:
+        C().a
+    except IOError: # unrelated exception
+        pass
+
+try:
+    f4()
+except AttributeError:
+    print "******** 3", ''.join(traceback.format_exception(*sys.exc_info()))

--- a/test/tests/incremental_tb_bjit.py
+++ b/test/tests/incremental_tb_bjit.py
@@ -4,57 +4,5 @@ try:
     __pyston__.setOption("REOPT_THRESHOLD_INTERPRETER", 1)
 except:
     pass
-import traceback
-import sys
-def f():
-    a, b, c = sys.exc_info()
-    raise a, b, c
 
-et0, ev0, tb0 = None, None, None
-
-try:
-    1/0
-except:
-    pass
-
-for i in xrange(10):
-    try:
-        f()
-    except:
-        et0, ev0, tb0 = sys.exc_info()
-
-print "******** 0", ''.join(traceback.format_exception(et0, ev0, tb0))
-
-
-et1, ev1, tb1 = None, None, None
-et2, ev2, tb2 = None, None, None
-
-def f1():
-    raise
-
-def f2():
-    f1()
-
-def f21():
-    raise Exception()
-
-def f3():
-    try:
-        f21()
-    except:
-        global et1, tv1, tb1
-        et1, tv1, tb1 = sys.exc_info()
-        f2()
-
-
-try:
-    f3()
-except:
-    et2, tv2, tb2 = sys.exc_info()
-
-print "******** 1", ''.join(traceback.format_exception(et1, ev1, tb1))
-print "******** 2", ''.join(traceback.format_exception(et2, ev2, tb2))
-
-print et1 is et2
-print ev1 is ev2
-print tb1 is tb2
+import incremental_tb


### PR DESCRIPTION
Specifically, for any attribute accesses inside a try-catch block.  Even with the new rewrites added here, there's still some perf penalty to using CAPI exceptions, so as we add more of these we should add some better heuristics for determining when to use them.  One idea is to only do this for try-catch blocks that catch AttributeErrors; at some point we'll need to make it profiling-based, since quite a few exceptions get thrown through intermediate frames without try-catch blocks.  (But then again, the cost of a c++ exception is roughly proportional to the number of frames it crosses so we might not have to do that to start seeing benefit in those cases.)

I'm getting a lot of variability when testing this change, so I tried benchmarking using the pgo build and it seems like the results are more stable:
```
      django_template3.py             3.2s (2)             3.2s (2)  +0.0%
            pyxl_bench.py             2.8s (2)             2.7s (2)  -2.6%
sqlalchemy_imperative2.py             3.1s (2)             3.1s (2)  -0.8%
                  geomean                 3.0s                 3.0s  -1.1%
```
or maybe they are just more favorable :)
