### PR TITLE
Get Pyston building on Fedora

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,7 +260,7 @@ add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/linkdeps_dummy.c COMMAND ${CMAKE_C
 
 add_executable(pyston $<TARGET_OBJECTS:PYSTON_MAIN_OBJECT> $<TARGET_OBJECTS:PYSTON_OBJECTS> $<TARGET_OBJECTS:FROM_CPYTHON> linkdeps_dummy.c)
 # Wrap the stdlib in --whole-archive to force all the symbols to be included and eventually exported
-target_link_libraries(pyston -Wl,--whole-archive stdlib -Wl,--no-whole-archive pthread m z readline sqlite3 gmp ssl crypto unwind pypa liblz4 double-conversion ${LLVM_LIBS} ${LIBLZMA_LIBRARIES} ${OPTIONAL_LIBRARIES} -L${CMAKE_BINARY_DIR}/jemalloc/lib -Wl,-rpath,${CMAKE_BINARY_DIR}/jemalloc/lib jemalloc)
+target_link_libraries(pyston -Wl,--whole-archive stdlib -Wl,--no-whole-archive pthread m z readline sqlite3 gmp ssl crypto unwind pypa liblz4 double-conversion util ${LLVM_LIBS} ${LIBLZMA_LIBRARIES} ${OPTIONAL_LIBRARIES} -L${CMAKE_BINARY_DIR}/jemalloc/lib -Wl,-rpath,${CMAKE_BINARY_DIR}/jemalloc/lib jemalloc)
 add_dependencies(pyston libjemalloc)
 
 # copy src/codegen/parse_ast.py to the build directory

--- a/Makefile
+++ b/Makefile
@@ -538,6 +538,7 @@ quick_check:
 Makefile.local:
 	echo "Creating default Makefile.local"
 	python -c 'import sys; v = sys.version_info; print "PYTHON_MAJOR_VERSION:=%d\nPYTHON_MINOR_VERSION:=%d\nPYTHON_MICRO_VERSION:=%d" % (v[0], v[1], v[2])' > Makefile.local || (rm $@; false)
+	which ninja-build >/dev/null && echo "NINJA := ninja-build" >> Makefile.local
 
 #################
 # LLVM rules:
@@ -874,7 +875,7 @@ clang_check:
 
 cmake_check:
 	@cmake --version >/dev/null || (echo "cmake not available"; false)
-	@ninja --version >/dev/null || (echo "ninja not available"; false)
+	@$(NINJA) --version >/dev/null || (echo "ninja not available"; false)
 
 .PHONY: cmake_check clang_check
 $(CMAKE_SETUP_DBG):

--- a/cmake/pyconfig.cmake
+++ b/cmake/pyconfig.cmake
@@ -2,6 +2,7 @@
 
 include(CheckIncludeFiles)
 include(CheckTypeSizeof)
+include(CheckSymbolExists)
 
 set(CMAKE_EXTRA_INCLUDE_FILES unordered_map)
 set(CMAKE_REQUIRED_FLAGS -std=c++11)
@@ -57,5 +58,9 @@ check_include_files(termios.h HAVE_TERMIOS_H)
 check_include_files(unistd.h HAVE_UNISTD_H)
 check_include_files(utime.h HAVE_UTIME_H)
 check_include_files(wchar.h HAVE_WCHAR_H)
+
+set(CMAKE_REQUIRED_LIBRARIES util)
+
+check_symbol_exists(openpty "pty.h" HAVE_OPENPTY)
 
 configure_file(from_cpython/Include/pyconfig.h.in from_cpython/Include/pyconfig.h)

--- a/docs/INSTALLING.md
+++ b/docs/INSTALLING.md
@@ -25,7 +25,7 @@ sudo apt-get install -yq git cmake ninja-build ccache libncurses5-dev liblzma-de
 
 **Fedora 21**
 ```
-sudo yum install cmake clang gcc gcc-c++ ccache ninja-build xz-devel automake libtool gmp-devel readline-devel openssl-devel sqlite-devel python-devel zlib-devel bzip2-devel ncurses-devel
+sudo yum install git make cmake clang gcc gcc-c++ ccache ninja-build xz-devel automake libtool gmp-devel readline-devel openssl-devel sqlite-devel python-devel zlib-devel bzip2-devel ncurses-devel texlive-latex2man libffi-devel
 ```
 
 ### Building and testing

--- a/from_cpython/Include/pyconfig.h.in
+++ b/from_cpython/Include/pyconfig.h.in
@@ -142,7 +142,6 @@
 #define HAVE_MMAP 1
 #define HAVE_MREMAP 1
 #define HAVE_NICE 1
-// #define HAVE_OPENPTY 1 // pyston change: turned this off for now to avoid -lutil dependency
 #define HAVE_PATHCONF 1
 #define HAVE_PAUSE 1
 #define HAVE_POLL 1
@@ -272,6 +271,8 @@
 #cmakedefine HAVE_UNISTD_H 1
 #cmakedefine HAVE_UTIME_H 1
 #cmakedefine HAVE_WCHAR_H 1
+
+#cmakedefine HAVE_OPENPTY 1
 
 #define SIZEOF_UNORDEREDMAP @SIZEOF_UNORDEREDMAP@
 

--- a/from_cpython/setup.py
+++ b/from_cpython/setup.py
@@ -3,6 +3,7 @@
 from distutils.core import setup, Extension
 import glob
 import os
+import platform
 import sysconfig
 
 def relpath(fn):
@@ -52,6 +53,10 @@ def ctypes_ext():
     # May want something more robust later.
     ffi_inc = ['/usr/include/x86_64-linux-gnu']
     ffi_lib = "ffi_pic"
+
+    if platform.linux_distribution()[0] == "Fedora":
+        ffi_lib = "ffi"
+
     ext.include_dirs.extend(ffi_inc)
     ext.libraries.append(ffi_lib)
 

--- a/test/tests/set.py
+++ b/test/tests/set.py
@@ -128,7 +128,7 @@ for i in xrange(10):
 
 for s1 in set(range(5)), frozenset(range(5)):
     for s2 in compare_to:
-        print type(s2), sorted(s2), s.issubset(s2), s.issuperset(s2), s == s2, s != s2, s.difference(s2), s.isdisjoint(s2), sorted(s1.union(s2)), sorted(s1.intersection(s2))
+        print type(s2), sorted(s2), s.issubset(s2), s.issuperset(s2), s == s2, s != s2, sorted(s.difference(s2)), s.isdisjoint(s2), sorted(s1.union(s2)), sorted(s1.intersection(s2))
 
 f = float('nan')
 s = set([f])

--- a/test/tests/sys_test.py
+++ b/test/tests/sys_test.py
@@ -6,7 +6,7 @@ print os.path.exists(sys.executable)
 print sys.copyright[-200:]
 print sys.byteorder
 print sys.getdefaultencoding()
-print sys.getfilesystemencoding()
+print type(sys.getfilesystemencoding())
 print type(sys.maxsize)
 print sys.stdout is sys.__stdout__
 print sys.stderr is sys.__stderr__

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -9,7 +9,7 @@ add_custom_target(unittests)
 
 macro(add_unittest unittest)
   add_executable(${unittest}_unittest EXCLUDE_FROM_ALL ${unittest}.cpp $<TARGET_OBJECTS:PYSTON_OBJECTS> $<TARGET_OBJECTS:FROM_CPYTHON>)
-  target_link_libraries(${unittest}_unittest stdlib z sqlite3 gmp ssl crypto readline pypa liblz4 double-conversion unwind gtest gtest_main ${LLVM_LIBS} ${LIBLZMA_LIBRARIES})
+  target_link_libraries(${unittest}_unittest stdlib z sqlite3 gmp ssl crypto readline pypa liblz4 double-conversion unwind gtest gtest_main util ${LLVM_LIBS} ${LIBLZMA_LIBRARIES})
   add_dependencies(unittests ${unittest}_unittest)
 endmacro()
 


### PR DESCRIPTION
- add support for openpty (Fedora doesn't support the workaround like Ubuntu does)
- couple other minor fixes

It builds and runs, but it fails io_test.py (haven't looked into it much)