### PR TITLE
Class gc fix: integrate with the finalization logic

### DIFF
--- a/from_cpython/Python/dtoa.c
+++ b/from_cpython/Python/dtoa.c
@@ -118,6 +118,9 @@
 
 #include "Python.h"
 
+// Pyston change: disable custom memory managment because it confuses our GC
+#define Py_USING_MEMORY_DEBUGGER 1
+
 /* if PY_NO_SHORT_FLOAT_REPR is defined, then don't even try to compile
    the following code */
 #ifndef PY_NO_SHORT_FLOAT_REPR

--- a/src/codegen/compvars.cpp
+++ b/src/codegen/compvars.cpp
@@ -824,7 +824,9 @@ public:
     struct Sig {
         std::vector<ConcreteCompilerType*> arg_types;
         CompilerType* rtn_type;
-        int ndefaults;
+        int ndefaults = 0;
+        bool takes_varargs = false;
+        bool takes_kwargs = false;
     };
 
 private:
@@ -847,14 +849,20 @@ public:
         RELEASE_ASSERT(!argspec.has_starargs, "");
         RELEASE_ASSERT(!argspec.has_kwargs, "");
         RELEASE_ASSERT(argspec.num_keywords == 0, "");
+        RELEASE_ASSERT(!keyword_names || keyword_names->empty() == 0, "");
 
         for (int i = 0; i < sigs.size(); i++) {
             Sig* sig = sigs[i];
-            if (arg_types.size() < sig->arg_types.size() - sig->ndefaults || arg_types.size() > sig->arg_types.size())
+            int num_normal_args = sig->arg_types.size() - ((sig->takes_varargs ? 1 : 0) + (sig->takes_kwargs ? 1 : 0));
+            if (arg_types.size() < num_normal_args - sig->ndefaults)
+                continue;
+            if (!sig->takes_varargs && arg_types.size() > sig->arg_types.size())
                 continue;
 
             bool works = true;
             for (int j = 0; j < arg_types.size(); j++) {
+                if (j == num_normal_args)
+                    break;
                 if (!arg_types[j]->canConvertTo(sig->arg_types[j])) {
                     works = false;
                     break;
@@ -883,6 +891,8 @@ public:
             Sig* type_sig = new Sig();
             type_sig->rtn_type = fspec->rtn_type;
             type_sig->ndefaults = clf->paramspec.num_defaults;
+            type_sig->takes_varargs = clf->paramspec.takes_varargs;
+            type_sig->takes_kwargs = clf->paramspec.takes_kwargs;
 
             if (stripfirst) {
                 assert(fspec->arg_types.size() >= 1);
@@ -1292,6 +1302,14 @@ public:
     ConcreteCompilerVariable* nonzero(IREmitter& emitter, const OpInfo& info, ConcreteCompilerVariable* var) override {
         llvm::Value* cmp = emitter.getBuilder()->CreateFCmpUNE(var->getValue(), llvm::ConstantFP::get(g.double_, 0));
         return boolFromI1(emitter, cmp);
+    }
+
+    ConcreteCompilerVariable* unaryop(IREmitter& emitter, const OpInfo& info, ConcreteCompilerVariable* var,
+                                      AST_TYPE::AST_TYPE op_type) override {
+        ConcreteCompilerVariable* converted = var->makeConverted(emitter, BOXED_FLOAT);
+        auto rtn = converted->unaryop(emitter, info, op_type);
+        converted->decvref(emitter);
+        return rtn;
     }
 
     CompilerVariable* getitem(IREmitter& emitter, const OpInfo& info, VAR* var, CompilerVariable* slice) override {
@@ -1885,6 +1903,15 @@ public:
 
     ConcreteCompilerVariable* unaryop(IREmitter& emitter, const OpInfo& info, ConcreteCompilerVariable* var,
                                       AST_TYPE::AST_TYPE op_type) override {
+        BoxedString* attr = getOpName(op_type);
+
+        bool no_attribute = false;
+        ConcreteCompilerVariable* called_constant
+            = tryCallattrConstant(emitter, info, var, attr, true, ArgPassSpec(0, 0, 0, 0), {}, NULL, &no_attribute);
+
+        if (called_constant && !no_attribute)
+            return called_constant;
+
         return UNKNOWN->unaryop(emitter, info, var, op_type);
     }
 

--- a/src/gc/heap.cpp
+++ b/src/gc/heap.cpp
@@ -128,7 +128,12 @@ void _bytesAllocatedTripped() {
 /// Finalizers
 
 bool hasOrderedFinalizer(BoxedClass* cls) {
-    if (cls->has_safe_tp_dealloc) {
+    if (PyType_FastSubclass(cls, Py_TPFLAGS_TYPE_SUBCLASS)) {
+        // Class objects need to be kept alive for at least as long as any objects that point
+        // to them, even if those objects are garbage (or involved in finalizer chains).
+        // Marking class objects as having finalizers should get us this behavior.
+        return true;
+    } else if (cls->has_safe_tp_dealloc) {
         ASSERT(!cls->tp_del, "class \"%s\" with safe tp_dealloc also has tp_del?", cls->tp_name);
         return false;
     } else if (cls->hasNonDefaultTpDealloc()) {

--- a/src/runtime/types.cpp
+++ b/src/runtime/types.cpp
@@ -3382,6 +3382,7 @@ void setupRuntime() {
     mem = gc_alloc(sizeof(BoxedHeapClass), gc::GCKind::PYTHON);
     type_cls = ::new (mem) BoxedHeapClass(object_cls, &BoxedHeapClass::gcHandler, offsetof(BoxedClass, attrs),
                                           offsetof(BoxedClass, tp_weaklist), sizeof(BoxedHeapClass), false, NULL);
+    type_cls->has_safe_tp_dealloc = false;
     type_cls->tp_flags |= Py_TPFLAGS_TYPE_SUBCLASS;
     type_cls->tp_itemsize = sizeof(BoxedHeapClass::SlotOffset);
     PyObject_Init(object_cls, type_cls);

--- a/test/tests/float.py
+++ b/test/tests/float.py
@@ -108,3 +108,6 @@ for lhs in all_args:
 
 import sys
 print sys.float_info
+
+if 1:
+    x = -2.0

--- a/test/tests/str_functions.py
+++ b/test/tests/str_functions.py
@@ -173,3 +173,11 @@ class C(object):
     def __str__(self):
         return "my class"
 print "{0}".format(C())
+
+def irgen_error():
+	for i in range(1):
+		fail = "test".format()
+		print fail
+		fail = "test {0} {1} {2}".format(1, 2, 3)
+		print fail
+irgen_error()


### PR DESCRIPTION
I was noticing that classes were getting freed a few
collections after they were seen to be not-marked; the
issue with the old keep-classes-alive implementation is
that it assumed that !isMarked() implies that the object
will be freed in the sweep phase.  With the finalization
ordering, this isn't true.  We could move the ordering
before the keep-classes-alive behavior, but then the
finalization ordering might get things wrong since it
wouldn't see the final set of mark bits.  So I think
we need to integrate the two phases.

I think it ends up working to just say that type objects
have ordered finalizers, even though they typically don't;
I think this gets us the guarantees we need.