### PR TITLE
WIP: bjit: register functions with GDB

### DIFF
--- a/src/codegen/baseline_jit.h
+++ b/src/codegen/baseline_jit.h
@@ -155,6 +155,9 @@ public:
     bool shouldCreateNewBlock() const { return asm_failed || a.bytesLeft() < 128; }
     void fragmentAbort(bool not_enough_space);
     void fragmentFinished(int bytes_witten, int num_bytes_overlapping, void* next_fragment_start);
+
+private:
+    void registerFunctionWithGDB(const std::string& sym_name);
 };
 
 class JitFragmentWriter : public Rewriter {


### PR DESCRIPTION
Tell GDB the function name and EH table of the jited function
this is extremely slow [0]  and should only be used for debugging and the implementation is dangerous...

Tried different routes, elf template, using LLVM MC layer, but I only got this one to work :-(.
This maybe okay if it's disabled per default and one can enable it if needed.
Currently WIP but would like to know what if you guys think it's worth to clean this up.

[0] probably: https://code.google.com/p/v8-wiki/wiki/GDBJITInterface
GDB side of JIT Interface currently (as of GDB 7.2) does not handle registration of code objects very effectively. Each next registration takes more time: with 500 registered objects each next registration takes more than 50ms, with 1000 registered code objects - more than 300 ms. This problem was reported to GDB developers (http://sourceware.org/ml/gdb/2011-01/msg00002.html) but currently there is no solution available.
