### PR TITLE
Support non-module-globals in the llvm tier

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -287,7 +287,7 @@ endmacro()
 
 # tests         testname directory arguments
 add_pyston_test(defaults tests --order-by-mtime)
-add_pyston_test(old_parser tests -a=-n -a=-x -t50)
+add_pyston_test(force_llvm tests -a=-n -a=-x -t50)
 if(${CMAKE_BUILD_TYPE} STREQUAL "Release")
   add_pyston_test(max_compilation_tier tests -a=-O -a=-x -t50)
 endif()

--- a/microbenchmarks/dict_globals_ubench.py
+++ b/microbenchmarks/dict_globals_ubench.py
@@ -1,0 +1,23 @@
+d = dict(x=1, y=0)
+exec """
+def g():
+    global y
+    y += x
+""" in d
+
+def f():
+    g = d['g']
+    for i in xrange(1000000):
+        g()
+        g()
+        g()
+        g()
+        g()
+        g()
+        g()
+        g()
+        g()
+        g()
+        d['y'] += i
+f()
+print d['y']

--- a/microbenchmarks/namedtuple_ubench.py
+++ b/microbenchmarks/namedtuple_ubench.py
@@ -1,0 +1,19 @@
+from collections import namedtuple
+
+NT = namedtuple("NT", "")
+
+def f():
+    C = NT
+    for i in xrange(1000000):
+        C()
+        C()
+        C()
+        C()
+        C()
+        C()
+        C()
+        C()
+        C()
+        C()
+f()
+

--- a/src/codegen/compvars.cpp
+++ b/src/codegen/compvars.cpp
@@ -776,7 +776,7 @@ ConcreteCompilerVariable* UnknownType::hasnext(IREmitter& emitter, const OpInfo&
     return boolFromI1(emitter, rtn_val);
 }
 
-CompilerVariable* makeFunction(IREmitter& emitter, CLFunction* f, CompilerVariable* closure, Box* globals,
+CompilerVariable* makeFunction(IREmitter& emitter, CLFunction* f, CompilerVariable* closure, llvm::Value* globals,
                                const std::vector<ConcreteCompilerVariable*>& defaults) {
     // Unlike the CLFunction*, which can be shared between recompilations, the Box* around it
     // should be created anew every time the functiondef is encountered
@@ -805,14 +805,13 @@ CompilerVariable* makeFunction(IREmitter& emitter, CLFunction* f, CompilerVariab
         scratch = getNullPtr(g.llvm_value_type_ptr_ptr);
     }
 
-    assert(globals == NULL);
-    llvm::Value* globals_v = getNullPtr(g.llvm_value_type_ptr);
+    assert(globals);
 
     // We know this function call can't throw, so it's safe to use emitter.getBuilder()->CreateCall() rather than
     // emitter.createCall().
     llvm::Value* boxed = emitter.getBuilder()->CreateCall(
         g.funcs.boxCLFunction, std::vector<llvm::Value*>{ embedRelocatablePtr(f, g.llvm_clfunction_type_ptr), closure_v,
-                                                          globals_v, scratch, getConstantInt(defaults.size(), g.i64) });
+                                                          globals, scratch, getConstantInt(defaults.size(), g.i64) });
 
     if (convertedClosure)
         convertedClosure->decvref(emitter);

--- a/src/codegen/compvars.h
+++ b/src/codegen/compvars.h
@@ -416,7 +416,7 @@ CompilerVariable* makeUnicode(Box*);
 #if 0
 CompilerVariable* makeUnicode(IREmitter& emitter, llvm::StringRef);
 #endif
