### PR TITLE
Hash improvement for complex, str and long.

### DIFF
--- a/src/codegen/pypa-parser.cpp
+++ b/src/codegen/pypa-parser.cpp
@@ -363,10 +363,19 @@ struct expr_dispatcher {
     }
 
     ResultPtr read(pypa::AstComplex& c) {
-        AST_Num* ptr = new AST_Num();
-        ptr->num_type = AST_Num::COMPLEX;
-        pypa::string_to_double(c.imag, ptr->n_float);
-        return ptr;
+        AST_Num* imag = new AST_Num();
+        location(imag, c);
+        imag->num_type = AST_Num::COMPLEX;
+        sscanf(c.imag.c_str(), "%lf", &imag->n_float);
+        if (!c.real)
+            return imag;
+
+        AST_BinOp* binop = new AST_BinOp();
+        location(binop, c);
+        binop->op_type = AST_TYPE::Add;
+        binop->right = readItem(c.real, interned_strings);
+        binop->left = imag;
+        return binop;
     }
 
     ResultPtr read(pypa::AstComprehension& c) {

--- a/src/runtime/long.cpp
+++ b/src/runtime/long.cpp
@@ -661,7 +661,7 @@ BoxedLong* _longNew(Box* val, Box* _base) {
             int r = mpz_init_set_str(rtn->n, s.data(), 10);
             RELEASE_ASSERT(r == 0, "");
         } else if (val->cls == float_cls) {
-            mpz_init_set_si(rtn->n, static_cast<BoxedFloat*>(val)->d);
+            mpz_init_set_d(rtn->n, static_cast<BoxedFloat*>(val)->d);
         } else {
             static BoxedString* long_str = internStringImmortal("__long__");
             CallattrFlags callattr_flags{.cls_only = true, .null_on_nonexistent = true, .argspec = ArgPassSpec(0) };

--- a/src/runtime/str.cpp
+++ b/src/runtime/str.cpp
@@ -1526,6 +1526,10 @@ extern "C" size_t unicodeHashUnboxed(PyUnicodeObject* self) {
         return self->hash;
 
     Py_ssize_t len = PyUnicode_GET_SIZE(self);
+
+    if (len == 0)
+        return 0;
+
     Py_UNICODE* p = PyUnicode_AS_UNICODE(self);
     pyston::StringHash<Py_UNICODE> H;
     return H(p, len);
@@ -1533,6 +1537,10 @@ extern "C" size_t unicodeHashUnboxed(PyUnicodeObject* self) {
 
 extern "C" Box* strHash(BoxedString* self) {
     assert(PyString_Check(self));
+
+    // CPython set the hash empty string to 0 manually
+    if (self->size() == 0)
+        return boxInt(0);
 
     StringHash<char> H;
     return boxInt(H(self->data(), self->size()));


### PR DESCRIPTION
**Change**
* Pypy parser could not handle complex literal correctly, it always treat complex as 0.0j. Fix it. The code originally write by Marius.
* Add hash function to complex. Already tested. (But did not enable test_hash, please see below)
* Fix the wrong `mpz` usage in `long` constructor.
* Treat the hash value of empty string as Zero, like CPython did.

**Note**
After read CPython code. CPython str hash function will check `PYTHONHASHSEED` enviroment varialble in `random.c` file. But the Pyston DJB based str hash function didn't support it. I did some experiments try to fix it. But seems I couldn't use random number in str hash function (`types.h`). Pyston will report error:
```
pyston: ../../src/runtime/builtin_modules/thread.cpp:189: void pyston::setupThread():
Assertion `thread_module' failed.
```