### PR TITLE
bjit: don't generate a 'getGlobal' call for 'None'

### DIFF
--- a/src/codegen/baseline_jit.cpp
+++ b/src/codegen/baseline_jit.cpp
@@ -314,6 +314,8 @@ RewriterVar* JitFragmentWriter::emitGetClsAttr(RewriterVar* obj, BoxedString* s)
 }
 
 RewriterVar* JitFragmentWriter::emitGetGlobal(Box* global, BoxedString* s) {
+    if (s->s() == "None")
+        return imm(None);
     return emitPPCall((void*)getGlobal, { imm(global), imm(s) }, 2, 512);
 }
 


### PR DESCRIPTION
```
      django_template3.py             3.0s (6)             3.0s (6)  -0.6%
            pyxl_bench.py             2.6s (6)             2.6s (6)  -0.7%
sqlalchemy_imperative2.py             3.0s (6)             3.0s (6)  +0.2%
                  geomean                 2.9s                 2.9s  -0.4%

```