### PR TITLE
Optionally move objects around in memory to prepare Pyston for a moving collector.

### DIFF
--- a/src/capi/typeobject.cpp
+++ b/src/capi/typeobject.cpp
@@ -28,7 +28,7 @@ typedef int (*update_callback)(PyTypeObject*, void*);
 PyObject* tp_new_wrapper(PyTypeObject* self, BoxedTuple* args, Box* kwds) noexcept;
 
 extern "C" void conservativeGCHandler(GCVisitor* v, Box* b) noexcept {
-    v->visitPotentialRange((void* const*)b, (void* const*)((char*)b + b->cls->tp_basicsize));
+    v->visitPotentialRange((void**)b, (void**)((char*)b + b->cls->tp_basicsize));
 }
 
 extern "C" void conservativeAndBasesGCHandler(GCVisitor* v, Box* b) noexcept {

--- a/src/capi/types.h
+++ b/src/capi/types.h
@@ -68,8 +68,8 @@ public:
         BoxedCApiFunction* o = static_cast<BoxedCApiFunction*>(_o);
 
         Box::gcHandler(v, o);
-        v->visit(o->passthrough);
-        v->visit(o->module);
+        v->visit(&o->passthrough);
+        v->visit(&o->module);
     }
 };
 static_assert(sizeof(BoxedCApiFunction) == sizeof(PyCFunctionObject), "");

--- a/src/codegen/unwinding.cpp
+++ b/src/codegen/unwinding.cpp
@@ -580,9 +580,12 @@ public:
 
         PythonUnwindSession* o = static_cast<PythonUnwindSession*>(_o);
 
-        v->visitIf(o->exc_info.type);
-        v->visitIf(o->exc_info.value);
-        v->visitIf(o->exc_info.traceback);
+        if (o->exc_info.type)
+            v->visit(&o->exc_info.type);
+        if (o->exc_info.value)
+            v->visit(&o->exc_info.value);
+        if (o->exc_info.traceback)
+            v->visit(&o->exc_info.traceback);
     }
 };
 static __thread PythonUnwindSession* cur_unwind;

--- a/src/core/threading.cpp
+++ b/src/core/threading.cpp
@@ -125,16 +125,16 @@ public:
     void accept(gc::GCVisitor* v) {
         auto pub_state = public_thread_state;
         if (pub_state->curexc_type)
-            v->visit(pub_state->curexc_type);
+            v->visit(&pub_state->curexc_type);
         if (pub_state->curexc_value)
-            v->visit(pub_state->curexc_value);
+            v->visit(&pub_state->curexc_value);
         if (pub_state->curexc_traceback)
-            v->visit(pub_state->curexc_traceback);
+            v->visit(&pub_state->curexc_traceback);
         if (pub_state->dict)
-            v->visit(pub_state->dict);
+            v->visit(&pub_state->dict);
 
         for (auto& stack_info : previous_stacks) {
-            v->visit(stack_info.next_generator);
+            v->visit(&stack_info.next_generator);
 #if STACK_GROWS_DOWN
             v->visitPotentialRange((void**)stack_info.stack_limit, (void**)stack_info.stack_start);
 #else

--- a/src/gc/collector.h
+++ b/src/gc/collector.h
@@ -62,13 +62,15 @@ void startGCUnexpectedRegion();
 void endGCUnexpectedRegion();
 
 class GCVisitorNoRedundancy : public GCVisitor {
+public:
+    void _visitRedundant(void** ptr_address) override { visit(ptr_address); }
+    void _visitRangeRedundant(void** start, void** end) override { visitRange(start, end); }
+
+public:
     virtual ~GCVisitorNoRedundancy() {}
 
-    virtual void visitRedundant(void* p) { visit(p); }
-    virtual void visitRangeRedundant(void* const* start, void* const* end) { visitRange(start, end); }
-    virtual void visitPotentialRedundant(void* p) { visitPotential(p); }
-    virtual void visitPotentialRangeRedundant(void* const* start, void* const* end) { visitPotentialRange(start, end); }
-    virtual bool shouldVisitRedundants() { return true; }
+    void visitPotentialRedundant(void* p) override { visitPotential(p); }
+    void visitPotentialRangeRedundant(void** start, void** end) override { visitPotentialRange(start, end); }
 };
 }
 }

