### PR TITLE
more capi exceptions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1260,6 +1260,12 @@ $(FROM_CPYTHON_SRCS:.c=.prof.o): %.prof.o: %.c $(BUILD_SYSTEM_DEPS)
 	$(ECHO) Compiling C file to $@
 	$(VERB) $(CC_PROFILE) $(EXT_CFLAGS_PROFILE) -c $< -o $@ -g -MMD -MP -MF $(patsubst %.o,%.d,$@)
 
+.PHONY: update_section_ordering
+update_section_ordering: pyston_release
+	perf record -o perf_section_ordering.data -- ./pyston_release -q minibenchmarks/combined.py
+	$(MAKE) pyston_pgo
+	python tools/generate_section_ordering_from_pgo_build.py pyston_pgo perf_section_ordering.data > section_ordering.txt
+	rm perf_section_ordering.data
 
 
 

--- a/from_cpython/Include/object.h
+++ b/from_cpython/Include/object.h
@@ -460,7 +460,8 @@ struct _typeobject {
     bool _flags[7];
     void* _tpp_descr_get;
     void* _tpp_hasnext;
-    void* _tpp_call;
+    void* _tpp_call_capi;
+    void* _tpp_call_cxx;
 };
 
 /* The *real* layout of a type object when allocated on the heap */

--- a/from_cpython/setup.py
+++ b/from_cpython/setup.py
@@ -1,6 +1,7 @@
 # CPython has a 2kloc version of this file
 
 from distutils.core import setup, Extension
+import glob
 import os
 import sysconfig
 
@@ -131,6 +132,11 @@ ext_modules = [future_builtins_ext(),
                grp_ext(),
                curses_ext(),
                termios_ext()]
+
+builtin_headers = map(relpath, glob.glob("Include/*.h"))
+
+for m in ext_modules:
+    m.depends += builtin_headers
 
 
 setup(name="Pyston", version="1.0", description="Pyston shared modules", ext_modules=ext_modules)

--- a/src/capi/typeobject.cpp
+++ b/src/capi/typeobject.cpp
@@ -3184,8 +3184,10 @@ extern "C" void PyType_Modified(PyTypeObject* type) noexcept {
     // We don't cache anything yet that would need to be invalidated:
 }
 
