### PR TITLE
Some improvements to make test unary could pass

### DIFF
--- a/from_cpython/Lib/test/test_unary.py
+++ b/from_cpython/Lib/test/test_unary.py
@@ -1,4 +1,3 @@
-# expected: fail
 """Test compiler changes for unary ops (+, -, ~) introduced in Python 2.2"""
 
 import unittest

--- a/src/runtime/float.cpp
+++ b/src/runtime/float.cpp
@@ -537,6 +537,11 @@ Box* floatNeg(BoxedFloat* self) {
     return boxFloat(-self->d);
 }
 
+Box* floatPos(BoxedFloat* self) {
+    assert(self->cls == float_cls);
+    return PyFloat_FromDouble(self->d);
+}
+
 bool floatNonzeroUnboxed(BoxedFloat* self) {
     assert(self->cls == float_cls);
     return self->d != 0.0;
@@ -1475,6 +1480,7 @@ void setupFloat() {
         "__new__", new BoxedFunction(boxRTFunction((void*)floatNew, UNKNOWN, 2, 1, false, false), { boxFloat(0.0) }));
 
     float_cls->giveAttr("__neg__", new BoxedFunction(boxRTFunction((void*)floatNeg, BOXED_FLOAT, 1)));
+    float_cls->giveAttr("__pos__", new BoxedFunction(boxRTFunction((void*)floatPos, BOXED_FLOAT, 1)));
 
     CLFunction* nonzero = boxRTFunction((void*)floatNonzeroUnboxed, BOOL, 1);
     addRTFunction(nonzero, (void*)floatNonzero, UNKNOWN);

--- a/src/runtime/objmodel.cpp
+++ b/src/runtime/objmodel.cpp
@@ -4378,10 +4378,11 @@ extern "C" Box* unaryop(Box* operand, int op_type) {
 
     BoxedString* op_name = getOpName(op_type);
 
-    // TODO: this code looks very old and like it should be a callattr instead?
-    Box* attr_func = getclsattrInternal(operand, op_name, NULL);
-    RELEASE_ASSERT(attr_func, "%s.%s", getTypeName(operand), op_name->c_str());
-    Box* rtn = runtimeCallInternal<CXX>(attr_func, NULL, ArgPassSpec(0), NULL, NULL, NULL, NULL, NULL);
+    CallattrFlags callattr_flags{.cls_only = true, .null_on_nonexistent = true, .argspec = ArgPassSpec(0) };
+    Box* rtn = callattr(operand, op_name, callattr_flags, NULL, NULL, NULL, NULL, NULL);
+    if (rtn == NULL) {
+        raiseExcHelper(TypeError, "bad operand type for unary '%s': '%s'", op_name->c_str(), getTypeName(operand));
+    }
 
     return rtn;
 }


### PR DESCRIPTION
__Change:__
* Add `__pos__` to `float` and `complex`
* Add compare support to `complex`
* Use new `callattr` replace old `getclsattrInternal` to find attribute, add error checking.