### PR TITLE
Change isSubclass(obj->cls, int_cls) to PyInt_Check

### DIFF
--- a/plugins/clang_linter.cpp
+++ b/plugins/clang_linter.cpp
@@ -1,0 +1,87 @@
+// Originally from https://github.com/eliben/llvm-clang-samples/blob/master/src_clang/tooling_sample.cpp with the following header.  Modifications copyright Dropbox, Inc.
+//
+//------------------------------------------------------------------------------
+// Tooling sample. Demonstrates:
+//
+// * How to write a simple source tool using libTooling.
+// * How to use RecursiveASTVisitor to find interesting AST nodes.
+// * How to use the Rewriter API to rewrite the source code.
+//
+// Eli Bendersky (eliben@gmail.com)
+// This code is in the public domain
+//------------------------------------------------------------------------------
+#include <sstream>
+#include <string>
+
+#include "clang/AST/AST.h"
+#include "clang/AST/ASTConsumer.h"
+#include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/ASTMatchers/ASTMatchers.h"
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+#include "clang/Frontend/ASTConsumers.h"
+#include "clang/Frontend/FrontendActions.h"
+#include "clang/Frontend/FrontendPluginRegistry.h"
+#include "clang/Frontend/CompilerInstance.h"
+#include "clang/Tooling/CommonOptionsParser.h"
+#include "clang/Tooling/Tooling.h"
+#include "clang/Rewrite/Core/Rewriter.h"
+#include "llvm/Support/raw_ostream.h"
+
+using namespace llvm;
+using namespace clang;
+using namespace clang::driver;
+using namespace clang::tooling;
+using namespace clang::ast_matchers;
+
+auto matcher = callExpr(
+        callee(functionDecl(hasName("pyston::isSubclass"))),
+        hasArgument(0, memberExpr(member(fieldDecl(hasName("cls"))))),
+        hasArgument(1, declRefExpr(to(namedDecl(matchesName("(int|long|list|tuple|string|unicode|dict|baseexc|type)_cls")))).bind("parent_cls"))
+    ).bind("call");
+
+MatchFinder Finder;
+DiagnosticsEngine* diagnostics;
+
+// Not sure why the build wants us to add this:
+extern "C" void AnnotateHappensAfter(const char* file, int line, const volatile void *cv) {}
+
+std::set<SourceLocation> reported;
+
+class Replacer : public MatchFinder::MatchCallback {
+public:
+    virtual void run (const MatchFinder::MatchResult &Result) {
+        const CallExpr* ME = Result.Nodes.getNodeAs<clang::CallExpr>("call");
+
+        //errs() << "matched!\n";
+        //ME->dump();
+        //Result.Nodes.getNodeAs<clang::DeclRefExpr>("parent_cls")->dump();
+
+        unsigned diag_id = diagnostics->getCustomDiagID(
+            DiagnosticsEngine::Error, "perf issue: use PyFoo_Check instead of isSubclass(obj->cls, foo_cls)");
+        auto source = ME->getSourceRange().getBegin();
+        if (!reported.count(source)) {
+            reported.insert(source);
+            diagnostics->Report(source, diag_id);
+        }
+    }
+};
+
+Replacer replacer;
+
+class MyFrontendAction : public PluginASTAction {
+public:
+    MyFrontendAction() {}
+
+    bool ParseArgs(const CompilerInstance &CI, const std::vector<std::string> &args) override {
+        diagnostics = &CI.getDiagnostics();
+        return true;
+    }
+
+    std::unique_ptr<ASTConsumer> CreateASTConsumer(CompilerInstance& CI, StringRef file) override {
+        Finder.addMatcher(matcher, &replacer);
+
+        return Finder.newASTConsumer();
+    }
+};
+
+static FrontendPluginRegistry::Add<MyFrontendAction> X("pyston-linter", "run some Pyston-specific lint checks");

