### PR TITLE
rewrite oldstyle class getattro

### DIFF
--- a/src/runtime/classobj.h
+++ b/src/runtime/classobj.h
@@ -81,6 +81,11 @@ public:
             v->visit(&o->inst_cls);
     }
 };
+
+Box* instance_getattro(Box* cls, Box* attr) noexcept;
+class GetattrRewriteArgs;
+template <ExceptionStyle S>
+Box* instanceGetattroInternal(Box* self, Box* attr, GetattrRewriteArgs* rewrite_args) noexcept(S == CAPI);
 }
 
 #endif

--- a/src/runtime/objmodel.cpp
+++ b/src/runtime/objmodel.cpp
@@ -1440,6 +1440,8 @@ Box* getattrInternalEx(Box* obj, BoxedString* attr, GetattrRewriteArgs* rewrite_
 
             if (obj->cls->tp_getattro == slot_tp_getattr_hook) {
                 return slotTpGetattrHookInternal<S>(obj, attr, rewrite_args);
+            } else if (obj->cls->tp_getattro == instance_getattro) {
+                return instanceGetattroInternal<S>(obj, attr, rewrite_args);
             }
 
             Box* r = obj->cls->tp_getattro(obj, attr);


### PR DESCRIPTION
This just rewrites attribute reads, this helps a small microbenchmark I created but doesn't show up on our benchmarks.
I tried to also rewrite some attribute calls but it didn't work because I had to add guards after call instructions, so I removed it again.
At some point we should change the instance_* funcs to integrate the getattr+runtimeCall like we do for callattr to really fix the perf issue. But it looks like oldstyle classes aren't used often enough currently to make this a priority.
