### PR TITLE
Don't malloc-allocate rewriter lambdas

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -961,7 +961,7 @@ test_cpp_dwarf:
 	objdump -W test_asm | less
 	rm test_asm
 test_cpp_ll:
-	$(CLANGPP_EXE) $(TEST_DIR)/test.cpp -o test.ll -c -O3 -emit-llvm -S -std=c++11 -g
+	$(CLANGPP_EXE) $(TEST_DIR)/test.cpp -o test.ll -c -O3 -emit-llvm -S -std=c++11
 	less test.ll
 	rm test.ll
 .PHONY: bench_exceptions

--- a/src/asm_writing/rewriter.cpp
+++ b/src/asm_writing/rewriter.cpp
@@ -2128,4 +2128,16 @@ PatchpointInitializationInfo initializePatchpoint3(void* slowpath_func, uint8_t*
     return PatchpointInitializationInfo(slowpath_start, slowpath_rtn_addr, continue_addr,
                                         std::move(live_outs_for_slot));
 }
+
+void* Rewriter::RegionAllocator::alloc(size_t bytes) {
+    assert(bytes <= BLOCK_SIZE);
+    if (cur_offset + bytes > BLOCK_SIZE) {
+        blocks.emplace_back();
+        cur_offset = 0;
+    }
+
+    char* rtn = blocks.back() + cur_offset;
+    cur_offset += bytes;
+    return rtn;
+}
 }

--- a/src/codegen/baseline_jit.h
+++ b/src/codegen/baseline_jit.h
@@ -294,7 +294,7 @@ private:
     void _emitGetLocal(RewriterVar* val_var, const char* name);
     void _emitJump(CFGBlock* b, RewriterVar* block_next, int& size_of_exit_to_interp);
     void _emitOSRPoint(RewriterVar* result, RewriterVar* node_var);
-    void _emitPPCall(RewriterVar* result, void* func_addr, const RewriterVar::SmallVector& args, int num_slots,
+    void _emitPPCall(RewriterVar* result, void* func_addr, llvm::ArrayRef<RewriterVar*> args, int num_slots,
                      int slot_size);
     void _emitRecordType(RewriterVar* type_recorder_var, RewriterVar* obj_cls_var);
     void _emitReturn(RewriterVar* v);


### PR DESCRIPTION
By adding a SmallFunction class that is similar to std::function but stores closure data inline rather than in a dynamic allocation.

```
           django_template3.py             3.0s (4)             2.9s (4)  -1.5%
                 pyxl_bench.py             2.7s (4)             2.6s (4)  -2.6%
     sqlalchemy_imperative2.py             3.1s (4)             3.1s (4)  -0.7%
                       geomean                 2.9s                 2.9s  -1.6%
```