--- a/src/capi/abstract.cpp
+++ b/src/capi/abstract.cpp
@@ -1650,7 +1650,7 @@ extern "C" int PyNumber_Check(PyObject* obj) noexcept {
     assert(obj && obj->cls);
 
     // Our check, since we don't currently fill in tp_as_number:
-    if (isSubclass(obj->cls, int_cls) || isSubclass(obj->cls, long_cls) || isSubclass(obj->cls, float_cls))
+    if (PyFloat_Check(obj) || PyFloat_Check(obj) || PyFloat_Check(obj))
         return true;
 
     // The CPython check:

--- a/src/capi/typeobject.cpp
+++ b/src/capi/typeobject.cpp
@@ -2002,7 +2002,7 @@ static int recurse_down_subclasses(PyTypeObject* type, PyObject* name, update_ca
 }
 
 static PyObject* tp_new_wrapper(PyTypeObject* self, BoxedTuple* args, Box* kwds) noexcept {
-    RELEASE_ASSERT(isSubclass(self->cls, type_cls), "");
+    RELEASE_ASSERT(PyType_Check(self), "");
 
     // ASSERT(self->tp_new != Py_CallPythonNew, "going to get in an infinite loop");
 
@@ -2011,7 +2011,7 @@ static PyObject* tp_new_wrapper(PyTypeObject* self, BoxedTuple* args, Box* kwds)
     RELEASE_ASSERT(args->size() >= 1, "");
 
     BoxedClass* subtype = static_cast<BoxedClass*>(args->elts[0]);
-    RELEASE_ASSERT(isSubclass(subtype->cls, type_cls), "");
+    RELEASE_ASSERT(PyType_Check(subtype), "");
     RELEASE_ASSERT(isSubclass(subtype, self), "");
 
     BoxedTuple* new_args = BoxedTuple::create(args->size() - 1, &args->elts[1]);

--- a/src/codegen/irgen/hooks.cpp
+++ b/src/codegen/irgen/hooks.cpp
@@ -449,14 +449,14 @@ Box* compile(Box* source, Box* fn, Box* type, Box** _args) {
         if (!fn)
             throwCAPIException();
     }
-    RELEASE_ASSERT(isSubclass(fn->cls, str_cls), "");
+    RELEASE_ASSERT(PyString_Check(fn), "");
 
     if (isSubclass(type->cls, unicode_cls)) {
         type = _PyUnicode_AsDefaultEncodedString(type, NULL);
         if (!type)
             throwCAPIException();
     }
-    RELEASE_ASSERT(isSubclass(type->cls, str_cls), "");
+    RELEASE_ASSERT(PyString_Check(type), "");
 
     llvm::StringRef filename_str = static_cast<BoxedString*>(fn)->s();
     llvm::StringRef type_str = static_cast<BoxedString*>(type)->s();
@@ -489,7 +489,7 @@ Box* compile(Box* source, Box* fn, Box* type, Box** _args) {
     if (PyAST_Check(source)) {
         parsed = unboxAst(source);
     } else {
-        RELEASE_ASSERT(isSubclass(source->cls, str_cls), "");
+        RELEASE_ASSERT(PyString_Check(source), "");
         llvm::StringRef source_str = static_cast<BoxedString*>(source)->s();
 
         if (type_str == "exec") {
@@ -585,7 +585,7 @@ Box* eval(Box* boxedCode, Box* globals, Box* locals) {
 }
 
 Box* execMain(Box* boxedCode, Box* globals, Box* locals, PyCompilerFlags* flags) {
-    if (isSubclass(boxedCode->cls, tuple_cls)) {
+    if (PyTuple_Check(boxedCode)) {
         RELEASE_ASSERT(!globals, "");
         RELEASE_ASSERT(!locals, "");
 

--- a/src/codegen/unwinding.cpp
+++ b/src/codegen/unwinding.cpp
@@ -376,7 +376,7 @@ public:
         if (!globals)
             return NULL;
 
-        if (isSubclass(globals->cls, module_cls))
+        if (PyModule_Check(globals))
             return globals->getAttrWrapper();
         return globals;
     }

--- a/src/runtime/builtin_modules/builtins.cpp
+++ b/src/runtime/builtin_modules/builtins.cpp
@@ -86,7 +86,7 @@ extern "C" Box* vars(Box* obj) {
 }
 
 extern "C" Box* abs_(Box* x) {
-    if (isSubclass(x->cls, int_cls)) {
+    if (PyInt_Check(x)) {
         i64 n = static_cast<BoxedInt*>(x)->n;
         return boxInt(n >= 0 ? n : -n);
     } else if (x->cls == float_cls) {
@@ -108,7 +108,7 @@ extern "C" Box* hexFunc(Box* x) {
     if (!r)
         raiseExcHelper(TypeError, "hex() argument can't be converted to hex");
 
-    if (!isSubclass(r->cls, str_cls))
+    if (!PyString_Check(r))
         raiseExcHelper(TypeError, "__hex__() returned non-string (type %.200s)", r->cls->tp_name);
 
     return r;
@@ -121,7 +121,7 @@ extern "C" Box* octFunc(Box* x) {
     if (!r)
         raiseExcHelper(TypeError, "oct() argument can't be converted to oct");
 
-    if (!isSubclass(r->cls, str_cls))
+    if (!PyString_Check(r))
         raiseExcHelper(TypeError, "__oct__() returned non-string (type %.200s)", r->cls->tp_name);
 
     return r;
@@ -887,7 +887,7 @@ public:
 };
 
 Box* exceptionNew(BoxedClass* cls, BoxedTuple* args) {
-    if (!isSubclass(cls->cls, type_cls))
+    if (!PyType_Check(cls))
         raiseExcHelper(TypeError, "exceptions.__new__(X): X is not a type object (%s)", getTypeName(cls));
 
     if (!isSubclass(cls, BaseException))
@@ -960,7 +960,7 @@ extern "C" PyObject* PyErr_NewException(char* name, PyObject* _base, PyObject* d
         BoxedString* boxedName = boxString(llvm::StringRef(dot_pos + 1, n - (dot_pos - name) - 1));
 
         // It can also be a tuple of bases
-        RELEASE_ASSERT(isSubclass(_base->cls, type_cls), "");
+        RELEASE_ASSERT(PyType_Check(_base), "");
         BoxedClass* base = static_cast<BoxedClass*>(_base);
 
         if (PyDict_GetItemString(dict, "__module__") == NULL) {
@@ -997,7 +997,7 @@ public:
 
     static Box* new_(Box* cls, Box* obj, Box* start) {
         RELEASE_ASSERT(cls == enumerate_cls, "");
-        RELEASE_ASSERT(isSubclass(start->cls, int_cls), "");
+        RELEASE_ASSERT(PyInt_Check(start), "");
         int64_t idx = static_cast<BoxedInt*>(start)->n;
 
         llvm::iterator_range<BoxIterator> range = obj->pyElements();
@@ -1076,7 +1076,7 @@ Box* powFunc(Box* x, Box* y, Box* z) {
 
 Box* execfile(Box* _fn) {
     // The "globals" and "locals" arguments aren't implemented for now
-    if (!isSubclass(_fn->cls, str_cls)) {
+    if (!PyString_Check(_fn)) {
         raiseExcHelper(TypeError, "must be string, not %s", getTypeName(_fn));
     }
 

--- a/src/runtime/builtin_modules/sys.cpp
+++ b/src/runtime/builtin_modules/sys.cpp
@@ -105,7 +105,7 @@ Box* getSysStdout() {
 Box* sysGetFrame(Box* val) {
     int depth = 0;
     if (val) {
-        if (!isSubclass(val->cls, int_cls)) {
+        if (!PyInt_Check(val)) {
             raiseExcHelper(TypeError, "TypeError: an integer is required");
         }
         depth = static_cast<BoxedInt*>(val)->n;

--- a/src/runtime/builtin_modules/thread.cpp
+++ b/src/runtime/builtin_modules/thread.cpp
@@ -122,7 +122,7 @@ public:
         RELEASE_ASSERT(_self->cls == thread_lock_cls, "");
         BoxedThreadLock* self = static_cast<BoxedThreadLock*>(_self);
 
-        RELEASE_ASSERT(isSubclass(_waitflag->cls, int_cls), "");
+        RELEASE_ASSERT(PyInt_Check(_waitflag), "");
         int waitflag = static_cast<BoxedInt*>(_waitflag)->n;
 
         int rtn;

--- a/src/runtime/capi.cpp
+++ b/src/runtime/capi.cpp
@@ -807,7 +807,7 @@ void checkAndThrowCAPIException() {
 
     if (_type) {
         BoxedClass* type = static_cast<BoxedClass*>(_type);
-        assert(isSubclass(_type->cls, type_cls) && isSubclass(static_cast<BoxedClass*>(type), BaseException)
+        assert(PyType_Check(_type) && isSubclass(static_cast<BoxedClass*>(type), BaseException)
                && "Only support throwing subclass of BaseException for now");
 
         Box* value = cur_thread_state.curexc_value;

--- a/src/runtime/classobj.cpp
+++ b/src/runtime/classobj.cpp
@@ -67,7 +67,7 @@ extern "C" int PyClass_IsSubclass(PyObject* klass, PyObject* base) noexcept {
 }
 
 Box* classobjNew(Box* _cls, Box* _name, Box* _bases, Box** _args) {
-    if (!isSubclass(_cls->cls, type_cls))
+    if (!PyType_Check(_cls))
         raiseExcHelper(TypeError, "classobj.__new__(X): X is not a type object (%s)", getTypeName(_cls));
 
     BoxedClass* cls = static_cast<BoxedClass*>(_cls);

--- a/src/runtime/complex.cpp
+++ b/src/runtime/complex.cpp
@@ -87,13 +87,13 @@ extern "C" Box* complexAddFloat(BoxedComplex* lhs, BoxedFloat* rhs) {
 
 extern "C" Box* complexAddInt(BoxedComplex* lhs, BoxedInt* rhs) {
     assert(lhs->cls == complex_cls);
-    assert(isSubclass(rhs->cls, int_cls));
+    assert(PyInt_Check(rhs));
     return boxComplex(lhs->real + (double)rhs->n, lhs->imag);
 }
 
 extern "C" Box* complexAdd(BoxedComplex* lhs, Box* rhs) {
     assert(lhs->cls == complex_cls);
-    if (isSubclass(rhs->cls, int_cls)) {
+    if (PyInt_Check(rhs)) {
         return complexAddInt(lhs, static_cast<BoxedInt*>(rhs));
     } else if (rhs->cls == float_cls) {
         return complexAddFloat(lhs, static_cast<BoxedFloat*>(rhs));
@@ -120,13 +120,13 @@ extern "C" Box* complexSubFloat(BoxedComplex* lhs, BoxedFloat* rhs) {
 
 extern "C" Box* complexSubInt(BoxedComplex* lhs, BoxedInt* rhs) {
     assert(lhs->cls == complex_cls);
-    assert(isSubclass(rhs->cls, int_cls));
+    assert(PyInt_Check(rhs));
     return boxComplex(lhs->real - (double)rhs->n, lhs->imag);
 }
 
 extern "C" Box* complexSub(BoxedComplex* lhs, Box* rhs) {
     assert(lhs->cls == complex_cls);
-    if (isSubclass(rhs->cls, int_cls)) {
+    if (PyInt_Check(rhs)) {
         return complexSubInt(lhs, static_cast<BoxedInt*>(rhs));
     } else if (rhs->cls == float_cls) {
         return complexSubFloat(lhs, static_cast<BoxedFloat*>(rhs));
@@ -153,13 +153,13 @@ extern "C" Box* complexMulFloat(BoxedComplex* lhs, BoxedFloat* rhs) {
 
 extern "C" Box* complexMulInt(BoxedComplex* lhs, BoxedInt* rhs) {
     assert(lhs->cls == complex_cls);
-    assert(isSubclass(rhs->cls, int_cls));
+    assert(PyInt_Check(rhs));
     return boxComplex(lhs->real * (double)rhs->n, lhs->imag * (double)rhs->n);
 }
 
 extern "C" Box* complexMul(BoxedComplex* lhs, Box* rhs) {
     assert(lhs->cls == complex_cls);
-    if (isSubclass(rhs->cls, int_cls)) {
+    if (PyInt_Check(rhs)) {
         return complexMulInt(lhs, static_cast<BoxedInt*>(rhs));
     } else if (rhs->cls == float_cls) {
         return complexMulFloat(lhs, static_cast<BoxedFloat*>(rhs));
@@ -190,7 +190,7 @@ extern "C" Box* complexDivFloat(BoxedComplex* lhs, BoxedFloat* rhs) {
 
 extern "C" Box* complexDivInt(BoxedComplex* lhs, BoxedInt* rhs) {
     assert(lhs->cls == complex_cls);
-    assert(isSubclass(rhs->cls, int_cls));
+    assert(PyInt_Check(rhs));
     if (rhs->n == 0) {
         raiseDivZeroExc();
     }
@@ -199,7 +199,7 @@ extern "C" Box* complexDivInt(BoxedComplex* lhs, BoxedInt* rhs) {
 
 extern "C" Box* complexDiv(BoxedComplex* lhs, Box* rhs) {
     assert(lhs->cls == complex_cls);
-    if (isSubclass(rhs->cls, int_cls)) {
+    if (PyInt_Check(rhs)) {
         return complexDivInt(lhs, static_cast<BoxedInt*>(rhs));
     } else if (rhs->cls == float_cls) {
         return complexDivFloat(lhs, static_cast<BoxedFloat*>(rhs));
@@ -287,7 +287,7 @@ Box* complexNew(Box* _cls, Box* real, Box* imag) {
     RELEASE_ASSERT(_cls == complex_cls, "");
 
     double real_f;
-    if (isSubclass(real->cls, int_cls)) {
+    if (PyInt_Check(real)) {
         real_f = static_cast<BoxedInt*>(real)->n;
     } else if (real->cls == float_cls) {
         real_f = static_cast<BoxedFloat*>(real)->d;
@@ -297,7 +297,7 @@ Box* complexNew(Box* _cls, Box* real, Box* imag) {
     }
 
     double imag_f;
-    if (isSubclass(imag->cls, int_cls)) {
+    if (PyInt_Check(imag)) {
         imag_f = static_cast<BoxedInt*>(imag)->n;
     } else if (imag->cls == float_cls) {
         imag_f = static_cast<BoxedFloat*>(imag)->d;

--- a/src/runtime/descr.cpp
+++ b/src/runtime/descr.cpp
@@ -309,7 +309,7 @@ Box* BoxedMethodDescriptor::tppCall(Box* _self, CallRewriteArgs* rewrite_args, A
 
     if (ml_flags & METH_CLASS) {
         rewrite_args = NULL;
-        if (!isSubclass(arg1->cls, type_cls))
+        if (!PyType_Check(arg1))
             raiseExcHelper(TypeError, "descriptor '%s' requires a type but received a '%s'", self->method->ml_name,
                            getFullTypeName(arg1).c_str());
     } else {

--- a/src/runtime/dict.cpp
+++ b/src/runtime/dict.cpp
@@ -73,7 +73,7 @@ Box* dictRepr(BoxedDict* self) {
 }
 
 Box* dictClear(BoxedDict* self) {
-    if (!isSubclass(self->cls, dict_cls))
+    if (!PyDict_Check(self))
         raiseExcHelper(TypeError, "descriptor 'clear' requires a 'dict' object but received a '%s'", getTypeName(self));
 
     self->d.clear();
@@ -81,7 +81,7 @@ Box* dictClear(BoxedDict* self) {
 }
 
 Box* dictCopy(BoxedDict* self) {
-    if (!isSubclass(self->cls, dict_cls))
+    if (!PyDict_Check(self))
         raiseExcHelper(TypeError, "descriptor 'copy' requires a 'dict' object but received a '%s'", getTypeName(self));
 
     BoxedDict* r = new BoxedDict();
@@ -111,7 +111,7 @@ Box* dictValues(BoxedDict* self) {
 }
 
 Box* dictKeys(BoxedDict* self) {
-    RELEASE_ASSERT(isSubclass(self->cls, dict_cls), "");
+    RELEASE_ASSERT(PyDict_Check(self), "");
 
     BoxedList* rtn = new BoxedList();
     rtn->ensure(self->d.size());
@@ -148,7 +148,7 @@ extern "C" PyObject* PyDict_Items(PyObject* mp) noexcept {
 }
 
 Box* dictViewKeys(BoxedDict* self) {
-    if (!isSubclass(self->cls, dict_cls)) {
+    if (!PyDict_Check(self)) {
         raiseExcHelper(TypeError, "descriptor 'viewkeys' requires a 'dict' object but received a '%s'",
                        getTypeName(self));
     }
@@ -157,7 +157,7 @@ Box* dictViewKeys(BoxedDict* self) {
 }
 
 Box* dictViewValues(BoxedDict* self) {
-    if (!isSubclass(self->cls, dict_cls)) {
+    if (!PyDict_Check(self)) {
         raiseExcHelper(TypeError, "descriptor 'viewvalues' requires a 'dict' object but received a '%s'",
                        getTypeName(self));
     }
@@ -166,7 +166,7 @@ Box* dictViewValues(BoxedDict* self) {
 }
 
 Box* dictViewItems(BoxedDict* self) {
-    if (!isSubclass(self->cls, dict_cls)) {
+    if (!PyDict_Check(self)) {
         raiseExcHelper(TypeError, "descriptor 'viewitems' requires a 'dict' object but received a '%s'",
                        getTypeName(self));
     }
@@ -180,7 +180,7 @@ static Py_ssize_t dict_length(PyDictObject* mp) {
 }
 
 Box* dictLen(BoxedDict* self) {
-    if (!isSubclass(self->cls, dict_cls))
+    if (!PyDict_Check(self))
         raiseExcHelper(TypeError, "descriptor '__len__' requires a 'dict' object but received a '%s'",
                        getTypeName(self));
 
@@ -212,7 +212,7 @@ extern "C" int PyDict_Update(PyObject* a, PyObject* b) noexcept {
 }
 
 template <enum ExceptionStyle S> Box* dictGetitem(BoxedDict* self, Box* k) noexcept(S == CAPI) {
-    if (!isSubclass(self->cls, dict_cls)) {
+    if (!PyDict_Check(self)) {
         if (S == CAPI) {
             PyErr_Format(TypeError, "descriptor '__getitem__' requires a 'dict' object but received a '%s'",
                          getTypeName(self));
@@ -272,7 +272,7 @@ extern "C" PyObject* PyDict_New() noexcept {
 // The performance should hopefully be comparable to the CPython fast case, since we can use
 // runtimeICs.
 extern "C" int PyDict_SetItem(PyObject* mp, PyObject* _key, PyObject* _item) noexcept {
-    ASSERT(isSubclass(mp->cls, dict_cls) || mp->cls == attrwrapper_cls, "%s", getTypeName(mp));
+    ASSERT(PyDict_Check(mp) || mp->cls == attrwrapper_cls, "%s", getTypeName(mp));
 
     assert(mp);
     Box* b = static_cast<Box*>(mp);
@@ -303,8 +303,8 @@ extern "C" int PyDict_SetItemString(PyObject* mp, const char* key, PyObject* ite
 }
 
 extern "C" PyObject* PyDict_GetItem(PyObject* dict, PyObject* key) noexcept {
-    ASSERT(isSubclass(dict->cls, dict_cls) || dict->cls == attrwrapper_cls, "%s", getTypeName(dict));
-    if (isSubclass(dict->cls, dict_cls)) {
+    ASSERT(PyDict_Check(dict) || dict->cls == attrwrapper_cls, "%s", getTypeName(dict));
+    if (PyDict_Check(dict)) {
         BoxedDict* d = static_cast<BoxedDict*>(dict);
         return d->getOrNull(key);
     }
@@ -325,7 +325,7 @@ extern "C" PyObject* PyDict_GetItem(PyObject* dict, PyObject* key) noexcept {
 }
 
 extern "C" int PyDict_Next(PyObject* op, Py_ssize_t* ppos, PyObject** pkey, PyObject** pvalue) noexcept {
-    assert(isSubclass(op->cls, dict_cls));
+    assert(PyDict_Check(op));
     BoxedDict* self = static_cast<BoxedDict*>(op);
 
     // Callers of PyDict_New() provide a pointer to some storage for this function to use, in
@@ -391,7 +391,7 @@ Box* dictSetitem(BoxedDict* self, Box* k, Box* v) {
 }
 
 Box* dictDelitem(BoxedDict* self, Box* k) {
-    if (!isSubclass(self->cls, dict_cls))
+    if (!PyDict_Check(self))
         raiseExcHelper(TypeError, "descriptor '__delitem__' requires a 'dict' object but received a '%s'",
                        getTypeName(self));
 
@@ -422,7 +422,7 @@ static int dict_ass_sub(PyDictObject* mp, PyObject* v, PyObject* w) noexcept {
 }
 
 extern "C" int PyDict_DelItem(PyObject* op, PyObject* key) noexcept {
-    ASSERT(isSubclass(op->cls, dict_cls) || op->cls == attrwrapper_cls, "%s", getTypeName(op));
+    ASSERT(PyDict_Check(op) || op->cls == attrwrapper_cls, "%s", getTypeName(op));
     try {
         delitem(op, key);
         return 0;
@@ -444,7 +444,7 @@ extern "C" int PyDict_DelItemString(PyObject* v, const char* key) noexcept {
 }
 
 Box* dictPop(BoxedDict* self, Box* k, Box* d) {
-    if (!isSubclass(self->cls, dict_cls))
+    if (!PyDict_Check(self))
         raiseExcHelper(TypeError, "descriptor 'pop' requires a 'dict' object but received a '%s'", getTypeName(self));
 
     auto it = self->d.find(k);
@@ -461,7 +461,7 @@ Box* dictPop(BoxedDict* self, Box* k, Box* d) {
 }
 
 Box* dictPopitem(BoxedDict* self) {
-    if (!isSubclass(self->cls, dict_cls))
+    if (!PyDict_Check(self))
         raiseExcHelper(TypeError, "descriptor 'popitem' requires a 'dict' object but received a '%s'",
                        getTypeName(self));
 
@@ -479,7 +479,7 @@ Box* dictPopitem(BoxedDict* self) {
 }
 
 Box* dictGet(BoxedDict* self, Box* k, Box* d) {
-    if (!isSubclass(self->cls, dict_cls))
+    if (!PyDict_Check(self))
         raiseExcHelper(TypeError, "descriptor 'get' requires a 'dict' object but received a '%s'", getTypeName(self));
 
     auto it = self->d.find(k);
@@ -490,7 +490,7 @@ Box* dictGet(BoxedDict* self, Box* k, Box* d) {
 }
 
 Box* dictSetdefault(BoxedDict* self, Box* k, Box* v) {
-    if (!isSubclass(self->cls, dict_cls))
+    if (!PyDict_Check(self))
         raiseExcHelper(TypeError, "descriptor 'setdefault' requires a 'dict' object but received a '%s'",
                        getTypeName(self));
 
@@ -503,7 +503,7 @@ Box* dictSetdefault(BoxedDict* self, Box* k, Box* v) {
 }
 
 Box* dictContains(BoxedDict* self, Box* k) {
-    if (!isSubclass(self->cls, dict_cls))
+    if (!PyDict_Check(self))
         raiseExcHelper(TypeError, "descriptor '__contains__' requires a 'dict' object but received a '%s'",
                        getTypeName(self));
 
@@ -528,7 +528,7 @@ extern "C" int PyDict_Contains(PyObject* op, PyObject* key) noexcept {
         }
 
         BoxedDict* mp = (BoxedDict*)op;
-        assert(isSubclass(mp->cls, dict_cls));
+        assert(PyDict_Check(mp));
         return mp->getOrNull(key) ? 1 : 0;
     } catch (ExcInfo e) {
         setCAPIException(e);
@@ -551,11 +551,11 @@ Box* dictFromkeys(Box* cls, Box* iterable, Box* default_value) {
 }
 
 Box* dictEq(BoxedDict* self, Box* _rhs) {
-    if (!isSubclass(self->cls, dict_cls))
+    if (!PyDict_Check(self))
         raiseExcHelper(TypeError, "descriptor '__eq__' requires a 'dict' object but received a '%s'",
                        getTypeName(self));
 
-    if (!isSubclass(_rhs->cls, dict_cls))
+    if (!PyDict_Check(_rhs))
         return NotImplemented;
 
     BoxedDict* rhs = static_cast<BoxedDict*>(_rhs);
@@ -585,7 +585,7 @@ Box* dictNe(BoxedDict* self, Box* _rhs) {
 
 
 extern "C" Box* dictNew(Box* _cls, BoxedTuple* args, BoxedDict* kwargs) {
-    if (!isSubclass(_cls->cls, type_cls))
+    if (!PyType_Check(_cls))
         raiseExcHelper(TypeError, "dict.__new__(X): X is not a type object (%s)", getTypeName(_cls));
 
     BoxedClass* cls = static_cast<BoxedClass*>(_cls);
@@ -597,7 +597,7 @@ extern "C" Box* dictNew(Box* _cls, BoxedTuple* args, BoxedDict* kwargs) {
 }
 
 void dictMerge(BoxedDict* self, Box* other) {
-    if (isSubclass(other->cls, dict_cls)) {
+    if (PyDict_Check(other)) {
         for (const auto& p : static_cast<BoxedDict*>(other)->d)
             self->d[p.first] = p.second;
         return;
@@ -702,7 +702,7 @@ extern "C" Box* dictInit(BoxedDict* self, BoxedTuple* args, BoxedDict* kwargs) {
 }
 
 void BoxedDict::gcHandler(GCVisitor* v, Box* b) {
-    assert(isSubclass(b->cls, dict_cls));
+    assert(PyDict_Check(b));
 
     Box::gcHandler(v, b);
 
@@ -731,7 +731,7 @@ void BoxedDictView::gcHandler(GCVisitor* v, Box* b) {
 }
 
 static int dict_init(PyObject* self, PyObject* args, PyObject* kwds) noexcept {
-    assert(isSubclass(self->cls, dict_cls));
+    assert(PyDict_Check(self));
     try {
         dictInit(static_cast<BoxedDict*>(self), static_cast<BoxedTuple*>(args), static_cast<BoxedDict*>(kwds));
     } catch (ExcInfo e) {
@@ -742,7 +742,7 @@ static int dict_init(PyObject* self, PyObject* args, PyObject* kwds) noexcept {
 }
 
 static Box* dict_repr(PyObject* self) noexcept {
-    assert(isSubclass(self->cls, dict_cls));
+    assert(PyDict_Check(self));
     try {
         return dictRepr(static_cast<BoxedDict*>(self));
     } catch (ExcInfo e) {

--- a/src/runtime/exceptions.cpp
+++ b/src/runtime/exceptions.cpp
@@ -74,7 +74,7 @@ void ExcInfo::printExcAndTraceback() const {
 
 bool ExcInfo::matches(BoxedClass* cls) const {
     assert(this->type);
-    RELEASE_ASSERT(isSubclass(this->type->cls, type_cls), "throwing old-style objects not supported yet (%s)",
+    RELEASE_ASSERT(PyType_Check(this->type), "throwing old-style objects not supported yet (%s)",
                    getTypeName(this->type));
     return isSubclass(static_cast<BoxedClass*>(this->type), cls);
 }

--- a/src/runtime/float.cpp
+++ b/src/runtime/float.cpp
@@ -116,13 +116,13 @@ extern "C" Box* floatAddFloat(BoxedFloat* lhs, BoxedFloat* rhs) {
 
 extern "C" Box* floatAddInt(BoxedFloat* lhs, BoxedInt* rhs) {
     assert(lhs->cls == float_cls);
-    assert(isSubclass(rhs->cls, int_cls));
+    assert(PyInt_Check(rhs));
     return boxFloat(lhs->d + rhs->n);
 }
 
 extern "C" Box* floatAdd(BoxedFloat* lhs, Box* rhs) {
     assert(lhs->cls == float_cls);
-    if (isSubclass(rhs->cls, int_cls)) {
+    if (PyInt_Check(rhs)) {
         return floatAddInt(lhs, static_cast<BoxedInt*>(rhs));
     } else if (rhs->cls == float_cls) {
         return floatAddFloat(lhs, static_cast<BoxedFloat*>(rhs));
@@ -142,14 +142,14 @@ extern "C" Box* floatDivFloat(BoxedFloat* lhs, BoxedFloat* rhs) {
 
 extern "C" Box* floatDivInt(BoxedFloat* lhs, BoxedInt* rhs) {
     assert(lhs->cls == float_cls);
-    assert(isSubclass(rhs->cls, int_cls));
+    assert(PyInt_Check(rhs));
     raiseDivZeroExcIfZero(rhs->n);
     return boxFloat(lhs->d / rhs->n);
 }
 
 extern "C" Box* floatDiv(BoxedFloat* lhs, Box* rhs) {
     assert(lhs->cls == float_cls);
-    if (isSubclass(rhs->cls, int_cls)) {
+    if (PyInt_Check(rhs)) {
         return floatDivInt(lhs, static_cast<BoxedInt*>(rhs));
     } else if (rhs->cls == float_cls) {
         return floatDivFloat(lhs, static_cast<BoxedFloat*>(rhs));
@@ -162,7 +162,7 @@ extern "C" Box* floatDiv(BoxedFloat* lhs, Box* rhs) {
 
 extern "C" Box* floatTruediv(BoxedFloat* lhs, Box* rhs) {
     assert(lhs->cls == float_cls);
-    if (isSubclass(rhs->cls, int_cls)) {
+    if (PyInt_Check(rhs)) {
         return floatDivInt(lhs, static_cast<BoxedInt*>(rhs));
     } else if (rhs->cls == float_cls) {
         return floatDivFloat(lhs, static_cast<BoxedFloat*>(rhs));
@@ -182,14 +182,14 @@ extern "C" Box* floatRDivFloat(BoxedFloat* lhs, BoxedFloat* rhs) {
 
 extern "C" Box* floatRDivInt(BoxedFloat* lhs, BoxedInt* rhs) {
     assert(lhs->cls == float_cls);
-    assert(isSubclass(rhs->cls, int_cls));
+    assert(PyInt_Check(rhs));
     raiseDivZeroExcIfZero(lhs->d);
     return boxFloat(rhs->n / lhs->d);
 }
 
 extern "C" Box* floatRDiv(BoxedFloat* lhs, Box* rhs) {
     assert(lhs->cls == float_cls);
-    if (isSubclass(rhs->cls, int_cls)) {
+    if (PyInt_Check(rhs)) {
         return floatRDivInt(lhs, static_cast<BoxedInt*>(rhs));
     } else if (rhs->cls == float_cls) {
         return floatRDivFloat(lhs, static_cast<BoxedFloat*>(rhs));
@@ -209,14 +209,14 @@ extern "C" Box* floatFloorDivFloat(BoxedFloat* lhs, BoxedFloat* rhs) {
 
 extern "C" Box* floatFloorDivInt(BoxedFloat* lhs, BoxedInt* rhs) {
     assert(lhs->cls == float_cls);
-    assert(isSubclass(rhs->cls, int_cls));
+    assert(PyInt_Check(rhs));
     raiseDivZeroExcIfZero(rhs->n);
     return boxFloat(floor(lhs->d / rhs->n));
 }
 
 extern "C" Box* floatFloorDiv(BoxedFloat* lhs, Box* rhs) {
     assert(lhs->cls == float_cls);
-    if (isSubclass(rhs->cls, int_cls)) {
+    if (PyInt_Check(rhs)) {
         return floatFloorDivInt(lhs, static_cast<BoxedInt*>(rhs));
     } else if (rhs->cls == float_cls) {
         return floatFloorDivFloat(lhs, static_cast<BoxedFloat*>(rhs));
@@ -450,7 +450,7 @@ Unimplemented:
 }
 
 extern "C" Box* floatEq(BoxedFloat* lhs, Box* rhs) {
-    if (!isSubclass(lhs->cls, float_cls)) {
+    if (!PyFloat_Check(lhs)) {
         raiseExcHelper(TypeError, "descriptor '__eq__' requires a 'float' object but received a '%s'",
                        getTypeName(lhs));
     }
@@ -463,7 +463,7 @@ extern "C" Box* floatEq(BoxedFloat* lhs, Box* rhs) {
 }
 
 extern "C" Box* floatNe(BoxedFloat* lhs, Box* rhs) {
-    if (!isSubclass(lhs->cls, float_cls)) {
+    if (!PyFloat_Check(lhs)) {
         raiseExcHelper(TypeError, "descriptor '__ne__' requires a 'float' object but received a '%s'",
                        getTypeName(lhs));
     }
@@ -476,7 +476,7 @@ extern "C" Box* floatNe(BoxedFloat* lhs, Box* rhs) {
 }
 
 extern "C" Box* floatLe(BoxedFloat* lhs, Box* rhs) {
-    if (!isSubclass(lhs->cls, float_cls)) {
+    if (!PyFloat_Check(lhs)) {
         raiseExcHelper(TypeError, "descriptor '__le__' requires a 'float' object but received a '%s'",
                        getTypeName(lhs));
     }
@@ -489,7 +489,7 @@ extern "C" Box* floatLe(BoxedFloat* lhs, Box* rhs) {
 }
 
 extern "C" Box* floatLt(BoxedFloat* lhs, Box* rhs) {
-    if (!isSubclass(lhs->cls, float_cls)) {
+    if (!PyFloat_Check(lhs)) {
         raiseExcHelper(TypeError, "descriptor '__lt__' requires a 'float' object but received a '%s'",
                        getTypeName(lhs));
     }
@@ -502,7 +502,7 @@ extern "C" Box* floatLt(BoxedFloat* lhs, Box* rhs) {
 }
 
 extern "C" Box* floatGe(BoxedFloat* lhs, Box* rhs) {
-    if (!isSubclass(lhs->cls, float_cls)) {
+    if (!PyFloat_Check(lhs)) {
         raiseExcHelper(TypeError, "descriptor '__ge__' requires a 'float' object but received a '%s'",
                        getTypeName(lhs));
     }
@@ -515,7 +515,7 @@ extern "C" Box* floatGe(BoxedFloat* lhs, Box* rhs) {
 }
 
 extern "C" Box* floatGt(BoxedFloat* lhs, Box* rhs) {
-    if (!isSubclass(lhs->cls, float_cls)) {
+    if (!PyFloat_Check(lhs)) {
         raiseExcHelper(TypeError, "descriptor '__gt__' requires a 'float' object but received a '%s'",
                        getTypeName(lhs));
     }
@@ -535,13 +535,13 @@ extern "C" Box* floatModFloat(BoxedFloat* lhs, BoxedFloat* rhs) {
 
 extern "C" Box* floatModInt(BoxedFloat* lhs, BoxedInt* rhs) {
     assert(lhs->cls == float_cls);
-    assert(isSubclass(rhs->cls, int_cls));
+    assert(PyInt_Check(rhs));
     return boxFloat(mod_float_float(lhs->d, rhs->n));
 }
 
 extern "C" Box* floatMod(BoxedFloat* lhs, Box* rhs) {
     assert(lhs->cls == float_cls);
-    if (isSubclass(rhs->cls, int_cls)) {
+    if (PyInt_Check(rhs)) {
         return floatModInt(lhs, static_cast<BoxedInt*>(rhs));
     } else if (rhs->cls == float_cls) {
         return floatModFloat(lhs, static_cast<BoxedFloat*>(rhs));
@@ -560,13 +560,13 @@ extern "C" Box* floatRModFloat(BoxedFloat* lhs, BoxedFloat* rhs) {
 
 extern "C" Box* floatRModInt(BoxedFloat* lhs, BoxedInt* rhs) {
     assert(lhs->cls == float_cls);
-    assert(isSubclass(rhs->cls, int_cls));
+    assert(PyInt_Check(rhs));
     return boxFloat(mod_float_float(rhs->n, lhs->d));
 }
 
 extern "C" Box* floatRMod(BoxedFloat* lhs, Box* rhs) {
     assert(lhs->cls == float_cls);
-    if (isSubclass(rhs->cls, int_cls)) {
+    if (PyInt_Check(rhs)) {
         return floatRModInt(lhs, static_cast<BoxedInt*>(rhs));
     } else if (rhs->cls == float_cls) {
         return floatRModFloat(lhs, static_cast<BoxedFloat*>(rhs));
@@ -595,7 +595,7 @@ extern "C" Box* floatPowFloat(BoxedFloat* lhs, BoxedFloat* rhs, Box* mod = None)
 extern "C" Box* floatPowInt(BoxedFloat* lhs, BoxedInt* rhs, Box* mod = None) {
     // TODO to specialize this, need to account for all the special cases in float_pow
     assert(lhs->cls == float_cls);
-    assert(isSubclass(rhs->cls, int_cls));
+    assert(PyInt_Check(rhs));
     return floatPow(lhs, rhs, mod);
 }
 
@@ -617,13 +617,13 @@ extern "C" Box* floatMulFloat(BoxedFloat* lhs, BoxedFloat* rhs) {
 
 extern "C" Box* floatMulInt(BoxedFloat* lhs, BoxedInt* rhs) {
     assert(lhs->cls == float_cls);
-    assert(isSubclass(rhs->cls, int_cls));
+    assert(PyInt_Check(rhs));
     return boxFloat(lhs->d * rhs->n);
 }
 
 extern "C" Box* floatMul(BoxedFloat* lhs, Box* rhs) {
     assert(lhs->cls == float_cls);
-    if (isSubclass(rhs->cls, int_cls)) {
+    if (PyInt_Check(rhs)) {
         return floatMulInt(lhs, static_cast<BoxedInt*>(rhs));
     } else if (rhs->cls == float_cls) {
         return floatMulFloat(lhs, static_cast<BoxedFloat*>(rhs));
@@ -642,13 +642,13 @@ extern "C" Box* floatSubFloat(BoxedFloat* lhs, BoxedFloat* rhs) {
 
 extern "C" Box* floatSubInt(BoxedFloat* lhs, BoxedInt* rhs) {
     assert(lhs->cls == float_cls);
-    assert(isSubclass(rhs->cls, int_cls));
+    assert(PyInt_Check(rhs));
     return boxFloat(lhs->d - rhs->n);
 }
 
 extern "C" Box* floatSub(BoxedFloat* lhs, Box* rhs) {
     assert(lhs->cls == float_cls);
-    if (isSubclass(rhs->cls, int_cls)) {
+    if (PyInt_Check(rhs)) {
         return floatSubInt(lhs, static_cast<BoxedInt*>(rhs));
     } else if (rhs->cls == float_cls) {
         return floatSubFloat(lhs, static_cast<BoxedFloat*>(rhs));
@@ -667,13 +667,13 @@ extern "C" Box* floatRSubFloat(BoxedFloat* lhs, BoxedFloat* rhs) {
 
 extern "C" Box* floatRSubInt(BoxedFloat* lhs, BoxedInt* rhs) {
     assert(lhs->cls == float_cls);
-    assert(isSubclass(rhs->cls, int_cls));
+    assert(PyInt_Check(rhs));
     return boxFloat(rhs->n - lhs->d);
 }
 
 extern "C" Box* floatRSub(BoxedFloat* lhs, Box* rhs) {
     assert(lhs->cls == float_cls);
-    if (isSubclass(rhs->cls, int_cls)) {
+    if (PyInt_Check(rhs)) {
         return floatRSubInt(lhs, static_cast<BoxedInt*>(rhs));
     } else if (rhs->cls == float_cls) {
         return floatRSubFloat(lhs, static_cast<BoxedFloat*>(rhs));
@@ -793,9 +793,9 @@ template <ExceptionStyle S> static BoxedFloat* _floatNew(Box* a) noexcept(S == C
 
     if (a->cls == float_cls) {
         return static_cast<BoxedFloat*>(a);
-    } else if (isSubclass(a->cls, float_cls)) {
+    } else if (PyFloat_Check(a)) {
         return new BoxedFloat(static_cast<BoxedFloat*>(a)->d);
-    } else if (isSubclass(a->cls, int_cls)) {
+    } else if (PyInt_Check(a)) {
         return new BoxedFloat(static_cast<BoxedInt*>(a)->n);
     } else if (a->cls == str_cls) {
         llvm::StringRef s = static_cast<BoxedString*>(a)->s();
@@ -836,7 +836,7 @@ template <ExceptionStyle S> static BoxedFloat* _floatNew(Box* a) noexcept(S == C
             }
         }
 
-        if (!isSubclass(r->cls, float_cls)) {
+        if (!PyFloat_Check(r)) {
             if (S == CAPI) {
                 PyErr_Format(TypeError, "__float__ returned non-float (type %s)", r->cls->tp_name);
                 return NULL;
@@ -848,7 +848,7 @@ template <ExceptionStyle S> static BoxedFloat* _floatNew(Box* a) noexcept(S == C
 }
 
 template <ExceptionStyle S> Box* floatNew(BoxedClass* _cls, Box* a) noexcept(S == CAPI) {
-    if (!isSubclass(_cls->cls, type_cls)) {
+    if (!PyType_Check(_cls)) {
         if (S == CAPI) {
             PyErr_Format(TypeError, "float.__new__(X): X is not a type object (%s)", getTypeName(_cls));
             return NULL;
@@ -882,7 +882,7 @@ template <ExceptionStyle S> Box* floatNew(BoxedClass* _cls, Box* a) noexcept(S =
 }
 
 Box* floatStr(BoxedFloat* self) {
-    if (!isSubclass(self->cls, float_cls))
+    if (!PyFloat_Check(self))
         raiseExcHelper(TypeError, "descriptor '__str__' requires a 'float' object but received a '%s'",
                        getTypeName(self));
 
@@ -895,7 +895,7 @@ Box* floatRepr(BoxedFloat* self) {
 }
 
 Box* floatTrunc(BoxedFloat* self) {
-    if (!isSubclass(self->cls, float_cls))
+    if (!PyFloat_Check(self))
         raiseExcHelper(TypeError, "descriptor '__trunc__' requires a 'float' object but received a '%s'",
                        getTypeName(self));
 
@@ -925,7 +925,7 @@ Box* floatTrunc(BoxedFloat* self) {
 }
 
 Box* floatHash(BoxedFloat* self) {
-    if (!isSubclass(self->cls, float_cls))
+    if (!PyFloat_Check(self))
         raiseExcHelper(TypeError, "descriptor '__hash__' requires a 'float' object but received a '%s'",
                        getTypeName(self));
 

--- a/src/runtime/inline/dict.cpp
+++ b/src/runtime/inline/dict.cpp
@@ -24,19 +24,19 @@ BoxedDictIterator::BoxedDictIterator(BoxedDict* d, IteratorType type)
 }
 
 Box* dictIterKeys(Box* s) {
-    assert(isSubclass(s->cls, dict_cls));
+    assert(PyDict_Check(s));
     BoxedDict* self = static_cast<BoxedDict*>(s);
     return new BoxedDictIterator(self, BoxedDictIterator::KeyIterator);
 }
 
 Box* dictIterValues(Box* s) {
-    assert(isSubclass(s->cls, dict_cls));
+    assert(PyDict_Check(s));
     BoxedDict* self = static_cast<BoxedDict*>(s);
     return new BoxedDictIterator(self, BoxedDictIterator::ValueIterator);
 }
 
 Box* dictIterItems(Box* s) {
-    assert(isSubclass(s->cls, dict_cls));
+    assert(PyDict_Check(s));
     BoxedDict* self = static_cast<BoxedDict*>(s);
     return new BoxedDictIterator(self, BoxedDictIterator::ItemIterator);
 }

--- a/src/runtime/inline/list.cpp
+++ b/src/runtime/inline/list.cpp
@@ -30,7 +30,7 @@ Box* listIterIter(Box* s) {
 }
 
 Box* listIter(Box* s) noexcept {
-    assert(isSubclass(s->cls, list_cls));
+    assert(PyList_Check(s));
     BoxedList* self = static_cast<BoxedList*>(s);
     return new BoxedListIterator(self, 0);
 }
@@ -95,7 +95,7 @@ template Box* listiterNext<CAPI>(Box*);
 template Box* listiterNext<CXX>(Box*);
 
 Box* listReversed(Box* s) {
-    assert(isSubclass(s->cls, list_cls));
+    assert(PyList_Check(s));
     BoxedList* self = static_cast<BoxedList*>(s);
     return new (list_reverse_iterator_cls) BoxedListIterator(self, self->size - 1);
 }
@@ -146,7 +146,7 @@ void BoxedList::shrink() {
 
 
 extern "C" void listAppendArrayInternal(Box* s, Box** v, int nelts) {
-    assert(isSubclass(s->cls, list_cls));
+    assert(PyList_Check(s));
     BoxedList* self = static_cast<BoxedList*>(s);
 
     assert(self->size <= self->capacity);
@@ -160,7 +160,7 @@ extern "C" void listAppendArrayInternal(Box* s, Box** v, int nelts) {
 
 // TODO the inliner doesn't want to inline these; is there any point to having them in the inline section?
 extern "C" Box* listAppend(Box* s, Box* v) {
-    assert(isSubclass(s->cls, list_cls));
+    assert(PyList_Check(s));
     BoxedList* self = static_cast<BoxedList*>(s);
 
     listAppendInternal(self, v);

--- a/src/runtime/inline/list.h
+++ b/src/runtime/inline/list.h
@@ -45,7 +45,7 @@ inline void BoxedList::ensure(int min_free) {
 extern "C" inline void listAppendInternal(Box* s, Box* v) {
     // Lock must be held!
 
-    assert(isSubclass(s->cls, list_cls));
+    assert(PyList_Check(s));
     BoxedList* self = static_cast<BoxedList*>(s);
 
     assert(self->size <= self->capacity);

--- a/src/runtime/inline/tuple.cpp
+++ b/src/runtime/inline/tuple.cpp
@@ -27,7 +27,7 @@ Box* tupleIterIter(Box* s) {
 }
 
 Box* tupleIter(Box* s) noexcept {
-    assert(isSubclass(s->cls, tuple_cls));
+    assert(PyTuple_Check(s));
     BoxedTuple* self = static_cast<BoxedTuple*>(s);
     return new BoxedTupleIterator(self);
 }

--- a/src/runtime/int.cpp
+++ b/src/runtime/int.cpp
@@ -50,7 +50,7 @@ extern "C" unsigned long PyInt_AsUnsignedLongMask(PyObject* op) noexcept {
 extern "C" long PyInt_AsLong(PyObject* op) noexcept {
     // This method should do quite a bit more, including checking tp_as_number->nb_int (or calling __int__?)
 
-    if (isSubclass(op->cls, int_cls))
+    if (PyInt_Check(op))
         return static_cast<BoxedInt*>(op)->n;
 
     if (op->cls == long_cls)
@@ -111,7 +111,7 @@ static Box* int_to_decimal_string(BoxedInt* v) noexcept {
 
 extern "C" PyAPI_FUNC(PyObject*) _PyInt_Format(PyIntObject* v, int base, int newstyle) noexcept {
     BoxedInt* bint = reinterpret_cast<BoxedInt*>(v);
-    RELEASE_ASSERT(isSubclass(bint->cls, int_cls), "");
+    RELEASE_ASSERT(PyInt_Check(bint), "");
 
     /* There are no doubt many, many ways to optimize this, using code
        similar to _PyLong_Format */
@@ -390,22 +390,22 @@ extern "C" i1 ge_i64_i64(i64 lhs, i64 rhs) {
 
 
 extern "C" Box* intAddInt(BoxedInt* lhs, BoxedInt* rhs) {
-    assert(isSubclass(lhs->cls, int_cls));
-    assert(isSubclass(rhs->cls, int_cls));
+    assert(PyInt_Check(lhs));
+    assert(PyInt_Check(rhs));
     return add_i64_i64(lhs->n, rhs->n);
 }
 
 extern "C" Box* intAddFloat(BoxedInt* lhs, BoxedFloat* rhs) {
-    assert(isSubclass(lhs->cls, int_cls));
+    assert(PyInt_Check(lhs));
     assert(rhs->cls == float_cls);
     return boxFloat(lhs->n + rhs->d);
 }
 
 extern "C" Box* intAdd(BoxedInt* lhs, Box* rhs) {
-    if (!isSubclass(lhs->cls, int_cls))
+    if (!PyInt_Check(lhs))
         raiseExcHelper(TypeError, "descriptor '__add__' requires a 'int' object but received a '%s'", getTypeName(lhs));
 
-    if (isSubclass(rhs->cls, int_cls)) {
+    if (PyInt_Check(rhs)) {
         BoxedInt* rhs_int = static_cast<BoxedInt*>(rhs);
         return add_i64_i64(lhs->n, rhs_int->n);
     } else if (rhs->cls == float_cls) {
@@ -417,16 +417,16 @@ extern "C" Box* intAdd(BoxedInt* lhs, Box* rhs) {
 }
 
 extern "C" Box* intAndInt(BoxedInt* lhs, BoxedInt* rhs) {
-    assert(isSubclass(lhs->cls, int_cls));
-    assert(isSubclass(rhs->cls, int_cls));
+    assert(PyInt_Check(lhs));
+    assert(PyInt_Check(rhs));
     return boxInt(lhs->n & rhs->n);
 }
 
 extern "C" Box* intAnd(BoxedInt* lhs, Box* rhs) {
-    if (!isSubclass(lhs->cls, int_cls))
+    if (!PyInt_Check(lhs))
         raiseExcHelper(TypeError, "descriptor '__and__' requires a 'int' object but received a '%s'", getTypeName(lhs));
 
-    if (!isSubclass(rhs->cls, int_cls)) {
+    if (!PyInt_Check(rhs)) {
         return NotImplemented;
     }
     BoxedInt* rhs_int = static_cast<BoxedInt*>(rhs);
@@ -434,16 +434,16 @@ extern "C" Box* intAnd(BoxedInt* lhs, Box* rhs) {
 }
 
 extern "C" Box* intOrInt(BoxedInt* lhs, BoxedInt* rhs) {
-    assert(isSubclass(lhs->cls, int_cls));
-    assert(isSubclass(rhs->cls, int_cls));
+    assert(PyInt_Check(lhs));
+    assert(PyInt_Check(rhs));
     return boxInt(lhs->n | rhs->n);
 }
 
 extern "C" Box* intOr(BoxedInt* lhs, Box* rhs) {
-    if (!isSubclass(lhs->cls, int_cls))
+    if (!PyInt_Check(lhs))
         raiseExcHelper(TypeError, "descriptor '__or__' requires a 'int' object but received a '%s'", getTypeName(lhs));
 
-    if (!isSubclass(rhs->cls, int_cls)) {
+    if (!PyInt_Check(rhs)) {
         return NotImplemented;
     }
     BoxedInt* rhs_int = static_cast<BoxedInt*>(rhs);
@@ -451,16 +451,16 @@ extern "C" Box* intOr(BoxedInt* lhs, Box* rhs) {
 }
 
 extern "C" Box* intXorInt(BoxedInt* lhs, BoxedInt* rhs) {
-    assert(isSubclass(lhs->cls, int_cls));
-    assert(isSubclass(rhs->cls, int_cls));
+    assert(PyInt_Check(lhs));
+    assert(PyInt_Check(rhs));
     return boxInt(lhs->n ^ rhs->n);
 }
 
 extern "C" Box* intXor(BoxedInt* lhs, Box* rhs) {
-    if (!isSubclass(lhs->cls, int_cls))
+    if (!PyInt_Check(lhs))
         raiseExcHelper(TypeError, "descriptor '__xor__' requires a 'int' object but received a '%s'", getTypeName(lhs));
 
-    if (!isSubclass(rhs->cls, int_cls)) {
+    if (!PyInt_Check(rhs)) {
         return NotImplemented;
     }
     BoxedInt* rhs_int = static_cast<BoxedInt*>(rhs);
@@ -468,13 +468,13 @@ extern "C" Box* intXor(BoxedInt* lhs, Box* rhs) {
 }
 
 extern "C" Box* intDivInt(BoxedInt* lhs, BoxedInt* rhs) {
-    assert(isSubclass(lhs->cls, int_cls));
-    assert(isSubclass(rhs->cls, int_cls));
+    assert(PyInt_Check(lhs));
+    assert(PyInt_Check(rhs));
     return div_i64_i64(lhs->n, rhs->n);
 }
 
 extern "C" Box* intDivFloat(BoxedInt* lhs, BoxedFloat* rhs) {
-    assert(isSubclass(lhs->cls, int_cls));
+    assert(PyInt_Check(lhs));
     assert(rhs->cls == float_cls);
 
     if (rhs->d == 0) {
@@ -484,10 +484,10 @@ extern "C" Box* intDivFloat(BoxedInt* lhs, BoxedFloat* rhs) {
 }
 
 extern "C" Box* intDiv(BoxedInt* lhs, Box* rhs) {
-    if (!isSubclass(lhs->cls, int_cls))
+    if (!PyInt_Check(lhs))
         raiseExcHelper(TypeError, "descriptor '__div__' requires a 'int' object but received a '%s'", getTypeName(lhs));
 
-    if (isSubclass(rhs->cls, int_cls)) {
+    if (PyInt_Check(rhs)) {
         return intDivInt(lhs, static_cast<BoxedInt*>(rhs));
     } else if (rhs->cls == float_cls) {
         return intDivFloat(lhs, static_cast<BoxedFloat*>(rhs));
@@ -497,13 +497,13 @@ extern "C" Box* intDiv(BoxedInt* lhs, Box* rhs) {
 }
 
 extern "C" Box* intFloordivInt(BoxedInt* lhs, BoxedInt* rhs) {
-    assert(isSubclass(lhs->cls, int_cls));
-    assert(isSubclass(rhs->cls, int_cls));
+    assert(PyInt_Check(lhs));
+    assert(PyInt_Check(rhs));
     return div_i64_i64(lhs->n, rhs->n);
 }
 
 extern "C" Box* intFloordivFloat(BoxedInt* lhs, BoxedFloat* rhs) {
-    assert(isSubclass(lhs->cls, int_cls));
+    assert(PyInt_Check(lhs));
     assert(rhs->cls == float_cls);
 
     if (rhs->d == 0) {
@@ -513,11 +513,11 @@ extern "C" Box* intFloordivFloat(BoxedInt* lhs, BoxedFloat* rhs) {
 }
 
 extern "C" Box* intFloordiv(BoxedInt* lhs, Box* rhs) {
-    if (!isSubclass(lhs->cls, int_cls))
+    if (!PyInt_Check(lhs))
         raiseExcHelper(TypeError, "descriptor '__floordiv__' requires a 'int' object but received a '%s'",
                        getTypeName(lhs));
 
-    if (isSubclass(rhs->cls, int_cls)) {
+    if (PyInt_Check(rhs)) {
         return intFloordivInt(lhs, static_cast<BoxedInt*>(rhs));
     } else if (rhs->cls == float_cls) {
         return intFloordivFloat(lhs, static_cast<BoxedFloat*>(rhs));
@@ -527,8 +527,8 @@ extern "C" Box* intFloordiv(BoxedInt* lhs, Box* rhs) {
 }
 
 extern "C" Box* intTruedivInt(BoxedInt* lhs, BoxedInt* rhs) {
-    assert(isSubclass(lhs->cls, int_cls));
-    assert(isSubclass(rhs->cls, int_cls));
+    assert(PyInt_Check(lhs));
+    assert(PyInt_Check(rhs));
 
     if (rhs->n == 0) {
         raiseExcHelper(ZeroDivisionError, "division by zero");
@@ -537,7 +537,7 @@ extern "C" Box* intTruedivInt(BoxedInt* lhs, BoxedInt* rhs) {
 }
 
 extern "C" Box* intTruedivFloat(BoxedInt* lhs, BoxedFloat* rhs) {
-    assert(isSubclass(lhs->cls, int_cls));
+    assert(PyInt_Check(lhs));
     assert(rhs->cls == float_cls);
 
     if (rhs->d == 0) {
@@ -547,11 +547,11 @@ extern "C" Box* intTruedivFloat(BoxedInt* lhs, BoxedFloat* rhs) {
 }
 
 extern "C" Box* intTruediv(BoxedInt* lhs, Box* rhs) {
-    if (!isSubclass(lhs->cls, int_cls))
+    if (!PyInt_Check(lhs))
         raiseExcHelper(TypeError, "descriptor '__truediv__' requires a 'int' object but received a '%s'",
                        getTypeName(lhs));
 
-    if (isSubclass(rhs->cls, int_cls)) {
+    if (PyInt_Check(rhs)) {
         return intTruedivInt(lhs, static_cast<BoxedInt*>(rhs));
     } else if (rhs->cls == float_cls) {
         return intTruedivFloat(lhs, static_cast<BoxedFloat*>(rhs));
@@ -561,8 +561,8 @@ extern "C" Box* intTruediv(BoxedInt* lhs, Box* rhs) {
 }
 
 extern "C" Box* intLShiftInt(BoxedInt* lhs, BoxedInt* rhs) {
-    assert(isSubclass(lhs->cls, int_cls));
-    assert(isSubclass(rhs->cls, int_cls));
+    assert(PyInt_Check(lhs));
+    assert(PyInt_Check(rhs));
 
     if (rhs->n < 0)
         raiseExcHelper(ValueError, "negative shift count");
@@ -577,14 +577,14 @@ extern "C" Box* intLShiftInt(BoxedInt* lhs, BoxedInt* rhs) {
 }
 
 extern "C" Box* intLShift(BoxedInt* lhs, Box* rhs) {
-    if (!isSubclass(lhs->cls, int_cls))
+    if (!PyInt_Check(lhs))
         raiseExcHelper(TypeError, "descriptor '__lshift__' requires a 'int' object but received a '%s'",
                        getTypeName(lhs));
 
     if (rhs->cls == long_cls)
         return longLshift(boxLong(lhs->n), rhs);
 
-    if (!isSubclass(rhs->cls, int_cls)) {
+    if (!PyInt_Check(rhs)) {
         return NotImplemented;
     }
     BoxedInt* rhs_int = static_cast<BoxedInt*>(rhs);
@@ -592,16 +592,16 @@ extern "C" Box* intLShift(BoxedInt* lhs, Box* rhs) {
 }
 
 extern "C" Box* intModInt(BoxedInt* lhs, BoxedInt* rhs) {
-    assert(isSubclass(lhs->cls, int_cls));
-    assert(isSubclass(rhs->cls, int_cls));
+    assert(PyInt_Check(lhs));
+    assert(PyInt_Check(rhs));
     return boxInt(mod_i64_i64(lhs->n, rhs->n));
 }
 
 extern "C" Box* intMod(BoxedInt* lhs, Box* rhs) {
-    if (!isSubclass(lhs->cls, int_cls))
+    if (!PyInt_Check(lhs))
         raiseExcHelper(TypeError, "descriptor '__mod__' requires a 'int' object but received a '%s'", getTypeName(lhs));
 
-    if (!isSubclass(rhs->cls, int_cls)) {
+    if (!PyInt_Check(rhs)) {
         return NotImplemented;
     }
     BoxedInt* rhs_int = static_cast<BoxedInt*>(rhs);
@@ -609,7 +609,7 @@ extern "C" Box* intMod(BoxedInt* lhs, Box* rhs) {
 }
 
 extern "C" Box* intDivmod(BoxedInt* lhs, Box* rhs) {
-    if (!isSubclass(lhs->cls, int_cls))
+    if (!PyInt_Check(lhs))
         raiseExcHelper(TypeError, "descriptor '__divmod__' requires a 'int' object but received a '%s'",
                        getTypeName(lhs));
 
@@ -631,22 +631,22 @@ extern "C" Box* intDivmod(BoxedInt* lhs, Box* rhs) {
 
 
 extern "C" Box* intMulInt(BoxedInt* lhs, BoxedInt* rhs) {
-    assert(isSubclass(lhs->cls, int_cls));
-    assert(isSubclass(rhs->cls, int_cls));
+    assert(PyInt_Check(lhs));
+    assert(PyInt_Check(rhs));
     return mul_i64_i64(lhs->n, rhs->n);
 }
 
 extern "C" Box* intMulFloat(BoxedInt* lhs, BoxedFloat* rhs) {
-    assert(isSubclass(lhs->cls, int_cls));
+    assert(PyInt_Check(lhs));
     assert(rhs->cls == float_cls);
     return boxFloat(lhs->n * rhs->d);
 }
 
 extern "C" Box* intMul(BoxedInt* lhs, Box* rhs) {
-    if (!isSubclass(lhs->cls, int_cls))
+    if (!PyInt_Check(lhs))
         raiseExcHelper(TypeError, "descriptor '__mul__' requires a 'int' object but received a '%s'", getTypeName(lhs));
 
-    if (isSubclass(rhs->cls, int_cls)) {
+    if (PyInt_Check(rhs)) {
         BoxedInt* rhs_int = static_cast<BoxedInt*>(rhs);
         return intMulInt(lhs, rhs_int);
     } else if (rhs->cls == float_cls) {
@@ -668,14 +668,14 @@ static void _addFuncPow(const char* name, ConcreteCompilerType* rtn_type, void* 
 }
 
 extern "C" Box* intPowLong(BoxedInt* lhs, BoxedLong* rhs, Box* mod) {
-    assert(isSubclass(lhs->cls, int_cls));
-    assert(isSubclass(rhs->cls, long_cls));
+    assert(PyInt_Check(lhs));
+    assert(PyLong_Check(rhs));
     BoxedLong* lhs_long = boxLong(lhs->n);
     return longPow(lhs_long, rhs, mod);
 }
 
 extern "C" Box* intPowFloat(BoxedInt* lhs, BoxedFloat* rhs, Box* mod) {
-    assert(isSubclass(lhs->cls, int_cls));
+    assert(PyInt_Check(lhs));
     assert(rhs->cls == float_cls);
 
     if (mod != None) {
@@ -685,14 +685,14 @@ extern "C" Box* intPowFloat(BoxedInt* lhs, BoxedFloat* rhs, Box* mod) {
 }
 
 extern "C" Box* intPow(BoxedInt* lhs, Box* rhs, Box* mod) {
-    if (!isSubclass(lhs->cls, int_cls))
+    if (!PyInt_Check(lhs))
         raiseExcHelper(TypeError, "descriptor '__pow__' requires a 'int' object but received a '%s'", getTypeName(lhs));
 
-    if (isSubclass(rhs->cls, long_cls))
+    if (PyLong_Check(rhs))
         return intPowLong(lhs, static_cast<BoxedLong*>(rhs), mod);
-    else if (isSubclass(rhs->cls, float_cls))
+    else if (PyFloat_Check(rhs))
         return intPowFloat(lhs, static_cast<BoxedFloat*>(rhs), mod);
-    else if (!isSubclass(rhs->cls, int_cls))
+    else if (!PyInt_Check(rhs))
         return NotImplemented;
 
     BoxedInt* rhs_int = static_cast<BoxedInt*>(rhs);
@@ -702,7 +702,7 @@ extern "C" Box* intPow(BoxedInt* lhs, Box* rhs, Box* mod) {
         if (rhs_int->n < 0)
             raiseExcHelper(TypeError, "pow() 2nd argument "
                                       "cannot be negative when 3rd argument specified");
-        if (!isSubclass(mod->cls, int_cls)) {
+        if (!PyInt_Check(mod)) {
             return NotImplemented;
         } else if (mod_int->n == 0) {
             raiseExcHelper(ValueError, "pow() 3rd argument cannot be 0");
@@ -710,14 +710,14 @@ extern "C" Box* intPow(BoxedInt* lhs, Box* rhs, Box* mod) {
     }
 
     Box* rtn = pow_i64_i64(lhs->n, rhs_int->n, mod);
-    if (isSubclass(rtn->cls, long_cls))
+    if (PyLong_Check(rtn))
         return longInt(rtn);
     return rtn;
 }
 
 extern "C" Box* intRShiftInt(BoxedInt* lhs, BoxedInt* rhs) {
-    assert(isSubclass(lhs->cls, int_cls));
-    assert(isSubclass(rhs->cls, int_cls));
+    assert(PyInt_Check(lhs));
+    assert(PyInt_Check(rhs));
 
     if (rhs->n < 0)
         raiseExcHelper(ValueError, "negative shift count");
@@ -726,14 +726,14 @@ extern "C" Box* intRShiftInt(BoxedInt* lhs, BoxedInt* rhs) {
 }
 
 extern "C" Box* intRShift(BoxedInt* lhs, Box* rhs) {
-    if (!isSubclass(lhs->cls, int_cls))
+    if (!PyInt_Check(lhs))
         raiseExcHelper(TypeError, "descriptor '__rshift__' requires a 'int' object but received a '%s'",
                        getTypeName(lhs));
 
     if (rhs->cls == long_cls)
         return longRshift(boxLong(lhs->n), rhs);
 
-    if (!isSubclass(rhs->cls, int_cls)) {
+    if (!PyInt_Check(rhs)) {
         return NotImplemented;
     }
     BoxedInt* rhs_int = static_cast<BoxedInt*>(rhs);
@@ -741,22 +741,22 @@ extern "C" Box* intRShift(BoxedInt* lhs, Box* rhs) {
 }
 
 extern "C" Box* intSubInt(BoxedInt* lhs, BoxedInt* rhs) {
-    assert(isSubclass(lhs->cls, int_cls));
-    assert(isSubclass(rhs->cls, int_cls));
+    assert(PyInt_Check(lhs));
+    assert(PyInt_Check(rhs));
     return sub_i64_i64(lhs->n, rhs->n);
 }
 
 extern "C" Box* intSubFloat(BoxedInt* lhs, BoxedFloat* rhs) {
-    assert(isSubclass(lhs->cls, int_cls));
+    assert(PyInt_Check(lhs));
     assert(rhs->cls == float_cls);
     return boxFloat(lhs->n - rhs->d);
 }
 
 extern "C" Box* intSub(BoxedInt* lhs, Box* rhs) {
-    if (!isSubclass(lhs->cls, int_cls))
+    if (!PyInt_Check(lhs))
         raiseExcHelper(TypeError, "descriptor '__sub__' requires a 'int' object but received a '%s'", getTypeName(lhs));
 
-    if (isSubclass(rhs->cls, int_cls)) {
+    if (PyInt_Check(rhs)) {
         BoxedInt* rhs_int = static_cast<BoxedInt*>(rhs);
         return intSubInt(lhs, rhs_int);
     } else if (rhs->cls == float_cls) {
@@ -768,7 +768,7 @@ extern "C" Box* intSub(BoxedInt* lhs, Box* rhs) {
 }
 
 extern "C" Box* intInvert(BoxedInt* v) {
-    if (!isSubclass(v->cls, int_cls))
+    if (!PyInt_Check(v))
         raiseExcHelper(TypeError, "descriptor '__invert__' requires a 'int' object but received a '%s'",
                        getTypeName(v));
 
@@ -776,7 +776,7 @@ extern "C" Box* intInvert(BoxedInt* v) {
 }
 
 extern "C" Box* intPos(BoxedInt* v) {
-    if (!isSubclass(v->cls, int_cls))
+    if (!PyInt_Check(v))
         raiseExcHelper(TypeError, "descriptor '__pos__' requires a 'int' object but received a '%s'", getTypeName(v));
 
     if (v->cls == int_cls)
@@ -785,7 +785,7 @@ extern "C" Box* intPos(BoxedInt* v) {
 }
 
 extern "C" Box* intNeg(BoxedInt* v) {
-    if (!isSubclass(v->cls, int_cls))
+    if (!PyInt_Check(v))
         raiseExcHelper(TypeError, "descriptor '__neg__' requires a 'int' object but received a '%s'", getTypeName(v));
 
 
@@ -802,7 +802,7 @@ extern "C" Box* intNeg(BoxedInt* v) {
 }
 
 extern "C" Box* intNonzero(BoxedInt* v) {
-    if (!isSubclass(v->cls, int_cls))
+    if (!PyInt_Check(v))
         raiseExcHelper(TypeError, "descriptor '__nonzero__' requires a 'int' object but received a '%s'",
                        getTypeName(v));
 
@@ -810,7 +810,7 @@ extern "C" Box* intNonzero(BoxedInt* v) {
 }
 
 extern "C" BoxedString* intRepr(BoxedInt* v) {
-    if (!isSubclass(v->cls, int_cls))
+    if (!PyInt_Check(v))
         raiseExcHelper(TypeError, "descriptor '__repr__' requires a 'int' object but received a '%s'", getTypeName(v));
 
     char buf[80];
@@ -819,7 +819,7 @@ extern "C" BoxedString* intRepr(BoxedInt* v) {
 }
 
 extern "C" Box* intHash(BoxedInt* self) {
-    if (!isSubclass(self->cls, int_cls))
+    if (!PyInt_Check(self))
         raiseExcHelper(TypeError, "descriptor '__hash__' requires a 'int' object but received a '%s'",
                        getTypeName(self));
 
@@ -829,7 +829,7 @@ extern "C" Box* intHash(BoxedInt* self) {
 }
 
 extern "C" Box* intHex(BoxedInt* self) {
-    if (!isSubclass(self->cls, int_cls))
+    if (!PyInt_Check(self))
         raiseExcHelper(TypeError, "descriptor '__hex__' requires a 'int' object but received a '%s'",
                        getTypeName(self));
 
@@ -844,7 +844,7 @@ extern "C" Box* intHex(BoxedInt* self) {
 }
 
 extern "C" Box* intOct(BoxedInt* self) {
-    if (!isSubclass(self->cls, int_cls))
+    if (!PyInt_Check(self))
         raiseExcHelper(TypeError, "descriptor '__oct__' requires a 'int' object but received a '%s'",
                        getTypeName(self));
 
@@ -859,7 +859,7 @@ extern "C" Box* intOct(BoxedInt* self) {
 }
 
 extern "C" Box* intTrunc(BoxedInt* self) {
-    if (!isSubclass(self->cls, int_cls))
+    if (!PyInt_Check(self))
         raiseExcHelper(TypeError, "descriptor '__trunc__' requires a 'int' object but received a '%s'",
                        getTypeName(self));
 
@@ -869,7 +869,7 @@ extern "C" Box* intTrunc(BoxedInt* self) {
 }
 
 extern "C" Box* intInt(BoxedInt* self) {
-    if (!isSubclass(self->cls, int_cls))
+    if (!PyInt_Check(self))
         raiseExcHelper(TypeError, "descriptor '__int__' requires a 'int' object but received a '%s'",
                        getTypeName(self));
 
@@ -891,7 +891,7 @@ template <ExceptionStyle S> static Box* _intNew(Box* val, Box* base) noexcept(S 
         if (val->cls == int_cls)
             return n;
         return new BoxedInt(n->n);
-    } else if (isSubclass(val->cls, str_cls)) {
+    } else if (PyString_Check(val)) {
         int base_n;
         if (!base)
             base_n = 10;
@@ -985,7 +985,7 @@ template <ExceptionStyle S> static Box* _intNew(Box* val, Box* base) noexcept(S 
 }
 
 template <ExceptionStyle S> Box* intNew(Box* _cls, Box* val, Box* base) noexcept(S == CAPI) {
-    if (!isSubclass(_cls->cls, type_cls)) {
+    if (!PyType_Check(_cls)) {
         if (S == CAPI) {
             PyErr_Format(TypeError, "int.__new__(X): X is not a type object (%s)", getTypeName(_cls));
             return NULL;
@@ -1040,7 +1040,7 @@ static int bits_in_ulong(unsigned long d) noexcept {
 }
 
 extern "C" Box* intBitLength(BoxedInt* v) {
-    if (!isSubclass(v->cls, int_cls))
+    if (!PyInt_Check(v))
         raiseExcHelper(TypeError, "descriptor 'bit_length' requires a 'int' object but received a '%s'",
                        getTypeName(v));
 

--- a/src/runtime/set.cpp
+++ b/src/runtime/set.cpp
@@ -491,7 +491,7 @@ Box* setHash(BoxedSet* self) {
     int64_t rtn = 1927868237L;
     for (Box* e : self->s) {
         BoxedInt* h = hash(e);
-        assert(isSubclass(h->cls, int_cls));
+        assert(PyInt_Check(h));
         rtn ^= h->n + 0x9e3779b9 + (rtn << 6) + (rtn >> 2);
     }
 

--- a/src/runtime/str.cpp
+++ b/src/runtime/str.cpp
@@ -1141,7 +1141,7 @@ extern "C" Box* strMul(BoxedString* lhs, Box* rhs) {
     assert(PyString_Check(lhs));
 
     int n;
-    if (isSubclass(rhs->cls, int_cls))
+    if (PyInt_Check(rhs))
         n = static_cast<BoxedInt*>(rhs)->n;
     else
         return NotImplemented;
@@ -1602,7 +1602,7 @@ extern "C" Box* strNew(BoxedClass* cls, Box* obj) {
 
     if (cls != str_cls) {
         Box* tmp = strNew(str_cls, obj);
-        assert(isSubclass(tmp->cls, str_cls));
+        assert(PyString_Check(tmp));
         BoxedString* tmp_s = static_cast<BoxedString*>(tmp);
 
         return new (cls, tmp_s->size()) BoxedString(tmp_s->s());
@@ -1826,7 +1826,7 @@ Box* strReplace(Box* _self, Box* _old, Box* _new, Box** _args) {
     BoxedString* new_ = static_cast<BoxedString*>(_new);
 
     Box* _maxreplace = _args[0];
-    if (!isSubclass(_maxreplace->cls, int_cls))
+    if (!PyInt_Check(_maxreplace))
         raiseExcHelper(TypeError, "an integer is required");
 
     int max_replaces = static_cast<BoxedInt*>(_maxreplace)->n;
@@ -2134,7 +2134,7 @@ Box* strStartswith(BoxedString* self, Box* elt, Box* start, Box** _args) {
             throwCAPIException();
     }
 
-    if (isSubclass(elt->cls, tuple_cls)) {
+    if (PyTuple_Check(elt)) {
         for (auto e : *static_cast<BoxedTuple*>(elt)) {
             auto b = strStartswith(self, e, start, _args);
             assert(b->cls == bool_cls);
@@ -2205,7 +2205,7 @@ Box* strEndswith(BoxedString* self, Box* elt, Box* start, Box** _args) {
         return boxBool(r);
     }
 
-    if (isSubclass(elt->cls, tuple_cls)) {
+    if (PyTuple_Check(elt)) {
         for (auto e : *static_cast<BoxedTuple*>(elt)) {
             auto b = strEndswith(self, e, start, _args);
             assert(b->cls == bool_cls);
@@ -2340,7 +2340,7 @@ template <ExceptionStyle S> Box* strGetitem(BoxedString* self, Box* slice) {
 }
 
 extern "C" Box* strGetslice(BoxedString* self, Box* boxedStart, Box* boxedStop) {
-    assert(isSubclass(self->cls, str_cls));
+    assert(PyString_Check(self));
 
     i64 start, stop;
     sliceIndex(boxedStart, &start);

--- a/src/runtime/super.cpp
+++ b/src/runtime/super.cpp
@@ -159,7 +159,7 @@ Box* superRepr(Box* _s) {
 
 // Ported from the CPython version:
 BoxedClass* supercheck(BoxedClass* type, Box* obj) {
-    if (isSubclass(obj->cls, type_cls) && isSubclass(static_cast<BoxedClass*>(obj), type))
+    if (PyType_Check(obj) && isSubclass(static_cast<BoxedClass*>(obj), type))
         return static_cast<BoxedClass*>(obj);
 
     if (isSubclass(obj->cls, type)) {
@@ -168,7 +168,7 @@ BoxedClass* supercheck(BoxedClass* type, Box* obj) {
 
     static BoxedString* class_str = internStringImmortal("__class__");
     Box* class_attr = obj->getattr(class_str);
-    if (class_attr && isSubclass(class_attr->cls, type_cls) && class_attr != obj->cls) {
+    if (class_attr && PyType_Check(class_attr) && class_attr != obj->cls) {
         Py_FatalError("warning: this path never tested"); // blindly copied from CPython
         return static_cast<BoxedClass*>(class_attr);
     }
@@ -180,7 +180,7 @@ Box* superInit(Box* _self, Box* _type, Box* obj) {
     RELEASE_ASSERT(_self->cls == super_cls, "");
     BoxedSuper* self = static_cast<BoxedSuper*>(_self);
 
-    if (!isSubclass(_type->cls, type_cls))
+    if (!PyType_Check(_type))
         raiseExcHelper(TypeError, "must be type, not %s", getTypeName(_type));
     BoxedClass* type = static_cast<BoxedClass*>(_type);
 

--- a/src/runtime/tuple.cpp
+++ b/src/runtime/tuple.cpp
@@ -80,7 +80,7 @@ extern "C" PyObject* PyTuple_GetItem(PyObject* op, Py_ssize_t i) noexcept {
 }
 
 Box* tupleGetitemSlice(BoxedTuple* self, BoxedSlice* slice) {
-    assert(isSubclass(self->cls, tuple_cls));
+    assert(PyTuple_Check(self));
     assert(slice->cls == slice_cls);
 
     i64 start, stop, step, length;
@@ -89,7 +89,7 @@ Box* tupleGetitemSlice(BoxedTuple* self, BoxedSlice* slice) {
 }
 
 extern "C" PyObject* PyTuple_GetSlice(PyObject* p, Py_ssize_t low, Py_ssize_t high) noexcept {
-    RELEASE_ASSERT(isSubclass(p->cls, tuple_cls), "");
+    RELEASE_ASSERT(PyTuple_Check(p), "");
     BoxedTuple* t = static_cast<BoxedTuple*>(p);
 
     Py_ssize_t n = t->size();
@@ -144,7 +144,7 @@ template <ExceptionStyle S> Box* tupleGetitem(BoxedTuple* self, Box* slice) {
         }
     }
 
-    assert(isSubclass(self->cls, tuple_cls));
+    assert(PyTuple_Check(self));
 
     if (PyIndex_Check(slice)) {
         Py_ssize_t i = PyNumber_AsSsize_t(slice, PyExc_IndexError);
@@ -158,7 +158,7 @@ template <ExceptionStyle S> Box* tupleGetitem(BoxedTuple* self, Box* slice) {
 }
 
 Box* tupleAdd(BoxedTuple* self, Box* rhs) {
-    if (!isSubclass(rhs->cls, tuple_cls)) {
+    if (!PyTuple_Check(rhs)) {
         return NotImplemented;
     }
 
@@ -199,7 +199,7 @@ Box* tupleMul(BoxedTuple* self, Box* rhs) {
 }
 
 Box* tupleLen(BoxedTuple* t) {
-    assert(isSubclass(t->cls, tuple_cls));
+    assert(PyTuple_Check(t));
     return boxInt(t->size());
 }
 
@@ -210,7 +210,7 @@ extern "C" Py_ssize_t PyTuple_Size(PyObject* op) noexcept {
 
 Box* tupleRepr(BoxedTuple* t) {
 
-    assert(isSubclass(t->cls, tuple_cls));
+    assert(PyTuple_Check(t));
     int n;
     std::vector<char> chars;
     int status = Py_ReprEnter((PyObject*)t);
@@ -258,7 +258,7 @@ Box* tupleRepr(BoxedTuple* t) {
 }
 
 Box* tupleNonzero(BoxedTuple* self) {
-    RELEASE_ASSERT(isSubclass(self->cls, tuple_cls), "");
+    RELEASE_ASSERT(PyTuple_Check(self), "");
     return boxBool(self->size() != 0);
 }
 

--- a/src/runtime/util.cpp
+++ b/src/runtime/util.cpp
@@ -183,7 +183,7 @@ extern "C" void dumpEx(void* p, int levels) {
             printf("The %s object\n", b == True ? "True" : "False");
         }
 
-        if (isSubclass(b->cls, type_cls)) {
+        if (PyType_Check(b)) {
             auto cls = static_cast<BoxedClass*>(b);
             printf("Type name: %s\n", getFullNameOfClass(cls).c_str());
 
@@ -201,11 +201,11 @@ extern "C" void dumpEx(void* p, int levels) {
             printf("\n");
         }
 
-        if (isSubclass(b->cls, str_cls)) {
+        if (PyString_Check(b)) {
             printf("String value: %s\n", static_cast<BoxedString*>(b)->data());
         }
 
-        if (isSubclass(b->cls, tuple_cls)) {
+        if (PyTuple_Check(b)) {
             BoxedTuple* t = static_cast<BoxedTuple*>(b);
             printf("%ld elements\n", t->size());
 
@@ -219,7 +219,7 @@ extern "C" void dumpEx(void* p, int levels) {
             }
         }
 
-        if (isSubclass(b->cls, dict_cls)) {
+        if (PyDict_Check(b)) {
             BoxedDict* d = static_cast<BoxedDict*>(b);
             printf("%d elements\n", d->d.size());
 
@@ -234,11 +234,11 @@ extern "C" void dumpEx(void* p, int levels) {
             }
         }
 
-        if (isSubclass(b->cls, int_cls)) {
+        if (PyInt_Check(b)) {
             printf("Int value: %ld\n", static_cast<BoxedInt*>(b)->n);
         }
 
-        if (isSubclass(b->cls, list_cls)) {
+        if (PyList_Check(b)) {
             auto l = static_cast<BoxedList*>(b);
             printf("%ld elements\n", l->size);
 
@@ -276,7 +276,7 @@ extern "C" void dumpEx(void* p, int levels) {
             }
         }
 
-        if (isSubclass(b->cls, module_cls)) {
+        if (PyModule_Check(b)) {
             printf("The '%s' module\n", static_cast<BoxedModule*>(b)->name().c_str());
         }
 


### PR DESCRIPTION
Which is faster for most of the builtin types since we use CPython's set-a-special-bit-on-the-class optimization.

Also, introduce a new clang-based linter which we can use to spot things like this.  It's currently disabled since it has a few issues (it's slow and not integrated with cmake), but should hopefully give us a base to write things like "make sure CAPI-style functions only call Pyston-style functions when inside a try block".  It might be a bit excessive for that though -- it seems to take just about as long to lint the code as it does to compile it.  There was a cool case though; I set up the linter to look for any occurrences of `isSubclass({.*}->cls, int_cls)`, and it found an instance where we did `isSubclass(cls, int_cls)` where cls was an implicit reference to `this->cls`!  Pretty cool from a technology perspective at the very least.

And for this massive diff we get about an 0.5% perf improvement.