### PR TITLE
Clean up our exception handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ pystontmp*/
 *.cache
 tests/t.py
 tests/t2.py
+tests/t3.py
 *.bc
 stdlib.ll
 *.o

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -90,6 +90,7 @@ add_library(PYSTON_OBJECTS OBJECT ${OPTIONAL_SRCS}
 		runtime/cxx_unwind.cpp
 		runtime/descr.cpp
 		runtime/dict.cpp
+		runtime/exceptions.cpp
 		runtime/file.cpp
 		runtime/float.cpp
 		runtime/frame.cpp
@@ -104,7 +105,6 @@ add_library(PYSTON_OBJECTS OBJECT ${OPTIONAL_SRCS}
 		runtime/long.cpp
 		runtime/objmodel.cpp
 		runtime/set.cpp
-		runtime/stacktrace.cpp
 		runtime/str.cpp
 		runtime/super.cpp
 		runtime/traceback.cpp

--- a/src/codegen/ast_interpreter.cpp
+++ b/src/codegen/ast_interpreter.cpp
@@ -333,7 +333,7 @@ Box* ASTInterpreter::execJITedBlock(CFGBlock* b) {
 
         auto source = getCL()->source.get();
         stmt->cxx_exception_count++;
-        exceptionCaughtInInterpreter(LineInfo(stmt->lineno, stmt->col_offset, source->fn, source->getName()), &e);
+        caughtCxxException(LineInfo(stmt->lineno, stmt->col_offset, source->fn, source->getName()), &e);
 
         next_block = ((AST_Invoke*)stmt)->exc_dest;
         last_exception = e;
@@ -773,7 +773,7 @@ Value ASTInterpreter::visit_invoke(AST_Invoke* node) {
 
         auto source = getCL()->source.get();
         node->cxx_exception_count++;
-        exceptionCaughtInInterpreter(LineInfo(node->lineno, node->col_offset, source->fn, source->getName()), &e);
+        caughtCxxException(LineInfo(node->lineno, node->col_offset, source->fn, source->getName()), &e);
 
         next_block = node->exc_dest;
         last_exception = e;

--- a/src/codegen/irgen/hooks.h
+++ b/src/codegen/irgen/hooks.h
@@ -39,10 +39,6 @@ void compileAndRunModule(AST_Module* m, BoxedModule* bm);
 // will we always want to generate unique function names? (ie will this function always be reasonable?)
 CompiledFunction* cfForMachineFunctionName(const std::string&);
 
-extern "C" void capiExcCaughtInJit(AST_stmt* current_stmt, void* source_info);
-// This is just meant for the use of the JIT (normal runtime code should call throwCAPIException)
-extern "C" void reraiseJitCapiExc() __attribute__((noreturn));
-
 extern "C" Box* exec(Box* boxedCode, Box* globals, Box* locals, FutureFlags caller_future_flags);
 extern "C" Box* eval(Box* boxedCode, Box* globals, Box* locals);
 extern "C" Box* compile(Box* source, Box* filename, Box* mode, Box** _args /* flags, dont_inherit */);

--- a/src/codegen/irgen/irgenerator.cpp
+++ b/src/codegen/irgen/irgenerator.cpp
@@ -131,8 +131,8 @@ static llvm::Value* getClosureElementGep(IREmitter& emitter, llvm::Value* closur
 
 static llvm::Value* getBoxedLocalsGep(llvm::IRBuilder<true>& builder, llvm::Value* v) {
     static_assert(offsetof(FrameInfo, exc) == 0, "");
-    static_assert(sizeof(ExcInfo) == 32, "");
-    static_assert(offsetof(FrameInfo, boxedLocals) == 32, "");
+    static_assert(sizeof(ExcInfo) == 24, "");
+    static_assert(offsetof(FrameInfo, boxedLocals) == 24, "");
     return builder.CreateConstInBoundsGEP2_32(v, 0, 1);
 }
 
@@ -143,9 +143,9 @@ static llvm::Value* getExcinfoGep(llvm::IRBuilder<true>& builder, llvm::Value* v
 
 static llvm::Value* getFrameObjGep(llvm::IRBuilder<true>& builder, llvm::Value* v) {
     static_assert(offsetof(FrameInfo, exc) == 0, "");
-    static_assert(sizeof(ExcInfo) == 32, "");
+    static_assert(sizeof(ExcInfo) == 24, "");
     static_assert(sizeof(Box*) == 8, "");
-    static_assert(offsetof(FrameInfo, frame_obj) == 40, "");
+    static_assert(offsetof(FrameInfo, frame_obj) == 32, "");
     return builder.CreateConstInBoundsGEP2_32(v, 0, 2);
     // TODO: this could be made more resilient by doing something like
     // gep->accumulateConstantOffset(g.tm->getDataLayout(), ap_offset)

--- a/src/codegen/irgen/irgenerator.cpp
+++ b/src/codegen/irgen/irgenerator.cpp
@@ -2805,14 +2805,14 @@ public:
         capi_current_statements[final_dest] = current_stmt;
 
         emitter.setCurrentBasicBlock(capi_exc_dest);
-        emitter.getBuilder()->CreateCall2(g.funcs.capiExcCaughtInJit,
+        emitter.getBuilder()->CreateCall2(g.funcs.caughtCapiException,
                                           embedRelocatablePtr(current_stmt, g.llvm_aststmt_type_ptr),
                                           embedRelocatablePtr(irstate->getSourceInfo(), g.i8_ptr));
 
         if (!final_dest) {
             // Propagate the exception out of the function:
             if (irstate->getExceptionStyle() == CXX) {
-                emitter.getBuilder()->CreateCall(g.funcs.reraiseJitCapiExc);
+                emitter.getBuilder()->CreateCall(g.funcs.reraiseCapiExcAsCxx);
                 emitter.getBuilder()->CreateUnreachable();
             } else {
                 emitter.getBuilder()->CreateRet(getNullPtr(g.llvm_value_type_ptr));

--- a/src/codegen/runtime_hooks.cpp
+++ b/src/codegen/runtime_hooks.cpp
@@ -312,8 +312,8 @@ void initGlobalFuncs(GlobalState& g) {
     GET(PyErr_Fetch);
     GET(PyErr_NormalizeException);
     GET(PyErr_Restore);
-    GET(capiExcCaughtInJit);
-    GET(reraiseJitCapiExc);
+    GET(caughtCapiException);
+    GET(reraiseCapiExcAsCxx);
     GET(deopt);
 
     GET(div_float_float);

--- a/src/codegen/runtime_hooks.h
+++ b/src/codegen/runtime_hooks.h
@@ -51,7 +51,7 @@ struct GlobalFuncs {
 
     llvm::Value* __cxa_end_catch;
     llvm::Value* raise0, *raise3, *raise3_capi;
-    llvm::Value* PyErr_Fetch, *PyErr_NormalizeException, *PyErr_Restore, *capiExcCaughtInJit, *reraiseJitCapiExc;
+    llvm::Value* PyErr_Fetch, *PyErr_NormalizeException, *PyErr_Restore, *caughtCapiException, *reraiseCapiExcAsCxx;
     llvm::Value* deopt;
 
     llvm::Value* div_float_float, *floordiv_float_float, *mod_float_float, *pow_float_float;

--- a/src/codegen/unwinding.cpp
+++ b/src/codegen/unwinding.cpp
@@ -493,6 +493,11 @@ static const LineInfo lineInfoForFrame(PythonFrameIteratorImpl* frame_it) {
     return LineInfo(current_stmt->lineno, current_stmt->col_offset, source->fn, source->getName());
 }
 
+// A class that converts a C stack trace to a Python stack trace.
+// It allows for different ways of driving the C stack trace; it just needs
+// to have handleCFrame called once per frame.
+// If you want to do a normal (non-destructive) stack walk, use unwindPythonStack
+// which will use this internally.
 class PythonStackExtractor {
 private:
     bool skip_next_pythonlike_frame = false;
@@ -522,64 +527,26 @@ public:
 class PythonUnwindSession : public Box {
     ExcInfo exc_info;
     PythonStackExtractor pystack_extractor;
-    bool is_active;
+
     Timer t;
 
 public:
     DEFAULT_CLASS_SIMPLE(unwind_session_cls);
 
-    PythonUnwindSession() : exc_info(NULL, NULL, NULL), is_active(false), t(/*min_usec=*/10000) {}
+    PythonUnwindSession() : exc_info(NULL, NULL, NULL), t(/*min_usec=*/10000) {}
 
-    ExcInfo* getExcInfoStorage() {
-        RELEASE_ASSERT(is_active, "");
-        return &exc_info;
-    }
-    bool isActive() const { return is_active; }
+    ExcInfo* getExcInfoStorage() { return &exc_info; }
 
     void begin() {
-        RELEASE_ASSERT(!is_active, "");
         exc_info = ExcInfo(NULL, NULL, NULL);
-        is_active = true;
         t.restart();
 
         static StatCounter stat("unwind_sessions");
         stat.log();
     }
     void end() {
-        RELEASE_ASSERT(is_active, "");
-        is_active = false;
-
         static StatCounter stat("us_unwind_session");
         stat.log(t.end());
-    }
-
-    void addTraceback(PythonFrameIteratorImpl& frame_iter) {
-        RELEASE_ASSERT(is_active, "");
-        if (exc_info.reraise) {
-            exc_info.reraise = false;
-            return;
-        }
-        // TODO: shouldn't fetch this multiple times?
-        frame_iter.getCurrentStatement()->cxx_exception_count++;
-        auto line_info = lineInfoForFrame(&frame_iter);
-        BoxedTraceback::here(line_info, &exc_info.traceback);
-    }
-
-    void logException() {
-#if STAT_EXCEPTIONS
-        static StatCounter num_exceptions("num_exceptions");
-        num_exceptions.log();
-
-        std::string stat_name;
-        if (PyType_Check(exc_info.type))
-            stat_name = "num_exceptions_" + std::string(static_cast<BoxedClass*>(exc_info.type)->tp_name);
-        else
-            stat_name = "num_exceptions_" + std::string(exc_info.value->cls->tp_name);
-        Stats::log(Stats::getStatCounter(stat_name));
-#if STAT_EXCEPTIONS_LOCATION
-        logByCurrentPythonLine(stat_name);
-#endif
-#endif
     }
 
     void handleCFrame(unw_cursor_t* cursor) {
@@ -588,22 +555,20 @@ public:
 
         PythonFrameIteratorImpl frame_iter;
         bool found_frame = pystack_extractor.handleCFrame(cursor, &frame_iter);
-        if (found_frame)
-            addTraceback(frame_iter);
+        if (found_frame) {
+            if (exceptionAtLineCheck()) {
+                // TODO: shouldn't fetch this multiple times?
+                frame_iter.getCurrentStatement()->cxx_exception_count++;
+                auto line_info = lineInfoForFrame(&frame_iter);
+                exceptionAtLine(line_info, &exc_info.traceback);
+            }
+        }
     }
 
     static void gcHandler(GCVisitor* v, Box* _o) {
         assert(_o->cls == unwind_session_cls);
 
         PythonUnwindSession* o = static_cast<PythonUnwindSession*>(_o);
-
-        // this is our hack for eventually collecting
-        // exceptions/tracebacks after the exception has been caught.
-        // If a collection happens and a given thread's
-        // PythonUnwindSession isn't active, its exception info can be
-        // collected.
-        if (!o->is_active)
-            return;
 
         v->visitIf(o->exc_info.type);
         v->visitIf(o->exc_info.value);
@@ -612,17 +577,22 @@ public:
 };
 static __thread PythonUnwindSession* cur_unwind;
 
-PythonUnwindSession* beginPythonUnwindSession() {
+static PythonUnwindSession* getUnwindSession() {
     if (!cur_unwind) {
         cur_unwind = new PythonUnwindSession();
         pyston::gc::registerPermanentRoot(cur_unwind);
     }
+    return cur_unwind;
+}
+
+PythonUnwindSession* beginPythonUnwindSession() {
+    getUnwindSession();
     cur_unwind->begin();
     return cur_unwind;
 }
 
 PythonUnwindSession* getActivePythonUnwindSession() {
-    RELEASE_ASSERT(cur_unwind && cur_unwind->isActive(), "");
+    ASSERT(cur_unwind, "");
     return cur_unwind;
 }
 
@@ -630,56 +600,11 @@ void endPythonUnwindSession(PythonUnwindSession* unwind) {
     RELEASE_ASSERT(unwind && unwind == cur_unwind, "");
     unwind->end();
 }
+
 void* getPythonUnwindSessionExceptionStorage(PythonUnwindSession* unwind) {
     RELEASE_ASSERT(unwind && unwind == cur_unwind, "");
     PythonUnwindSession* state = static_cast<PythonUnwindSession*>(unwind);
     return state->getExcInfoStorage();
-}
-
-void throwingException(PythonUnwindSession* unwind) {
-    RELEASE_ASSERT(unwind && unwind == cur_unwind, "");
-    unwind->logException();
-}
-
-extern "C" void capiExcCaughtInJit(AST_stmt* stmt, void* _source_info) {
-    SourceInfo* source = static_cast<SourceInfo*>(_source_info);
-    // TODO: handle reraise (currently on the ExcInfo object)
-    PyThreadState* tstate = PyThreadState_GET();
-    BoxedTraceback::here(LineInfo(stmt->lineno, stmt->col_offset, source->fn, source->getName()),
-                         &tstate->curexc_traceback);
-}
-
-extern "C" void reraiseJitCapiExc() {
-    ensureCAPIExceptionSet();
-    // TODO: we are normalizing to many times?
-    ExcInfo e = excInfoForRaise(cur_thread_state.curexc_type, cur_thread_state.curexc_value,
-                                cur_thread_state.curexc_traceback);
-    PyErr_Clear();
-    e.reraise = true;
-    throw e;
-}
-
-void exceptionCaughtInInterpreter(LineInfo line_info, ExcInfo* exc_info) {
-    static StatCounter frames_unwound("num_frames_unwound_python");
-    frames_unwound.log();
-
-    // basically the same as PythonUnwindSession::addTraceback, but needs to
-    // be callable after an PythonUnwindSession has ended.  The interpreter
-    // will call this from catch blocks if it needs to ensure that a
-    // line is added.  Right now this only happens in
-    // ASTInterpreter::visit_invoke.
-
-    // It's basically the same except for one thing: we don't have to
-    // worry about the 'skip' (osr) state that PythonUnwindSession handles
-    // here, because the only way we could have gotten into the ast
-    // interpreter is if the exception wasn't caught, and if there was
-    // the osr frame for the one the interpreter is running, it would
-    // have already caught it.
-    if (exc_info->reraise) {
-        exc_info->reraise = false;
-        return;
-    }
-    BoxedTraceback::here(line_info, &exc_info->traceback);
 }
 
 void unwindingThroughFrame(PythonUnwindSession* unwind_session, unw_cursor_t* cursor) {

--- a/src/codegen/unwinding.h
+++ b/src/codegen/unwinding.h
@@ -53,7 +53,9 @@ void logException(ExcInfo* exc_info);
 void startReraise();
 bool exceptionAtLineCheck();
 void exceptionAtLine(LineInfo line_info, Box** traceback);
-void exceptionCaughtInInterpreter(LineInfo line_info, ExcInfo* exc_info);
+void caughtCxxException(LineInfo line_info, ExcInfo* exc_info);
+extern "C" void caughtCapiException(AST_stmt* current_stmt, void* source_info);
+extern "C" void reraiseCapiExcAsCxx() __attribute__((noreturn));
 
 
 CLFunction* getTopPythonFunction();

--- a/src/codegen/unwinding.h
+++ b/src/codegen/unwinding.h
@@ -44,12 +44,17 @@ Box* getTraceback();
 class PythonUnwindSession;
 PythonUnwindSession* beginPythonUnwindSession();
 PythonUnwindSession* getActivePythonUnwindSession();
-void throwingException(PythonUnwindSession* unwind_session);
 void endPythonUnwindSession(PythonUnwindSession* unwind_session);
 void* getPythonUnwindSessionExceptionStorage(PythonUnwindSession* unwind_session);
 void unwindingThroughFrame(PythonUnwindSession* unwind_session, unw_cursor_t* cursor);
 
+// TODO move these to exceptions.h
+void logException(ExcInfo* exc_info);
+void startReraise();
+bool exceptionAtLineCheck();
+void exceptionAtLine(LineInfo line_info, Box** traceback);
 void exceptionCaughtInInterpreter(LineInfo line_info, ExcInfo* exc_info);
+
 
 CLFunction* getTopPythonFunction();
 

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -777,13 +777,8 @@ public:
 
 struct ExcInfo {
     Box* type, *value, *traceback;
-    bool reraise;
 
-#ifndef NDEBUG
-    ExcInfo(Box* type, Box* value, Box* traceback);
-#else
-    ExcInfo(Box* type, Box* value, Box* traceback) : type(type), value(value), traceback(traceback), reraise(false) {}
-#endif
+    constexpr ExcInfo(Box* type, Box* value, Box* traceback) : type(type), value(value), traceback(traceback) {}
     bool matches(BoxedClass* cls) const;
     void printExcAndTraceback() const;
 };

--- a/src/runtime/cxx_unwind.cpp
+++ b/src/runtime/cxx_unwind.cpp
@@ -688,7 +688,7 @@ extern "C" void __cxa_throw(void* exc_obj, std::type_info* tinfo, void (*dtor)(v
     pyston::StatTimer::overrideCounter(unwinding_stattimer);
 #endif
     // let unwinding.cpp know we've started unwinding
-    pyston::throwingException(pyston::getActivePythonUnwindSession());
+    pyston::logException(exc_data);
     pyston::unwind(exc_data);
 }
 

--- a/src/runtime/exceptions.cpp
+++ b/src/runtime/exceptions.cpp
@@ -220,14 +220,14 @@ void logException(ExcInfo* exc_info) {
 #endif
 }
 
-extern "C" void capiExcCaughtInJit(AST_stmt* stmt, void* _source_info) {
+extern "C" void caughtCapiException(AST_stmt* stmt, void* _source_info) {
     SourceInfo* source = static_cast<SourceInfo*>(_source_info);
     PyThreadState* tstate = PyThreadState_GET();
 
     exceptionAtLine(LineInfo(stmt->lineno, stmt->col_offset, source->fn, source->getName()), &tstate->curexc_traceback);
 }
 
-extern "C" void reraiseJitCapiExc() {
+extern "C" void reraiseCapiExcAsCxx() {
     ensureCAPIExceptionSet();
     // TODO: we are normalizing to many times?
     ExcInfo e = excInfoForRaise(cur_thread_state.curexc_type, cur_thread_state.curexc_value,
@@ -237,7 +237,7 @@ extern "C" void reraiseJitCapiExc() {
     throw e;
 }
 
-void exceptionCaughtInInterpreter(LineInfo line_info, ExcInfo* exc_info) {
+void caughtCxxException(LineInfo line_info, ExcInfo* exc_info) {
     static StatCounter frames_unwound("num_frames_unwound_python");
     frames_unwound.log();
 

--- a/src/runtime/inline/link_forcer.cpp
+++ b/src/runtime/inline/link_forcer.cpp
@@ -130,8 +130,8 @@ void force() {
     FORCE(PyErr_Fetch);
     FORCE(PyErr_NormalizeException);
     FORCE(PyErr_Restore);
-    FORCE(capiExcCaughtInJit);
-    FORCE(reraiseJitCapiExc);
+    FORCE(caughtCapiException);
+    FORCE(reraiseCapiExcAsCxx);
     FORCE(deopt);
 
     FORCE(div_i64_i64);

--- a/tools/tester.py
+++ b/tools/tester.py
@@ -518,7 +518,7 @@ def main(orig_dir):
     patterns = opts.pattern
 
     if not patterns and not TESTS_TO_SKIP:
-        TESTS_TO_SKIP = ["t", "t2"]
+        TESTS_TO_SKIP = ["t", "t2", "t3"]
 
     assert os.path.isdir(TEST_DIR), "%s doesn't look like a directory with tests in it" % TEST_DIR
 


### PR DESCRIPTION
Our exception-handling and unwinding code has always been a bit mixed together, which
makes it hard to add new features since things are pretty tightly coupled.  For instance,
the notion of a "reraise" was tightly coupled to the idea of a C stack frame and it was also
being tracked in the wrong place, and for these reasons we couldn't use capi exceptions
when we needed to do a reraise.

I think this PR makes things a bit cleaner:
- cxx_unwind.cpp handles C++ unwinding semantics
- unwinding.cpp converts C stacks to Python stacks
- exceptions.cpp takes Python stack frames and handles them appropriately