+template <ExceptionStyle S>
 static Box* tppProxyToTpCall(Box* self, CallRewriteArgs* rewrite_args, ArgPassSpec argspec, Box* arg1, Box* arg2,
-                             Box* arg3, Box** args, const std::vector<BoxedString*>* keyword_names) {
+                             Box* arg3, Box** args,
+                             const std::vector<BoxedString*>* keyword_names) noexcept(S == CAPI) {
     ParamReceiveSpec paramspec(0, 0, true, true);
     if (!argspec.has_kwargs && argspec.num_keywords == 0) {
         paramspec.takes_kwargs = false;
@@ -3193,8 +3195,16 @@ static Box* tppProxyToTpCall(Box* self, CallRewriteArgs* rewrite_args, ArgPassSp
 
     bool rewrite_success = false;
     Box* oarg1, * oarg2 = NULL, *oarg3, ** oargs = NULL;
-    rearrangeArguments(paramspec, NULL, "", NULL, rewrite_args, rewrite_success, argspec, arg1, arg2, arg3, args,
-                       keyword_names, oarg1, oarg2, oarg3, oargs);
+    try {
+        rearrangeArguments(paramspec, NULL, "", NULL, rewrite_args, rewrite_success, argspec, arg1, arg2, arg3, args,
+                           keyword_names, oarg1, oarg2, oarg3, oargs);
+    } catch (ExcInfo e) {
+        if (S == CAPI) {
+            setCAPIException(e);
+            return NULL;
+        } else
+            throw e;
+    }
 
     if (!rewrite_success)
         rewrite_args = NULL;
@@ -3213,12 +3223,13 @@ static Box* tppProxyToTpCall(Box* self, CallRewriteArgs* rewrite_args, ArgPassSp
 
         rewrite_args->out_rtn = rewrite_args->rewriter->call(true, (void*)self->cls->tp_call, rewrite_args->obj,
                                                              rewrite_args->arg1, rewrite_args->arg2);
-        rewrite_args->rewriter->call(true, (void*)checkAndThrowCAPIException);
+        if (S == CXX)
+            rewrite_args->rewriter->call(true, (void*)checkAndThrowCAPIException);
         rewrite_args->out_success = true;
     }
 
     Box* r = self->cls->tp_call(self, oarg1, oarg2);
-    if (!r)
+    if (!r && S == CXX)
         throwCAPIException();
     return r;
 }
@@ -3267,8 +3278,10 @@ extern "C" int PyType_Ready(PyTypeObject* cls) noexcept {
 
     assert(cls->tp_name);
 
-    if (cls->tp_call)
-        cls->tpp_call = tppProxyToTpCall;
+    if (cls->tp_call) {
+        cls->tpp_call.capi_val = tppProxyToTpCall<CAPI>;
+        cls->tpp_call.cxx_val = tppProxyToTpCall<CXX>;
+    }
 
     try {
         add_operators(cls);

--- a/src/capi/typeobject.cpp
+++ b/src/capi/typeobject.cpp
@@ -1068,8 +1068,8 @@ Box* slotTpGetattrHookInternal(Box* self, BoxedString* name, GetattrRewriteArgs*
         assert(PyString_CHECK_INTERNED(name) == SSTATE_INTERNED_IMMORTAL);
         crewrite_args.arg1 = rewrite_args->rewriter->loadConst((intptr_t)name, Location::forArg(1));
 
-        res = callattrInternal(self, _getattr_str, LookupScope::CLASS_ONLY, &crewrite_args, ArgPassSpec(1), name, NULL,
-                               NULL, NULL, NULL);
+        res = callattrInternal<CXX>(self, _getattr_str, LookupScope::CLASS_ONLY, &crewrite_args, ArgPassSpec(1), name,
+                                    NULL, NULL, NULL, NULL);
         assert(res);
 
         if (!crewrite_args.out_success)
@@ -1082,8 +1082,8 @@ Box* slotTpGetattrHookInternal(Box* self, BoxedString* name, GetattrRewriteArgs*
         // the rewrite_args and non-rewrite_args case the same.
         // Actually, we might have gotten to the point that doing a runtimeCall on an instancemethod is as
         // fast as a callattr, but that hasn't typically been the case.
-        res = callattrInternal(self, _getattr_str, LookupScope::CLASS_ONLY, NULL, ArgPassSpec(1), name, NULL, NULL,
-                               NULL, NULL);
+        res = callattrInternal<CXX>(self, _getattr_str, LookupScope::CLASS_ONLY, NULL, ArgPassSpec(1), name, NULL, NULL,
+                                    NULL, NULL);
         assert(res);
     }
 

--- a/src/capi/types.h
+++ b/src/capi/types.h
@@ -43,8 +43,9 @@ public:
     }
 
     static Box* __call__(BoxedCApiFunction* self, BoxedTuple* varargs, BoxedDict* kwargs);
+    template <ExceptionStyle S>
     static Box* tppCall(Box* _self, CallRewriteArgs* rewrite_args, ArgPassSpec argspec, Box* arg1, Box* arg2, Box* arg3,
-                        Box** args, const std::vector<BoxedString*>* keyword_names);
+                        Box** args, const std::vector<BoxedString*>* keyword_names) noexcept(S == CAPI);
 
     static Box* getname(Box* b, void*) {
         RELEASE_ASSERT(b->cls == capifunc_cls, "");

--- a/src/codegen/ast_interpreter.cpp
+++ b/src/codegen/ast_interpreter.cpp
@@ -332,6 +332,7 @@ Box* ASTInterpreter::execJITedBlock(CFGBlock* b) {
             throw e;
 
         auto source = getCL()->source.get();
+        stmt->cxx_exception_count++;
         exceptionCaughtInInterpreter(LineInfo(stmt->lineno, stmt->col_offset, source->fn, source->getName()), &e);
 
         next_block = ((AST_Invoke*)stmt)->exc_dest;
@@ -764,6 +765,7 @@ Value ASTInterpreter::visit_invoke(AST_Invoke* node) {
         abortJITing();
 
         auto source = getCL()->source.get();
+        node->cxx_exception_count++;
         exceptionCaughtInInterpreter(LineInfo(node->lineno, node->col_offset, source->fn, source->getName()), &e);
 
         next_block = node->exc_dest;

--- a/src/codegen/compvars.cpp
+++ b/src/codegen/compvars.cpp
@@ -613,8 +613,8 @@ static ConcreteCompilerVariable* _call(IREmitter& emitter, const OpInfo& info, l
     // for (auto a : llvm_args)
     // a->dump();
 
-    bool do_patchpoint = ENABLE_ICCALLSITES
-                         && (func_addr == runtimeCall || func_addr == runtimeCallCapi || func_addr == pyston::callattr);
+    bool do_patchpoint = ENABLE_ICCALLSITES && (func_addr == runtimeCall || func_addr == runtimeCallCapi
+                                                || func_addr == pyston::callattr || func_addr == callattrCapi);
     if (do_patchpoint) {
         assert(func_addr);
 
@@ -691,25 +691,35 @@ CompilerVariable* UnknownType::callattr(IREmitter& emitter, const OpInfo& info, 
     bool pass_keywords = (flags.argspec.num_keywords != 0);
     int npassed_args = flags.argspec.totalPassed();
 
+    ExceptionStyle exception_style = ((FORCE_LLVM_CAPI && !info.unw_info.cxx_exc_dest && !flags.null_on_nonexistent)
+                                      || info.unw_info.capi_exc_dest)
+                                         ? ExceptionStyle::CAPI
+                                         : ExceptionStyle::CXX;
+
+    if (exception_style == CAPI)
+        assert(!flags.null_on_nonexistent); // Will conflict with CAPI's null-on-exception
+
     llvm::Value* func;
     if (pass_keywords)
-        func = g.funcs.callattr;
+        func = g.funcs.callattr.get(exception_style);
     else if (npassed_args == 0)
-        func = g.funcs.callattr0;
+        func = g.funcs.callattr0.get(exception_style);
     else if (npassed_args == 1)
-        func = g.funcs.callattr1;
+        func = g.funcs.callattr1.get(exception_style);
     else if (npassed_args == 2)
-        func = g.funcs.callattr2;
+        func = g.funcs.callattr2.get(exception_style);
     else if (npassed_args == 3)
-        func = g.funcs.callattr3;
+        func = g.funcs.callattr3.get(exception_style);
     else
-        func = g.funcs.callattrN;
+        func = g.funcs.callattrN.get(exception_style);
+
+    void* func_ptr = (exception_style == ExceptionStyle::CXX) ? (void*)pyston::callattr : (void*)callattrCapi;
 
     std::vector<llvm::Value*> other_args;
     other_args.push_back(var->getValue());
     other_args.push_back(embedRelocatablePtr(attr, g.llvm_boxedstring_type_ptr));
     other_args.push_back(getConstantInt(flags.asInt(), g.i64));
-    return _call(emitter, info, func, CXX, (void*)pyston::callattr, other_args, flags.argspec, args, keyword_names,
+    return _call(emitter, info, func, exception_style, func_ptr, other_args, flags.argspec, args, keyword_names,
                  UNKNOWN);
 }
 
@@ -1707,8 +1717,14 @@ public:
     CompilerVariable* callattr(IREmitter& emitter, const OpInfo& info, ConcreteCompilerVariable* var, BoxedString* attr,
                                CallattrFlags flags, const std::vector<CompilerVariable*>& args,
                                const std::vector<BoxedString*>* keyword_names) override {
-        ConcreteCompilerVariable* called_constant
-            = tryCallattrConstant(emitter, info, var, attr, flags.cls_only, flags.argspec, args, keyword_names);
+        ExceptionStyle exception_style = CXX;
+        // Not safe to force-capi here since most of the functions won't have capi variants:
+        if (/*FORCE_LLVM_CAPI ||*/ info.unw_info.capi_exc_dest)
+            exception_style = CAPI;
+
+        ConcreteCompilerVariable* called_constant = tryCallattrConstant(
+            emitter, info, var, attr, flags.cls_only, flags.argspec, args, keyword_names, NULL, exception_style);
+
         if (called_constant)
             return called_constant;
 

--- a/src/codegen/runtime_hooks.cpp
+++ b/src/codegen/runtime_hooks.cpp
@@ -245,17 +245,31 @@ void initGlobalFuncs(GlobalState& g) {
     GET(boxedLocalsGet);
     GET(boxedLocalsDel);
 
-    g.funcs.runtimeCall = getFunc((void*)runtimeCall, "runtimeCall");
-    g.funcs.runtimeCall0 = addFunc((void*)runtimeCall, g.llvm_value_type_ptr, g.llvm_value_type_ptr, g.i32);
-    g.funcs.runtimeCall1
+    g.funcs.runtimeCall.cxx_val = getFunc((void*)runtimeCall, "runtimeCall");
+    g.funcs.runtimeCall0.cxx_val = addFunc((void*)runtimeCall, g.llvm_value_type_ptr, g.llvm_value_type_ptr, g.i32);
+    g.funcs.runtimeCall1.cxx_val
         = addFunc((void*)runtimeCall, g.llvm_value_type_ptr, g.llvm_value_type_ptr, g.i32, g.llvm_value_type_ptr);
-    g.funcs.runtimeCall2 = addFunc((void*)runtimeCall, g.llvm_value_type_ptr, g.llvm_value_type_ptr, g.i32,
-                                   g.llvm_value_type_ptr, g.llvm_value_type_ptr);
-    g.funcs.runtimeCall3 = addFunc((void*)runtimeCall, g.llvm_value_type_ptr, g.llvm_value_type_ptr, g.i32,
-                                   g.llvm_value_type_ptr, g.llvm_value_type_ptr, g.llvm_value_type_ptr);
-    g.funcs.runtimeCallN
+    g.funcs.runtimeCall2.cxx_val = addFunc((void*)runtimeCall, g.llvm_value_type_ptr, g.llvm_value_type_ptr, g.i32,
+                                           g.llvm_value_type_ptr, g.llvm_value_type_ptr);
+    g.funcs.runtimeCall3.cxx_val = addFunc((void*)runtimeCall, g.llvm_value_type_ptr, g.llvm_value_type_ptr, g.i32,
+                                           g.llvm_value_type_ptr, g.llvm_value_type_ptr, g.llvm_value_type_ptr);
+    g.funcs.runtimeCallN.cxx_val
         = addFunc((void*)runtimeCall, g.llvm_value_type_ptr, g.llvm_value_type_ptr, g.i32, g.llvm_value_type_ptr,
                   g.llvm_value_type_ptr, g.llvm_value_type_ptr, g.llvm_value_type_ptr->getPointerTo());
+
+    g.funcs.runtimeCall.capi_val = getFunc((void*)runtimeCallCapi, "runtimeCallCapi");
+    g.funcs.runtimeCall0.capi_val
+        = addFunc((void*)runtimeCallCapi, g.llvm_value_type_ptr, g.llvm_value_type_ptr, g.i32);
+    g.funcs.runtimeCall1.capi_val
+        = addFunc((void*)runtimeCallCapi, g.llvm_value_type_ptr, g.llvm_value_type_ptr, g.i32, g.llvm_value_type_ptr);
+    g.funcs.runtimeCall2.capi_val = addFunc((void*)runtimeCallCapi, g.llvm_value_type_ptr, g.llvm_value_type_ptr, g.i32,
+                                            g.llvm_value_type_ptr, g.llvm_value_type_ptr);
+    g.funcs.runtimeCall3.capi_val = addFunc((void*)runtimeCallCapi, g.llvm_value_type_ptr, g.llvm_value_type_ptr, g.i32,
+                                            g.llvm_value_type_ptr, g.llvm_value_type_ptr, g.llvm_value_type_ptr);
+    g.funcs.runtimeCallN.capi_val
+        = addFunc((void*)runtimeCallCapi, g.llvm_value_type_ptr, g.llvm_value_type_ptr, g.i32, g.llvm_value_type_ptr,
+                  g.llvm_value_type_ptr, g.llvm_value_type_ptr, g.llvm_value_type_ptr->getPointerTo());
+
 
     g.funcs.callattr = getFunc((void*)callattr, "callattr");
     g.funcs.callattr0

--- a/src/codegen/runtime_hooks.cpp
+++ b/src/codegen/runtime_hooks.cpp
@@ -271,19 +271,36 @@ void initGlobalFuncs(GlobalState& g) {
                   g.llvm_value_type_ptr, g.llvm_value_type_ptr, g.llvm_value_type_ptr->getPointerTo());
 
 
-    g.funcs.callattr = getFunc((void*)callattr, "callattr");
-    g.funcs.callattr0
+    g.funcs.callattr.cxx_val = getFunc((void*)callattr, "callattr");
+    g.funcs.callattr0.cxx_val
         = addFunc((void*)callattr, g.llvm_value_type_ptr, g.llvm_value_type_ptr, g.llvm_boxedstring_type_ptr, g.i64);
-    g.funcs.callattr1 = addFunc((void*)callattr, g.llvm_value_type_ptr, g.llvm_value_type_ptr,
-                                g.llvm_boxedstring_type_ptr, g.i64, g.llvm_value_type_ptr);
-    g.funcs.callattr2 = addFunc((void*)callattr, g.llvm_value_type_ptr, g.llvm_value_type_ptr,
-                                g.llvm_boxedstring_type_ptr, g.i64, g.llvm_value_type_ptr, g.llvm_value_type_ptr);
-    g.funcs.callattr3
+    g.funcs.callattr1.cxx_val = addFunc((void*)callattr, g.llvm_value_type_ptr, g.llvm_value_type_ptr,
+                                        g.llvm_boxedstring_type_ptr, g.i64, g.llvm_value_type_ptr);
+    g.funcs.callattr2.cxx_val
+        = addFunc((void*)callattr, g.llvm_value_type_ptr, g.llvm_value_type_ptr, g.llvm_boxedstring_type_ptr, g.i64,
+                  g.llvm_value_type_ptr, g.llvm_value_type_ptr);
+    g.funcs.callattr3.cxx_val
         = addFunc((void*)callattr, g.llvm_value_type_ptr, g.llvm_value_type_ptr, g.llvm_boxedstring_type_ptr, g.i64,
                   g.llvm_value_type_ptr, g.llvm_value_type_ptr, g.llvm_value_type_ptr);
-    g.funcs.callattrN = addFunc((void*)callattr, g.llvm_value_type_ptr, g.llvm_value_type_ptr,
-                                g.llvm_boxedstring_type_ptr, g.i64, g.llvm_value_type_ptr, g.llvm_value_type_ptr,
-                                g.llvm_value_type_ptr, g.llvm_value_type_ptr->getPointerTo());
+    g.funcs.callattrN.cxx_val = addFunc(
+        (void*)callattr, g.llvm_value_type_ptr, g.llvm_value_type_ptr, g.llvm_boxedstring_type_ptr, g.i64,
+        g.llvm_value_type_ptr, g.llvm_value_type_ptr, g.llvm_value_type_ptr, g.llvm_value_type_ptr->getPointerTo());
+
+
+    g.funcs.callattr.capi_val = getFunc((void*)callattrCapi, "callattrCapi");
+    g.funcs.callattr0.capi_val = addFunc((void*)callattrCapi, g.llvm_value_type_ptr, g.llvm_value_type_ptr,
+                                         g.llvm_boxedstring_type_ptr, g.i64);
+    g.funcs.callattr1.capi_val = addFunc((void*)callattrCapi, g.llvm_value_type_ptr, g.llvm_value_type_ptr,
+                                         g.llvm_boxedstring_type_ptr, g.i64, g.llvm_value_type_ptr);
+    g.funcs.callattr2.capi_val
+        = addFunc((void*)callattrCapi, g.llvm_value_type_ptr, g.llvm_value_type_ptr, g.llvm_boxedstring_type_ptr, g.i64,
+                  g.llvm_value_type_ptr, g.llvm_value_type_ptr);
+    g.funcs.callattr3.capi_val
+        = addFunc((void*)callattrCapi, g.llvm_value_type_ptr, g.llvm_value_type_ptr, g.llvm_boxedstring_type_ptr, g.i64,
+                  g.llvm_value_type_ptr, g.llvm_value_type_ptr, g.llvm_value_type_ptr);
+    g.funcs.callattrN.capi_val = addFunc(
+        (void*)callattrCapi, g.llvm_value_type_ptr, g.llvm_value_type_ptr, g.llvm_boxedstring_type_ptr, g.i64,
+        g.llvm_value_type_ptr, g.llvm_value_type_ptr, g.llvm_value_type_ptr, g.llvm_value_type_ptr->getPointerTo());
 
     g.funcs.reoptCompiledFunc = addFunc((void*)reoptCompiledFunc, g.i8_ptr, g.i8_ptr);
     g.funcs.compilePartialFunc = addFunc((void*)compilePartialFunc, g.i8_ptr, g.i8_ptr);

--- a/src/codegen/runtime_hooks.h
+++ b/src/codegen/runtime_hooks.h
@@ -43,7 +43,7 @@ struct GlobalFuncs {
         *raiseAttributeErrorStrCapi, *raiseNotIterableError, *raiseIndexErrorStr, *raiseIndexErrorStrCapi,
         *assertNameDefined, *assertFail, *assertFailDerefNameDefined, *printExprHelper;
     llvm::Value* printFloat, *listAppendInternal, *getSysStdout;
-    llvm::Value* runtimeCall0, *runtimeCall1, *runtimeCall2, *runtimeCall3, *runtimeCall, *runtimeCallN;
+    ExceptionSwitchable<llvm::Value*> runtimeCall0, runtimeCall1, runtimeCall2, runtimeCall3, runtimeCall, runtimeCallN;
     llvm::Value* callattr0, *callattr1, *callattr2, *callattr3, *callattr, *callattrN;
     llvm::Value* reoptCompiledFunc, *compilePartialFunc;
     llvm::Value* exec;

--- a/src/codegen/runtime_hooks.h
+++ b/src/codegen/runtime_hooks.h
@@ -44,7 +44,7 @@ struct GlobalFuncs {
         *assertNameDefined, *assertFail, *assertFailDerefNameDefined, *printExprHelper;
     llvm::Value* printFloat, *listAppendInternal, *getSysStdout;
     ExceptionSwitchable<llvm::Value*> runtimeCall0, runtimeCall1, runtimeCall2, runtimeCall3, runtimeCall, runtimeCallN;
-    llvm::Value* callattr0, *callattr1, *callattr2, *callattr3, *callattr, *callattrN;
+    ExceptionSwitchable<llvm::Value*> callattr0, callattr1, callattr2, callattr3, callattr, callattrN;
     llvm::Value* reoptCompiledFunc, *compilePartialFunc;
     llvm::Value* exec;
     llvm::Value* boxedLocalsSet, *boxedLocalsGet, *boxedLocalsDel;

--- a/src/codegen/unwinding.cpp
+++ b/src/codegen/unwinding.cpp
@@ -536,6 +536,8 @@ public:
             exc_info.reraise = false;
             return;
         }
+        // TODO: shouldn't fetch this multiple times?
+        frame_iter.getCurrentStatement()->cxx_exception_count++;
         auto line_info = lineInfoForFrame(&frame_iter);
         BoxedTraceback::here(line_info, &exc_info.traceback);
     }

--- a/src/core/ast.h
+++ b/src/core/ast.h
@@ -182,6 +182,8 @@ class AST_stmt : public AST {
 public:
     virtual void accept_stmt(StmtVisitor* v) = 0;
 
+    int cxx_exception_count = 0;
+
     AST_stmt(AST_TYPE::AST_TYPE type) : AST(type) {}
 };
 

--- a/src/runtime/inline/link_forcer.cpp
+++ b/src/runtime/inline/link_forcer.cpp
@@ -120,6 +120,7 @@ void force() {
     FORCE(getSysStdout);
 
     FORCE(runtimeCall);
+    FORCE(runtimeCallCapi);
     FORCE(callattr);
 
     FORCE(raise0);

--- a/src/runtime/inline/link_forcer.cpp
+++ b/src/runtime/inline/link_forcer.cpp
@@ -122,6 +122,7 @@ void force() {
     FORCE(runtimeCall);
     FORCE(runtimeCallCapi);
     FORCE(callattr);
+    FORCE(callattrCapi);
 
     FORCE(raise0);
     FORCE(raise3);

--- a/src/runtime/int.cpp
+++ b/src/runtime/int.cpp
@@ -960,7 +960,7 @@ static Box* _intNew(Box* val, Box* base) {
             raiseExcHelper(TypeError, "");
         }
 
-        if (!isSubclass(r->cls, int_cls) && !isSubclass(r->cls, long_cls)) {
+        if (!PyInt_Check(r) && !PyLong_Check(r)) {
             raiseExcHelper(TypeError, "__int__ returned non-int (type %s)", r->cls->tp_name);
         }
         return r;

--- a/src/runtime/objmodel.cpp
+++ b/src/runtime/objmodel.cpp
@@ -2578,7 +2578,8 @@ template <ExceptionStyle S> BoxedInt* lenInternal(Box* obj, LenRewriteArgs* rewr
 
     if (rtn == NULL) {
         if (S == CAPI) {
-            PyErr_Format(TypeError, "object of type '%s' has no len()", getTypeName(obj));
+            if (!PyErr_Occurred())
+                PyErr_Format(TypeError, "object of type '%s' has no len()", getTypeName(obj));
             return NULL;
         } else
             raiseExcHelper(TypeError, "object of type '%s' has no len()", getTypeName(obj));
@@ -3694,7 +3695,8 @@ Box* runtimeCallInternal(Box* obj, CallRewriteArgs* rewrite_args, ArgPassSpec ar
 
         if (!rtn) {
             if (S == CAPI) {
-                PyErr_Format(TypeError, "'%s' object is not callable", getTypeName(obj));
+                if (!PyErr_Occurred())
+                    PyErr_Format(TypeError, "'%s' object is not callable", getTypeName(obj));
                 return NULL;
             } else
                 raiseExcHelper(TypeError, "'%s' object is not callable", getTypeName(obj));
@@ -4689,7 +4691,7 @@ extern "C" Box* getitem_capi(Box* target, Box* slice) noexcept {
 
         if (!rewrite_args.out_success) {
             rewriter.reset(NULL);
-        } else {
+        } else if (rtn) {
             rewriter->commitReturning(rewrite_args.out_rtn);
         }
     } else {

--- a/src/runtime/objmodel.h
+++ b/src/runtime/objmodel.h
@@ -67,6 +67,8 @@ extern "C" bool nonzero(Box* obj);
 extern "C" Box* runtimeCall(Box*, ArgPassSpec, Box*, Box*, Box*, Box**, const std::vector<BoxedString*>*);
 extern "C" Box* runtimeCallCapi(Box*, ArgPassSpec, Box*, Box*, Box*, Box**, const std::vector<BoxedString*>*) noexcept;
 extern "C" Box* callattr(Box*, BoxedString*, CallattrFlags, Box*, Box*, Box*, Box**, const std::vector<BoxedString*>*);
+extern "C" Box* callattrCapi(Box*, BoxedString*, CallattrFlags, Box*, Box*, Box*, Box**,
+                             const std::vector<BoxedString*>*) noexcept;
 extern "C" BoxedString* str(Box* obj);
 extern "C" BoxedString* repr(Box* obj);
 extern "C" BoxedString* reprOrNull(Box* obj); // similar to repr, but returns NULL on exception

--- a/src/runtime/objmodel.h
+++ b/src/runtime/objmodel.h
@@ -135,9 +135,10 @@ enum LookupScope {
     INST_ONLY = 2,
     CLASS_OR_INST = 3,
 };
-extern "C" Box* callattrInternal(Box* obj, BoxedString* attr, LookupScope, CallRewriteArgs* rewrite_args,
-                                 ArgPassSpec argspec, Box* arg1, Box* arg2, Box* arg3, Box** args,
-                                 const std::vector<BoxedString*>* keyword_names);
+template <ExceptionStyle S>
+Box* callattrInternal(Box* obj, BoxedString* attr, LookupScope, CallRewriteArgs* rewrite_args, ArgPassSpec argspec,
+                      Box* arg1, Box* arg2, Box* arg3, Box** args,
+                      const std::vector<BoxedString*>* keyword_names) noexcept(S == CAPI);
 extern "C" void delattr_internal(Box* obj, BoxedString* attr, bool allow_custom, DelattrRewriteArgs* rewrite_args);
 struct CompareRewriteArgs;
 Box* compareInternal(Box* lhs, Box* rhs, int op_type, CompareRewriteArgs* rewrite_args);

--- a/src/runtime/objmodel.h
+++ b/src/runtime/objmodel.h
@@ -65,6 +65,7 @@ extern "C" void delattrMaybeNonstring(Box* obj, Box* attr);
 extern "C" void delattrGeneric(Box* obj, BoxedString* attr, DelattrRewriteArgs* rewrite_args);
 extern "C" bool nonzero(Box* obj);
 extern "C" Box* runtimeCall(Box*, ArgPassSpec, Box*, Box*, Box*, Box**, const std::vector<BoxedString*>*);
+extern "C" Box* runtimeCallCapi(Box*, ArgPassSpec, Box*, Box*, Box*, Box**, const std::vector<BoxedString*>*) noexcept;
 extern "C" Box* callattr(Box*, BoxedString*, CallattrFlags, Box*, Box*, Box*, Box**, const std::vector<BoxedString*>*);
 extern "C" BoxedString* str(Box* obj);
 extern "C" BoxedString* repr(Box* obj);

--- a/src/runtime/tuple.cpp
+++ b/src/runtime/tuple.cpp
@@ -143,7 +143,7 @@ template <ExceptionStyle S> Box* tupleGetitem(BoxedTuple* self, Box* slice) {
         }
     }
 
-    assert(self->cls == tuple_cls);
+    assert(isSubclass(self->cls, tuple_cls));
 
     if (PyIndex_Check(slice)) {
         Py_ssize_t i = PyNumber_AsSsize_t(slice, PyExc_IndexError);

--- a/src/runtime/types.cpp
+++ b/src/runtime/types.cpp
@@ -1063,8 +1063,8 @@ static Box* typeCallInner(CallRewriteArgs* rewrite_args, ArgPassSpec argspec, Bo
             srewrite_args.args_guarded = rewrite_args->args_guarded;
             srewrite_args.func_guarded = true;
 
-            // initrtn = callattrInternal(cls, _init_str, INST_ONLY, &srewrite_args, argspec, made, arg2, arg3, args,
-            // keyword_names);
+            // initrtn = callattrInternal<CXX>(cls, _init_str, INST_ONLY, &srewrite_args, argspec, made, arg2, arg3,
+            // args, keyword_names);
             initrtn
                 = runtimeCallInternal<CXX>(init_attr, &srewrite_args, argspec, made, arg2, arg3, args, keyword_names);
 
@@ -2319,8 +2319,8 @@ public:
         BoxedDict* dict = (BoxedDict*)AttrWrapper::copy(_self);
         assert(dict->cls == dict_cls);
         static BoxedString* eq_str = internStringImmortal("__eq__");
-        return callattrInternal(dict, eq_str, LookupScope::CLASS_ONLY, NULL, ArgPassSpec(1), _other, NULL, NULL, NULL,
-                                NULL);
+        return callattrInternal<CXX>(dict, eq_str, LookupScope::CLASS_ONLY, NULL, ArgPassSpec(1), _other, NULL, NULL,
+                                     NULL, NULL);
     }
 
     static Box* ne(Box* _self, Box* _other) { return eq(_self, _other) == True ? False : True; }

--- a/src/runtime/types.cpp
+++ b/src/runtime/types.cpp
@@ -599,22 +599,13 @@ extern "C" CLFunction* unboxCLFunction(Box* b) {
     return static_cast<BoxedFunction*>(b)->f;
 }
 
+template <ExceptionStyle S>
 static Box* typeCallInner(CallRewriteArgs* rewrite_args, ArgPassSpec argspec, Box* arg1, Box* arg2, Box* arg3,
-                          Box** args, const std::vector<BoxedString*>* keyword_names);
+                          Box** args, const std::vector<BoxedString*>* keyword_names) noexcept(S == CAPI);
 
 template <ExceptionStyle S>
 static Box* typeTppCall(Box* self, CallRewriteArgs* rewrite_args, ArgPassSpec argspec, Box* arg1, Box* arg2, Box* arg3,
                         Box** args, const std::vector<BoxedString*>* keyword_names) noexcept(S == CAPI) {
-    if (S == CAPI) {
-        try {
-            return typeTppCall<CXX>(self, NULL, argspec, arg1, arg2, arg3, args, keyword_names);
-        } catch (ExcInfo e) {
-            setCAPIException(e);
-            return NULL;
-        }
-    }
-
-    assert(S == CXX);
     int npassed_args = argspec.totalPassed();
 
     if (argspec.has_starargs || argspec.has_kwargs) {
@@ -636,7 +627,7 @@ static Box* typeTppCall(Box* self, CallRewriteArgs* rewrite_args, ArgPassSpec ar
     ArgPassSpec new_argspec
         = bindObjIntoArgs(self, r_bind_obj, rewrite_args, argspec, arg1, arg2, arg3, args, new_args);
 
-    return typeCallInner(rewrite_args, new_argspec, arg1, arg2, arg3, new_args, keyword_names);
+    return typeCallInner<S>(rewrite_args, new_argspec, arg1, arg2, arg3, new_args, keyword_names);
 }
 
 static Box* typeCallInternal(BoxedFunctionBase* f, CallRewriteArgs* rewrite_args, ArgPassSpec argspec, Box* arg1,
@@ -653,7 +644,7 @@ static Box* typeCallInternal(BoxedFunctionBase* f, CallRewriteArgs* rewrite_args
         return callFunc<CXX>(f, rewrite_args, argspec, arg1, arg2, arg3, args, keyword_names);
     }
 
-    return typeCallInner(rewrite_args, argspec, arg1, arg2, arg3, args, keyword_names);
+    return typeCallInner<CXX>(rewrite_args, argspec, arg1, arg2, arg3, args, keyword_names);
 }
 
 // For use on __init__ return values
@@ -720,8 +711,20 @@ static Box* unicodeNewHelper(BoxedClass* type, Box* string, Box* encoding_obj, B
     return r;
 }
 
+static Box* objectNewNoArgs(BoxedClass* cls) noexcept {
+    assert(isSubclass(cls->cls, type_cls));
+#ifndef NDEBUG
+    static BoxedString* new_str = internStringImmortal("__new__");
+    static BoxedString* init_str = internStringImmortal("__init__");
+    assert(typeLookup(cls, new_str, NULL) == typeLookup(object_cls, new_str, NULL)
+           && typeLookup(cls, init_str, NULL) != typeLookup(object_cls, init_str, NULL));
+#endif
+    return new (cls) Box();
+}
+
+template <ExceptionStyle S>
 static Box* typeCallInner(CallRewriteArgs* rewrite_args, ArgPassSpec argspec, Box* arg1, Box* arg2, Box* arg3,
-                          Box** args, const std::vector<BoxedString*>* keyword_names) {
+                          Box** args, const std::vector<BoxedString*>* keyword_names) noexcept(S == CAPI) {
     int npassed_args = argspec.totalPassed();
     int npositional = argspec.num_args;
 
@@ -730,15 +733,21 @@ static Box* typeCallInner(CallRewriteArgs* rewrite_args, ArgPassSpec argspec, Bo
     Box* _cls = arg1;
 
     if (!isSubclass(_cls->cls, type_cls)) {
-        raiseExcHelper(TypeError, "descriptor '__call__' requires a 'type' object but received an '%s'",
-                       getTypeName(_cls));
+        if (S == CAPI)
+            PyErr_Format(TypeError, "descriptor '__call__' requires a 'type' object but received an '%s'",
+                         getTypeName(_cls));
+        else
+            raiseExcHelper(TypeError, "descriptor '__call__' requires a 'type' object but received an '%s'",
+                           getTypeName(_cls));
     }
 
     BoxedClass* cls = static_cast<BoxedClass*>(_cls);
 
     if (cls == unicode_cls && !argspec.has_kwargs && !argspec.has_starargs
-        && (argspec.num_args == 1 || (argspec.num_args == 2 && arg2->cls == str_cls))) {
+        && (argspec.num_args == 1 || (argspec.num_args == 2 && arg2->cls == str_cls)) && S == CXX) {
         // unicode() takes an "encoding" parameter which can cause the constructor to return unicode subclasses.
+
+        assert(S == CXX && "implement me");
 
         if (rewrite_args) {
             rewrite_args->arg1->addGuard((intptr_t)cls);
@@ -772,10 +781,13 @@ static Box* typeCallInner(CallRewriteArgs* rewrite_args, ArgPassSpec argspec, Bo
         return unicodeNewHelper(cls, oarg2, oarg3, oargs);
     }
 
-    if (cls->tp_new != object_cls->tp_new && cls->tp_new != slot_tp_new) {
+    if (cls->tp_new != object_cls->tp_new && cls->tp_new != slot_tp_new && S == CXX) {
         // Looks like we're calling an extension class and we're not going to be able to
         // separately rewrite the new + init calls.  But we can rewrite the fact that we
         // should just call the cpython version, which will end up working pretty well.
+
+        assert(S == CXX && "implement me");
+
         ParamReceiveSpec paramspec(1, false, true, true);
         bool rewrite_success = false;
         Box* oarg1, *oarg2, *oarg3, ** oargs = NULL;
@@ -848,15 +860,31 @@ static Box* typeCallInner(CallRewriteArgs* rewrite_args, ArgPassSpec argspec, Bo
 
         // Special-case functions to allow them to still rewrite:
         if (new_attr->cls != function_cls) {
-            Box* descr_r = processDescriptorOrNull(new_attr, None, cls);
-            if (descr_r) {
-                new_attr = descr_r;
-                rewrite_args = NULL;
+            try {
+                Box* descr_r = processDescriptorOrNull(new_attr, None, cls);
+                if (descr_r) {
+                    new_attr = descr_r;
+                    rewrite_args = NULL;
+                }
+            } catch (ExcInfo e) {
+                if (S == CAPI) {
+                    setCAPIException(e);
+                    return NULL;
+                } else
+                    throw e;
             }
         }
     } else {
         new_attr = typeLookup(cls, new_str, NULL);
-        new_attr = processDescriptor(new_attr, None, cls);
+        try {
+            new_attr = processDescriptor(new_attr, None, cls);
+        } catch (ExcInfo e) {
+            if (S == CAPI) {
+                setCAPIException(e);
+                return NULL;
+            } else
+                throw e;
+        }
     }
     assert(new_attr && "This should always resolve");
 
@@ -895,7 +923,7 @@ static Box* typeCallInner(CallRewriteArgs* rewrite_args, ArgPassSpec argspec, Bo
     if (allowable_news.empty()) {
         for (BoxedClass* allowed_cls : { object_cls, enumerate_cls, xrange_cls, tuple_cls, list_cls, dict_cls }) {
             auto new_obj = typeLookup(allowed_cls, new_str, NULL);
-            gc::registerPermanentRoot(new_obj);
+            gc::registerPermanentRoot(new_obj, /* allow_duplicates= */ true);
             allowable_news.push_back(new_obj);
         }
     }
@@ -982,6 +1010,20 @@ static Box* typeCallInner(CallRewriteArgs* rewrite_args, ArgPassSpec argspec, Bo
 
     ArgPassSpec new_argspec = argspec;
 
+    if (S == CAPI && cls->tp_new != object_cls->tp_new && cls->tp_init != object_cls->tp_init) {
+        // If there's a custom new and custom init, in CAPI mode we don't have any way of handling
+        // any exceptions thrown by the new.
+        rewrite_args = NULL;
+    }
+
+    if (S == CAPI && cls->tp_init != object_cls->tp_init) {
+        // If there's a custom init, in CAPI mode we don't have any way of handling the exception that
+        // we assertInitNone might have to throw from the init returning non-None.
+        // TODO actually looks we only have to be doing that check for Python-level objects; ie in CPython
+        // that check is done in slot_tp_init
+        rewrite_args = NULL;
+    }
+
     if (rewrite_args) {
         if (cls->tp_new == object_cls->tp_new && cls->tp_init != object_cls->tp_init) {
             // Fast case: if we are calling object_new, we normally doesn't look at the arguments at all.
@@ -992,6 +1034,7 @@ static Box* typeCallInner(CallRewriteArgs* rewrite_args, ArgPassSpec argspec, Bo
             // a custom internal callable to object.__new__
             made = objectNewNoArgs(cls);
             r_made = rewrite_args->rewriter->call(true, (void*)objectNewNoArgs, r_ccls);
+            assert(made);
         } else {
             CallRewriteArgs srewrite_args(rewrite_args->rewriter, r_new, rewrite_args->destination);
             srewrite_args.args_guarded = rewrite_args->args_guarded;
@@ -1008,8 +1051,11 @@ static Box* typeCallInner(CallRewriteArgs* rewrite_args, ArgPassSpec argspec, Bo
             if (new_npassed_args >= 4)
                 srewrite_args.args = rewrite_args->args;
 
-            made
-                = runtimeCallInternal<CXX>(new_attr, &srewrite_args, new_argspec, cls, arg2, arg3, args, keyword_names);
+            made = runtimeCallInternal<S>(new_attr, &srewrite_args, new_argspec, cls, arg2, arg3, args, keyword_names);
+            if (!made) {
+                assert(S == CAPI);
+                return NULL;
+            }
 
             if (!srewrite_args.out_success) {
                 rewrite_args = NULL;
@@ -1023,10 +1069,16 @@ static Box* typeCallInner(CallRewriteArgs* rewrite_args, ArgPassSpec argspec, Bo
                "We should only have allowed the rewrite to continue if we were guaranteed that made "
                "would have class cls!");
     } else {
-        if (cls->tp_new == object_cls->tp_new && cls->tp_init != object_cls->tp_init)
+        if (cls->tp_new == object_cls->tp_new && cls->tp_init != object_cls->tp_init) {
             made = objectNewNoArgs(cls);
-        else
-            made = runtimeCallInternal<CXX>(new_attr, NULL, new_argspec, cls, arg2, arg3, args, keyword_names);
+            assert(made);
+        } else
+            made = runtimeCallInternal<S>(new_attr, NULL, new_argspec, cls, arg2, arg3, args, keyword_names);
+
+        if (!made) {
+            assert(S == CAPI);
+            return NULL;
+        }
     }
 
     assert(made);
@@ -1076,18 +1128,31 @@ static Box* typeCallInner(CallRewriteArgs* rewrite_args, ArgPassSpec argspec, Bo
 
             // initrtn = callattrInternal<CXX>(cls, _init_str, INST_ONLY, &srewrite_args, argspec, made, arg2, arg3,
             // args, keyword_names);
-            initrtn
-                = runtimeCallInternal<CXX>(init_attr, &srewrite_args, argspec, made, arg2, arg3, args, keyword_names);
+            initrtn = runtimeCallInternal<S>(init_attr, &srewrite_args, argspec, made, arg2, arg3, args, keyword_names);
+
+            if (!initrtn) {
+                assert(S == CAPI);
+                return NULL;
+            }
 
             if (!srewrite_args.out_success) {
                 rewrite_args = NULL;
             } else {
+                assert(S == CXX && "this need to be converted");
                 rewrite_args->rewriter->call(true, (void*)assertInitNone, srewrite_args.out_rtn);
             }
         } else {
             rewrite_args = NULL;
 
-            init_attr = processDescriptor(init_attr, made, cls);
+            try {
+                init_attr = processDescriptor(init_attr, made, cls);
+            } catch (ExcInfo e) {
+                if (S == CAPI) {
+                    setCAPIException(e);
+                    return NULL;
+                } else
+                    throw e;
+            }
 
             ArgPassSpec init_argspec = argspec;
             init_argspec.num_args--;
@@ -1096,17 +1161,31 @@ static Box* typeCallInner(CallRewriteArgs* rewrite_args, ArgPassSpec argspec, Bo
 
             // If we weren't passed the args array, it's not safe to index into it
             if (passed <= 2)
-                initrtn
-                    = runtimeCallInternal<CXX>(init_attr, NULL, init_argspec, arg2, arg3, NULL, NULL, keyword_names);
+                initrtn = runtimeCallInternal<S>(init_attr, NULL, init_argspec, arg2, arg3, NULL, NULL, keyword_names);
             else
-                initrtn = runtimeCallInternal<CXX>(init_attr, NULL, init_argspec, arg2, arg3, args[0], &args[1],
-                                                   keyword_names);
+                initrtn = runtimeCallInternal<S>(init_attr, NULL, init_argspec, arg2, arg3, args[0], &args[1],
+                                                 keyword_names);
+
+            if (!initrtn) {
+                assert(S == CAPI);
+                return NULL;
+            }
+        }
+        assert(initrtn);
+
+        if (S == CAPI && initrtn != None) {
+            PyErr_Format(TypeError, "__init__() should return None, not '%s'", getTypeName(initrtn));
+            return NULL;
         }
         assertInitNone(initrtn);
     } else {
         if (new_attr == NULL && npassed_args != 1) {
             // TODO not npassed args, since the starargs or kwargs could be null
-            raiseExcHelper(TypeError, objectNewParameterTypeErrorMsg());
+            if (S == CAPI) {
+                PyErr_SetString(TypeError, objectNewParameterTypeErrorMsg());
+                return NULL;
+            } else
+                raiseExcHelper(TypeError, objectNewParameterTypeErrorMsg());
         }
     }
 
@@ -1115,6 +1194,7 @@ static Box* typeCallInner(CallRewriteArgs* rewrite_args, ArgPassSpec argspec, Bo
         rewrite_args->out_success = true;
     }
 
+    assert(made);
     return made;
 }
 
@@ -2403,17 +2483,6 @@ Box* attrwrapperKeys(Box* b) {
 
 void attrwrapperDel(Box* b, llvm::StringRef attr) {
     AttrWrapper::delitem(b, boxString(attr));
-}
-
-Box* objectNewNoArgs(BoxedClass* cls) {
-    assert(isSubclass(cls->cls, type_cls));
-#ifndef NDEBUG
-    static BoxedString* new_str = internStringImmortal("__new__");
-    static BoxedString* init_str = internStringImmortal("__init__");
-    assert(typeLookup(cls, new_str, NULL) == typeLookup(object_cls, new_str, NULL)
-           && typeLookup(cls, init_str, NULL) != typeLookup(object_cls, init_str, NULL));
-#endif
-    return new (cls) Box();
 }
 
 static int excess_args(PyObject* args, PyObject* kwds) noexcept {

--- a/src/runtime/types.h
+++ b/src/runtime/types.h
@@ -1007,7 +1007,6 @@ public:
     static void gcHandler(GCVisitor* v, Box* _o);
 };
 
-Box* objectNewNoArgs(BoxedClass* cls);
 Box* objectSetattr(Box* obj, Box* attr, Box* value);
 
 Box* unwrapAttrWrapper(Box* b);

--- a/src/runtime/types.h
+++ b/src/runtime/types.h
@@ -242,9 +242,8 @@ public:
 
     pyston_inquiry tpp_hasnext;
 
-    typedef Box* (*pyston_call)(Box*, CallRewriteArgs*, ArgPassSpec, Box*, Box*, Box*, Box**,
-                                const std::vector<BoxedString*>*);
-    pyston_call tpp_call;
+    ExceptionSwitchableFunction<Box*, Box*, CallRewriteArgs*, ArgPassSpec, Box*, Box*, Box*, Box**,
+                                const std::vector<BoxedString*>*> tpp_call;
 
     bool hasGenericGetattr() {
         if (tp_getattr || tp_getattro != object_cls->tp_getattro)
@@ -985,8 +984,9 @@ public:
     DEFAULT_CLASS(wrapperobject_cls);
 
     static Box* __call__(BoxedWrapperObject* self, Box* args, Box* kwds);
+    template <ExceptionStyle S>
     static Box* tppCall(Box* _self, CallRewriteArgs* rewrite_args, ArgPassSpec argspec, Box* arg1, Box* arg2, Box* arg3,
-                        Box** args, const std::vector<BoxedString*>* keyword_names);
+                        Box** args, const std::vector<BoxedString*>* keyword_names) noexcept(S == CAPI);
     static void gcHandler(GCVisitor* v, Box* _o);
 };
 
@@ -1001,8 +1001,9 @@ public:
 
     static Box* __get__(BoxedMethodDescriptor* self, Box* inst, Box* owner);
     static Box* __call__(BoxedMethodDescriptor* self, Box* obj, BoxedTuple* varargs, Box** _args);
+    template <ExceptionStyle S>
     static Box* tppCall(Box* _self, CallRewriteArgs* rewrite_args, ArgPassSpec argspec, Box* arg1, Box* arg2, Box* arg3,
-                        Box** args, const std::vector<BoxedString*>* keyword_names);
+                        Box** args, const std::vector<BoxedString*>* keyword_names) noexcept(S == CAPI);
     static void gcHandler(GCVisitor* v, Box* _o);
 };
 

--- a/src/runtime/util.cpp
+++ b/src/runtime/util.cpp
@@ -41,11 +41,11 @@ void parseSlice(BoxedSlice* slice, int size, i64* out_start, i64* out_stop, i64*
         throwCAPIException();
 }
 
-bool isSliceIndex(Box* b) {
+bool isSliceIndex(Box* b) noexcept {
     return b->cls == none_cls || b->cls == int_cls || PyIndex_Check(b);
 }
 
-void adjustNegativeIndicesOnObject(Box* obj, i64* start_out, i64* stop_out) {
+void adjustNegativeIndicesOnObject(Box* obj, i64* start_out, i64* stop_out) noexcept {
     i64 start = *start_out;
     i64 stop = *stop_out;
     PySequenceMethods* m;

--- a/src/runtime/util.h
+++ b/src/runtime/util.h
@@ -36,9 +36,9 @@ inline void sliceIndex(Box* b, int64_t* out) {
         throwCAPIException();
 }
 
-bool isSliceIndex(Box* b);
+bool isSliceIndex(Box* b) noexcept;
 
-void adjustNegativeIndicesOnObject(Box* obj, i64* start, i64* stop);
+void adjustNegativeIndicesOnObject(Box* obj, i64* start, i64* stop) noexcept;
 
 // Adjust the start and stop bounds of the sequence we are slicing to its size.
 // Ensure stop >= start and remain within bounds.

--- a/test/test_extension/setup.py
+++ b/test/test_extension/setup.py
@@ -1,11 +1,26 @@
 from distutils.core import setup, Extension
+import glob
+import os
+
+extensions = [
+    Extension("basic_test", sources = ["basic_test.c"]),
+    Extension("descr_test", sources = ["descr_test.c"]),
+    Extension("slots_test", sources = ["slots_test.c"]),
+]
+
+def relpath(fn):
+    r =  os.path.join(os.path.dirname(__file__), fn)
+    return r
+
+print glob.glob("../from_cpython/Include/*.h")
+builtin_headers = map(relpath, glob.glob("../../from_cpython/Include/*.h"))
+
+for m in extensions:
+    m.depends += builtin_headers
+
 
 setup(name="test",
         version="1.0",
         description="test",
-        ext_modules=[
-            Extension("basic_test", sources = ["basic_test.c"]),
-            Extension("descr_test", sources = ["descr_test.c"]),
-            Extension("slots_test", sources = ["slots_test.c"]),
-        ],
+        ext_modules=extensions,
     )

--- a/test/tests/varargs_ics.py
+++ b/test/tests/varargs_ics.py
@@ -1,5 +1,5 @@
 # run_args: -n
-# statcheck: 1 <= noninit_count("slowpath_runtimecall") < 20
+# statcheck: 1 <= noninit_count("slowpath_runtimecall") + noninit_count("slowpath_runtimecall_capi") < 20
 
 # Make sure we can patch some basic varargs cases
 


### PR DESCRIPTION
- add+use capi variants of runtimeCall and callattr entry points
- add some simple profiling to determine when to use C++ vs CAPI exceptions

Sorry for the huge PR; the early commits can stand on their own but they have a perf hit that is only made up by the later ones, so I didn't feel like separating into multiple prs.