### PR TITLE
Some improvments that let test_index could pass

### DIFF
--- a/from_cpython/Include/longobject.h
+++ b/from_cpython/Include/longobject.h
@@ -75,6 +75,9 @@ PyAPI_FUNC(PyObject *) PyLong_FromUnicode(Py_UNICODE*, Py_ssize_t, int) PYSTON_N
 */
 PyAPI_FUNC(int) _PyLong_Sign(PyObject *v) PYSTON_NOEXCEPT;
 
+// Pyston change: copied from CPython/Include/longintrepr.h
+/* Return a copy of src. */
+PyAPI_FUNC(PyObject *) _PyLong_Copy(PyLongObject *src) PYSTON_NOEXCEPT;
 
 /* _PyLong_NumBits.  Return the number of bits needed to represent the
    absolute value of a long.  For example, this returns 1 for 1 and -1, 2

--- a/from_cpython/Lib/test/test_index.py
+++ b/from_cpython/Lib/test/test_index.py
@@ -1,4 +1,3 @@
-# expected: fail
 import unittest
 from test import test_support
 import operator

--- a/src/capi/abstract.cpp
+++ b/src/capi/abstract.cpp
@@ -2071,7 +2071,7 @@ extern "C" PyObject* PyNumber_Long(PyObject* o) noexcept {
         return res;
     }
     if (PyLong_Check(o)) { /* A long subclass without nb_long */
-        return o;
+        return _PyLong_Copy((PyLongObject*)o);
     }
     trunc_func = PyObject_GetAttr(o, trunc_name);
     if (trunc_func) {

--- a/src/capi/abstract.cpp
+++ b/src/capi/abstract.cpp
@@ -2071,8 +2071,7 @@ extern "C" PyObject* PyNumber_Long(PyObject* o) noexcept {
         return res;
     }
     if (PyLong_Check(o)) { /* A long subclass without nb_long */
-        BoxedInt* lo = (BoxedInt*)o;
-        return PyLong_FromLong(lo->n);
+        return o;
     }
     trunc_func = PyObject_GetAttr(o, trunc_name);
     if (trunc_func) {

--- a/src/runtime/long.cpp
+++ b/src/runtime/long.cpp
@@ -72,6 +72,12 @@ extern "C" int _PyLong_Sign(PyObject* l) noexcept {
     return mpz_sgn(static_cast<BoxedLong*>(l)->n);
 }
 
+extern "C" PyObject* _PyLong_Copy(PyLongObject* src) noexcept {
+    BoxedLong* rtn = new BoxedLong();
+    mpz_init_set(((BoxedLong*)src)->n, rtn->n);
+    return rtn;
+}
+
 extern "C" unsigned PY_LONG_LONG PyLong_AsUnsignedLongLong(PyObject* vv) noexcept {
     unsigned PY_LONG_LONG bytes;
     int one = 1;

--- a/src/runtime/str.cpp
+++ b/src/runtime/str.cpp
@@ -1149,7 +1149,7 @@ extern "C" Box* strMul(BoxedString* lhs, Box* rhs) {
 
     if (PyIndex_Check(rhs)) {
         Box* index = PyNumber_Index(rhs);
-        if (PyErr_Occurred()) {
+        if (!index) {
             throwCAPIException();
         }
         rhs = index;

--- a/src/runtime/str.cpp
+++ b/src/runtime/str.cpp
@@ -1146,9 +1146,24 @@ extern "C" Box* strMul(BoxedString* lhs, Box* rhs) {
     assert(PyString_Check(lhs));
 
     int n;
+
+    if (PyIndex_Check(rhs)) {
+        Box* index = PyNumber_Index(rhs);
+        if (PyErr_Occurred()) {
+            throwCAPIException();
+        }
+        rhs = index;
+    }
+
     if (PyInt_Check(rhs))
         n = static_cast<BoxedInt*>(rhs)->n;
-    else
+    else if (isSubclass(rhs->cls, long_cls)) {
+        n = _PyLong_AsInt(rhs);
+        if (PyErr_Occurred()) {
+            PyErr_Clear();
+            raiseExcHelper(OverflowError, "cannot fit 'long' into index-sized integer");
+        }
+    } else
         return NotImplemented;
     if (n <= 0)
         return EmptyString;

--- a/test/CPYTHON_TEST_NOTES.md
+++ b/test/CPYTHON_TEST_NOTES.md
@@ -23,7 +23,6 @@ test_builtin            execfile scoping issue
 test_class              needs ellipsis
 test_coercion           1**1L, divmod(1, 1L); some unknown bug
 test_collections        assertion failed when doing vars(collections.namedtuple('Point', 'x y')(11, 12))
-test_complex            need complex.__nonzero__
 test_contextlib         lock.locked attributes
 test_datetime           needs _PyObject_GetDictPtr
 test_decimal            I think we need to copy decimaltestdata from cpython
@@ -47,7 +46,6 @@ test_generators         crash when sending non-None to a just-started generator
 test_genexps            parser not raising a SyntaxError when assigning to a genexp
 test_global             SyntaxWarnings for global statements after uses
 test_grammar            bug in our tokenizer
-test_index              slice.indices, old-styl-class __mul__
 test_io                 memory/gc issue?
 test_iterlen            [unknown]
 test_itertools          [unknown]


### PR DESCRIPTION
**Changes**:

- Add `__imul__` to `list` object, and let `list` could multiple with the instance which has `__index__` attribute.
- Let `str` could multiple with `long`.

Full list improvements is on the way. @kmod I saw your comment in current `listSort` function, should we use CPython's list sort with some Pyston changes, or improve the exist Pyston implementation? 

I have no preference. Just want to know copy lots of CPython code whether is suitable here.(the code of CPython list sort has many lines. Not only the `list_sort`, but also dependent functions.)