### PR TITLE
Type system fix: need to add unpacking to the type system

### DIFF
--- a/src/analysis/type_analysis.cpp
+++ b/src/analysis/type_analysis.cpp
@@ -177,8 +177,10 @@ private:
                 break;
             case AST_TYPE::Tuple: {
                 AST_Tuple* tt = ast_cast<AST_Tuple>(target);
+                auto val_types = t->unpackTypes(tt->elts.size());
+                assert(val_types.size() == tt->elts.size());
                 for (int i = 0; i < tt->elts.size(); i++) {
-                    _doSet(tt->elts[i], UNKNOWN);
+                    _doSet(tt->elts[i], val_types[i]);
                 }
                 break;
             }

--- a/src/codegen/compvars.cpp
+++ b/src/codegen/compvars.cpp
@@ -57,6 +57,12 @@ CompilerType::Result CompilerType::hasattr(BoxedString* attr) {
     return Result::Yes;
 }
 
+std::vector<CompilerType*> CompilerType::unpackTypes(int num_into) {
+    assert((CompilerType*)this != UNKNOWN);
+
+    return UNKNOWN->unpackTypes(num_into);
+}
+
 void ConcreteCompilerType::serializeToFrame(VAR* var, std::vector<llvm::Value*>& stackmap_args) {
 #ifndef NDEBUG
     if (llvmType() == g.i1) {
@@ -489,6 +495,10 @@ public:
             rtn.push_back(new ConcreteCompilerVariable(UNKNOWN, val, true));
         }
         return rtn;
+    }
+
+    std::vector<CompilerType*> unpackTypes(int num_into) override {
+        return std::vector<CompilerType*>(num_into, UNKNOWN);
     }
 };
 
@@ -2505,6 +2515,14 @@ public:
             e->incvref();
 
         return *var->getValue();
+    }
+
+    std::vector<CompilerType*> unpackTypes(int num_into) override {
+        if (num_into != elt_types.size()) {
+            return ValuedCompilerType::unpackTypes(num_into);
+        }
+
+        return elt_types;
     }
 };
 

--- a/src/codegen/compvars.h
+++ b/src/codegen/compvars.h
@@ -57,6 +57,7 @@ public:
     virtual BoxedClass* guaranteedClass() = 0;
     virtual Box* deserializeFromFrame(const FrameVals& vals) = 0;
     virtual int numFrameArgs() = 0;
+    virtual std::vector<CompilerType*> unpackTypes(int num_into);
 };
 
 typedef std::unordered_map<CompilerVariable*, CompilerVariable*> DupCache;

--- a/src/runtime/objmodel.cpp
+++ b/src/runtime/objmodel.cpp
@@ -2821,7 +2821,7 @@ Box* callattrInternal(Box* obj, BoxedString* attr, LookupScope scope, CallRewrit
             r_val = grewrite_args.out_rtn;
         }
     } else {
-        val = getattrInternalEx<CXX>(obj, attr, NULL, scope == CLASS_ONLY, true, &bind_obj, &r_bind_obj);
+        val = getattrInternalEx<S>(obj, attr, NULL, scope == CLASS_ONLY, true, &bind_obj, &r_bind_obj);
     }
 
     if (val == NULL) {

--- a/test/tests/callattr_exceptions.py
+++ b/test/tests/callattr_exceptions.py
@@ -1,0 +1,14 @@
+# Make sure that callattrs handle exceptions (including
+# different exception styles) correctly.
+class C(object):
+    def __getattr__(self, attr):
+        raise ValueError()
+
+def f():
+    c = C()
+    for i in xrange(10000):
+        try:
+            c.foo()
+        except ValueError:
+            pass
+f()

--- a/test/tests/unpacking_types.py
+++ b/test/tests/unpacking_types.py
@@ -1,0 +1,12 @@
+# Regression test: make sure that irgen and type analysis
+# both handle tuple -packing and -unpcaking.
+
+def get_str():
+    return "Hello world"
+
+def f():
+    _, a = 1, get_str()
+    a.lower()
+
+for i in xrange(100000):
+    f()


### PR DESCRIPTION
ie concerning things like:
  a, b = 1, 2

The irgen phase already knows how to do unpacking in a type-analyzed
way (a and b will be of type int), but type speculation needed to
have that added.

(this caused issues with speculation)