### PR TITLE
Fix a few errors encountered while running test/cpython/test_math.py

### DIFF
--- a/from_cpython/Python/dtoa.c
+++ b/from_cpython/Python/dtoa.c
@@ -118,6 +118,9 @@
 
 #include "Python.h"
 
+// Pyston change: disable custom memory managment because it confuses our GC
+#define Py_USING_MEMORY_DEBUGGER 1
+
 /* if PY_NO_SHORT_FLOAT_REPR is defined, then don't even try to compile
    the following code */
 #ifndef PY_NO_SHORT_FLOAT_REPR

--- a/src/analysis/type_analysis.cpp
+++ b/src/analysis/type_analysis.cpp
@@ -225,7 +225,7 @@ private:
         return rtn;
     }
 
-    bool hasFixedBinops(CompilerType* type) {
+    bool hasFixedOps(CompilerType* type) {
         // This is non-exhaustive:
         return type == STR || type == INT || type == FLOAT || type == LIST || type == DICT;
     }
@@ -233,7 +233,7 @@ private:
     void* visit_augbinop(AST_AugBinOp* node) override {
         CompilerType* left = getType(node->left);
         CompilerType* right = getType(node->right);
-        if (!hasFixedBinops(left) || !hasFixedBinops(right))
+        if (!hasFixedOps(left) || !hasFixedOps(right))
             return UNKNOWN;
 
         // TODO this isn't the exact behavior
@@ -262,7 +262,7 @@ private:
     void* visit_binop(AST_BinOp* node) override {
         CompilerType* left = getType(node->left);
         CompilerType* right = getType(node->right);
-        if (!hasFixedBinops(left) || !hasFixedBinops(right))
+        if (!hasFixedOps(left) || !hasFixedOps(right))
             return UNKNOWN;
 
         // TODO this isn't the exact behavior
@@ -508,12 +508,20 @@ private:
 
     void* visit_unaryop(AST_UnaryOp* node) override {
         CompilerType* operand = getType(node->operand);
+        if (!hasFixedOps(operand))
+            return UNKNOWN;
 
         // TODO this isn't the exact behavior
         BoxedString* name = getOpName(node->op_type);
         CompilerType* attr_type = operand->getattrType(name, true);
+
+        if (attr_type == UNDEF)
+            attr_type = UNKNOWN;
+
         std::vector<CompilerType*> arg_types;
-        return attr_type->callType(ArgPassSpec(0), arg_types, NULL);
+        CompilerType* rtn_type = attr_type->callType(ArgPassSpec(0), arg_types, NULL);
+        rtn_type = unboxedType(rtn_type->getConcreteType());
+        return rtn_type;
     }
 
     void* visit_yield(AST_Yield*) override { return UNKNOWN; }

--- a/src/codegen/compvars.cpp
+++ b/src/codegen/compvars.cpp
@@ -1294,6 +1294,14 @@ public:
         return boolFromI1(emitter, cmp);
     }
 
+    ConcreteCompilerVariable* unaryop(IREmitter& emitter, const OpInfo& info, ConcreteCompilerVariable* var,
+                                      AST_TYPE::AST_TYPE op_type) override {
+        ConcreteCompilerVariable* converted = var->makeConverted(emitter, BOXED_FLOAT);
+        auto rtn = converted->unaryop(emitter, info, op_type);
+        converted->decvref(emitter);
+        return rtn;
+    }
+
     CompilerVariable* getitem(IREmitter& emitter, const OpInfo& info, VAR* var, CompilerVariable* slice) override {
         ConcreteCompilerVariable* converted = var->makeConverted(emitter, BOXED_FLOAT);
         CompilerVariable* rtn = converted->getitem(emitter, info, slice);
@@ -1885,6 +1893,15 @@ public:
 
     ConcreteCompilerVariable* unaryop(IREmitter& emitter, const OpInfo& info, ConcreteCompilerVariable* var,
                                       AST_TYPE::AST_TYPE op_type) override {
+        BoxedString* attr = getOpName(op_type);
+
+        bool no_attribute = false;
+        ConcreteCompilerVariable* called_constant
+            = tryCallattrConstant(emitter, info, var, attr, true, ArgPassSpec(0, 0, 0, 0), {}, NULL, &no_attribute);
+
+        if (called_constant && !no_attribute)
+            return called_constant;
+
         return UNKNOWN->unaryop(emitter, info, var, op_type);
     }
 

--- a/test/tests/float.py
+++ b/test/tests/float.py
@@ -108,3 +108,6 @@ for lhs in all_args:
 
 import sys
 print sys.float_info
+
+if 1:
+    x = -2.0

--- a/test/tests/str_functions.py
+++ b/test/tests/str_functions.py
@@ -173,3 +173,11 @@ class C(object):
     def __str__(self):
         return "my class"
 print "{0}".format(C())
+
+def irgen_error():
+	for i in range(1):
+		fail = "test".format()
+		print fail
+		fail = "test {0} {1} {2}".format(1, 2, 3)
+		print fail
+irgen_error()


### PR DESCRIPTION
The first one (memory error) was the one I initially was planning to fix but then I run the test with ```-n``` and saw that there are additional problems. I'm somewhat surprised that no current test triggers them.

I'm not sure if ```AbstractFunctionType::callType``` should not in addition return ```UNKNOWN``` instead of ```UNDEF```. Because of this we will trigger an assert if we can't find a function that supports the requested args instead of just throwing an exception at runtime.
I don't like the ```AbstractFunctionType``` arg handling code I think it shouldn't copy so much, but I'm not currently feeling like rewriting it...
