### PR TITLE
Refactor location and names of gc visit functions.

### DIFF
--- a/src/capi/types.h
+++ b/src/capi/types.h
@@ -58,7 +58,7 @@ public:
         assert(_o->cls == capifunc_cls);
         BoxedCApiFunction* o = static_cast<BoxedCApiFunction*>(_o);
 
-        boxGCHandler(v, o);
+        Box::gcHandler(v, o);
         v->visit(o->passthrough);
         v->visit(o->module);
     }

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -603,6 +603,8 @@ public:
     Box* hasnextOrNullIC();
 
     friend class AttrWrapper;
+
+    static void gcHandler(GCVisitor* v, Box* b);
 };
 static_assert(offsetof(Box, cls) == offsetof(struct _object, ob_type), "");
 

--- a/src/runtime/builtin_modules/builtins.cpp
+++ b/src/runtime/builtin_modules/builtins.cpp
@@ -1013,7 +1013,7 @@ public:
     }
 
     static void gcHandler(GCVisitor* v, Box* b) {
-        boxGCHandler(v, b);
+        Box::gcHandler(v, b);
 
         BoxedEnumerate* it = (BoxedEnumerate*)b;
         it->iterator.gcHandler(v);

--- a/src/runtime/builtin_modules/sys.cpp
+++ b/src/runtime/builtin_modules/sys.cpp
@@ -228,7 +228,7 @@ public:
 
     static void gcHandler(GCVisitor* v, Box* _b) {
         assert(_b->cls == sys_flags_cls);
-        boxGCHandler(v, _b);
+        Box::gcHandler(v, _b);
 
         BoxedSysFlags* self = static_cast<BoxedSysFlags*>(_b);
         v->visit(self->division_warning);

--- a/src/runtime/classobj.h
+++ b/src/runtime/classobj.h
@@ -52,7 +52,7 @@ public:
         assert(_o->cls == classobj_cls);
         BoxedClassobj* o = static_cast<BoxedClassobj*>(_o);
 
-        boxGCHandler(v, o);
+        Box::gcHandler(v, o);
         if (o->bases)
             v->visit(o->bases);
         if (o->name)
@@ -76,7 +76,7 @@ public:
         assert(_o->cls == instance_cls);
         BoxedInstance* o = static_cast<BoxedInstance*>(_o);
 
-        boxGCHandler(v, o);
+        Box::gcHandler(v, o);
         if (o->inst_cls)
             v->visit(o->inst_cls);
     }

--- a/src/runtime/code.cpp
+++ b/src/runtime/code.cpp
@@ -39,7 +39,7 @@ public:
 
     static void gcHandler(GCVisitor* v, Box* b) {
         assert(b->cls == code_cls);
-        boxGCHandler(v, b);
+        Box::gcHandler(v, b);
     }
 
     static Box* name(Box* b, void*) {

--- a/src/runtime/descr.cpp
+++ b/src/runtime/descr.cpp
@@ -413,7 +413,7 @@ void BoxedMethodDescriptor::gcHandler(GCVisitor* v, Box* _o) {
     assert(_o->cls == method_cls);
     BoxedMethodDescriptor* o = static_cast<BoxedMethodDescriptor*>(_o);
 
-    boxGCHandler(v, o);
+    Box::gcHandler(v, o);
     v->visit(o->type);
 }
 
@@ -452,7 +452,7 @@ void BoxedWrapperDescriptor::gcHandler(GCVisitor* v, Box* _o) {
     assert(_o->cls == wrapperdescr_cls);
     BoxedWrapperDescriptor* o = static_cast<BoxedWrapperDescriptor*>(_o);
 
-    boxGCHandler(v, o);
+    Box::gcHandler(v, o);
     v->visit(o->type);
 }
 
@@ -570,7 +570,7 @@ void BoxedWrapperObject::gcHandler(GCVisitor* v, Box* _o) {
     assert(_o->cls == wrapperobject_cls);
     BoxedWrapperObject* o = static_cast<BoxedWrapperObject*>(_o);
 
-    boxGCHandler(v, o);
+    Box::gcHandler(v, o);
     v->visit(o->obj);
 }
 

--- a/src/runtime/dict.cpp
+++ b/src/runtime/dict.cpp
@@ -685,7 +685,7 @@ extern "C" Box* dictInit(BoxedDict* self, BoxedTuple* args, BoxedDict* kwargs) {
 void BoxedDict::gcHandler(GCVisitor* v, Box* b) {
     assert(isSubclass(b->cls, dict_cls));
 
-    boxGCHandler(v, b);
+    Box::gcHandler(v, b);
 
     BoxedDict* d = (BoxedDict*)b;
 
@@ -701,7 +701,7 @@ void BoxedDict::gcHandler(GCVisitor* v, Box* b) {
 
 void BoxedDictIterator::gcHandler(GCVisitor* v, Box* b) {
     assert(b->cls == dict_iterator_cls);
-    boxGCHandler(v, b);
+    Box::gcHandler(v, b);
 
     BoxedDictIterator* it = static_cast<BoxedDictIterator*>(b);
     v->visit(it->d);
@@ -709,7 +709,7 @@ void BoxedDictIterator::gcHandler(GCVisitor* v, Box* b) {
 
 void BoxedDictView::gcHandler(GCVisitor* v, Box* b) {
     assert(b->cls == dict_items_cls);
-    boxGCHandler(v, b);
+    Box::gcHandler(v, b);
 
     BoxedDictView* view = static_cast<BoxedDictView*>(b);
     v->visit(view->d);

--- a/src/runtime/dict.h
+++ b/src/runtime/dict.h
@@ -24,6 +24,7 @@ extern BoxedClass* dict_iterator_cls;
 extern BoxedClass* dict_keys_cls;
 extern BoxedClass* dict_values_cls;
 extern BoxedClass* dict_items_cls;
+
 class BoxedDictIterator : public Box {
 public:
     enum IteratorType { KeyIterator, ValueIterator, ItemIterator };
@@ -36,6 +37,8 @@ public:
     BoxedDictIterator(BoxedDict* d, IteratorType type);
 
     DEFAULT_CLASS(dict_iterator_cls);
+
+    static void gcHandler(GCVisitor* v, Box* self);
 };
 
 Box* dictGetitem(BoxedDict* self, Box* k);
@@ -52,6 +55,8 @@ class BoxedDictView : public Box {
 public:
     BoxedDict* d;
     BoxedDictView(BoxedDict* d);
+
+    static void gcHandler(GCVisitor* v, Box* self);
 };
 
 Box* dictViewKeysIter(Box* self);

--- a/src/runtime/file.cpp
+++ b/src/runtime/file.cpp
@@ -1744,7 +1744,7 @@ void fileDestructor(Box* b) {
 }
 
 void BoxedFile::gcHandler(GCVisitor* v, Box* b) {
-    boxGCHandler(v, b);
+    Box::gcHandler(v, b);
 
     assert(isSubclass(b->cls, file_cls));
     BoxedFile* f = static_cast<BoxedFile*>(b);

--- a/src/runtime/frame.cpp
+++ b/src/runtime/frame.cpp
@@ -78,7 +78,7 @@ public:
     // ** = getter supported, but setter unsupported
 
     static void gchandler(GCVisitor* v, Box* b) {
-        boxGCHandler(v, b);
+        Box::gcHandler(v, b);
 
         auto f = static_cast<BoxedFrame*>(b);
 

--- a/src/runtime/generator.cpp
+++ b/src/runtime/generator.cpp
@@ -379,7 +379,7 @@ extern "C" BoxedGenerator::BoxedGenerator(BoxedFunctionBase* function, Box* arg1
 }
 
 void BoxedGenerator::gcHandler(GCVisitor* v, Box* b) {
-    boxGCHandler(v, b);
+    Box::gcHandler(v, b);
 
     BoxedGenerator* g = (BoxedGenerator*)b;
 

--- a/src/runtime/generator.cpp
+++ b/src/runtime/generator.cpp
@@ -378,7 +378,7 @@ extern "C" BoxedGenerator::BoxedGenerator(BoxedFunctionBase* function, Box* arg1
     context = makeContext(stack_begin, (void (*)(intptr_t))generatorEntry);
 }
 
-extern "C" void generatorGCHandler(GCVisitor* v, Box* b) {
+void BoxedGenerator::gcHandler(GCVisitor* v, Box* b) {
     boxGCHandler(v, b);
 
     BoxedGenerator* g = (BoxedGenerator*)b;
@@ -434,8 +434,8 @@ void generatorDestructor(Box* b) {
 
 void setupGenerator() {
     generator_cls
-        = BoxedHeapClass::create(type_cls, object_cls, &generatorGCHandler, 0, offsetof(BoxedGenerator, weakreflist),
-                                 sizeof(BoxedGenerator), false, "generator");
+        = BoxedHeapClass::create(type_cls, object_cls, &BoxedGenerator::gcHandler, 0,
+                                 offsetof(BoxedGenerator, weakreflist), sizeof(BoxedGenerator), false, "generator");
     generator_cls->tp_dealloc = generatorDestructor;
     generator_cls->has_safe_tp_dealloc = true;
     generator_cls->giveAttr("__iter__",

--- a/src/runtime/inline/xrange.cpp
+++ b/src/runtime/inline/xrange.cpp
@@ -118,7 +118,7 @@ public:
         return boxInt(xrangeIteratorNextUnboxed(s));
     }
 
-    static void xrangeIteratorGCHandler(GCVisitor* v, Box* b) {
+    static void gcHandler(GCVisitor* v, Box* b) {
         boxGCHandler(v, b);
 
         BoxedXrangeIterator* it = (BoxedXrangeIterator*)b;
@@ -195,8 +195,8 @@ Box* xrangeLen(Box* self) {
 
 void setupXrange() {
     xrange_cls = BoxedHeapClass::create(type_cls, object_cls, NULL, 0, 0, sizeof(BoxedXrange), false, "xrange");
-    xrange_iterator_cls = BoxedHeapClass::create(type_cls, object_cls, &BoxedXrangeIterator::xrangeIteratorGCHandler, 0,
-                                                 0, sizeof(BoxedXrangeIterator), false, "rangeiterator");
+    xrange_iterator_cls = BoxedHeapClass::create(type_cls, object_cls, &BoxedXrangeIterator::gcHandler, 0, 0,
+                                                 sizeof(BoxedXrangeIterator), false, "rangeiterator");
 
     xrange_cls->giveAttr(
         "__new__",

--- a/src/runtime/inline/xrange.cpp
+++ b/src/runtime/inline/xrange.cpp
@@ -119,7 +119,7 @@ public:
     }
 
     static void gcHandler(GCVisitor* v, Box* b) {
-        boxGCHandler(v, b);
+        Box::gcHandler(v, b);
 
         BoxedXrangeIterator* it = (BoxedXrangeIterator*)b;
         v->visit(it->xrange);

--- a/src/runtime/iterobject.cpp
+++ b/src/runtime/iterobject.cpp
@@ -112,7 +112,7 @@ Box* seqiterNext(Box* s) {
     return r;
 }
 
-static void seqiterGCVisit(GCVisitor* v, Box* b) {
+void BoxedSeqIter::gcHandler(GCVisitor* v, Box* b) {
     assert(b->cls == seqiter_cls || b->cls == seqreviter_cls);
     boxGCHandler(v, b);
 
@@ -122,7 +122,7 @@ static void seqiterGCVisit(GCVisitor* v, Box* b) {
         v->visit(si->next);
 }
 
-static void iterwrapperGCVisit(GCVisitor* v, Box* b) {
+void BoxedIterWrapper::gcHandler(GCVisitor* v, Box* b) {
     assert(b->cls == iterwrapper_cls);
     boxGCHandler(v, b);
 
@@ -182,8 +182,8 @@ bool calliter_hasnext(Box* b) {
 
 
 void setupIter() {
-    seqiter_cls
-        = BoxedHeapClass::create(type_cls, object_cls, seqiterGCVisit, 0, 0, sizeof(BoxedSeqIter), false, "iterator");
+    seqiter_cls = BoxedHeapClass::create(type_cls, object_cls, &BoxedSeqIter::gcHandler, 0, 0, sizeof(BoxedSeqIter),
+                                         false, "iterator");
 
     seqiter_cls->giveAttr("next", new BoxedFunction(boxRTFunction((void*)seqiterNext, UNKNOWN, 1)));
     seqiter_cls->giveAttr("__hasnext__", new BoxedFunction(boxRTFunction((void*)seqiterHasnext, BOXED_BOOL, 1)));
@@ -192,8 +192,8 @@ void setupIter() {
     seqiter_cls->freeze();
     seqiter_cls->tpp_hasnext = seqiterHasnextUnboxed;
 
-    seqreviter_cls
-        = BoxedHeapClass::create(type_cls, object_cls, seqiterGCVisit, 0, 0, sizeof(BoxedSeqIter), false, "reversed");
+    seqreviter_cls = BoxedHeapClass::create(type_cls, object_cls, &BoxedSeqIter::gcHandler, 0, 0, sizeof(BoxedSeqIter),
+                                            false, "reversed");
 
     seqreviter_cls->giveAttr("next", new BoxedFunction(boxRTFunction((void*)seqiterNext, UNKNOWN, 1)));
     seqreviter_cls->giveAttr("__hasnext__", new BoxedFunction(boxRTFunction((void*)seqreviterHasnext, BOXED_BOOL, 1)));
@@ -201,8 +201,8 @@ void setupIter() {
 
     seqreviter_cls->freeze();
 
-    iterwrapper_cls = BoxedHeapClass::create(type_cls, object_cls, iterwrapperGCVisit, 0, 0, sizeof(BoxedIterWrapper),
-                                             false, "iterwrapper");
+    iterwrapper_cls = BoxedHeapClass::create(type_cls, object_cls, &BoxedIterWrapper::gcHandler, 0, 0,
+                                             sizeof(BoxedIterWrapper), false, "iterwrapper");
 
     iterwrapper_cls->giveAttr("next", new BoxedFunction(boxRTFunction((void*)iterwrapperNext, UNKNOWN, 1)));
     iterwrapper_cls->giveAttr("__hasnext__",

--- a/src/runtime/iterobject.cpp
+++ b/src/runtime/iterobject.cpp
@@ -114,7 +114,7 @@ Box* seqiterNext(Box* s) {
 
 void BoxedSeqIter::gcHandler(GCVisitor* v, Box* b) {
     assert(b->cls == seqiter_cls || b->cls == seqreviter_cls);
-    boxGCHandler(v, b);
+    Box::gcHandler(v, b);
 
     BoxedSeqIter* si = static_cast<BoxedSeqIter*>(b);
     v->visit(si->b);
@@ -124,7 +124,7 @@ void BoxedSeqIter::gcHandler(GCVisitor* v, Box* b) {
 
 void BoxedIterWrapper::gcHandler(GCVisitor* v, Box* b) {
     assert(b->cls == iterwrapper_cls);
-    boxGCHandler(v, b);
+    Box::gcHandler(v, b);
 
     BoxedIterWrapper* iw = static_cast<BoxedIterWrapper*>(b);
     v->visit(iw->iter);

--- a/src/runtime/iterobject.h
+++ b/src/runtime/iterobject.h
@@ -36,6 +36,8 @@ public:
     BoxedSeqIter(Box* b, int64_t start) : b(b), idx(start), next(NULL) {}
 
     DEFAULT_CLASS(seqiter_cls);
+
+    static void gcHandler(GCVisitor* v, Box* b);
 };
 
 extern BoxedClass* iterwrapper_cls;
@@ -49,6 +51,8 @@ public:
     BoxedIterWrapper(Box* iter) : iter(iter), next(NULL) {}
 
     DEFAULT_CLASS(iterwrapper_cls);
+
+    static void gcHandler(GCVisitor* v, Box* b);
 };
 
 bool calliter_hasnext(Box* b);

--- a/src/runtime/list.cpp
+++ b/src/runtime/list.cpp
@@ -1092,7 +1092,7 @@ extern "C" int PyList_SetSlice(PyObject* a, Py_ssize_t ilow, Py_ssize_t ihigh, P
 }
 
 void BoxedListIterator::gcHandler(GCVisitor* v, Box* b) {
-    boxGCHandler(v, b);
+    Box::gcHandler(v, b);
     BoxedListIterator* it = (BoxedListIterator*)b;
     v->visit(it->l);
 }
@@ -1100,7 +1100,7 @@ void BoxedListIterator::gcHandler(GCVisitor* v, Box* b) {
 void BoxedList::gcHandler(GCVisitor* v, Box* b) {
     assert(isSubclass(b->cls, list_cls));
 
-    boxGCHandler(v, b);
+    Box::gcHandler(v, b);
 
     BoxedList* l = (BoxedList*)b;
     int size = l->size;

--- a/src/runtime/list.h
+++ b/src/runtime/list.h
@@ -29,6 +29,8 @@ public:
     BoxedListIterator(BoxedList* l, int start);
 
     DEFAULT_CLASS(list_iterator_cls);
+
+    static void gcHandler(GCVisitor* v, Box* b);
 };
 
 Box* listIter(Box* self) noexcept;

--- a/src/runtime/long.cpp
+++ b/src/runtime/long.cpp
@@ -62,7 +62,7 @@ int _PyLong_DigitValue[256] = {
 #define PY_ABS_LLONG_MIN (0 - (unsigned PY_LONG_LONG)PY_LLONG_MIN)
 
 void BoxedLong::gchandler(GCVisitor* v, Box* b) {
-    boxGCHandler(v, b);
+    Box::gcHandler(v, b);
 
     BoxedLong* l = (BoxedLong*)b;
 

--- a/src/runtime/set.cpp
+++ b/src/runtime/set.cpp
@@ -26,7 +26,7 @@ extern "C" Box* createSet() {
 }
 
 void BoxedSet::gcHandler(GCVisitor* v, Box* b) {
-    boxGCHandler(v, b);
+    Box::gcHandler(v, b);
 
     BoxedSet* s = (BoxedSet*)b;
 
@@ -60,7 +60,7 @@ public:
     }
 
     static void gcHandler(GCVisitor* v, Box* b) {
-        boxGCHandler(v, b);
+        Box::gcHandler(v, b);
 
         BoxedSetIterator* it = (BoxedSetIterator*)b;
 

--- a/src/runtime/set.h
+++ b/src/runtime/set.h
@@ -38,6 +38,8 @@ public:
     template <typename T> __attribute__((visibility("default"))) BoxedSet(T&& s) : s(std::forward<T>(s)) {}
 
     DEFAULT_CLASS(set_cls);
+
+    static void gcHandler(GCVisitor* v, Box* b);
 };
 }
 

--- a/src/runtime/str.cpp
+++ b/src/runtime/str.cpp
@@ -2313,7 +2313,7 @@ public:
     }
 
     static void gcHandler(GCVisitor* v, Box* b) {
-        boxGCHandler(v, b);
+        Box::gcHandler(v, b);
         BoxedStringIterator* it = (BoxedStringIterator*)b;
         v->visit(it->s);
     }

--- a/src/runtime/str.cpp
+++ b/src/runtime/str.cpp
@@ -2311,13 +2311,13 @@ public:
         ++self->it;
         return characters[c & UCHAR_MAX];
     }
-};
 
-extern "C" void strIteratorGCHandler(GCVisitor* v, Box* b) {
-    boxGCHandler(v, b);
-    BoxedStringIterator* it = (BoxedStringIterator*)b;
-    v->visit(it->s);
-}
+    static void gcHandler(GCVisitor* v, Box* b) {
+        boxGCHandler(v, b);
+        BoxedStringIterator* it = (BoxedStringIterator*)b;
+        v->visit(it->s);
+    }
+};
 
 Box* strIter(BoxedString* self) noexcept {
     assert(PyString_Check(self));
@@ -2698,7 +2698,7 @@ static PyMethodDef string_methods[] = {
 void setupStr() {
     str_cls->tp_flags |= Py_TPFLAGS_HAVE_NEWBUFFER;
 
-    str_iterator_cls = BoxedHeapClass::create(type_cls, object_cls, &strIteratorGCHandler, 0, 0,
+    str_iterator_cls = BoxedHeapClass::create(type_cls, object_cls, &BoxedStringIterator::gcHandler, 0, 0,
                                               sizeof(BoxedStringIterator), false, "striterator");
     str_iterator_cls->giveAttr("__hasnext__",
                                new BoxedFunction(boxRTFunction((void*)BoxedStringIterator::hasnext, BOXED_BOOL, 1)));

--- a/src/runtime/super.cpp
+++ b/src/runtime/super.cpp
@@ -41,7 +41,7 @@ public:
         assert(_o->cls == super_cls);
         BoxedSuper* o = static_cast<BoxedSuper*>(_o);
 
-        boxGCHandler(v, o);
+        Box::gcHandler(v, o);
         if (o->type)
             v->visit(o->type);
         if (o->obj)

--- a/src/runtime/traceback.cpp
+++ b/src/runtime/traceback.cpp
@@ -45,7 +45,7 @@ void BoxedTraceback::gcHandler(GCVisitor* v, Box* b) {
     if (self->tb_next)
         v->visit(self->tb_next);
 
-    boxGCHandler(v, b);
+    Box::gcHandler(v, b);
 }
 
 void printTraceback(Box* b) {

--- a/src/runtime/tuple.cpp
+++ b/src/runtime/tuple.cpp
@@ -559,14 +559,14 @@ static Py_ssize_t tuplelength(PyTupleObject* a) {
 }
 
 void BoxedTuple::gcHandler(GCVisitor* v, Box* b) {
-    boxGCHandler(v, b);
+    Box::gcHandler(v, b);
 
     BoxedTuple* t = (BoxedTuple*)b;
     v->visitRange((void* const*)&t->elts[0], (void* const*)&t->elts[t->size()]);
 }
 
 extern "C" void BoxedTupleIterator::gcHandler(GCVisitor* v, Box* b) {
-    boxGCHandler(v, b);
+    Box::gcHandler(v, b);
     BoxedTupleIterator* it = (BoxedTupleIterator*)b;
     v->visit(it->t);
 }

--- a/src/runtime/tuple.cpp
+++ b/src/runtime/tuple.cpp
@@ -412,12 +412,6 @@ extern "C" PyObject* PyTuple_New(Py_ssize_t size) noexcept {
 
 
 BoxedClass* tuple_iterator_cls = NULL;
-extern "C" void tupleIteratorGCHandler(GCVisitor* v, Box* b) {
-    boxGCHandler(v, b);
-    BoxedTupleIterator* it = (BoxedTupleIterator*)b;
-    v->visit(it->t);
-}
-
 static int64_t tuple_hash(BoxedTuple* v) noexcept {
     long x, y;
     Py_ssize_t len = Py_SIZE(v);
@@ -564,8 +558,21 @@ static Py_ssize_t tuplelength(PyTupleObject* a) {
     return Py_SIZE(a);
 }
 
+void BoxedTuple::gcHandler(GCVisitor* v, Box* b) {
+    boxGCHandler(v, b);
+
+    BoxedTuple* t = (BoxedTuple*)b;
+    v->visitRange((void* const*)&t->elts[0], (void* const*)&t->elts[t->size()]);
+}
+
+extern "C" void BoxedTupleIterator::gcHandler(GCVisitor* v, Box* b) {
+    boxGCHandler(v, b);
+    BoxedTupleIterator* it = (BoxedTupleIterator*)b;
+    v->visit(it->t);
+}
+
 void setupTuple() {
-    tuple_iterator_cls = BoxedHeapClass::create(type_cls, object_cls, &tupleIteratorGCHandler, 0, 0,
+    tuple_iterator_cls = BoxedHeapClass::create(type_cls, object_cls, &BoxedTupleIterator::gcHandler, 0, 0,
                                                 sizeof(BoxedTupleIterator), false, "tuple");
 
     tuple_cls->giveAttr("__new__", new BoxedFunction(boxRTFunction((void*)tupleNew, UNKNOWN, 1, 0, true, true)));

--- a/src/runtime/tuple.h
+++ b/src/runtime/tuple.h
@@ -28,6 +28,8 @@ public:
     BoxedTupleIterator(BoxedTuple* t);
 
     DEFAULT_CLASS(tuple_iterator_cls);
+
+    static void gcHandler(GCVisitor* v, Box* _o);
 };
 
 Box* tupleIter(Box* self) noexcept;

--- a/src/runtime/types.cpp
+++ b/src/runtime/types.cpp
@@ -408,23 +408,7 @@ BoxedFunction::BoxedFunction(CLFunction* f, std::initializer_list<Box*> defaults
     }
 }
 
-BoxedBuiltinFunctionOrMethod::BoxedBuiltinFunctionOrMethod(CLFunction* f, const char* name, const char* doc)
-    : BoxedBuiltinFunctionOrMethod(f, name, {}) {
-
-    this->doc = doc ? boxString(doc) : None;
-}
-
-BoxedBuiltinFunctionOrMethod::BoxedBuiltinFunctionOrMethod(CLFunction* f, const char* name,
-                                                           std::initializer_list<Box*> defaults, BoxedClosure* closure,
-                                                           const char* doc)
-    : BoxedFunctionBase(f, defaults, closure) {
-
-    assert(name);
-    this->name = static_cast<BoxedString*>(boxString(name));
-    this->doc = doc ? boxString(doc) : None;
-}
-
-extern "C" void functionGCHandler(GCVisitor* v, Box* b) {
+void BoxedFunction::gcHandler(GCVisitor* v, Box* b) {
     boxGCHandler(v, b);
 
     BoxedFunction* f = (BoxedFunction*)b;
@@ -454,6 +438,22 @@ extern "C" void functionGCHandler(GCVisitor* v, Box* b) {
         v->visitPotentialRange(reinterpret_cast<void* const*>(&f->defaults->elts[0]),
                                reinterpret_cast<void* const*>(&f->defaults->elts[f->ndefaults]));
     }
+}
+
+BoxedBuiltinFunctionOrMethod::BoxedBuiltinFunctionOrMethod(CLFunction* f, const char* name, const char* doc)
+    : BoxedBuiltinFunctionOrMethod(f, name, {}) {
+
+    this->doc = doc ? boxString(doc) : None;
+}
+
+BoxedBuiltinFunctionOrMethod::BoxedBuiltinFunctionOrMethod(CLFunction* f, const char* name,
+                                                           std::initializer_list<Box*> defaults, BoxedClosure* closure,
+                                                           const char* doc)
+    : BoxedFunctionBase(f, defaults, closure) {
+
+    assert(name);
+    this->name = static_cast<BoxedString*>(boxString(name));
+    this->doc = doc ? boxString(doc) : None;
 }
 
 static void functionDtor(Box* b) {
@@ -1131,7 +1131,7 @@ Box* typeCall(Box* obj, BoxedTuple* vararg, BoxedDict* kwargs) {
     return typeCallInternal(NULL, NULL, ArgPassSpec(n + 1, 0, false, pass_kwargs), arg1, arg2, arg3, args, NULL);
 }
 
-extern "C" void typeGCHandler(GCVisitor* v, Box* b) {
+void BoxedHeapClass::gcHandler(GCVisitor* v, Box* b) {
     boxGCHandler(v, b);
 
     BoxedClass* cls = (BoxedClass*)b;
@@ -1195,7 +1195,7 @@ static void typeSubSetDict(Box* obj, Box* val, void* context) {
 
 Box* dict_descr = NULL;
 
-extern "C" void instancemethodGCHandler(GCVisitor* v, Box* b) {
+void BoxedInstanceMethod::gcHandler(GCVisitor* v, Box* b) {
     boxGCHandler(v, b);
 
     BoxedInstanceMethod* im = (BoxedInstanceMethod*)b;
@@ -1205,7 +1205,7 @@ extern "C" void instancemethodGCHandler(GCVisitor* v, Box* b) {
     v->visit(im->im_class);
 }
 
-extern "C" void propertyGCHandler(GCVisitor* v, Box* b) {
+void BoxedProperty::gcHandler(GCVisitor* v, Box* b) {
     boxGCHandler(v, b);
 
     BoxedProperty* prop = (BoxedProperty*)b;
@@ -1220,7 +1220,7 @@ extern "C" void propertyGCHandler(GCVisitor* v, Box* b) {
         v->visit(prop->prop_doc);
 }
 
-extern "C" void staticmethodGCHandler(GCVisitor* v, Box* b) {
+void BoxedStaticmethod::gcHandler(GCVisitor* v, Box* b) {
     boxGCHandler(v, b);
 
     BoxedStaticmethod* sm = (BoxedStaticmethod*)b;
@@ -1229,7 +1229,7 @@ extern "C" void staticmethodGCHandler(GCVisitor* v, Box* b) {
         v->visit(sm->sm_callable);
 }
 
-extern "C" void classmethodGCHandler(GCVisitor* v, Box* b) {
+void BoxedClassmethod::gcHandler(GCVisitor* v, Box* b) {
     boxGCHandler(v, b);
 
     BoxedClassmethod* cm = (BoxedClassmethod*)b;
@@ -1238,40 +1238,12 @@ extern "C" void classmethodGCHandler(GCVisitor* v, Box* b) {
         v->visit(cm->cm_callable);
 }
 
-// This probably belongs in list.cpp?
-extern "C" void listGCHandler(GCVisitor* v, Box* b) {
-    boxGCHandler(v, b);
+void BoxedSlice::gcHandler(GCVisitor* v, Box* b) {
+    assert(b->cls == slice_cls);
 
-    BoxedList* l = (BoxedList*)b;
-    int size = l->size;
-    int capacity = l->capacity;
-    assert(capacity >= size);
-    if (capacity)
-        v->visit(l->elts);
-    if (size)
-        v->visitRange((void**)&l->elts->elts[0], (void**)&l->elts->elts[size]);
-}
-
-extern "C" void setGCHandler(GCVisitor* v, Box* b) {
-    boxGCHandler(v, b);
-
-    BoxedSet* s = (BoxedSet*)b;
-
-    // This feels like a cludge, but we need to find anything that
-    // the unordered_map might have allocated.
-    // Another way to handle this would be to rt_alloc the unordered_map
-    // as well, though that incurs extra memory dereferences which would
-    // be nice to avoid.
-    void** start = (void**)&s->s;
-    void** end = start + (sizeof(s->s) / 8);
-    v->visitPotentialRange(start, end);
-}
-
-extern "C" void sliceGCHandler(GCVisitor* v, Box* b) {
     boxGCHandler(v, b);
 
     BoxedSlice* sl = static_cast<BoxedSlice*>(b);
-    assert(sl->cls == slice_cls);
 
     v->visit(sl->start);
     v->visit(sl->stop);
@@ -1293,31 +1265,9 @@ static void proxy_to_tp_traverse(GCVisitor* v, Box* b) {
     b->cls->tp_traverse(b, call_gc_visit, v);
 }
 
-// This probably belongs in tuple.cpp?
-extern "C" void tupleGCHandler(GCVisitor* v, Box* b) {
-    boxGCHandler(v, b);
+void BoxedClosure::gcHandler(GCVisitor* v, Box* b) {
+    assert(isSubclass(b->cls, closure_cls));
 
-    BoxedTuple* t = (BoxedTuple*)b;
-    v->visitRange((void* const*)&t->elts[0], (void* const*)&t->elts[t->size()]);
-}
-
-// This probably belongs in dict.cpp?
-extern "C" void dictGCHandler(GCVisitor* v, Box* b) {
-    boxGCHandler(v, b);
-
-    BoxedDict* d = (BoxedDict*)b;
-
-    // This feels like a cludge, but we need to find anything that
-    // the unordered_map might have allocated.
-    // Another way to handle this would be to rt_alloc the unordered_map
-    // as well, though that incurs extra memory dereferences which would
-    // be nice to avoid.
-    void** start = (void**)&d->d;
-    void** end = start + (sizeof(d->d) / 8);
-    v->visitPotentialRange(start, end);
-}
-
-extern "C" void closureGCHandler(GCVisitor* v, Box* b) {
     boxGCHandler(v, b);
 
     BoxedClosure* c = (BoxedClosure*)b;
@@ -3245,7 +3195,7 @@ void setupRuntime() {
     void* mem = gc_alloc(sizeof(BoxedClass), gc::GCKind::PYTHON);
     object_cls = ::new (mem) BoxedClass(NULL, &boxGCHandler, 0, 0, sizeof(Box), false);
     mem = gc_alloc(sizeof(BoxedHeapClass), gc::GCKind::PYTHON);
-    type_cls = ::new (mem) BoxedHeapClass(object_cls, &typeGCHandler, offsetof(BoxedClass, attrs),
+    type_cls = ::new (mem) BoxedHeapClass(object_cls, &BoxedHeapClass::gcHandler, offsetof(BoxedClass, attrs),
                                           offsetof(BoxedClass, tp_weaklist), sizeof(BoxedHeapClass), false, NULL);
     type_cls->tp_flags |= Py_TPFLAGS_TYPE_SUBCLASS;
     type_cls->tp_itemsize = sizeof(BoxedHeapClass::SlotOffset);
@@ -3297,20 +3247,21 @@ void setupRuntime() {
 
     // Not sure why CPython defines sizeof(PyTupleObject) to include one element,
     // but we copy that, which means we have to subtract that extra pointer to get the tp_basicsize:
-    tuple_cls = new (0)
-        BoxedHeapClass(object_cls, &tupleGCHandler, 0, 0, sizeof(BoxedTuple) - sizeof(Box*), false, boxString("tuple"));
+    tuple_cls = new (0) BoxedHeapClass(object_cls, &BoxedTuple::gcHandler, 0, 0, sizeof(BoxedTuple) - sizeof(Box*),
+                                       false, boxString("tuple"));
     tuple_cls->tp_flags |= Py_TPFLAGS_TUPLE_SUBCLASS;
     tuple_cls->tp_itemsize = sizeof(Box*);
     tuple_cls->tp_mro = BoxedTuple::create({ tuple_cls, object_cls });
     EmptyTuple = BoxedTuple::create({});
     gc::registerPermanentRoot(EmptyTuple);
-    list_cls = new (0) BoxedHeapClass(object_cls, &listGCHandler, 0, 0, sizeof(BoxedList), false, boxString("list"));
+    list_cls = new (0)
+        BoxedHeapClass(object_cls, &BoxedList::gcHandler, 0, 0, sizeof(BoxedList), false, boxString("list"));
     list_cls->tp_flags |= Py_TPFLAGS_LIST_SUBCLASS;
     pyston_getset_cls = new (0)
         BoxedHeapClass(object_cls, NULL, 0, 0, sizeof(BoxedGetsetDescriptor), false, boxString("getset_descriptor"));
     attrwrapper_cls = new (0) BoxedHeapClass(object_cls, &AttrWrapper::gcHandler, 0, 0, sizeof(AttrWrapper), false,
                                              static_cast<BoxedString*>(boxString("attrwrapper")));
-    dict_cls = new (0) BoxedHeapClass(object_cls, &dictGCHandler, 0, 0, sizeof(BoxedDict), false,
+    dict_cls = new (0) BoxedHeapClass(object_cls, &BoxedDict::gcHandler, 0, 0, sizeof(BoxedDict), false,
                                       static_cast<BoxedString*>(boxString("dict")));
     dict_cls->tp_flags |= Py_TPFLAGS_DICT_SUBCLASS;
     file_cls = new (0) BoxedHeapClass(object_cls, &BoxedFile::gcHandler, 0, offsetof(BoxedFile, weakreflist),
@@ -3327,11 +3278,11 @@ void setupRuntime() {
     long_cls->tp_flags |= Py_TPFLAGS_LONG_SUBCLASS;
     float_cls = new (0) BoxedHeapClass(object_cls, NULL, 0, 0, sizeof(BoxedFloat), false,
                                        static_cast<BoxedString*>(boxString("float")));
-    function_cls = new (0) BoxedHeapClass(object_cls, &functionGCHandler, offsetof(BoxedFunction, attrs),
+    function_cls = new (0) BoxedHeapClass(object_cls, &BoxedFunction::gcHandler, offsetof(BoxedFunction, attrs),
                                           offsetof(BoxedFunction, in_weakreflist), sizeof(BoxedFunction), false,
                                           static_cast<BoxedString*>(boxString("function")));
     builtin_function_or_method_cls = new (0)
-        BoxedHeapClass(object_cls, &functionGCHandler, 0, offsetof(BoxedBuiltinFunctionOrMethod, in_weakreflist),
+        BoxedHeapClass(object_cls, &BoxedFunction::gcHandler, 0, offsetof(BoxedBuiltinFunctionOrMethod, in_weakreflist),
                        sizeof(BoxedBuiltinFunctionOrMethod), false,
                        static_cast<BoxedString*>(boxString("builtin_function_or_method")));
     function_cls->tp_dealloc = builtin_function_or_method_cls->tp_dealloc = functionDtor;
@@ -3455,24 +3406,25 @@ void setupRuntime() {
     type_cls->giveAttr("__dict__", new (pyston_getset_cls) BoxedGetsetDescriptor(typeDict, NULL, NULL));
 
 
-    instancemethod_cls = BoxedHeapClass::create(type_cls, object_cls, &instancemethodGCHandler, 0,
+    instancemethod_cls = BoxedHeapClass::create(type_cls, object_cls, &BoxedInstanceMethod::gcHandler, 0,
                                                 offsetof(BoxedInstanceMethod, in_weakreflist),
                                                 sizeof(BoxedInstanceMethod), false, "instancemethod");
 
-    slice_cls = BoxedHeapClass::create(type_cls, object_cls, &sliceGCHandler, 0, 0, sizeof(BoxedSlice), false, "slice");
-    set_cls = BoxedHeapClass::create(type_cls, object_cls, &setGCHandler, 0, offsetof(BoxedSet, weakreflist),
+    slice_cls = BoxedHeapClass::create(type_cls, object_cls, &BoxedSlice::gcHandler, 0, 0, sizeof(BoxedSlice), false,
+                                       "slice");
+    set_cls = BoxedHeapClass::create(type_cls, object_cls, &BoxedSet::gcHandler, 0, offsetof(BoxedSet, weakreflist),
                                      sizeof(BoxedSet), false, "set");
-    frozenset_cls = BoxedHeapClass::create(type_cls, object_cls, &setGCHandler, 0, offsetof(BoxedSet, weakreflist),
-                                           sizeof(BoxedSet), false, "frozenset");
+    frozenset_cls = BoxedHeapClass::create(type_cls, object_cls, &BoxedSet::gcHandler, 0,
+                                           offsetof(BoxedSet, weakreflist), sizeof(BoxedSet), false, "frozenset");
     capi_getset_cls
         = BoxedHeapClass::create(type_cls, object_cls, NULL, 0, 0, sizeof(BoxedGetsetDescriptor), false, "getset");
-    closure_cls
-        = BoxedHeapClass::create(type_cls, object_cls, &closureGCHandler, 0, 0, sizeof(BoxedClosure), false, "closure");
-    property_cls = BoxedHeapClass::create(type_cls, object_cls, &propertyGCHandler, 0, 0, sizeof(BoxedProperty), false,
-                                          "property");
-    staticmethod_cls = BoxedHeapClass::create(type_cls, object_cls, &staticmethodGCHandler, 0, 0,
+    closure_cls = BoxedHeapClass::create(type_cls, object_cls, &BoxedClosure::gcHandler, 0, 0, sizeof(BoxedClosure),
+                                         false, "closure");
+    property_cls = BoxedHeapClass::create(type_cls, object_cls, &BoxedProperty::gcHandler, 0, 0, sizeof(BoxedProperty),
+                                          false, "property");
+    staticmethod_cls = BoxedHeapClass::create(type_cls, object_cls, &BoxedStaticmethod::gcHandler, 0, 0,
                                               sizeof(BoxedStaticmethod), false, "staticmethod");
-    classmethod_cls = BoxedHeapClass::create(type_cls, object_cls, &classmethodGCHandler, 0, 0,
+    classmethod_cls = BoxedHeapClass::create(type_cls, object_cls, &BoxedClassmethod::gcHandler, 0, 0,
                                              sizeof(BoxedClassmethod), false, "classmethod");
     attrwrapperiter_cls = BoxedHeapClass::create(type_cls, object_cls, &AttrWrapperIter::gcHandler, 0, 0,
                                                  sizeof(AttrWrapperIter), false, "attrwrapperiter");

--- a/src/runtime/types.h
+++ b/src/runtime/types.h
@@ -298,6 +298,8 @@ public:
     static BoxedHeapClass* create(BoxedClass* metatype, BoxedClass* base, gcvisit_func gc_visit, int attrs_offset,
                                   int weaklist_offset, int instance_size, bool is_user_defined, llvm::StringRef name);
 
+    static void gcHandler(GCVisitor* v, Box* b);
+
 private:
     // These functions are not meant for external callers and will mostly just be called
     // by BoxedHeapClass::create(), but setupRuntime() also needs to do some manual class
@@ -471,6 +473,8 @@ public:
     : in_weakreflist(NULL), obj(obj), func(func), im_class(im_class) {}
 
     DEFAULT_CLASS_SIMPLE(instancemethod_cls);
+
+    static void gcHandler(GCVisitor* v, Box* b);
 };
 
 class GCdArray {
@@ -505,6 +509,8 @@ public:
     static const int INITIAL_CAPACITY;
 
     DEFAULT_CLASS_SIMPLE(list_cls);
+
+    static void gcHandler(GCVisitor* v, Box* b);
 };
 static_assert(sizeof(BoxedList) <= sizeof(PyListObject), "");
 static_assert(sizeof(BoxedList) >= sizeof(PyListObject), "");
@@ -639,6 +645,8 @@ public:
         return rtn;
     }
 
+    static void gcHandler(GCVisitor* v, Box* b);
+
 private:
     BoxedTuple() {}
 
@@ -697,6 +705,8 @@ public:
             return p->second;
         return NULL;
     }
+
+    static void gcHandler(GCVisitor* v, Box* b);
 };
 static_assert(sizeof(BoxedDict) == sizeof(PyDictObject), "");
 
@@ -737,6 +747,8 @@ public:
                   Box* globals = NULL);
 
     DEFAULT_CLASS(function_cls);
+
+    static void gcHandler(GCVisitor* v, Box* b);
 };
 
 class BoxedBuiltinFunctionOrMethod : public BoxedFunctionBase {
@@ -790,6 +802,8 @@ public:
     BoxedSlice(Box* lower, Box* upper, Box* step) : start(lower), stop(upper), step(step) {}
 
     DEFAULT_CLASS_SIMPLE(slice_cls);
+
+    static void gcHandler(GCVisitor* v, Box* b);
 };
 static_assert(sizeof(BoxedSlice) == sizeof(PySliceObject), "");
 static_assert(offsetof(BoxedSlice, start) == offsetof(PySliceObject, start), "");
@@ -855,6 +869,8 @@ public:
         : prop_get(get), prop_set(set), prop_del(del), prop_doc(doc) {}
 
     DEFAULT_CLASS_SIMPLE(property_cls);
+
+    static void gcHandler(GCVisitor* v, Box* b);
 };
 
 class BoxedStaticmethod : public Box {
@@ -864,6 +880,8 @@ public:
     BoxedStaticmethod(Box* callable) : sm_callable(callable){};
 
     DEFAULT_CLASS_SIMPLE(staticmethod_cls);
+
+    static void gcHandler(GCVisitor* v, Box* b);
 };
 
 class BoxedClassmethod : public Box {
@@ -873,6 +891,8 @@ public:
     BoxedClassmethod(Box* callable) : cm_callable(callable){};
 
     DEFAULT_CLASS_SIMPLE(classmethod_cls);
+
+    static void gcHandler(GCVisitor* v, Box* b);
 };
 
 // TODO is there any particular reason to make this a Box, i.e. a python-level object?
@@ -896,6 +916,8 @@ public:
         memset((void*)rtn->elts, 0, sizeof(Box*) * nelts);
         return rtn;
     }
+
+    static void gcHandler(GCVisitor* v, Box* b);
 };
 
 class BoxedGenerator : public Box {
@@ -923,6 +945,8 @@ public:
     BoxedGenerator(BoxedFunctionBase* function, Box* arg1, Box* arg2, Box* arg3, Box** args);
 
     DEFAULT_CLASS(generator_cls);
+
+    static void gcHandler(GCVisitor* v, Box* b);
 };
 
 struct wrapper_def {

--- a/src/runtime/types.h
+++ b/src/runtime/types.h
@@ -1006,8 +1006,6 @@ public:
     static void gcHandler(GCVisitor* v, Box* _o);
 };
 
-extern "C" void boxGCHandler(GCVisitor* v, Box* b);
-
 Box* objectNewNoArgs(BoxedClass* cls);
 Box* objectSetattr(Box* obj, Box* attr, Box* value);
 


### PR DESCRIPTION
Make them static functions on the type that the visit function is associated to whenever possible. Makes it more consistent and less likely to forget to update the visit function if we change the type's fields.