### PR TITLE
Allow guards after calls in rewriting

### DIFF
--- a/src/asm_writing/rewriter.cpp
+++ b/src/asm_writing/rewriter.cpp
@@ -231,11 +231,7 @@ assembler::Register Rewriter::ConstLoader::loadConst(uint64_t val, Location othe
 }
 
 void Rewriter::restoreArgs() {
-    ASSERT(!done_guarding, "this will probably work but why are we calling this at this time");
-
     for (int i = 0; i < args.size(); i++) {
-        args[i]->bumpUse();
-
         Location l = Location::forArg(i);
         if (l.type == Location::Stack)
             continue;
@@ -265,8 +261,6 @@ void Rewriter::restoreArgs() {
 }
 
 void Rewriter::assertArgsInPlace() {
-    ASSERT(!done_guarding, "this will probably work but why are we calling this at this time");
-
     for (int i = 0; i < args.size(); i++) {
         assert(args[i]->isInLocation(args[i]->arg_loc));
     }
@@ -821,9 +815,6 @@ RewriterVar* Rewriter::call(bool has_side_effects, void* func_addr, const Rewrit
 
 void Rewriter::_setupCall(bool has_side_effects, const RewriterVar::SmallVector& args,
                           const RewriterVar::SmallVector& args_xmm) {
-    if (has_side_effects)
-        assert(done_guarding);
-
     if (has_side_effects) {
         // We need some fixed amount of space at the beginning of the IC that we can use to invalidate
         // it by writing a jmp.
@@ -1024,11 +1015,6 @@ void RewriterVar::bumpUse() {
     next_use++;
     assert(next_use <= uses.size());
     if (next_use == uses.size()) {
-        // shouldn't be clearing an arg unless we are done guarding
-        if (!rewriter->done_guarding && this->is_arg) {
-            return;
-        }
-
         for (Location loc : locations) {
             rewriter->vars_by_location.erase(loc);
         }
@@ -1119,34 +1105,20 @@ void Rewriter::commit() {
     // Emit assembly for each action, and set done_guarding when
     // we reach the last guard.
 
-    // Note: If an arg finishes its uses before we're done guarding, we don't release it at that point;
-    // instead, we release it here, at the point when we set done_guarding.
-    // An alternate, maybe cleaner, way to accomplish this would be to add a use for each arg
-    // at each guard in the var's `uses` list.
-
-    // First: check if we're done guarding before we even begin emitting.
-
-    auto on_done_guarding = [&]() {
-        done_guarding = true;
-        for (RewriterVar* arg : args) {
-            if (arg->next_use == arg->uses.size()) {
-                for (Location loc : arg->locations) {
-                    vars_by_location.erase(loc);
-                }
-                arg->locations.clear();
-            }
-        }
-        assertConsistent();
-    };
-
-    if (last_guard_action == -1) {
-        on_done_guarding();
-    }
-
     picked_slot = rewrite->prepareEntry();
     if (picked_slot == NULL) {
         on_assemblyfail();
         return;
+    }
+
+    for (RewriterVar& var : vars) {
+        // XXX we're doing extra work if we have any of these
+        if (var.uses.size() == 0) {
+            for (Location loc : var.locations) {
+                vars_by_location.erase(loc);
+            }
+            var.locations.clear();
+        }
     }
 
     // Now, start emitting assembly; check if we're dong guarding after each.
@@ -1160,8 +1132,12 @@ void Rewriter::commit() {
         }
 
         assertConsistent();
-        if (i == last_guard_action) {
-            on_done_guarding();
+
+        if (actions[i].type == ActionType::GUARD) {
+            for (RewriterVar* var : args) {
+                var->bumpUse();
+            }
+            assertConsistent();
         }
     }
 
@@ -1600,9 +1576,6 @@ assembler::Register Rewriter::allocReg(Location dest, Location otherThan) {
                     return reg;
                 }
                 RewriterVar* var = vars_by_location[reg];
-                if (!done_guarding && var->is_arg && var->arg_loc == Location(reg)) {
-                    continue;
-                }
                 if (var->uses[var->next_use] > best) {
                     found = true;
                     best = var->uses[var->next_use];
@@ -1707,14 +1680,6 @@ RewriterVar* Rewriter::createNewConstantVar(uint64_t val) {
 assembler::Register RewriterVar::initializeInReg(Location l) {
     rewriter->assertPhaseEmitting();
 
-    // TODO um should we check this in more places, or what?
-    // The thing is: if we aren't done guarding, and the register we want to use
-    // is taken by an arg, we can't spill it, so we shouldn't ask to alloc it.
-    if (l.type == Location::Register && !rewriter->done_guarding && rewriter->vars_by_location[l] != NULL
-        && rewriter->vars_by_location[l]->is_arg) {
-        l = Location::any();
-    }
-
     assembler::Register reg = rewriter->allocReg(l);
     l = Location(reg);
 
@@ -1758,9 +1723,7 @@ Rewriter::Rewriter(std::unique_ptr<ICSlotRewrite> rewrite, int num_args, const s
       return_location(this->rewrite->returnRegister()),
       failed(false),
       added_changing_action(false),
-      marked_inside_ic(false),
-      last_guard_action(-1),
-      done_guarding(false) {
+      marked_inside_ic(false) {
     initPhaseCollecting();
 
     finished = false;

--- a/src/runtime/objmodel.cpp
+++ b/src/runtime/objmodel.cpp
@@ -1340,11 +1340,6 @@ Box* dataDescriptorInstanceSpecialCases(GetattrRewriteArgs* rewrite_args, BoxedS
                            attr_name->data(), getTypeName(getset_descr));
         }
 
-        // Abort because right now we can't call twice in a rewrite
-        if (for_call) {
-            rewrite_args = NULL;
-        }
-
         if (rewrite_args) {
             // hmm, maybe we should write assembly which can look up the function address and call any function
             r_descr->addAttrGuard(offsetof(BoxedGetsetDescriptor, get), (intptr_t)getset_descr->get);
@@ -1653,21 +1648,6 @@ Box* getattrInternalGeneric(Box* obj, BoxedString* attr, GetattrRewriteArgs* rew
 
                 // Call __get__(descr, obj, obj->cls)
                 if (_set_) {
-                    // Have to abort because we're about to call now, but there will be before more
-                    // guards between this call and the next...
-                    if (for_call) {
-#if STAT_CALLATTR_DESCR_ABORTS
-                        if (rewrite_args) {
-                            std::string attr_name = "num_callattr_descr_abort";
-                            Stats::log(Stats::getStatCounter(attr_name));
-                            logByCurrentPythonLine(attr_name);
-                        }
-#endif
-
-                        rewrite_args = NULL;
-                        REWRITE_ABORTED("");
-                    }
-
                     Box* res;
                     if (rewrite_args) {
                         CallRewriteArgs crewrite_args(rewrite_args->rewriter, r_get, rewrite_args->destination);
@@ -1768,19 +1748,6 @@ Box* getattrInternalGeneric(Box* obj, BoxedString* attr, GetattrRewriteArgs* rew
                 if (local_get) {
                     Box* res;
 
-                    if (for_call) {
-#if STAT_CALLATTR_DESCR_ABORTS
-                        if (rewrite_args) {
-                            std::string attr_name = "num_callattr_descr_abort";
-                            Stats::log(Stats::getStatCounter(attr_name));
-                            logByCurrentPythonLine(attr_name);
-                        }
-#endif
-
-                        rewrite_args = NULL;
-                        REWRITE_ABORTED("");
-                    }
-
                     if (rewrite_args) {
                         CallRewriteArgs crewrite_args(rewrite_args->rewriter, r_get, rewrite_args->destination);
                         crewrite_args.arg1 = r_val;
@@ -1822,20 +1789,6 @@ Box* getattrInternalGeneric(Box* obj, BoxedString* attr, GetattrRewriteArgs* rew
         // We looked up __get__ above. If we found it, call it and return
         // the result.
         if (descr_get) {
-            // this could happen for the callattr path...
-            if (for_call) {
-#if STAT_CALLATTR_DESCR_ABORTS
-                if (rewrite_args) {
-                    std::string attr_name = "num_callattr_descr_abort";
-                    Stats::log(Stats::getStatCounter(attr_name));
-                    logByCurrentPythonLine(attr_name);
-                }
-#endif
-
-                rewrite_args = NULL;
-                REWRITE_ABORTED("");
-            }
-
             Box* res;
             if (rewrite_args) {
                 assert(_get_);
@@ -2738,6 +2691,25 @@ extern "C" Box* callattrInternal(Box* obj, BoxedString* attr, LookupScope scope,
     } else {
         if (rewrite_args) {
             rewrite_args->obj = r_val;
+        }
+
+        if (rewrite_args && rewrite_args->rewriter->hasAddedChangingAction()) {
+            // It's possible that `getattrInternalEx` did some mutation operation, like a runtimeCall
+            // (Could do that if it's a descriptor). Since we would have to make guards for the runtimeCall below,
+            // we would have to abort if we don't add this new slowpath.
+            RewriterVar* r_null = rewrite_args->rewriter->loadConst(0);
+            llvm::SmallVector<RewriterVar*, 8> args;
+            args.push_back(r_val);
+            args.push_back(r_null);
+            args.push_back(rewrite_args->rewriter->loadConst(argspec.asInt()));
+            // Pass r_null because we need to pass *something* as an arg
+            // TODO let the rewriter accept NULL as an argument to mean "doesn't matter what you pass"
+            args.push_back(rewrite_args->arg1 == NULL ? r_null : rewrite_args->arg1);
+            args.push_back(rewrite_args->arg2 == NULL ? r_null : rewrite_args->arg2);
+            args.push_back(rewrite_args->arg3 == NULL ? r_null : rewrite_args->arg3);
+            args.push_back(rewrite_args->args == NULL ? r_null : rewrite_args->args);
+            args.push_back(rewrite_args->rewriter->loadConst((intptr_t)(void*)keyword_names));
+            rewrite_args->rewriter->addSecondSlowpath((void*)(runtimeCallInternal<CXX>), args);
         }
 
         Box* rtn = runtimeCallInternal<CXX>(val, rewrite_args, argspec, arg1, arg2, arg3, args, keyword_names);

--- a/test/tests/callattr_guards.py
+++ b/test/tests/callattr_guards.py
@@ -1,0 +1,26 @@
+def f(a, b):
+    print 'f is called', a, b
+
+def g(a, b, c=3):
+    print 'g is called', a, b, c
+
+counter = 0
+
+class Desc(object):
+    def __get__(self, obj, type):
+        global counter
+        counter += 1
+        if counter <= 800:
+            return f
+        else:
+            return g
+
+class C(object):
+    d = Desc()
+
+def do():
+    c = C()
+    c.d('a', 'b')
+
+for i in xrange(1000):
+    do()

--- a/test/tests/callattr_ics.py
+++ b/test/tests/callattr_ics.py
@@ -1,0 +1,19 @@
+# run_args: -n
+# statcheck: noninit_count('slowpath_callattr') <= 200
+
+def f(a, b):
+    print 'f is called', a, b
+
+class Desc(object):
+    def __get__(self, obj, type):
+        return f
+
+class C(object):
+    d = Desc()
+
+def do():
+    c = C()
+    c.d('a', 'b')
+
+for i in xrange(1000):
+    do()

--- a/test/tests/descriptors_callattr_cls_ics.py
+++ b/test/tests/descriptors_callattr_cls_ics.py
@@ -1,13 +1,5 @@
-# expected: statfail
 # run_args: -n
 # statcheck: stats['slowpath_callattr'] <= 100
-
-# Right now this won't work because callattr involves two calls
-# one call to __get__ and then another call to the returned function.
-# Of course, if the callattr were split up into getattr and a call,
-# each could be re-written separately...
-# Not sure if this is a case worth handling or what is the best way
-# to handle it, but I'm throwing the test in here anyway to remind us.
 
 # Note: difference between DataDescriptor and NonDataDescriptor shouldn't matter
 #  __enter__ is looked up via callattr with class_only set to true

--- a/test/tests/descriptors_callattr_ics.py
+++ b/test/tests/descriptors_callattr_ics.py
@@ -1,14 +1,6 @@
-# expected: statfail
 # run_args: -n
 # statcheck: stats['slowpath_callattr'] <= 80
 # statcheck: stats['slowpath_getattr'] <= 80
-
-# Right now this won't work because callattr involves two calls
-# one call to __get__ and then another call to the returned function.
-# Of course, if the callattr were split up into getattr and a call,
-# each could be re-written separately...
-# Not sure if this is a case worth handling or what is the best way
-# to handle it, but I'm throwing the test in here anyway to remind us.
 
 def g():
     print 'in g'


### PR DESCRIPTION
By allowing the user of the rewriter to provide a new slowpath with new args.

It's pretty hacky/lazy right now; it's kind of sketchy in the way it handles the new args and emits jmps, and also it only supports adding a single additional slowpath (I guess this could be extended easily.)

I used this to add support for callattr-rewriting when the getattr part requires a call into python (e.g. a descriptor call)