### PR TITLE
Notion of redundant visits to slowly move towards scanning everything

### DIFF
--- a/src/gc/collector.cpp
+++ b/src/gc/collector.cpp
@@ -318,10 +318,6 @@ GCRootHandle::~GCRootHandle() {
     getRootHandles()->erase(this);
 }
 
-bool GCVisitor::isValid(void* p) {
-    return global_heap.getAllocationFromInteriorPointer(p) != NULL;
-}
-
 void GCVisitor::visit(void* p) {
     if ((uintptr_t)p < SMALL_ARENA_START || (uintptr_t)p >= HUGE_ARENA_START + ARENA_SIZE) {
         ASSERT(!p || isNonheapRoot(p), "%p", p);

--- a/src/gc/collector.h
+++ b/src/gc/collector.h
@@ -68,6 +68,7 @@ class GCVisitorNoRedundancy : public GCVisitor {
     virtual void visitRangeRedundant(void* const* start, void* const* end) { visitRange(start, end); }
     virtual void visitPotentialRedundant(void* p) { visitPotential(p); }
     virtual void visitPotentialRangeRedundant(void* const* start, void* const* end) { visitPotentialRange(start, end); }
+    virtual bool shouldVisitRedundants() { return true; }
 };
 }
 }

--- a/src/gc/collector.h
+++ b/src/gc/collector.h
@@ -15,6 +15,8 @@
 #ifndef PYSTON_GC_COLLECTOR_H
 #define PYSTON_GC_COLLECTOR_H
 
+#include "gc/gc.h"
+
 namespace pyston {
 
 class Box;
@@ -58,6 +60,15 @@ void invalidateOrderedFinalizerList();
 // assert rather than delaying of the next GC.
 void startGCUnexpectedRegion();
 void endGCUnexpectedRegion();
+
+class GCVisitorNoRedundancy : public GCVisitor {
+    virtual ~GCVisitorNoRedundancy() {}
+
+    virtual void visitRedundant(void* p) { visit(p); }
+    virtual void visitRangeRedundant(void* const* start, void* const* end) { visitRange(start, end); }
+    virtual void visitPotentialRedundant(void* p) { visitPotential(p); }
+    virtual void visitPotentialRangeRedundant(void* const* start, void* const* end) { visitPotentialRange(start, end); }
+};
 }
 }
 

--- a/src/gc/gc.h
+++ b/src/gc/gc.h
@@ -22,6 +22,10 @@
 // Files outside of the gc/ folder should only import gc.h or gc_alloc.h
 // which are the "public" memory management interface.
 
+// Some code is only useful towards an effort to implement a
+// moving gc, gate behind this flag for now.
+#define MOVING_GC 0
+
 #define GC_KEEP_ALIVE(t) asm volatile("" : : "X"(t))
 
 #define TRACE_GC_MARKING 0

--- a/src/gc/gc.h
+++ b/src/gc/gc.h
@@ -16,6 +16,8 @@
 #define PYSTON_GC_GC_H
 
 #include <deque>
+#include <memory>
+#include <stddef.h>
 
 // Files outside of the gc/ folder should only import gc.h or gc_alloc.h
 // which are the "public" memory management interface.
