### PR TITLE
when calling a BoxedWrapperDescriptor don't create a BoxedWrapperObject

### DIFF
--- a/src/codegen/compvars.cpp
+++ b/src/codegen/compvars.cpp
@@ -1878,8 +1878,10 @@ public:
     }
 
     ConcreteCompilerVariable* nonzero(IREmitter& emitter, const OpInfo& info, ConcreteCompilerVariable* var) override {
-        static BoxedString* attr = internStringImmortal("__nonzero__");
+        if (cls == None->cls)
+            return makeBool(false);
 
+        static BoxedString* attr = internStringImmortal("__nonzero__");
         bool no_attribute = false;
         ConcreteCompilerVariable* called_constant
             = tryCallattrConstant(emitter, info, var, attr, true, ArgPassSpec(0, 0, 0, 0), {}, NULL, &no_attribute);

--- a/src/runtime/objmodel.cpp
+++ b/src/runtime/objmodel.cpp
@@ -2456,20 +2456,20 @@ extern "C" bool nonzero(Box* obj) {
     static BoxedString* len_str = internStringImmortal("__len__");
 
     // try __nonzero__
-    GetattrRewriteArgs grewrite_args(rewriter.get(), r_obj, rewriter ? rewriter->getReturnDestination() : Location());
-    Box* func = getclsattrInternal(obj, nonzero_str, rewriter ? &grewrite_args : NULL);
-    if (!grewrite_args.out_success)
+    CallRewriteArgs crewrite_args(rewriter.get(), r_obj, rewriter ? rewriter->getReturnDestination() : Location());
+    Box* rtn = callattrInternal0<CXX>(obj, nonzero_str, CLASS_ONLY, rewriter ? &crewrite_args : NULL, ArgPassSpec(0));
+    if (!crewrite_args.out_success)
         rewriter.reset();
 
-    if (!func) {
+    if (!rtn) {
         // try __len__
-        grewrite_args
-            = GetattrRewriteArgs(rewriter.get(), r_obj, rewriter ? rewriter->getReturnDestination() : Location());
-        func = getclsattrInternal(obj, len_str, rewriter ? &grewrite_args : NULL);
-        if (!grewrite_args.out_success)
+        crewrite_args
+            = CallRewriteArgs(rewriter.get(), r_obj, rewriter ? rewriter->getReturnDestination() : Location());
+        rtn = callattrInternal0<CXX>(obj, len_str, CLASS_ONLY, rewriter ? &crewrite_args : NULL, ArgPassSpec(0));
+        if (!crewrite_args.out_success)
             rewriter.reset();
 
-        if (func == NULL) {
+        if (rtn == NULL) {
             ASSERT(obj->cls->is_user_defined || obj->cls == classobj_cls || obj->cls == type_cls
                        || isSubclass(obj->cls, Exception) || obj->cls == file_cls || obj->cls == traceback_cls
                        || obj->cls == instancemethod_cls || obj->cls == module_cls || obj->cls == capifunc_cls
@@ -2485,11 +2485,8 @@ extern "C" bool nonzero(Box* obj) {
             return true;
         }
     }
-    CallRewriteArgs cargs(rewriter.get(), grewrite_args.out_rtn,
-                          rewriter ? rewriter->getReturnDestination() : Location());
-    Box* rtn = runtimeCallInternal0<CXX>(func, rewriter ? &cargs : NULL, ArgPassSpec(0));
-    if (cargs.out_success) {
-        RewriterVar* b = rewriter->call(false, (void*)nonzeroHelper, cargs.out_rtn);
+    if (crewrite_args.out_success) {
+        RewriterVar* b = rewriter->call(false, (void*)nonzeroHelper, crewrite_args.out_rtn);
         rewriter->commitReturning(b);
     }
     return nonzeroHelper(rtn);

--- a/src/runtime/types.h
+++ b/src/runtime/types.h
@@ -1008,6 +1008,9 @@ public:
 
     static Box* descr_get(Box* self, Box* inst, Box* owner) noexcept;
     static Box* __call__(BoxedWrapperDescriptor* descr, PyObject* self, BoxedTuple* args, Box** _args);
+    template <ExceptionStyle S>
+    static Box* tppCall(Box* _self, CallRewriteArgs* rewrite_args, ArgPassSpec argspec, Box* arg1, Box* arg2, Box* arg3,
+                        Box** args, const std::vector<BoxedString*>* keyword_names) noexcept(S == CAPI);
 
     static void gcHandler(GCVisitor* v, Box* _o);
 };


### PR DESCRIPTION
I want to get ride of the thousands of BoxedWrapperObject we create during calls.
Do do you guys think this is the right way?
If so I will clean it up / reduce the duplication between ```BoxedWrapperDescriptor::tppCall``` and ```BoxedWrapperObject::tppCall```