### PR TITLE
descriptor/format fix

### DIFF
--- a/src/capi/typeobject.cpp
+++ b/src/capi/typeobject.cpp
@@ -1888,8 +1888,13 @@ static const slotdef* update_one_slot(BoxedClass* type, const slotdef* p) noexce
                point out a bug in this reasoning a beer. */
         } else if (offset == offsetof(BoxedClass, tp_descr_get) && descr->cls == function_cls
                    && static_cast<BoxedFunction*>(descr)->f->always_use_version) {
-            type->tpp_descr_get = (descrgetfunc) static_cast<BoxedFunction*>(descr)->f->always_use_version->code;
-            specific = (void*)slot_tp_tpp_descr_get;
+            CompiledFunction* cf = static_cast<BoxedFunction*>(descr)->f->always_use_version;
+            if (cf->exception_style == CXX) {
+                type->tpp_descr_get = (descrgetfunc)cf->code;
+                specific = (void*)slot_tp_tpp_descr_get;
+            } else {
+                specific = cf->code;
+            }
         } else if (descr == Py_None && ptr == (void**)&type->tp_hash) {
             /* We specifically allow __hash__ to be set to None
                to prevent inheritance of the default

--- a/src/runtime/descr.cpp
+++ b/src/runtime/descr.cpp
@@ -407,7 +407,7 @@ static Box* methodRepr(Box* _o) {
     return PyString_FromFormat("<method '%s' of '%s' objects>", name, getNameOfClass(md->type));
 }
 
-Box* BoxedMethodDescriptor::__get__(BoxedMethodDescriptor* self, Box* inst, Box* owner) {
+Box* BoxedMethodDescriptor::descr_get(BoxedMethodDescriptor* self, Box* inst, Box* owner) noexcept {
     RELEASE_ASSERT(self->cls == method_cls, "");
 
     // CPython handles this differently: they create the equivalent of different BoxedMethodDescriptor
@@ -420,7 +420,7 @@ Box* BoxedMethodDescriptor::__get__(BoxedMethodDescriptor* self, Box* inst, Box*
     if (self->method->ml_flags & METH_COEXIST)
         Py_FatalError("unimplemented");
 
-    if (inst == None)
+    if (inst == NULL)
         return self;
     else
         return boxInstanceMethod(inst, self, self->type);
@@ -653,8 +653,8 @@ void setupDescr() {
         "__get__", new BoxedFunction(boxRTFunction((void*)classmethodGet, UNKNOWN, 3, 1, false, false), { None }));
     classmethod_cls->freeze();
 
-    method_cls->giveAttr("__get__",
-                         new BoxedFunction(boxRTFunction((void*)BoxedMethodDescriptor::__get__, UNKNOWN, 3)));
+    method_cls->giveAttr("__get__", new BoxedFunction(boxRTFunction((void*)BoxedMethodDescriptor::descr_get, UNKNOWN, 3,
+                                                                    ParamNames::empty(), CAPI)));
     CLFunction* method_call_cl = boxRTFunction((void*)BoxedMethodDescriptor::__call__, UNKNOWN, 2, 0, true, true);
     method_cls->giveAttr("__call__", new BoxedFunction(method_call_cl));
     method_cls->tpp_call.capi_val = BoxedMethodDescriptor::tppCall<CAPI>;

--- a/src/runtime/types.h
+++ b/src/runtime/types.h
@@ -1017,7 +1017,7 @@ public:
 
     DEFAULT_CLASS(method_cls);
 
-    static Box* __get__(BoxedMethodDescriptor* self, Box* inst, Box* owner);
+    static Box* descr_get(BoxedMethodDescriptor* self, Box* inst, Box* owner) noexcept;
     static Box* __call__(BoxedMethodDescriptor* self, Box* obj, BoxedTuple* varargs, Box** _args);
     template <ExceptionStyle S>
     static Box* tppCall(Box* _self, CallRewriteArgs* rewrite_args, ArgPassSpec argspec, Box* arg1, Box* arg2, Box* arg3,

--- a/test/tests/builtins.py
+++ b/test/tests/builtins.py
@@ -123,3 +123,5 @@ print apply(sorted, [l], { "reverse" : True })
 print format(5.0, '+')
 print format(5.011111111111, '+.6')
 print format("abc", '')
+
+print '{n}'.format(n=None)

--- a/test/tests/float.py
+++ b/test/tests/float.py
@@ -105,3 +105,6 @@ for lhs in all_args:
                 print pow(lhs, rhs, mod)
             except Exception as e:
                 print type(e), e
+
+import sys
+print sys.float_info


### PR DESCRIPTION
This might make the getattr slowpath a bit slower for Python classes (though actually, probably not that much slower since it won't be able to rewrite I think), but improves compatibility (some of those travis-ci crash-on-retry cases) and probably helps perf for non-special-cased extension types.