--- a/src/gc/collector.h
+++ b/src/gc/collector.h
@@ -91,6 +91,7 @@ class ReferenceMapWorklist;
 #define MOVING_OVERRIDE
 #endif
 
+#if MOVING_GC
 // Bulds the reference map, and also determine which objects cannot be moved.
 class GCVisitorPinning : public GCVisitorNoRedundancy {
 private:
@@ -134,6 +135,7 @@ public:
     // Track movement (reallocation) of objects.
     std::unordered_map<GCAllocation*, GCAllocation*> moves;
 };
+#endif
 }
 }
 

--- a/src/runtime/builtin_modules/sys.cpp
+++ b/src/runtime/builtin_modules/sys.cpp
@@ -233,10 +233,10 @@ public:
         Box::gcHandler(v, _b);
 
         BoxedSysFlags* self = static_cast<BoxedSysFlags*>(_b);
-        v->visit(self->division_warning);
-        v->visit(self->bytes_warning);
-        v->visit(self->no_user_site);
-        v->visit(self->optimize);
+        v->visit(&self->division_warning);
+        v->visit(&self->bytes_warning);
+        v->visit(&self->no_user_site);
+        v->visit(&self->optimize);
     }
 
     static Box* __new__(Box* cls, Box* args, Box* kwargs) {

--- a/src/runtime/classobj.h
+++ b/src/runtime/classobj.h
@@ -54,9 +54,9 @@ public:
 
         Box::gcHandler(v, o);
         if (o->bases)
-            v->visit(o->bases);
+            v->visit(&o->bases);
         if (o->name)
-            v->visit(o->name);
+            v->visit(&o->name);
     }
 };
 
@@ -78,7 +78,7 @@ public:
 
         Box::gcHandler(v, o);
         if (o->inst_cls)
-            v->visit(o->inst_cls);
+            v->visit(&o->inst_cls);
     }
 };
 }