-CompilerVariable* makeFunction(IREmitter& emitter, CLFunction*, CompilerVariable* closure, Box* globals,
+CompilerVariable* makeFunction(IREmitter& emitter, CLFunction*, CompilerVariable* closure, llvm::Value* globals,
                                const std::vector<ConcreteCompilerVariable*>& defaults);
 ConcreteCompilerVariable* undefVariable();
 CompilerVariable* makeTuple(const std::vector<CompilerVariable*>& elts);

--- a/src/codegen/irgen/irgenerator.cpp
+++ b/src/codegen/irgen/irgenerator.cpp
@@ -2180,6 +2180,11 @@ private:
         sorted_symbol_table[internString(FRAME_INFO_PTR_NAME)]
             = new ConcreteCompilerVariable(FRAME_INFO, irstate->getFrameInfoVar(), true);
 
+        if (!irstate->getSourceInfo()->scoping->areGlobalsFromModule()) {
+            sorted_symbol_table[internString(PASSED_GLOBALS_NAME)]
+                = new ConcreteCompilerVariable(UNKNOWN, irstate->getGlobals(), true);
+        }
+
         // For OSR calls, we use the same calling convention as in some other places; namely,
         // arg1, arg2, arg3, argarray [nargs is ommitted]
         // It would be nice to directly pass all variables as arguments, instead of packing them into
@@ -2559,6 +2564,11 @@ public:
         int initial_args = stackmap_args.size();
 
         stackmap_args.push_back(irstate->getFrameInfoVar());
+
+        if (!irstate->getSourceInfo()->scoping->areGlobalsFromModule()) {
+            stackmap_args.push_back(irstate->getGlobals());
+            pp->addFrameVar(PASSED_GLOBALS_NAME, UNKNOWN);
+        }
 
         assert(INT->llvmType() == g.i64);
         if (ENABLE_JIT_OBJECT_CACHE) {

--- a/src/codegen/irgen/irgenerator.cpp
+++ b/src/codegen/irgen/irgenerator.cpp
@@ -56,6 +56,7 @@ IRGenState::IRGenState(CLFunction* clfunc, CompiledFunction* cf, SourceInfo* sou
       scratch_space(NULL),
       frame_info(NULL),
       frame_info_arg(NULL),
+      globals(NULL),
       scratch_size(0) {
     assert(cf->func);
     assert(!cf->clfunc); // in this case don't need to pass in sourceinfo
@@ -244,6 +245,26 @@ ScopeInfo* IRGenState::getScopeInfoForNode(AST* node) {
     return source->scoping->getScopeInfoForNode(node);
 }
 
+void IRGenState::setGlobals(llvm::Value* globals) {
+    assert(!source_info->scoping->areGlobalsFromModule());
+    assert(!this->globals);
+    this->globals = globals;
+}
+
+llvm::Value* IRGenState::getGlobals() {
+    if (!globals) {
+        assert(source_info->scoping->areGlobalsFromModule());
+        this->globals = embedRelocatablePtr(source_info->parent_module, g.llvm_value_type_ptr);
+    }
+    return this->globals;
+}
+
+llvm::Value* IRGenState::getGlobalsIfCustom() {
+    if (source_info->scoping->areGlobalsFromModule())
+        return getNullPtr(g.llvm_value_type_ptr);
+    return getGlobals();
+}
+
 class IREmitterImpl : public IREmitter {
 private:
     IRGenState* irstate;
@@ -351,9 +372,6 @@ public:
         // Perf note: it seems to be more efficient to separately allocate the "builder" member,
         // even though we could allocate it in-line; maybe it's infrequently used enough that it's better
         // to not have it take up cache space.
-
-        RELEASE_ASSERT(irstate->getSourceInfo()->scoping->areGlobalsFromModule(),
-                       "jit doesn't support custom globals yet");
 
         builder->setEmitter(this);
         builder->SetInsertPoint(curblock);
@@ -508,6 +526,7 @@ const std::string CREATED_CLOSURE_NAME = "#created_closure";
 const std::string PASSED_CLOSURE_NAME = "#passed_closure";
 const std::string PASSED_GENERATOR_NAME = "#passed_generator";
 const std::string FRAME_INFO_PTR_NAME = "#frame_info_ptr";
+const std::string PASSED_GLOBALS_NAME = "#passed_globals";
 
 bool isIsDefinedName(llvm::StringRef name) {
     return startswith(name, "!is_defined_");
@@ -741,7 +760,7 @@ private:
                 module->decvref(emitter);
 
                 llvm::Value* r = emitter.createCall2(unw_info, g.funcs.importStar, converted_module->getValue(),
-                                                     embedParentModulePtr());
+                                                     irstate->getGlobals());
                 CompilerVariable* v = new ConcreteCompilerVariable(UNKNOWN, r, true);
 
                 converted_module->decvref(emitter);
@@ -1072,14 +1091,14 @@ private:
             ICSetupInfo* pp = createGetGlobalIC(getOpInfoForNode(node, unw_info).getTypeRecorder());
 
             std::vector<llvm::Value*> llvm_args;
-            llvm_args.push_back(embedParentModulePtr());
+            llvm_args.push_back(irstate->getGlobals());
             llvm_args.push_back(embedRelocatablePtr(node->id.getBox(), g.llvm_boxedstring_type_ptr));
 
             llvm::Value* uncasted = emitter.createIC(pp, (void*)pyston::getGlobal, llvm_args, unw_info);
             llvm::Value* r = emitter.getBuilder()->CreateIntToPtr(uncasted, g.llvm_value_type_ptr);
             return new ConcreteCompilerVariable(UNKNOWN, r, true);
         } else {
-            llvm::Value* r = emitter.createCall2(unw_info, g.funcs.getGlobal, embedParentModulePtr(),
+            llvm::Value* r = emitter.createCall2(unw_info, g.funcs.getGlobal, irstate->getGlobals(),
                                                  embedRelocatablePtr(node->id.getBox(), g.llvm_boxedstring_type_ptr));
             return new ConcreteCompilerVariable(UNKNOWN, r, true);
         }
@@ -1147,7 +1166,7 @@ private:
         } else if (vst == ScopeInfo::VarScopeType::NAME) {
             llvm::Value* boxedLocals = irstate->getBoxedLocalsVar();
             llvm::Value* attr = embedRelocatablePtr(node->id.getBox(), g.llvm_boxedstring_type_ptr);
-            llvm::Value* module = embedParentModulePtr();
+            llvm::Value* module = irstate->getGlobals();
             llvm::Value* r = emitter.createCall3(unw_info, g.funcs.boxedLocalsGet, boxedLocals, attr, module);
             return new ConcreteCompilerVariable(UNKNOWN, r, true);
         } else {
@@ -1402,7 +1421,7 @@ private:
         // but since the classdef can't create its own closure, shouldn't need to explicitly
         // create that scope to pass the closure through.
         assert(irstate->getSourceInfo()->scoping->areGlobalsFromModule());
-        CompilerVariable* func = makeFunction(emitter, cl, created_closure, NULL, {});
+        CompilerVariable* func = makeFunction(emitter, cl, created_closure, irstate->getGlobalsIfCustom(), {});
 
         CompilerVariable* attr_dict = func->call(emitter, getEmptyOpInfo(unw_info), ArgPassSpec(0), {}, NULL);
 
@@ -1465,8 +1484,7 @@ private:
             assert(created_closure);
         }
 
-        assert(irstate->getSourceInfo()->scoping->areGlobalsFromModule());
-        CompilerVariable* func = makeFunction(emitter, cl, created_closure, NULL, defaults);
+        CompilerVariable* func = makeFunction(emitter, cl, created_closure, irstate->getGlobalsIfCustom(), defaults);
 
         for (auto d : defaults) {
             d->decvref(emitter);
@@ -1694,11 +1712,18 @@ private:
         assert(vst != ScopeInfo::VarScopeType::DEREF);
 
         if (vst == ScopeInfo::VarScopeType::GLOBAL) {
-            // TODO do something special here so that it knows to only emit a monomorphic inline cache?
-            auto parent_module = llvm::ConstantExpr::getPointerCast(embedParentModulePtr(), g.llvm_value_type_ptr);
-            ConcreteCompilerVariable* module = new ConcreteCompilerVariable(MODULE, parent_module, false);
-            module->setattr(emitter, getEmptyOpInfo(unw_info), name.getBox(), val);
-            module->decvref(emitter);
+            if (irstate->getSourceInfo()->scoping->areGlobalsFromModule()) {
+                auto parent_module = llvm::ConstantExpr::getPointerCast(embedParentModulePtr(), g.llvm_value_type_ptr);
+                ConcreteCompilerVariable* module = new ConcreteCompilerVariable(MODULE, parent_module, false);
+                module->setattr(emitter, getEmptyOpInfo(unw_info), name.getBox(), val);
+                module->decvref(emitter);
+            } else {
+                auto converted = val->makeConverted(emitter, val->getBoxType());
+                emitter.createCall3(unw_info, g.funcs.setGlobal, irstate->getGlobals(),
+                                    embedRelocatablePtr(name.getBox(), g.llvm_boxedstring_type_ptr),
+                                    converted->getValue());
+                converted->decvref(emitter);
+            }
         } else if (vst == ScopeInfo::VarScopeType::NAME) {
             // TODO inefficient
             llvm::Value* boxedLocals = irstate->getBoxedLocalsVar();
@@ -1825,7 +1850,7 @@ private:
         // We could patchpoint this or try to avoid the overhead, but this should only
         // happen when the assertion is actually thrown so I don't think it will be necessary.
         static BoxedString* AssertionError_str = internStringImmortal("AssertionError");
-        llvm_args.push_back(emitter.createCall2(unw_info, g.funcs.getGlobal, embedParentModulePtr(),
+        llvm_args.push_back(emitter.createCall2(unw_info, g.funcs.getGlobal, irstate->getGlobals(),
                                                 embedRelocatablePtr(AssertionError_str, g.llvm_boxedstring_type_ptr)));
 
         ConcreteCompilerVariable* converted_msg = NULL;
@@ -1906,7 +1931,7 @@ private:
         ScopeInfo::VarScopeType vst = scope_info->getScopeTypeOfName(target->id);
         if (vst == ScopeInfo::VarScopeType::GLOBAL) {
             // Can't use delattr since the errors are different:
-            emitter.createCall2(unw_info, g.funcs.delGlobal, embedParentModulePtr(),
+            emitter.createCall2(unw_info, g.funcs.delGlobal, irstate->getGlobals(),
                                 embedRelocatablePtr(target->id.getBox(), g.llvm_boxedstring_type_ptr));
             return;
         }
@@ -2697,6 +2722,11 @@ public:
 
         if (irstate->getSourceInfo()->is_generator) {
             symbol_table[internString(PASSED_GENERATOR_NAME)] = new ConcreteCompilerVariable(GENERATOR, AI, true);
+            ++AI;
+        }
+
+        if (!irstate->getSourceInfo()->scoping->areGlobalsFromModule()) {
+            irstate->setGlobals(AI);
             ++AI;
         }
 

--- a/src/codegen/irgen/irgenerator.h
+++ b/src/codegen/irgen/irgenerator.h
@@ -49,6 +49,7 @@ extern const std::string CREATED_CLOSURE_NAME;
 extern const std::string PASSED_CLOSURE_NAME;
 extern const std::string PASSED_GENERATOR_NAME;
 extern const std::string FRAME_INFO_PTR_NAME;
+extern const std::string PASSED_GLOBALS_NAME;
 
 
 // Class that holds state of the current IR generation, that might not be local
@@ -70,6 +71,7 @@ private:
     llvm::Value* frame_info;
     llvm::Value* boxed_locals;
     llvm::Value* frame_info_arg;
+    llvm::Value* globals;
     int scratch_size;
 
 public:
@@ -107,6 +109,12 @@ public:
     ParamNames* getParamNames() { return param_names; }
 
     void setFrameInfoArgument(llvm::Value* v) { frame_info_arg = v; }
+
+    void setGlobals(llvm::Value* globals);
+    // Returns the custom globals, or the module if the globals come from the module.
+    llvm::Value* getGlobals();
+    // Returns the custom globals, or null if the globals come from the module.
+    llvm::Value* getGlobalsIfCustom();
 };
 
 // turns CFGBlocks into LLVM IR

--- a/src/codegen/runtime_hooks.cpp
+++ b/src/codegen/runtime_hooks.cpp
@@ -209,6 +209,7 @@ void initGlobalFuncs(GlobalState& g) {
     GET(delitem);
     GET(getGlobal);
     GET(delGlobal);
+    GET(setGlobal);
     GET(binop);
     GET(compare);
     GET(augbinop);

--- a/src/codegen/runtime_hooks.h
+++ b/src/codegen/runtime_hooks.h
@@ -37,7 +37,8 @@ struct GlobalFuncs {
         *createGenerator, *createSet;
     llvm::Value* getattr, *getattr_capi, *setattr, *delattr, *delitem, *delGlobal, *nonzero, *binop, *compare,
         *augbinop, *unboxedLen, *getitem, *getitem_capi, *getclsattr, *getGlobal, *setitem, *unaryop, *import,
-        *importFrom, *importStar, *repr, *str, *strOrUnicode, *exceptionMatches, *yield, *getiterHelper, *hasnext;
+        *importFrom, *importStar, *repr, *str, *strOrUnicode, *exceptionMatches, *yield, *getiterHelper, *hasnext,
+        *setGlobal;
 
     llvm::Value* unpackIntoArray, *raiseAttributeError, *raiseAttributeErrorStr, *raiseAttributeErrorCapi,
         *raiseAttributeErrorStrCapi, *raiseNotIterableError, *raiseIndexErrorStr, *raiseIndexErrorStrCapi,

--- a/src/codegen/stackmaps.h
+++ b/src/codegen/stackmaps.h
@@ -90,6 +90,15 @@ public:
             llvm::SmallVector<StackMap::Record::Location, 1> locations;
         };
         llvm::SmallVector<LocationEntry, 2> locations;
+
+        const LocationEntry* findEntry(unsigned offset) const {
+            for (const LocationMap::LocationTable::LocationEntry& e : locations) {
+                if (e.offset < offset && offset <= e.offset + e.length) {
+                    return &e;
+                }
+            }
+            return NULL;
+        }
     };
 
     llvm::StringMap<LocationTable> names;

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -267,6 +267,9 @@ public:
         Box* (*closure_call)(BoxedClosure*, Box*, Box*, Box*, Box**);
         Box* (*closure_generator_call)(BoxedClosure*, BoxedGenerator*, Box*, Box*, Box*, Box**);
         Box* (*generator_call)(BoxedGenerator*, Box*, Box*, Box*, Box**);
+        Box* (*call1)(Box*, Box*, Box*, Box*, Box**);
+        Box* (*call2)(Box*, Box*, Box*, Box*, Box*, Box**);
+        Box* (*call3)(Box*, Box*, Box*, Box*, Box*, Box*, Box**);
         void* code;
         uintptr_t code_start;
     };

--- a/src/runtime/inline/link_forcer.cpp
+++ b/src/runtime/inline/link_forcer.cpp
@@ -87,6 +87,7 @@ void force() {
     FORCE(getclsattr);
     FORCE(getGlobal);
     FORCE(delGlobal);
+    FORCE(setGlobal);
     FORCE(setitem);
     FORCE(delitem);
     FORCE(unaryop);

--- a/src/runtime/objmodel.h
+++ b/src/runtime/objmodel.h
@@ -211,7 +211,7 @@ extern "C" Box* getGlobal(Box* globals, BoxedString* name);
 // Checks for the name just in the passed globals object, and returns NULL if it is not found.
 // This includes if the globals object defined a custom __getattr__ method that threw an AttributeError.
 Box* getFromGlobals(Box* globals, BoxedString* name);
-void setGlobal(Box* globals, BoxedString* name, Box* value);
+extern "C" void setGlobal(Box* globals, BoxedString* name, Box* value);
 extern "C" void delGlobal(Box* globals, BoxedString* name);
 
 extern "C" void boxedLocalsSet(Box* boxedLocals, BoxedString* attr, Box* val);

--- a/test/tests/exec_in_test.py
+++ b/test/tests/exec_in_test.py
@@ -199,3 +199,22 @@ print l
 
 exec s
 print __doc__
+
+
+# Create a function that needs all three extra arguments:
+# is a generator, takes a closure, and takes custom globals
+s = """
+def f(x):
+    def g(a, b, c, d, e):
+        for i in xrange(start, x):
+            print a, b, c, d, e
+            yield i
+    return g
+"""
+
+g = {'start':2}
+l = {}
+exec s in g, l
+
+for i in xrange(5):
+    print list(l['f'](5)(1, 2, 3, 4, 5))

--- a/test/tests/exec_in_test.py
+++ b/test/tests/exec_in_test.py
@@ -218,3 +218,9 @@ exec s in g, l
 
 for i in xrange(5):
     print list(l['f'](5)(1, 2, 3, 4, 5))
+
+d = dict(x=1, y=0)
+exec """
+def g():
+    print sorted(globals().items())
+""" in d

--- a/test/tests/generator_custom_globals.py
+++ b/test/tests/generator_custom_globals.py
@@ -1,0 +1,12 @@
+s = """
+def g():
+    yield x
+    yield y
+"""
+
+g = {'x': 1, 'y': 4}
+l = {}
+
+exec s in g, l
+
+print list(l['g']())


### PR DESCRIPTION
(motivated by namedtuple)

This involves two main changes:
- changing the calling convention to pass `globals` as an argument if needed
  (this only applies going into compiled code, it's already passed into the interpreter)
- changing the llvm irgenerator to use the new globals object

Perf change isn't crazy but I think there might be some more improvements that this unlocks:
```
           django_template3.py             2.9s (4)             2.9s (4)  +0.1%
                 pyxl_bench.py             2.3s (4)             2.3s (4)  -0.3%
     sqlalchemy_imperative2.py             2.9s (4)             2.9s (4)  -0.5%
       django_template3_10x.py            17.7s (2)            17.5s (2)  -0.9%
             pyxl_bench_10x.py            17.4s (2)            17.4s (2)  -0.3%
 sqlalchemy_imperative2_10x.py            21.8s (2)            21.5s (2)  -1.1%
                       geomean                 7.1s                 7.1s  -0.5%
```