@@ -42,11 +44,11 @@ namespace gc {
 class TraceStack;
 class GCVisitor {
 private:
-    bool isValid(void* p);
+    TraceStack* stack;
 
 public:
-    TraceStack* stack;
     GCVisitor(TraceStack* stack) : stack(stack) {}
+    virtual ~GCVisitor() {}
 
     // These all work on *user* pointers, ie pointers to the user_data section of GCAllocations
     void visitIf(void* p) {
@@ -57,6 +59,20 @@ public:
     void visitRange(void* const* start, void* const* end);
     void visitPotential(void* p);
     void visitPotentialRange(void* const* start, void* const* end);
+
+    // Some object have fields with pointers to Pyston heap objects that we are confident are
+    // already being scanned elsewhere.
+    //
+    // In a mark-and-sweep collector, scanning those fields would be redundant because the mark
+    // phase only needs to visit each object once, so there would be a performance hit.
+    //
+    // In a moving collector, every reference needs to be visited since the pointer value could
+    // change. We don't have a moving collector yet, but it's good practice to call visit every
+    // pointer value and no-op to avoid the performance hit of the mark-and-sweep case.
+    virtual void visitRedundant(void* p) {}
+    virtual void visitRedundantRange(void** start, void** end) {}
+    virtual void visitPotentialRedundant(void* p) {}
+    virtual void visitPotentialRangeRedundant(void* const* start, void* const* end) {}
 };
 
 enum class GCKind : uint8_t {


### PR DESCRIPTION
Not all references in the program are being scanned, but we get away with it for now. Until we having a moving collector, don't actually scan those references, but make note that they are there.

I have no idea how the extra code I added ended up making things faster, it's probably a fluke, but at least it's not slower.

```
Comparing to '['baseline']'
running ['python', '../pyston-perf/benchmarking/benchmark_suite/fannkuch_med.py']
1.03298902512
              pyston (calibration)                      :   1.03s baseline: 1.02 (  1.0%)
running ['../pyston-perf/benchmarking/../../pyston/./pyston_release', '../pyston-perf/benchmarking/be
nchmark_suite/django_template3.py']
4.54294991493
running ['../pyston-perf/benchmarking/../../pyston/./pyston_release', '../pyston-perf/benchmarking/be
nchmark_suite/django_template3.py']
2.61548089981
running ['../pyston-perf/benchmarking/../../pyston/./pyston_release', '../pyston-perf/benchmarking/be
nchmark_suite/django_template3.py']
2.55432510376
running ['../pyston-perf/benchmarking/../../pyston/./pyston_release', '../pyston-perf/benchmarking/be
nchmark_suite/django_template3.py']
2.54696393013
              pyston django_template3.py                :   2.55s baseline: 2.55 ( -0.1%)
running ['../pyston-perf/benchmarking/../../pyston/./pyston_release', '../pyston-perf/benchmarking/be
nchmark_suite/pyxl_bench.py']
3.22923612595
running ['../pyston-perf/benchmarking/../../pyston/./pyston_release', '../pyston-perf/benchmarking/be
nchmark_suite/pyxl_bench.py']
2.15312814713
running ['../pyston-perf/benchmarking/../../pyston/./pyston_release', '../pyston-perf/benchmarking/be
nchmark_suite/pyxl_bench.py']
2.12213397026
running ['../pyston-perf/benchmarking/../../pyston/./pyston_release', '../pyston-perf/benchmarking/be
nchmark_suite/pyxl_bench.py']
2.12070083618
              pyston pyxl_bench.py                      :   2.12s baseline: 2.16 ( -1.7%)
running ['../pyston-perf/benchmarking/../../pyston/./pyston_release', '../pyston-perf/benchmarking/be
nchmark_suite/sqlalchemy_imperative2.py']
3.63884902
running ['../pyston-perf/benchmarking/../../pyston/./pyston_release', '../pyston-perf/benchmarking/b$
nchmark_suite/sqlalchemy_imperative2.py']
2.62657094002
running ['../pyston-perf/benchmarking/../../pyston/./pyston_release', '../pyston-perf/benchmarking/b$
nchmark_suite/sqlalchemy_imperative2.py']
2.63046097755
running ['../pyston-perf/benchmarking/../../pyston/./pyston_release', '../pyston-perf/benchmarking/b$
nchmark_suite/sqlalchemy_imperative2.py']
2.62272500992
              pyston sqlalchemy_imperative2.py          :   2.62s baseline: 2.62 (  0.1%)
running ['../pyston-perf/benchmarking/../../pyston/./pyston_release', '../pyston-perf/benchmarking/be
nchmark_suite/django_template3_10x.py']
16.8686971664
running ['../pyston-perf/benchmarking/../../pyston/./pyston_release', '../pyston-perf/benchmarking/be
nchmark_suite/django_template3_10x.py']
15.7492239475
running ['../pyston-perf/benchmarking/../../pyston/./pyston_release', '../pyston-perf/benchmarking/be
nchmark_suite/django_template3_10x.py']
15.7083630562
running ['../pyston-perf/benchmarking/../../pyston/./pyston_release', '../pyston-perf/benchmarking/be
nchmark_suite/django_template3_10x.py']
14.6849870682
              pyston django_template3_10x.py            :  14.68s baseline: 14.72 ( -0.2%)
running ['../pyston-perf/benchmarking/../../pyston/./pyston_release', '../pyston-perf/benchmarking/be
nchmark_suite/pyxl_bench_10x.py']
18.3980820179
running ['../pyston-perf/benchmarking/../../pyston/./pyston_release', '../pyston-perf/benchmarking/be
nchmark_suite/pyxl_bench_10x.py']
16.8311018944
running ['../pyston-perf/benchmarking/../../pyston/./pyston_release', '../pyston-perf/benchmarking/be
nchmark_suite/pyxl_bench_10x.py']
bnMVXCZZZZZXCBVNN16.9298191071
running ['../pyston-perf/benchmarking/../../pyston/./pyston_release', '../pyston-perf/benchmarking/be
nchmark_suite/pyxl_bench_10x.py']
16.213558197
              pyston pyxl_bench_10x.py                  :  16.21s baseline: 16.62 ( -2.5%)
running ['../pyston-perf/benchmarking/../../pyston/./pyston_release', '../pyston-perf/benchmarking/be
nchmark_suite/sqlalchemy_imperative2_10x.py']
22.6907730103
running ['../pyston-perf/benchmarking/../../pyston/./pyston_release', '../pyston-perf/benchmarking/be
nchmark_suite/sqlalchemy_imperative2_10x.py']
20.723708868
running ['../pyston-perf/benchmarking/../../pyston/./pyston_release', '../pyston-perf/benchmarking/be
nchmark_suite/sqlalchemy_imperative2_10x.py']
20.665446043
running ['../pyston-perf/benchmarking/../../pyston/./pyston_release', '../pyston-perf/benchmarking/be
nchmark_suite/sqlalchemy_imperative2_10x.py']
20.5785398483
              pyston sqlalchemy_imperative2_10x.py      :  20.58s baseline: 20.34 (  1.2%)
              pyston (geomean-2ec9)                     :   2.42s baseline: 2.43 ( -0.6%)
Deleting report 'last'
Saving results to 'last'
```