--- a/src/runtime/descr.cpp
+++ b/src/runtime/descr.cpp
@@ -437,7 +437,7 @@ void BoxedMethodDescriptor::gcHandler(GCVisitor* v, Box* _o) {
     BoxedMethodDescriptor* o = static_cast<BoxedMethodDescriptor*>(_o);
 
     Box::gcHandler(v, o);
-    v->visit(o->type);
+    v->visit(&o->type);
 }
 
 Box* BoxedWrapperDescriptor::descr_get(Box* _self, Box* inst, Box* owner) noexcept {
@@ -576,7 +576,7 @@ void BoxedWrapperDescriptor::gcHandler(GCVisitor* v, Box* _o) {
     BoxedWrapperDescriptor* o = static_cast<BoxedWrapperDescriptor*>(_o);
 
     Box::gcHandler(v, o);
-    v->visit(o->type);
+    v->visit(&o->type);
 }
 
 static Box* wrapperdescrGetDoc(Box* b, void*) {
@@ -670,7 +670,7 @@ void BoxedWrapperObject::gcHandler(GCVisitor* v, Box* _o) {
     BoxedWrapperObject* o = static_cast<BoxedWrapperObject*>(_o);
 
     Box::gcHandler(v, o);
-    v->visit(o->obj);
+    v->visit(&o->obj);
 }
 
 void setupDescr() {

--- a/src/runtime/dict.cpp
+++ b/src/runtime/dict.cpp
@@ -727,8 +727,8 @@ void BoxedDict::gcHandler(GCVisitor* v, Box* b) {
     BoxedDict* d = (BoxedDict*)b;
 
     for (auto p : *d) {
-        v->visit(p.first);
-        v->visit(p.second);
+        v->visit(&p.first);
+        v->visit(&p.second);
     }
 }
 
@@ -737,7 +737,7 @@ void BoxedDictIterator::gcHandler(GCVisitor* v, Box* b) {
     Box::gcHandler(v, b);
 
     BoxedDictIterator* it = static_cast<BoxedDictIterator*>(b);
-    v->visit(it->d);
+    v->visit(&it->d);
 }
 
 void BoxedDictView::gcHandler(GCVisitor* v, Box* b) {
@@ -745,7 +745,7 @@ void BoxedDictView::gcHandler(GCVisitor* v, Box* b) {
     Box::gcHandler(v, b);
 
     BoxedDictView* view = static_cast<BoxedDictView*>(b);
-    v->visit(view->d);
+    v->visit(&view->d);
 }
 
 static int dict_init(PyObject* self, PyObject* args, PyObject* kwds) noexcept {

--- a/src/runtime/file.cpp
+++ b/src/runtime/file.cpp
@@ -1740,11 +1740,11 @@ void BoxedFile::gcHandler(GCVisitor* v, Box* b) {
     assert(isSubclass(b->cls, file_cls));
     BoxedFile* f = static_cast<BoxedFile*>(b);
 
-    v->visit(f->f_name);
-    v->visit(f->f_mode);
-    v->visit(f->f_encoding);
-    v->visit(f->f_errors);
-    v->visit(f->f_setbuf);
+    v->visit(&f->f_name);
+    v->visit(&f->f_mode);
+    v->visit(&f->f_encoding);
+    v->visit(&f->f_errors);
+    v->visit(&f->f_setbuf);
 }
 
 void setupFile() {

--- a/src/runtime/frame.cpp
+++ b/src/runtime/frame.cpp
@@ -82,8 +82,8 @@ public:
 
         auto f = static_cast<BoxedFrame*>(b);
 
-        v->visit(f->_code);
-        v->visit(f->_globals);
+        v->visit(&f->_code);
+        v->visit(&f->_globals);
     }
 
     static void simpleDestructor(Box* b) {

--- a/src/runtime/generator.cpp
+++ b/src/runtime/generator.cpp
@@ -427,27 +427,27 @@ void BoxedGenerator::gcHandler(GCVisitor* v, Box* b) {
 
     BoxedGenerator* g = (BoxedGenerator*)b;
 
-    v->visit(g->function);
+    v->visit(&g->function);
     int num_args = g->function->f->numReceivedArgs();
     if (num_args >= 1)
-        v->visit(g->arg1);
+        v->visit(&g->arg1);
     if (num_args >= 2)
-        v->visit(g->arg2);
+        v->visit(&g->arg2);
     if (num_args >= 3)
-        v->visit(g->arg3);
+        v->visit(&g->arg3);
     if (g->args)
-        v->visit(g->args);
+        v->visit(&g->args);
     if (num_args > 3)
-        v->visitPotentialRange(reinterpret_cast<void* const*>(&g->args->elts[0]),
-                               reinterpret_cast<void* const*>(&g->args->elts[num_args - 3]));
+        v->visitPotentialRange(reinterpret_cast<void**>(&g->args->elts[0]),
+                               reinterpret_cast<void**>(&g->args->elts[num_args - 3]));
     if (g->returnValue)
-        v->visit(g->returnValue);
+        v->visit(&g->returnValue);
     if (g->exception.type)
-        v->visit(g->exception.type);
+        v->visit(&g->exception.type);
     if (g->exception.value)
-        v->visit(g->exception.value);
+        v->visit(&g->exception.value);
     if (g->exception.traceback)
-        v->visit(g->exception.traceback);
+        v->visit(&g->exception.traceback);
 
     if (g->running) {
         v->visitPotentialRange((void**)g->returnContext,

--- a/src/runtime/hiddenclass.cpp
+++ b/src/runtime/hiddenclass.cpp
@@ -29,24 +29,25 @@ namespace pyston {
 
 void HiddenClass::gc_visit(GCVisitor* visitor) {
     // Visit children even for the dict-backed case, since children will just be empty
-    visitor->visitRange((void* const*)&children.vector()[0], (void* const*)&children.vector()[children.size()]);
-    visitor->visit(attrwrapper_child);
+    visitor->visitRange(const_cast<HiddenClass**>(&children.vector()[0]),
+                        const_cast<HiddenClass**>(&children.vector()[children.size()]));
+    visitor->visit(&attrwrapper_child);
 
     if (children.empty()) {
         for (auto p : attr_offsets)
-            visitor->visit(p.first);
+            visitor->visit(&p.first);
     } else {
 #if MOVING_GC
         // If we have any children, the attr_offsets map will be a subset of the child's map.
         for (const auto& p : attr_offsets)
-            visitor->visitRedundant(p.first);
+            visitor->visitRedundant(const_cast<BoxedString**>(&p.first));
 #endif
     }
 
 #if MOVING_GC
     // The children should have the entries of the keys of the 'children' map in the attr_offsets map.
     for (const auto& p : children) {
-        visitor->visitRedundant(p.first);
+        visitor->visitRedundant(const_cast<BoxedString**>(&p.first));
     }
 #endif
 }

--- a/src/runtime/inline/xrange.cpp
+++ b/src/runtime/inline/xrange.cpp
@@ -134,7 +134,7 @@ public:
         Box::gcHandler(v, b);
 
         BoxedXrangeIterator* it = (BoxedXrangeIterator*)b;
-        v->visit(it->xrange);
+        v->visit(const_cast<BoxedXrange**>(&it->xrange));
     }
 };
 

--- a/src/runtime/iterators.cpp
+++ b/src/runtime/iterators.cpp
@@ -65,9 +65,9 @@ public:
 
     void gc_visit(GCVisitor* v) override {
         if (iterator)
-            v->visit(iterator);
+            v->visit(&iterator);
         if (value)
-            v->visit(value);
+            v->visit(&value);
     }
 };
 
@@ -118,7 +118,7 @@ public:
 
     void gc_visit(GCVisitor* v) override {
         if (obj)
-            v->visit(obj);
+            v->visit(&obj);
     }
 };
 }

--- a/src/runtime/iterobject.cpp
+++ b/src/runtime/iterobject.cpp
@@ -116,9 +116,9 @@ void BoxedSeqIter::gcHandler(GCVisitor* v, Box* b) {
     Box::gcHandler(v, b);
 
     BoxedSeqIter* si = static_cast<BoxedSeqIter*>(b);
-    v->visit(si->b);
+    v->visit(&si->b);
     if (si->next)
-        v->visit(si->next);
+        v->visit(&si->next);
 }
 
 void BoxedIterWrapper::gcHandler(GCVisitor* v, Box* b) {
@@ -126,9 +126,9 @@ void BoxedIterWrapper::gcHandler(GCVisitor* v, Box* b) {
     Box::gcHandler(v, b);
 
     BoxedIterWrapper* iw = static_cast<BoxedIterWrapper*>(b);
-    v->visit(iw->iter);
+    v->visit(&iw->iter);
     if (iw->next)
-        v->visit(iw->next);
+        v->visit(&iw->next);
 }
 
 bool iterwrapperHasnextUnboxed(Box* s) {

--- a/src/runtime/list.cpp
+++ b/src/runtime/list.cpp
@@ -1179,7 +1179,7 @@ extern "C" int PyList_SetSlice(PyObject* a, Py_ssize_t ilow, Py_ssize_t ihigh, P
 void BoxedListIterator::gcHandler(GCVisitor* v, Box* b) {
     Box::gcHandler(v, b);
     BoxedListIterator* it = (BoxedListIterator*)b;
-    v->visit(it->l);
+    v->visit(&it->l);
 }
 
 void BoxedList::gcHandler(GCVisitor* v, Box* b) {
@@ -1192,9 +1192,9 @@ void BoxedList::gcHandler(GCVisitor* v, Box* b) {
     int capacity = l->capacity;
     assert(capacity >= size);
     if (capacity)
-        v->visit(l->elts);
+        v->visit(&l->elts);
     if (size)
-        v->visitRange((void**)&l->elts->elts[0], (void**)&l->elts->elts[size]);
+        v->visitRange(&l->elts->elts[0], &l->elts->elts[size]);
 }
 
 void setupList() {

--- a/src/runtime/set.cpp
+++ b/src/runtime/set.cpp
@@ -29,7 +29,7 @@ void BoxedSet::gcHandler(GCVisitor* v, Box* b) {
 
     BoxedSet* s = (BoxedSet*)b;
     for (auto&& p : s->s) {
-        v->visit(p.value);
+        v->visit(&p.value);
     }
 }
 
@@ -57,7 +57,7 @@ public:
 
         BoxedSetIterator* it = (BoxedSetIterator*)b;
 
-        v->visit(it->s);
+        v->visit(&it->s);
     }
 };
 

--- a/src/runtime/str.cpp
+++ b/src/runtime/str.cpp
@@ -2430,7 +2430,7 @@ public:
     static void gcHandler(GCVisitor* v, Box* b) {
         Box::gcHandler(v, b);
         BoxedStringIterator* it = (BoxedStringIterator*)b;
-        v->visit(it->s);
+        v->visit(&it->s);
     }
 };
 

--- a/src/runtime/super.cpp
+++ b/src/runtime/super.cpp
@@ -42,11 +42,11 @@ public:
 
         Box::gcHandler(v, o);
         if (o->type)
-            v->visit(o->type);
+            v->visit(&o->type);
         if (o->obj)
-            v->visit(o->obj);
+            v->visit(&o->obj);
         if (o->obj_type)
-            v->visit(o->obj_type);
+            v->visit(&o->obj_type);
     }
 };
 

--- a/src/runtime/traceback.cpp
+++ b/src/runtime/traceback.cpp
@@ -40,12 +40,12 @@ void BoxedTraceback::gcHandler(GCVisitor* v, Box* b) {
     BoxedTraceback* self = static_cast<BoxedTraceback*>(b);
 
     if (self->py_lines)
-        v->visit(self->py_lines);
+        v->visit(&self->py_lines);
     if (self->tb_next)
-        v->visit(self->tb_next);
+        v->visit(&self->tb_next);
 
-    v->visit(self->line.file);
-    v->visit(self->line.func);
+    v->visit(&self->line.file);
+    v->visit(&self->line.func);
 
     Box::gcHandler(v, b);
 }

--- a/src/runtime/tuple.cpp
+++ b/src/runtime/tuple.cpp
@@ -564,13 +564,13 @@ void BoxedTuple::gcHandler(GCVisitor* v, Box* b) {
     Box::gcHandler(v, b);
 
     BoxedTuple* t = (BoxedTuple*)b;
-    v->visitRange((void* const*)&t->elts[0], (void* const*)&t->elts[t->size()]);
+    v->visitRange(&t->elts[0], &t->elts[t->size()]);
 }
 
 extern "C" void BoxedTupleIterator::gcHandler(GCVisitor* v, Box* b) {
     Box::gcHandler(v, b);
     BoxedTupleIterator* it = (BoxedTupleIterator*)b;
-    v->visit(it->t);
+    v->visit(&it->t);
 }
 
 void setupTuple() {

--- a/test/tests/iter_gc.py
+++ b/test/tests/iter_gc.py
@@ -6,7 +6,7 @@ class C(object):
     def f(self, i):
         return i * i
     def __getitem__(self, i):
-        if i < 1000:
+        if i < 200:
             return self.f(i)
         raise IndexError(i)
 
@@ -25,7 +25,7 @@ class C2(object):
         self.n += 1
         return self.n * 2
     def next(self):
-        if self.n < 1000:
+        if self.n < 200:
             return self.f()
 
         raise StopIteration()

--- a/test/tests/testing_helpers.py
+++ b/test/tests/testing_helpers.py
@@ -17,7 +17,7 @@ def call_function_far_up_the_stack(fn, num_calls_left=200):
 # It's useful to call the GC at different locations in the stack in case that it's the
 # call to the GC itself that left a lingering pointer (e.g. the pointer could be the
 # __del__ attribute of an object we'd like to collect).
-def call_gc_throughout_the_stack(number_of_gc_calls, num_calls_left=100):
+def call_gc_throughout_the_stack(number_of_gc_calls, num_calls_left=30):
     if num_calls_left > 0:
         call_gc_throughout_the_stack(number_of_gc_calls, num_calls_left - 1)
         if number_of_gc_calls >= num_calls_left:

--- a/test/tests/unicode_test.py
+++ b/test/tests/unicode_test.py
@@ -31,7 +31,7 @@ def p(x):
     return [hex(ord(i)) for i in x]
 s = u"\u20AC" # euro sign
 print p(u"\N{EURO SIGN}")
-print p(s) 
+print p(s)
 print p(s.encode("utf8"))
 print p(s.encode("utf16"))
 print p(s.encode("utf32"))
@@ -51,7 +51,7 @@ for i in xrange(100):
     print repr(BaseException().__unicode__())
     gc.collect()
     # do some allocations:
-    for j in xrange(100):
+    for j in xrange(101):
         [None] * j
 
 print u'' in ''


### PR DESCRIPTION
Enable the code that does the moving by changing `MOVING_GC` in `gc.h`