### PR TITLE
Allow changing the number of default arguments

### DIFF
--- a/src/codegen/codegen.cpp
+++ b/src/codegen/codegen.cpp
@@ -38,28 +38,28 @@ namespace pyston {
 
 DS_DEFINE_RWLOCK(codegen_rwlock);
 
-CLFunction::CLFunction(int num_args, int num_defaults, bool takes_varargs, bool takes_kwargs,
-                       std::unique_ptr<SourceInfo> source)
+CLFunction::CLFunction(int num_args, bool takes_varargs, bool takes_kwargs, std::unique_ptr<SourceInfo> source)
     : code_obj(NULL),
-      paramspec(num_args, num_defaults, takes_varargs, takes_kwargs),
+      num_args(num_args),
+      takes_varargs(takes_varargs),
+      takes_kwargs(takes_kwargs),
       source(std::move(source)),
       param_names(this->source->ast, this->source->getInternedStrings()),
       always_use_version(NULL),
       times_interpreted(0),
       internal_callable(NULL, NULL) {
-    assert(num_args >= num_defaults);
 }
 
-CLFunction::CLFunction(int num_args, int num_defaults, bool takes_varargs, bool takes_kwargs,
-                       const ParamNames& param_names)
+CLFunction::CLFunction(int num_args, bool takes_varargs, bool takes_kwargs, const ParamNames& param_names)
     : code_obj(NULL),
-      paramspec(num_args, num_defaults, takes_varargs, takes_kwargs),
+      num_args(num_args),
+      takes_varargs(takes_varargs),
+      takes_kwargs(takes_kwargs),
       source(nullptr),
       param_names(param_names),
       always_use_version(NULL),
       times_interpreted(0),
       internal_callable(NULL, NULL) {
-    assert(num_args >= num_defaults);
 }
 
 BoxedCode* CLFunction::getCode() {
@@ -84,7 +84,7 @@ void CLFunction::addVersion(CompiledFunction* compiled) {
             && compiled->spec->accepts_all_inputs && compiled->spec->boxed_return_value)
             always_use_version = compiled;
 
-        assert(compiled->spec->arg_types.size() == paramspec.totalReceived());
+        assert(compiled->spec->arg_types.size() == numReceivedArgs());
         versions.push_back(compiled);
     } else {
         osr_versions[compiled->entry_descriptor] = compiled;

--- a/src/codegen/irgen/hooks.cpp
+++ b/src/codegen/irgen/hooks.cpp
@@ -322,7 +322,7 @@ void compileAndRunModule(AST_Module* m, BoxedModule* bm) {
         if (!bm->hasattr(builtins_str))
             bm->giveAttr(builtins_str, PyModule_GetDict(builtins_module));
 
-        clfunc = new CLFunction(0, 0, false, false, std::move(si));
+        clfunc = new CLFunction(0, false, false, std::move(si));
     }
 
     UNAVOIDABLE_STAT_TIMER(t0, "us_timer_interpreted_module_toplevel");
@@ -365,7 +365,7 @@ static CLFunction* compileForEvalOrExec(AST* source, std::vector<AST_stmt*> body
 
     std::unique_ptr<SourceInfo> si(
         new SourceInfo(getCurrentModule(), scoping, future_flags, source, std::move(body), fn));
-    CLFunction* cl_f = new CLFunction(0, 0, false, false, std::move(si));
+    CLFunction* cl_f = new CLFunction(0, false, false, std::move(si));
 
     return cl_f;
 }
@@ -890,9 +890,8 @@ extern "C" char* reoptCompiledFunc(CompiledFunction* cf) {
     return (char*)new_cf->code;
 }
 
-CLFunction* createRTFunction(int num_args, int num_defaults, bool takes_varargs, bool takes_kwargs,
-                             const ParamNames& param_names) {
-    return new CLFunction(num_args, num_defaults, takes_varargs, takes_kwargs, param_names);
+CLFunction* createRTFunction(int num_args, bool takes_varargs, bool takes_kwargs, const ParamNames& param_names) {
+    return new CLFunction(num_args, takes_varargs, takes_kwargs, param_names);
 }
 
 CLFunction* boxRTFunction(void* f, ConcreteCompilerType* rtn_type, int num_args, const ParamNames& param_names,
@@ -901,16 +900,16 @@ CLFunction* boxRTFunction(void* f, ConcreteCompilerType* rtn_type, int num_args,
     assert(param_names.vararg.str() == "");
     assert(param_names.kwarg.str() == "");
 
-    return boxRTFunction(f, rtn_type, num_args, 0, false, false, param_names, exception_style);
+    return boxRTFunction(f, rtn_type, num_args, false, false, param_names, exception_style);
 }
 
-CLFunction* boxRTFunction(void* f, ConcreteCompilerType* rtn_type, int num_args, int num_defaults, bool takes_varargs,
-                          bool takes_kwargs, const ParamNames& param_names, ExceptionStyle exception_style) {
+CLFunction* boxRTFunction(void* f, ConcreteCompilerType* rtn_type, int num_args, bool takes_varargs, bool takes_kwargs,
+                          const ParamNames& param_names, ExceptionStyle exception_style) {
     assert(!param_names.takes_param_names || num_args == param_names.args.size());
     assert(takes_varargs || param_names.vararg.str() == "");
     assert(takes_kwargs || param_names.kwarg.str() == "");
 
-    CLFunction* cl_f = createRTFunction(num_args, num_defaults, takes_varargs, takes_kwargs, param_names);
+    CLFunction* cl_f = createRTFunction(num_args, takes_varargs, takes_kwargs, param_names);
 
     addRTFunction(cl_f, f, rtn_type, exception_style);
     return cl_f;

--- a/src/codegen/irgen/irgenerator.cpp
+++ b/src/codegen/irgen/irgenerator.cpp
@@ -2990,10 +2990,9 @@ CLFunction* wrapFunction(AST* node, AST_arguments* args, const std::vector<AST_s
         std::unique_ptr<SourceInfo> si(
             new SourceInfo(source->parent_module, source->scoping, source->future_flags, node, body, source->getFn()));
         if (args)
-            cl = new CLFunction(args->args.size(), args->defaults.size(), args->vararg.s().size(),
-                                args->kwarg.s().size(), std::move(si));
+            cl = new CLFunction(args->args.size(), args->vararg.s().size(), args->kwarg.s().size(), std::move(si));
         else
-            cl = new CLFunction(0, 0, 0, 0, std::move(si));
+            cl = new CLFunction(0, false, false, std::move(si));
     }
     return cl;
 }

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -354,7 +354,9 @@ class CLFunction {
     BoxedCode* code_obj;
 
 public:
-    ParamReceiveSpec paramspec;
+    int num_args;
+    bool takes_varargs, takes_kwargs;
+    //ParamReceiveSpec paramspec;
 
     std::unique_ptr<SourceInfo> source;
     ParamNames param_names;
@@ -379,12 +381,11 @@ public:
                                         Box**, const std::vector<BoxedString*>*> InternalCallable;
     InternalCallable internal_callable;
 
-    CLFunction(int num_args, int num_defaults, bool takes_varargs, bool takes_kwargs,
-               std::unique_ptr<SourceInfo> source);
-    CLFunction(int num_args, int num_defaults, bool takes_varargs, bool takes_kwargs, const ParamNames& param_names);
+    CLFunction(int num_args, bool takes_varargs, bool takes_kwargs, std::unique_ptr<SourceInfo> source);
+    CLFunction(int num_args, bool takes_varargs, bool takes_kwargs, const ParamNames& param_names);
     ~CLFunction();
 
-    int numReceivedArgs() { return paramspec.totalReceived(); }
+    int numReceivedArgs() { return num_args + takes_varargs + takes_kwargs; }
 
     BoxedCode* getCode();
 
@@ -397,11 +398,10 @@ public:
     }
 };
 
-CLFunction* createRTFunction(int num_args, int num_defaults, bool takes_varargs, bool takes_kwargs,
+CLFunction* createRTFunction(int num_args, bool takes_varargs, bool takes_kwargs,
                              const ParamNames& param_names = ParamNames::empty());
-CLFunction* boxRTFunction(void* f, ConcreteCompilerType* rtn_type, int nargs, int num_defaults, bool takes_varargs,
-                          bool takes_kwargs, const ParamNames& param_names = ParamNames::empty(),
-                          ExceptionStyle exception_style = CXX);
+CLFunction* boxRTFunction(void* f, ConcreteCompilerType* rtn_type, int nargs, bool takes_varargs, bool takes_kwargs,
+                          const ParamNames& param_names = ParamNames::empty(), ExceptionStyle exception_style = CXX);
 CLFunction* boxRTFunction(void* f, ConcreteCompilerType* rtn_type, int nargs,
                           const ParamNames& param_names = ParamNames::empty(), ExceptionStyle exception_style = CXX);
 void addRTFunction(CLFunction* cf, void* f, ConcreteCompilerType* rtn_type, ExceptionStyle exception_style = CXX);

--- a/src/runtime/bool.cpp
+++ b/src/runtime/bool.cpp
@@ -91,8 +91,7 @@ void setupBool() {
     bool_cls->giveAttr("__repr__", new BoxedFunction(boxRTFunction((void*)boolRepr, STR, 1)));
     bool_cls->giveAttr("__hash__", new BoxedFunction(boxRTFunction((void*)boolHash, BOXED_INT, 1)));
 
-    bool_cls->giveAttr("__new__",
-                       new BoxedFunction(boxRTFunction((void*)boolNew, UNKNOWN, 2, 1, false, false), { None }));
+    bool_cls->giveAttr("__new__", new BoxedFunction(boxRTFunction((void*)boolNew, UNKNOWN, 2, false, false), { None }));
 
     bool_cls->giveAttr("__and__", new BoxedFunction(boxRTFunction((void*)boolAnd, BOXED_BOOL, 2)));
     bool_cls->giveAttr("__or__", new BoxedFunction(boxRTFunction((void*)boolOr, BOXED_BOOL, 2)));

--- a/src/runtime/builtin_modules/builtins.cpp
+++ b/src/runtime/builtin_modules/builtins.cpp
@@ -1110,7 +1110,7 @@ static BoxedClass* makeBuiltinException(BoxedClass* base, const char* name, int 
     cls->giveAttr("__module__", boxString("exceptions"));
 
     if (base == object_cls) {
-        cls->giveAttr("__new__", new BoxedFunction(boxRTFunction((void*)exceptionNew, UNKNOWN, 1, 0, true, true)));
+        cls->giveAttr("__new__", new BoxedFunction(boxRTFunction((void*)exceptionNew, UNKNOWN, 1, true, true)));
         cls->giveAttr("__str__", new BoxedFunction(boxRTFunction((void*)exceptionStr, STR, 1)));
         cls->giveAttr("__repr__", new BoxedFunction(boxRTFunction((void*)exceptionRepr, STR, 1)));
     }
@@ -1528,7 +1528,7 @@ void setupBuiltins() {
     builtins_module->giveAttr("__debug__", False);
 
     builtins_module->giveAttr(
-        "print", new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)print, NONE, 0, 0, true, true), "print"));
+        "print", new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)print, NONE, 0, true, true), "print"));
 
     notimplemented_cls
         = BoxedHeapClass::create(type_cls, object_cls, NULL, 0, 0, sizeof(Box), false, "NotImplementedType");
@@ -1544,8 +1544,8 @@ void setupBuiltins() {
     builtins_module->giveAttr("any", new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)any, BOXED_BOOL, 1), "any"));
 
     builtins_module->giveAttr(
-        "apply", new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)builtinApply, UNKNOWN, 3, 1, false, false),
-                                                  "apply", { NULL }));
+        "apply", new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)builtinApply, UNKNOWN, 3, false, false), "apply",
+                                                  { NULL }));
 
     repr_obj = new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)repr, UNKNOWN, 1), "repr");
     builtins_module->giveAttr("repr", repr_obj);
@@ -1566,18 +1566,18 @@ void setupBuiltins() {
     builtins_module->giveAttr("oct",
                               new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)octFunc, UNKNOWN, 1), "oct"));
 
-    min_obj = new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)min, UNKNOWN, 1, 1, true, true), "min", { None });
+    min_obj = new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)min, UNKNOWN, 1, true, true), "min", { None });
     builtins_module->giveAttr("min", min_obj);
 
-    max_obj = new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)max, UNKNOWN, 1, 1, true, true), "max", { None });
+    max_obj = new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)max, UNKNOWN, 1, true, true), "max", { None });
     builtins_module->giveAttr("max", max_obj);
 
-    builtins_module->giveAttr("next", new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)next, UNKNOWN, 2, 1, false,
-                                                                                     false, ParamNames::empty(), CAPI),
-                                                                       "next", { NULL }));
+    builtins_module->giveAttr(
+        "next", new BoxedBuiltinFunctionOrMethod(
+                    boxRTFunction((void*)next, UNKNOWN, 2, false, false, ParamNames::empty(), CAPI), "next", { NULL }));
 
     builtins_module->giveAttr("sum", new BoxedBuiltinFunctionOrMethod(
-                                         boxRTFunction((void*)sum, UNKNOWN, 2, 1, false, false), "sum", { boxInt(0) }));
+                                         boxRTFunction((void*)sum, UNKNOWN, 2, false, false), "sum", { boxInt(0) }));
 
     id_obj = new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)id, BOXED_INT, 1), "id");
     builtins_module->giveAttr("id", id_obj);
@@ -1597,22 +1597,21 @@ void setupBuiltins() {
     builtins_module->giveAttr("delattr",
                               new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)delattrFunc, NONE, 2), "delattr"));
 
-    auto getattr_func = createRTFunction(3, 1, 1, 1, ParamNames::empty());
+    auto getattr_func = createRTFunction(3, true, true, ParamNames::empty());
     getattr_func->internal_callable.capi_val = &getattrFuncInternal<CAPI>;
     getattr_func->internal_callable.cxx_val = &getattrFuncInternal<CXX>;
     builtins_module->giveAttr("getattr", new BoxedBuiltinFunctionOrMethod(getattr_func, "getattr", { NULL }));
 
-    builtins_module->giveAttr(
-        "setattr",
-        new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)setattrFunc, UNKNOWN, 3, 0, false, false), "setattr"));
+    builtins_module->giveAttr("setattr", new BoxedBuiltinFunctionOrMethod(
+                                             boxRTFunction((void*)setattrFunc, UNKNOWN, 3, false, false), "setattr"));
 
-    auto hasattr_func = createRTFunction(2, 0, false, false);
+    auto hasattr_func = createRTFunction(2, false, false);
     hasattr_func->internal_callable.capi_val = &hasattrFuncInternal<CAPI>;
     hasattr_func->internal_callable.cxx_val = &hasattrFuncInternal<CXX>;
     builtins_module->giveAttr("hasattr", new BoxedBuiltinFunctionOrMethod(hasattr_func, "hasattr"));
 
     builtins_module->giveAttr("pow", new BoxedBuiltinFunctionOrMethod(
-                                         boxRTFunction((void*)powFunc, UNKNOWN, 3, 1, false, false), "pow", { None }));
+                                         boxRTFunction((void*)powFunc, UNKNOWN, 3, false, false), "pow", { None }));
 
     Box* isinstance_obj
         = new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)isinstance_func, BOXED_BOOL, 2), "isinstance");
@@ -1625,7 +1624,7 @@ void setupBuiltins() {
     Box* intern_obj = new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)intern_func, UNKNOWN, 1), "intern");
     builtins_module->giveAttr("intern", intern_obj);
 
-    CLFunction* import_func = boxRTFunction((void*)bltinImport, UNKNOWN, 5, 4, false, false,
+    CLFunction* import_func = boxRTFunction((void*)bltinImport, UNKNOWN, 5, false, false,
                                             ParamNames({ "name", "globals", "locals", "fromlist", "level" }, "", ""));
     builtins_module->giveAttr("__import__", new BoxedBuiltinFunctionOrMethod(import_func, "__import__",
                                                                              { None, None, None, new BoxedInt(-1) }));
@@ -1634,7 +1633,7 @@ void setupBuiltins() {
                                            sizeof(BoxedEnumerate), false, "enumerate");
     enumerate_cls->giveAttr(
         "__new__",
-        new BoxedFunction(boxRTFunction((void*)BoxedEnumerate::new_, UNKNOWN, 3, 1, false, false), { boxInt(0) }));
+        new BoxedFunction(boxRTFunction((void*)BoxedEnumerate::new_, UNKNOWN, 3, false, false), { boxInt(0) }));
     enumerate_cls->giveAttr(
         "__iter__", new BoxedFunction(boxRTFunction((void*)BoxedEnumerate::iter, typeFromClass(enumerate_cls), 1)));
     enumerate_cls->giveAttr("next", new BoxedFunction(boxRTFunction((void*)BoxedEnumerate::next, BOXED_TUPLE, 1)));
@@ -1645,68 +1644,67 @@ void setupBuiltins() {
     builtins_module->giveAttr("enumerate", enumerate_cls);
 
 
-    CLFunction* sorted_func = createRTFunction(4, 3, false, false, ParamNames({ "", "cmp", "key", "reverse" }, "", ""));
+    CLFunction* sorted_func = createRTFunction(4, false, false, ParamNames({ "", "cmp", "key", "reverse" }, "", ""));
     addRTFunction(sorted_func, (void*)sorted, LIST, { UNKNOWN, UNKNOWN, UNKNOWN, UNKNOWN });
     builtins_module->giveAttr("sorted", new BoxedBuiltinFunctionOrMethod(sorted_func, "sorted", { None, None, False }));
 
     builtins_module->giveAttr("True", True);
     builtins_module->giveAttr("False", False);
 
-    range_obj = new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)range, LIST, 3, 2, false, false), "range",
-                                                 { NULL, NULL });
+    range_obj
+        = new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)range, LIST, 3, false, false), "range", { NULL, NULL });
     builtins_module->giveAttr("range", range_obj);
 
-    auto* round_obj = new BoxedBuiltinFunctionOrMethod(
-        boxRTFunction((void*)builtinRound, BOXED_FLOAT, 2, 1, false, false), "round", { boxInt(0) });
+    auto* round_obj = new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)builtinRound, BOXED_FLOAT, 2, false, false),
+                                                       "round", { boxInt(0) });
     builtins_module->giveAttr("round", round_obj);
 
     setupXrange();
     builtins_module->giveAttr("xrange", xrange_cls);
 
-    open_obj = new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)open, typeFromClass(file_cls), 3, 2, false, false,
+    open_obj = new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)open, typeFromClass(file_cls), 3, false, false,
                                                               ParamNames({ "name", "mode", "buffering" }, "", "")),
                                                 "open", { boxString("r"), boxInt(-1) });
     builtins_module->giveAttr("open", open_obj);
 
     builtins_module->giveAttr("globals", new BoxedBuiltinFunctionOrMethod(
-                                             boxRTFunction((void*)globals, UNKNOWN, 0, 0, false, false), "globals"));
-    builtins_module->giveAttr("locals", new BoxedBuiltinFunctionOrMethod(
-                                            boxRTFunction((void*)locals, UNKNOWN, 0, 0, false, false), "locals"));
+                                             boxRTFunction((void*)globals, UNKNOWN, 0, false, false), "globals"));
+    builtins_module->giveAttr(
+        "locals", new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)locals, UNKNOWN, 0, false, false), "locals"));
 
     builtins_module->giveAttr(
-        "iter", new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)builtinIter, UNKNOWN, 2, 1, false, false), "iter",
+        "iter", new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)builtinIter, UNKNOWN, 2, false, false), "iter",
                                                  { NULL }));
-    builtins_module->giveAttr(
-        "reversed",
-        new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)getreversed, UNKNOWN, 1, 0, false, false), "reversed"));
+    builtins_module->giveAttr("reversed", new BoxedBuiltinFunctionOrMethod(
+                                              boxRTFunction((void*)getreversed, UNKNOWN, 1, false, false), "reversed"));
     builtins_module->giveAttr("coerce", new BoxedBuiltinFunctionOrMethod(
-                                            boxRTFunction((void*)coerceFunc, UNKNOWN, 2, 0, false, false), "coerce"));
+                                            boxRTFunction((void*)coerceFunc, UNKNOWN, 2, false, false), "coerce"));
     builtins_module->giveAttr("divmod",
                               new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)divmod, UNKNOWN, 2), "divmod"));
 
-    builtins_module->giveAttr(
-        "execfile", new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)execfile, UNKNOWN, 3, 2, false, false),
-                                                     "execfile", { NULL, NULL }));
+    builtins_module->giveAttr("execfile",
+                              new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)execfile, UNKNOWN, 3, false, false),
+                                                               "execfile", { NULL, NULL }));
 
     CLFunction* compile_func = createRTFunction(
-        5, 2, false, false, ParamNames({ "source", "filename", "mode", "flags", "dont_inherit" }, "", ""));
+        5, false, false, ParamNames({ "source", "filename", "mode", "flags", "dont_inherit" }, "", ""));
     addRTFunction(compile_func, (void*)compile, UNKNOWN, { UNKNOWN, UNKNOWN, UNKNOWN, UNKNOWN, UNKNOWN });
     builtins_module->giveAttr("compile",
                               new BoxedBuiltinFunctionOrMethod(compile_func, "compile", { boxInt(0), boxInt(0) }));
 
+    builtins_module->giveAttr("map",
+                              new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)map, LIST, 1, true, false), "map"));
     builtins_module->giveAttr(
-        "map", new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)map, LIST, 1, 0, true, false), "map"));
-    builtins_module->giveAttr(
-        "reduce", new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)reduce, UNKNOWN, 3, 1, false, false), "reduce",
-                                                   { NULL }));
+        "reduce",
+        new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)reduce, UNKNOWN, 3, false, false), "reduce", { NULL }));
     builtins_module->giveAttr("filter",
                               new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)filter2, UNKNOWN, 2), "filter"));
+    builtins_module->giveAttr("zip",
+                              new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)zip, LIST, 0, true, false), "zip"));
     builtins_module->giveAttr(
-        "zip", new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)zip, LIST, 0, 0, true, false), "zip"));
-    builtins_module->giveAttr(
-        "dir", new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)dir, LIST, 1, 1, false, false), "dir", { NULL }));
+        "dir", new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)dir, LIST, 1, false, false), "dir", { NULL }));
     builtins_module->giveAttr("vars", new BoxedBuiltinFunctionOrMethod(
-                                          boxRTFunction((void*)vars, UNKNOWN, 1, 1, false, false), "vars", { NULL }));
+                                          boxRTFunction((void*)vars, UNKNOWN, 1, false, false), "vars", { NULL }));
     builtins_module->giveAttr("object", object_cls);
     builtins_module->giveAttr("str", str_cls);
     builtins_module->giveAttr("bytes", str_cls);
@@ -1743,18 +1741,17 @@ void setupBuiltins() {
     PyType_Ready(&PyBuffer_Type);
     builtins_module->giveAttr("buffer", &PyBuffer_Type);
 
-    builtins_module->giveAttr("eval",
-                              new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)eval, UNKNOWN, 3, 2, false, false),
-                                                               "eval", { NULL, NULL }));
+    builtins_module->giveAttr(
+        "eval",
+        new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)eval, UNKNOWN, 3, false, false), "eval", { NULL, NULL }));
     builtins_module->giveAttr("callable",
                               new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)callable, UNKNOWN, 1), "callable"));
 
-    builtins_module->giveAttr(
-        "raw_input", new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)rawInput, UNKNOWN, 1, 1, false, false),
-                                                      "raw_input", { NULL }));
-    builtins_module->giveAttr(
-        "input",
-        new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)input, UNKNOWN, 1, 1, false, false), "input", { NULL }));
+    builtins_module->giveAttr("raw_input",
+                              new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)rawInput, UNKNOWN, 1, false, false),
+                                                               "raw_input", { NULL }));
+    builtins_module->giveAttr("input", new BoxedBuiltinFunctionOrMethod(
+                                           boxRTFunction((void*)input, UNKNOWN, 1, false, false), "input", { NULL }));
     builtins_module->giveAttr("cmp",
                               new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)builtinCmp, UNKNOWN, 2), "cmp"));
     builtins_module->giveAttr(

--- a/src/runtime/builtin_modules/pyston.cpp
+++ b/src/runtime/builtin_modules/pyston.cpp
@@ -73,7 +73,7 @@ void setupPyston() {
     pyston_module->giveAttr("clearStats",
                             new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)clearStats, NONE, 0), "clearStats"));
     pyston_module->giveAttr("dumpStats",
-                            new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)dumpStats, NONE, 1, 1, false, false),
+                            new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)dumpStats, NONE, 1, false, false),
                                                              "dumpStats", { False }));
 }
 }

--- a/src/runtime/builtin_modules/sys.cpp
+++ b/src/runtime/builtin_modules/sys.cpp
@@ -605,8 +605,8 @@ void setupSys() {
         "exc_info", new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)sysExcInfo, BOXED_TUPLE, 0), "exc_info"));
     sys_module->giveAttr("exc_clear",
                          new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)sysExcClear, NONE, 0), "exc_clear"));
-    sys_module->giveAttr("exit", new BoxedBuiltinFunctionOrMethod(
-                                     boxRTFunction((void*)sysExit, NONE, 1, 1, false, false), "exit", { None }));
+    sys_module->giveAttr("exit", new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)sysExit, NONE, 1, false, false),
+                                                                  "exit", { None }));
 
     sys_module->giveAttr("warnoptions", new BoxedList());
     sys_module->giveAttr("py3kwarning", False);
@@ -617,7 +617,7 @@ void setupSys() {
     sys_module->giveAttr("executable", boxString(Py_GetProgramFullPath()));
 
     sys_module->giveAttr("_getframe",
-                         new BoxedFunction(boxRTFunction((void*)sysGetFrame, UNKNOWN, 1, 1, false, false), { NULL }));
+                         new BoxedFunction(boxRTFunction((void*)sysGetFrame, UNKNOWN, 1, false, false), { NULL }));
     sys_module->giveAttr(
         "getdefaultencoding",
         new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)sysGetDefaultEncoding, STR, 0), "getdefaultencoding"));
@@ -655,7 +655,7 @@ void setupSys() {
     sys_flags_cls = new (0) BoxedHeapClass(object_cls, BoxedSysFlags::gcHandler, 0, 0, sizeof(BoxedSysFlags), false,
                                            static_cast<BoxedString*>(boxString("flags")));
     sys_flags_cls->giveAttr("__new__",
-                            new BoxedFunction(boxRTFunction((void*)BoxedSysFlags::__new__, UNKNOWN, 1, 0, true, true)));
+                            new BoxedFunction(boxRTFunction((void*)BoxedSysFlags::__new__, UNKNOWN, 1, true, true)));
 #define ADD(name)                                                                                                      \
     sys_flags_cls->giveAttr(STRINGIFY(name),                                                                           \
                             new BoxedMemberDescriptor(BoxedMemberDescriptor::OBJECT, offsetof(BoxedSysFlags, name)))

--- a/src/runtime/builtin_modules/thread.cpp
+++ b/src/runtime/builtin_modules/thread.cpp
@@ -200,7 +200,7 @@ void setupThread() {
     assert(thread_module);
 
     thread_module->giveAttr("start_new_thread", new BoxedBuiltinFunctionOrMethod(
-                                                    boxRTFunction((void*)startNewThread, BOXED_INT, 3, 1, false, false),
+                                                    boxRTFunction((void*)startNewThread, BOXED_INT, 3, false, false),
                                                     "start_new_thread", { NULL }));
     thread_module->giveAttr("allocate_lock", new BoxedBuiltinFunctionOrMethod(
                                                  boxRTFunction((void*)allocateLock, UNKNOWN, 0), "allocate_lock"));
@@ -215,8 +215,8 @@ void setupThread() {
 
     thread_lock_cls->giveAttr("__module__", boxString("thread"));
     thread_lock_cls->giveAttr(
-        "acquire", new BoxedFunction(boxRTFunction((void*)BoxedThreadLock::acquire, BOXED_BOOL, 2, 1, false, false),
-                                     { boxInt(1) }));
+        "acquire",
+        new BoxedFunction(boxRTFunction((void*)BoxedThreadLock::acquire, BOXED_BOOL, 2, false, false), { boxInt(1) }));
     thread_lock_cls->giveAttr("release", new BoxedFunction(boxRTFunction((void*)BoxedThreadLock::release, NONE, 1)));
     thread_lock_cls->giveAttr("acquire_lock", thread_lock_cls->getattr(internStringMortal("acquire")));
     thread_lock_cls->giveAttr("release_lock", thread_lock_cls->getattr(internStringMortal("release")));

--- a/src/runtime/capi.cpp
+++ b/src/runtime/capi.cpp
@@ -1666,7 +1666,7 @@ void setupCAPI() {
     capifunc_cls->giveAttr("__repr__",
                            new BoxedFunction(boxRTFunction((void*)BoxedCApiFunction::__repr__, UNKNOWN, 1)));
 
-    auto capi_call = new BoxedFunction(boxRTFunction((void*)BoxedCApiFunction::__call__, UNKNOWN, 1, 0, true, true));
+    auto capi_call = new BoxedFunction(boxRTFunction((void*)BoxedCApiFunction::__call__, UNKNOWN, 1, true, true));
     capifunc_cls->giveAttr("__call__", capi_call);
     capifunc_cls->tpp_call.capi_val = BoxedCApiFunction::tppCall<CAPI>;
     capifunc_cls->tpp_call.cxx_val = BoxedCApiFunction::tppCall<CXX>;

--- a/src/runtime/classobj.cpp
+++ b/src/runtime/classobj.cpp
@@ -1498,11 +1498,9 @@ void setupClassobj() {
         = BoxedHeapClass::create(type_cls, object_cls, &BoxedInstance::gcHandler, offsetof(BoxedInstance, attrs),
                                  offsetof(BoxedInstance, weakreflist), sizeof(BoxedInstance), false, "instance");
 
-    classobj_cls->giveAttr("__new__",
-                           new BoxedFunction(boxRTFunction((void*)classobjNew, UNKNOWN, 4, 0, false, false)));
+    classobj_cls->giveAttr("__new__", new BoxedFunction(boxRTFunction((void*)classobjNew, UNKNOWN, 4, false, false)));
 
-    classobj_cls->giveAttr("__call__",
-                           new BoxedFunction(boxRTFunction((void*)classobjCall, UNKNOWN, 1, 0, true, true)));
+    classobj_cls->giveAttr("__call__", new BoxedFunction(boxRTFunction((void*)classobjCall, UNKNOWN, 1, true, true)));
 
     classobj_cls->giveAttr("__getattribute__",
                            new BoxedFunction(boxRTFunction((void*)classobjGetattribute, UNKNOWN, 2)));
@@ -1534,8 +1532,7 @@ void setupClassobj() {
     instance_cls->giveAttr("__hash__", new BoxedFunction(boxRTFunction((void*)instanceHash, UNKNOWN, 1)));
     instance_cls->giveAttr("__iter__", new BoxedFunction(boxRTFunction((void*)instanceIter, UNKNOWN, 1)));
     instance_cls->giveAttr("next", new BoxedFunction(boxRTFunction((void*)instanceNext, UNKNOWN, 1)));
-    instance_cls->giveAttr("__call__",
-                           new BoxedFunction(boxRTFunction((void*)instanceCall, UNKNOWN, 1, 0, true, true)));
+    instance_cls->giveAttr("__call__", new BoxedFunction(boxRTFunction((void*)instanceCall, UNKNOWN, 1, true, true)));
     instance_cls->giveAttr("__eq__", new BoxedFunction(boxRTFunction((void*)instanceEq, UNKNOWN, 2)));
     instance_cls->giveAttr("__ne__", new BoxedFunction(boxRTFunction((void*)instanceNe, UNKNOWN, 2)));
     instance_cls->giveAttr("__lt__", new BoxedFunction(boxRTFunction((void*)instanceLt, UNKNOWN, 2)));

--- a/src/runtime/code.cpp
+++ b/src/runtime/code.cpp
@@ -61,7 +61,7 @@ Box* BoxedCode::firstlineno(Box* b, void*) {
 Box* BoxedCode::argcount(Box* b, void*) {
     RELEASE_ASSERT(b->cls == code_cls, "");
 
-    return boxInt(static_cast<BoxedCode*>(b)->f->paramspec.num_args);
+    return boxInt(static_cast<BoxedCode*>(b)->f->num_args);
 }
 
 Box* BoxedCode::varnames(Box* b, void*) {

--- a/src/runtime/complex.cpp
+++ b/src/runtime/complex.cpp
@@ -389,7 +389,7 @@ done:
 
 static void _addFunc(const char* name, ConcreteCompilerType* rtn_type, void* complex_func, void* float_func,
                      void* int_func, void* boxed_func) {
-    CLFunction* cl = createRTFunction(2, 0, false, false);
+    CLFunction* cl = createRTFunction(2, false, false);
     addRTFunction(cl, complex_func, rtn_type, { BOXED_COMPLEX, BOXED_COMPLEX });
     addRTFunction(cl, float_func, rtn_type, { BOXED_COMPLEX, BOXED_FLOAT });
     addRTFunction(cl, int_func, rtn_type, { BOXED_COMPLEX, BOXED_INT });
@@ -1224,7 +1224,7 @@ static PyMethodDef complex_methods[] = {
 };
 
 void setupComplex() {
-    auto complex_new = boxRTFunction((void*)complexNew<CXX>, UNKNOWN, 3, 2, false, false,
+    auto complex_new = boxRTFunction((void*)complexNew<CXX>, UNKNOWN, 3, false, false,
                                      ParamNames({ "", "real", "imag" }, "", ""), CXX);
     addRTFunction(complex_new, (void*)complexNew<CAPI>, UNKNOWN, CAPI);
     complex_cls->giveAttr("__new__", new BoxedFunction(complex_new, { NULL, NULL }));
@@ -1248,7 +1248,7 @@ void setupComplex() {
     complex_cls->giveAttr("__rsub__", new BoxedFunction(boxRTFunction((void*)complexRSub, UNKNOWN, 2)));
     complex_cls->giveAttr("__rdiv__", new BoxedFunction(boxRTFunction((void*)complexRDiv, UNKNOWN, 2)));
     complex_cls->giveAttr("__pow__",
-                          new BoxedFunction(boxRTFunction((void*)complexPow, UNKNOWN, 3, 1, false, false), { None }));
+                          new BoxedFunction(boxRTFunction((void*)complexPow, UNKNOWN, 3, false, false), { None }));
     complex_cls->giveAttr("__mod__", new BoxedFunction(boxRTFunction((void*)complexMod, UNKNOWN, 2)));
     complex_cls->giveAttr("__divmod__", new BoxedFunction(boxRTFunction((void*)complexDivmod, BOXED_TUPLE, 2)));
     complex_cls->giveAttr("__floordiv__", new BoxedFunction(boxRTFunction((void*)complexFloordiv, UNKNOWN, 2)));

--- a/src/runtime/descr.cpp
+++ b/src/runtime/descr.cpp
@@ -678,7 +678,7 @@ void setupDescr() {
     member_descriptor_cls->freeze();
 
     property_cls->giveAttr("__init__",
-                           new BoxedFunction(boxRTFunction((void*)propertyInit, UNKNOWN, 5, 4, false, false,
+                           new BoxedFunction(boxRTFunction((void*)propertyInit, UNKNOWN, 5, false, false,
                                                            ParamNames({ "", "fget", "fset", "fdel", "doc" }, "", "")),
                                              { NULL, NULL, NULL, NULL }));
     property_cls->giveAttr("__get__", new BoxedFunction(boxRTFunction((void*)propertyGet, UNKNOWN, 3)));
@@ -698,23 +698,23 @@ void setupDescr() {
     property_cls->freeze();
 
     staticmethod_cls->giveAttr("__init__",
-                               new BoxedFunction(boxRTFunction((void*)staticmethodInit, UNKNOWN, 5, 4, false, false),
+                               new BoxedFunction(boxRTFunction((void*)staticmethodInit, UNKNOWN, 5, false, false),
                                                  { None, None, None, None }));
     staticmethod_cls->giveAttr(
-        "__get__", new BoxedFunction(boxRTFunction((void*)staticmethodGet, UNKNOWN, 3, 1, false, false), { None }));
+        "__get__", new BoxedFunction(boxRTFunction((void*)staticmethodGet, UNKNOWN, 3, false, false), { None }));
     staticmethod_cls->freeze();
 
 
-    classmethod_cls->giveAttr("__init__",
-                              new BoxedFunction(boxRTFunction((void*)classmethodInit, UNKNOWN, 5, 4, false, false),
-                                                { None, None, None, None }));
     classmethod_cls->giveAttr(
-        "__get__", new BoxedFunction(boxRTFunction((void*)classmethodGet, UNKNOWN, 3, 1, false, false), { None }));
+        "__init__",
+        new BoxedFunction(boxRTFunction((void*)classmethodInit, UNKNOWN, 5, false, false), { None, None, None, None }));
+    classmethod_cls->giveAttr(
+        "__get__", new BoxedFunction(boxRTFunction((void*)classmethodGet, UNKNOWN, 3, false, false), { None }));
     classmethod_cls->freeze();
 
     method_cls->giveAttr("__get__", new BoxedFunction(boxRTFunction((void*)BoxedMethodDescriptor::descr_get, UNKNOWN, 3,
                                                                     ParamNames::empty(), CAPI)));
-    CLFunction* method_call_cl = boxRTFunction((void*)BoxedMethodDescriptor::__call__, UNKNOWN, 2, 0, true, true);
+    CLFunction* method_call_cl = boxRTFunction((void*)BoxedMethodDescriptor::__call__, UNKNOWN, 2, true, true);
     method_cls->giveAttr("__call__", new BoxedFunction(method_call_cl));
     method_cls->tpp_call.capi_val = BoxedMethodDescriptor::tppCall<CAPI>;
     method_cls->tpp_call.cxx_val = BoxedMethodDescriptor::tppCall<CXX>;
@@ -722,8 +722,8 @@ void setupDescr() {
     method_cls->giveAttr("__repr__", new BoxedFunction(boxRTFunction((void*)methodRepr, UNKNOWN, 1)));
     method_cls->freeze();
 
-    wrapperdescr_cls->giveAttr("__call__", new BoxedFunction(boxRTFunction((void*)BoxedWrapperDescriptor::__call__,
-                                                                           UNKNOWN, 2, 0, true, true)));
+    wrapperdescr_cls->giveAttr(
+        "__call__", new BoxedFunction(boxRTFunction((void*)BoxedWrapperDescriptor::__call__, UNKNOWN, 2, true, true)));
     wrapperdescr_cls->giveAttr("__doc__",
                                new (pyston_getset_cls) BoxedGetsetDescriptor(wrapperdescrGetDoc, NULL, NULL));
     wrapperdescr_cls->tp_descr_get = BoxedWrapperDescriptor::descr_get;
@@ -735,7 +735,7 @@ void setupDescr() {
     assert(wrapperdescr_cls->tp_descr_get == BoxedWrapperDescriptor::descr_get);
 
     wrapperobject_cls->giveAttr(
-        "__call__", new BoxedFunction(boxRTFunction((void*)BoxedWrapperObject::__call__, UNKNOWN, 1, 0, true, true)));
+        "__call__", new BoxedFunction(boxRTFunction((void*)BoxedWrapperObject::__call__, UNKNOWN, 1, true, true)));
     wrapperobject_cls->tpp_call.capi_val = BoxedWrapperObject::tppCall<CAPI>;
     wrapperobject_cls->tpp_call.cxx_val = BoxedWrapperObject::tppCall<CXX>;
     wrapperobject_cls->giveAttr("__repr__", new BoxedFunction(boxRTFunction((void*)wrapperObjectRepr, UNKNOWN, 1)));

--- a/src/runtime/dict.cpp
+++ b/src/runtime/dict.cpp
@@ -789,8 +789,8 @@ void setupDict() {
     dict_cls->has_safe_tp_dealloc = true;
 
     dict_cls->giveAttr("__len__", new BoxedFunction(boxRTFunction((void*)dictLen, BOXED_INT, 1)));
-    dict_cls->giveAttr("__new__", new BoxedFunction(boxRTFunction((void*)dictNew, UNKNOWN, 1, 0, true, true)));
-    dict_cls->giveAttr("__init__", new BoxedFunction(boxRTFunction((void*)dictInit, NONE, 1, 0, true, true)));
+    dict_cls->giveAttr("__new__", new BoxedFunction(boxRTFunction((void*)dictNew, UNKNOWN, 1, true, true)));
+    dict_cls->giveAttr("__init__", new BoxedFunction(boxRTFunction((void*)dictInit, NONE, 1, true, true)));
     dict_cls->giveAttr("__repr__", new BoxedFunction(boxRTFunction((void*)dictRepr, STR, 1)));
 
     dict_cls->giveAttr("__eq__", new BoxedFunction(boxRTFunction((void*)dictEq, UNKNOWN, 2)));
@@ -799,7 +799,7 @@ void setupDict() {
     dict_cls->giveAttr("__iter__",
                        new BoxedFunction(boxRTFunction((void*)dictIterKeys, typeFromClass(dict_iterator_cls), 1)));
 
-    dict_cls->giveAttr("update", new BoxedFunction(boxRTFunction((void*)dictUpdate, NONE, 1, 0, true, true)));
+    dict_cls->giveAttr("update", new BoxedFunction(boxRTFunction((void*)dictUpdate, NONE, 1, true, true)));
 
     dict_cls->giveAttr("clear", new BoxedFunction(boxRTFunction((void*)dictClear, NONE, 1)));
     dict_cls->giveAttr("copy", new BoxedFunction(boxRTFunction((void*)dictCopy, DICT, 1)));
@@ -816,20 +816,20 @@ void setupDict() {
     dict_cls->giveAttr("keys", new BoxedFunction(boxRTFunction((void*)dictKeys, LIST, 1)));
     dict_cls->giveAttr("iterkeys", dict_cls->getattr(internStringMortal("__iter__")));
 
-    dict_cls->giveAttr("pop", new BoxedFunction(boxRTFunction((void*)dictPop, UNKNOWN, 3, 1, false, false), { NULL }));
+    dict_cls->giveAttr("pop", new BoxedFunction(boxRTFunction((void*)dictPop, UNKNOWN, 3, false, false), { NULL }));
     dict_cls->giveAttr("popitem", new BoxedFunction(boxRTFunction((void*)dictPopitem, BOXED_TUPLE, 1)));
 
-    auto* fromkeys_func = new BoxedFunction(boxRTFunction((void*)dictFromkeys, DICT, 3, 1, false, false), { None });
+    auto* fromkeys_func = new BoxedFunction(boxRTFunction((void*)dictFromkeys, DICT, 3, false, false), { None });
     dict_cls->giveAttr("fromkeys", boxInstanceMethod(dict_cls, fromkeys_func, dict_cls));
 
     dict_cls->giveAttr("viewkeys", new BoxedFunction(boxRTFunction((void*)dictViewKeys, UNKNOWN, 1)));
     dict_cls->giveAttr("viewvalues", new BoxedFunction(boxRTFunction((void*)dictViewValues, UNKNOWN, 1)));
     dict_cls->giveAttr("viewitems", new BoxedFunction(boxRTFunction((void*)dictViewItems, UNKNOWN, 1)));
 
-    dict_cls->giveAttr("get", new BoxedFunction(boxRTFunction((void*)dictGet, UNKNOWN, 3, 1, false, false), { None }));
+    dict_cls->giveAttr("get", new BoxedFunction(boxRTFunction((void*)dictGet, UNKNOWN, 3, false, false), { None }));
 
     dict_cls->giveAttr("setdefault",
-                       new BoxedFunction(boxRTFunction((void*)dictSetdefault, UNKNOWN, 3, 1, false, false), { None }));
+                       new BoxedFunction(boxRTFunction((void*)dictSetdefault, UNKNOWN, 3, false, false), { None }));
 
     auto dict_getitem = boxRTFunction((void*)dictGetitem<CXX>, UNKNOWN, 2, ParamNames::empty(), CXX);
     addRTFunction(dict_getitem, (void*)dictGetitem<CAPI>, UNKNOWN, CAPI);

--- a/src/runtime/file.cpp
+++ b/src/runtime/file.cpp
@@ -1751,8 +1751,7 @@ void setupFile() {
     file_cls->tp_dealloc = fileDestructor;
     file_cls->has_safe_tp_dealloc = true;
 
-    file_cls->giveAttr("read",
-                       new BoxedFunction(boxRTFunction((void*)fileRead, STR, 2, 1, false, false), { boxInt(-1) }));
+    file_cls->giveAttr("read", new BoxedFunction(boxRTFunction((void*)fileRead, STR, 2, false, false), { boxInt(-1) }));
 
     CLFunction* readline = boxRTFunction((void*)fileReadline1, STR, 1);
     file_cls->giveAttr("readline", new BoxedFunction(readline));
@@ -1779,7 +1778,7 @@ void setupFile() {
     file_cls->giveAttr("mode",
                        new BoxedMemberDescriptor(BoxedMemberDescriptor::OBJECT, offsetof(BoxedFile, f_mode), true));
 
-    file_cls->giveAttr("__new__", new BoxedFunction(boxRTFunction((void*)fileNew, UNKNOWN, 4, 2, false, false),
+    file_cls->giveAttr("__new__", new BoxedFunction(boxRTFunction((void*)fileNew, UNKNOWN, 4, false, false),
                                                     { boxString("r"), boxInt(-1) }));
 
     for (auto& md : file_methods) {

--- a/src/runtime/float.cpp
+++ b/src/runtime/float.cpp
@@ -935,7 +935,7 @@ static void _addFunc(const char* name, ConcreteCompilerType* rtn_type, void* flo
     v_fu.push_back(BOXED_FLOAT);
     v_fu.push_back(UNKNOWN);
 
-    CLFunction* cl = createRTFunction(2, 0, false, false);
+    CLFunction* cl = createRTFunction(2, false, false);
     addRTFunction(cl, float_func, rtn_type, v_ff);
     addRTFunction(cl, int_func, rtn_type, v_fi);
     addRTFunction(cl, boxed_func, UNKNOWN, v_fu);
@@ -948,7 +948,7 @@ static void _addFuncPow(const char* name, ConcreteCompilerType* rtn_type, void* 
     std::vector<ConcreteCompilerType*> v_fiu{ BOXED_FLOAT, BOXED_INT, UNKNOWN };
     std::vector<ConcreteCompilerType*> v_fuu{ BOXED_FLOAT, UNKNOWN, UNKNOWN };
 
-    CLFunction* cl = createRTFunction(3, 1, false, false);
+    CLFunction* cl = createRTFunction(3, false, false);
     addRTFunction(cl, float_func, rtn_type, v_ffu);
     addRTFunction(cl, int_func, rtn_type, v_fiu);
     addRTFunction(cl, boxed_func, UNKNOWN, v_fuu);
@@ -1650,7 +1650,7 @@ void setupFloat() {
     _addFunc("__sub__", BOXED_FLOAT, (void*)floatSubFloat, (void*)floatSubInt, (void*)floatSub);
     _addFunc("__rsub__", BOXED_FLOAT, (void*)floatRSubFloat, (void*)floatRSubInt, (void*)floatRSub);
 
-    auto float_new = boxRTFunction((void*)floatNew<CXX>, UNKNOWN, 2, 1, false, false, ParamNames::empty(), CXX);
+    auto float_new = boxRTFunction((void*)floatNew<CXX>, UNKNOWN, 2, false, false, ParamNames::empty(), CXX);
     addRTFunction(float_new, (void*)floatNew<CAPI>, UNKNOWN, CAPI);
     float_cls->giveAttr("__new__", new BoxedFunction(float_new, { boxFloat(0.0) }));
 

--- a/src/runtime/generator.cpp
+++ b/src/runtime/generator.cpp
@@ -496,7 +496,7 @@ void setupGenerator() {
     generator_cls->giveAttr("__hasnext__", new BoxedFunction(hasnext));
 
     generator_cls->giveAttr("send", new BoxedFunction(boxRTFunction((void*)generatorSend<CXX>, UNKNOWN, 2)));
-    auto gthrow = new BoxedFunction(boxRTFunction((void*)generatorThrow, UNKNOWN, 4, 2, false, false), { NULL, NULL });
+    auto gthrow = new BoxedFunction(boxRTFunction((void*)generatorThrow, UNKNOWN, 4, false, false), { NULL, NULL });
     generator_cls->giveAttr("throw", gthrow);
 
     generator_cls->giveAttr("__name__", new (pyston_getset_cls) BoxedGetsetDescriptor(generatorName, NULL, NULL));

--- a/src/runtime/import.cpp
+++ b/src/runtime/import.cpp
@@ -894,26 +894,25 @@ void setupImport() {
 
     null_importer_cls = BoxedHeapClass::create(type_cls, object_cls, NULL, 0, 0, sizeof(Box), false, "NullImporter");
     null_importer_cls->giveAttr(
-        "__init__", new BoxedFunction(boxRTFunction((void*)nullImporterInit, NONE, 2, 1, false, false), { None }));
-    null_importer_cls->giveAttr(
-        "find_module",
-        new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)nullImporterFindModule, NONE, 2, 1, false, false),
-                                         "find_module", { None }));
+        "__init__", new BoxedFunction(boxRTFunction((void*)nullImporterInit, NONE, 2, false, false), { None }));
+    null_importer_cls->giveAttr("find_module", new BoxedBuiltinFunctionOrMethod(
+                                                   boxRTFunction((void*)nullImporterFindModule, NONE, 2, false, false),
+                                                   "find_module", { None }));
     null_importer_cls->freeze();
     imp_module->giveAttr("NullImporter", null_importer_cls);
 
     CLFunction* find_module_func
-        = boxRTFunction((void*)impFindModule, UNKNOWN, 2, 1, false, false, ParamNames({ "name", "path" }, "", ""));
+        = boxRTFunction((void*)impFindModule, UNKNOWN, 2, false, false, ParamNames({ "name", "path" }, "", ""));
     imp_module->giveAttr("find_module", new BoxedBuiltinFunctionOrMethod(find_module_func, "find_module", { None }));
 
     CLFunction* load_module_func = boxRTFunction((void*)impLoadModule, UNKNOWN, 4,
                                                  ParamNames({ "name", "file", "pathname", "description" }, "", ""));
     imp_module->giveAttr("load_module", new BoxedBuiltinFunctionOrMethod(load_module_func, "load_module"));
-    imp_module->giveAttr(
-        "load_source", new BoxedBuiltinFunctionOrMethod(
-                           boxRTFunction((void*)impLoadSource, UNKNOWN, 3, 1, false, false), "load_source", { NULL }));
+    imp_module->giveAttr("load_source",
+                         new BoxedBuiltinFunctionOrMethod(boxRTFunction((void*)impLoadSource, UNKNOWN, 3, false, false),
+                                                          "load_source", { NULL }));
 
-    CLFunction* load_dynamic_func = boxRTFunction((void*)impLoadDynamic, UNKNOWN, 3, 1, false, false,
+    CLFunction* load_dynamic_func = boxRTFunction((void*)impLoadDynamic, UNKNOWN, 3, false, false,
                                                   ParamNames({ "name", "pathname", "file" }, "", ""));
     imp_module->giveAttr("load_dynamic", new BoxedBuiltinFunctionOrMethod(load_dynamic_func, "load_dynamic", { None }));
 

--- a/src/runtime/inline/xrange.cpp
+++ b/src/runtime/inline/xrange.cpp
@@ -212,7 +212,7 @@ void setupXrange() {
 
     xrange_cls->giveAttr(
         "__new__",
-        new BoxedFunction(boxRTFunction((void*)xrange, typeFromClass(xrange_cls), 4, 2, false, false), { NULL, NULL }));
+        new BoxedFunction(boxRTFunction((void*)xrange, typeFromClass(xrange_cls), 4, false, false), { NULL, NULL }));
     xrange_cls->giveAttr("__iter__",
                          new BoxedFunction(boxRTFunction((void*)xrangeIter, typeFromClass(xrange_iterator_cls), 1)));
     xrange_cls->giveAttr(

--- a/src/runtime/int.cpp
+++ b/src/runtime/int.cpp
@@ -694,7 +694,7 @@ static void _addFuncPow(const char* name, ConcreteCompilerType* rtn_type, void* 
     std::vector<ConcreteCompilerType*> v_ifu{ BOXED_INT, BOXED_FLOAT, UNKNOWN };
     std::vector<ConcreteCompilerType*> v_uuu{ UNKNOWN, UNKNOWN, UNKNOWN };
 
-    CLFunction* cl = createRTFunction(3, 1, false, false);
+    CLFunction* cl = createRTFunction(3, false, false);
     addRTFunction(cl, float_func, UNKNOWN, v_ifu);
     addRTFunction(cl, int_func, UNKNOWN, v_uuu);
     int_cls->giveAttr(name, new BoxedFunction(cl, { None }));
@@ -1134,7 +1134,7 @@ static void _addFuncIntFloatUnknown(const char* name, void* int_func, void* floa
     v_iu.push_back(UNKNOWN);
     v_iu.push_back(UNKNOWN);
 
-    CLFunction* cl = createRTFunction(2, 0, false, false);
+    CLFunction* cl = createRTFunction(2, false, false);
     addRTFunction(cl, int_func, UNKNOWN, v_ii);
     addRTFunction(cl, float_func, BOXED_FLOAT, v_if);
     addRTFunction(cl, boxed_func, UNKNOWN, v_iu);
@@ -1149,7 +1149,7 @@ static void _addFuncIntUnknown(const char* name, ConcreteCompilerType* rtn_type,
     v_iu.push_back(UNKNOWN);
     v_iu.push_back(UNKNOWN);
 
-    CLFunction* cl = createRTFunction(2, 0, false, false);
+    CLFunction* cl = createRTFunction(2, false, false);
     addRTFunction(cl, int_func, rtn_type, v_ii);
     addRTFunction(cl, boxed_func, UNKNOWN, v_iu);
     int_cls->giveAttr(name, new BoxedFunction(cl));
@@ -1246,7 +1246,7 @@ void setupInt() {
     int_cls->giveAttr("__int__", new BoxedFunction(boxRTFunction((void*)intInt, BOXED_INT, 1)));
 
     auto int_new
-        = boxRTFunction((void*)intNew<CXX>, UNKNOWN, 3, 2, false, false, ParamNames({ "", "x", "base" }, "", ""), CXX);
+        = boxRTFunction((void*)intNew<CXX>, UNKNOWN, 3, false, false, ParamNames({ "", "x", "base" }, "", ""), CXX);
     addRTFunction(int_new, (void*)intNew<CAPI>, UNKNOWN, CAPI);
     int_cls->giveAttr("__new__", new BoxedFunction(int_new, { boxInt(0), NULL }));
 

--- a/src/runtime/list.cpp
+++ b/src/runtime/list.cpp
@@ -1205,7 +1205,7 @@ void setupList() {
 
     list_cls->giveAttr("__len__", new BoxedFunction(boxRTFunction((void*)listLen, BOXED_INT, 1)));
 
-    CLFunction* getitem = createRTFunction(2, 0, false, false);
+    CLFunction* getitem = createRTFunction(2, false, false);
     addRTFunction(getitem, (void*)listGetitemInt, UNKNOWN, std::vector<ConcreteCompilerType*>{ LIST, BOXED_INT });
     addRTFunction(getitem, (void*)listGetitemSlice<CXX>, LIST, std::vector<ConcreteCompilerType*>{ LIST, SLICE }, CXX);
     addRTFunction(getitem, (void*)listGetitem<CXX>, UNKNOWN, std::vector<ConcreteCompilerType*>{ UNKNOWN, UNKNOWN },
@@ -1218,7 +1218,7 @@ void setupList() {
 
     list_cls->giveAttr("__getslice__", new BoxedFunction(boxRTFunction((void*)listGetslice, LIST, 3)));
 
-    CLFunction* setitem = createRTFunction(3, 0, false, false);
+    CLFunction* setitem = createRTFunction(3, false, false);
     addRTFunction(setitem, (void*)listSetitemInt, NONE, std::vector<ConcreteCompilerType*>{ LIST, BOXED_INT, UNKNOWN });
     addRTFunction(setitem, (void*)listSetitemSlice, NONE, std::vector<ConcreteCompilerType*>{ LIST, SLICE, UNKNOWN });
     addRTFunction(setitem, (void*)listSetitem, NONE, std::vector<ConcreteCompilerType*>{ UNKNOWN, UNKNOWN, UNKNOWN });
@@ -1226,7 +1226,7 @@ void setupList() {
 
     list_cls->giveAttr("__setslice__", new BoxedFunction(boxRTFunction((void*)listSetslice, NONE, 4)));
 
-    CLFunction* delitem = createRTFunction(2, 0, false, false);
+    CLFunction* delitem = createRTFunction(2, false, false);
     addRTFunction(delitem, (void*)listDelitemInt, NONE, std::vector<ConcreteCompilerType*>{ LIST, BOXED_INT });
     addRTFunction(delitem, (void*)listDelitemSlice, NONE, std::vector<ConcreteCompilerType*>{ LIST, SLICE });
     addRTFunction(delitem, (void*)listDelitem, NONE, std::vector<ConcreteCompilerType*>{ UNKNOWN, UNKNOWN });
@@ -1250,7 +1250,7 @@ void setupList() {
     list_cls->giveAttr("__repr__", new BoxedFunction(boxRTFunction((void*)listRepr, STR, 1)));
     list_cls->giveAttr("__nonzero__", new BoxedFunction(boxRTFunction((void*)listNonzero, BOXED_BOOL, 1)));
 
-    list_cls->giveAttr("pop", new BoxedFunction(boxRTFunction((void*)listPop, UNKNOWN, 2, 1, false, false), { None }));
+    list_cls->giveAttr("pop", new BoxedFunction(boxRTFunction((void*)listPop, UNKNOWN, 2, false, false), { None }));
 
     list_cls->giveAttr("append", new BoxedFunction(boxRTFunction((void*)listAppend, NONE, 2)));
     list_cls->giveAttr("extend", new BoxedFunction(boxRTFunction((void*)listIAdd, UNKNOWN, 2)));
@@ -1263,19 +1263,18 @@ void setupList() {
     list_cls->giveAttr("__iadd__", new BoxedFunction(boxRTFunction((void*)listIAdd, UNKNOWN, 2)));
     list_cls->giveAttr("__add__", new BoxedFunction(boxRTFunction((void*)listAdd, UNKNOWN, 2)));
 
-    list_cls->giveAttr("sort", new BoxedFunction(boxRTFunction((void*)listSortFunc, NONE, 4, 3, false, false,
+    list_cls->giveAttr("sort", new BoxedFunction(boxRTFunction((void*)listSortFunc, NONE, 4, false, false,
                                                                ParamNames({ "", "cmp", "key", "reverse" }, "", "")),
                                                  { None, None, False }));
     list_cls->giveAttr("__contains__", new BoxedFunction(boxRTFunction((void*)listContains, BOXED_BOOL, 2)));
 
-    list_cls->giveAttr("__new__",
-                       new BoxedFunction(boxRTFunction((void*)listNew, UNKNOWN, 2, 1, false, false), { None }));
+    list_cls->giveAttr("__new__", new BoxedFunction(boxRTFunction((void*)listNew, UNKNOWN, 2, false, false), { None }));
     list_cls->giveAttr("__init__",
-                       new BoxedFunction(boxRTFunction((void*)listInit, UNKNOWN, 2, 1, false, false), { NULL }));
+                       new BoxedFunction(boxRTFunction((void*)listInit, UNKNOWN, 2, false, false), { NULL }));
 
     list_cls->giveAttr("count", new BoxedFunction(boxRTFunction((void*)listCount, BOXED_INT, 2)));
-    list_cls->giveAttr(
-        "index", new BoxedFunction(boxRTFunction((void*)listIndex, BOXED_INT, 4, 2, false, false), { NULL, NULL }));
+    list_cls->giveAttr("index",
+                       new BoxedFunction(boxRTFunction((void*)listIndex, BOXED_INT, 4, false, false), { NULL, NULL }));
     list_cls->giveAttr("remove", new BoxedFunction(boxRTFunction((void*)listRemove, NONE, 2)));
     list_cls->giveAttr("reverse", new BoxedFunction(boxRTFunction((void*)listReverse, NONE, 1)));
 

--- a/src/runtime/long.cpp
+++ b/src/runtime/long.cpp
@@ -1229,7 +1229,7 @@ static void _addFuncPow(const char* name, ConcreteCompilerType* rtn_type, void* 
     std::vector<ConcreteCompilerType*> v_lfu{ UNKNOWN, BOXED_FLOAT, UNKNOWN };
     std::vector<ConcreteCompilerType*> v_uuu{ UNKNOWN, UNKNOWN, UNKNOWN };
 
-    CLFunction* cl = createRTFunction(3, 1, false, false);
+    CLFunction* cl = createRTFunction(3, false, false);
     addRTFunction(cl, float_func, UNKNOWN, v_lfu);
     addRTFunction(cl, long_func, UNKNOWN, v_uuu);
     long_cls->giveAttr(name, new BoxedFunction(cl, { None }));
@@ -1453,8 +1453,8 @@ void setupLong() {
     mp_set_memory_functions(customised_allocation, customised_realloc, customised_free);
 
     _addFuncPow("__pow__", UNKNOWN, (void*)longPowFloat, (void*)longPow);
-    long_cls->giveAttr(
-        "__new__", new BoxedFunction(boxRTFunction((void*)longNew, UNKNOWN, 3, 2, false, false), { boxInt(0), NULL }));
+    long_cls->giveAttr("__new__",
+                       new BoxedFunction(boxRTFunction((void*)longNew, UNKNOWN, 3, false, false), { boxInt(0), NULL }));
 
     long_cls->giveAttr("__mul__", new BoxedFunction(boxRTFunction((void*)longMul, UNKNOWN, 2)));
     long_cls->giveAttr("__rmul__", long_cls->getattr(internStringMortal("__mul__")));

--- a/src/runtime/set.cpp
+++ b/src/runtime/set.cpp
@@ -577,12 +577,10 @@ void setupSet() {
     set_iterator_cls->freeze();
     set_iterator_cls->tp_iternext = setiter_next;
 
-    set_cls->giveAttr("__new__",
-                      new BoxedFunction(boxRTFunction((void*)setNew, UNKNOWN, 2, 1, false, false), { NULL }));
-    set_cls->giveAttr("__init__",
-                      new BoxedFunction(boxRTFunction((void*)setInit, UNKNOWN, 2, 1, false, false), { NULL }));
-    frozenset_cls->giveAttr(
-        "__new__", new BoxedFunction(boxRTFunction((void*)frozensetNew, UNKNOWN, 2, 1, false, false), { NULL }));
+    set_cls->giveAttr("__new__", new BoxedFunction(boxRTFunction((void*)setNew, UNKNOWN, 2, false, false), { NULL }));
+    set_cls->giveAttr("__init__", new BoxedFunction(boxRTFunction((void*)setInit, UNKNOWN, 2, false, false), { NULL }));
+    frozenset_cls->giveAttr("__new__",
+                            new BoxedFunction(boxRTFunction((void*)frozensetNew, UNKNOWN, 2, false, false), { NULL }));
 
     Box* set_repr = new BoxedFunction(boxRTFunction((void*)setRepr, STR, 1));
     set_cls->giveAttr("__repr__", set_repr);
@@ -606,7 +604,7 @@ void setupSet() {
     v_fu.push_back(UNKNOWN);
 
     auto add = [&](const char* name, void* func) {
-        CLFunction* func_obj = createRTFunction(2, 0, false, false);
+        CLFunction* func_obj = createRTFunction(2, false, false);
         addRTFunction(func_obj, (void*)func, SET, v_ss);
         addRTFunction(func_obj, (void*)func, SET, v_sf);
         addRTFunction(func_obj, (void*)func, FROZENSET, v_fs);
@@ -645,19 +643,19 @@ void setupSet() {
     set_cls->giveAttr("discard", new BoxedFunction(boxRTFunction((void*)setDiscard, NONE, 2)));
 
     set_cls->giveAttr("clear", new BoxedFunction(boxRTFunction((void*)setClear, NONE, 1)));
-    set_cls->giveAttr("update", new BoxedFunction(boxRTFunction((void*)setUpdate, NONE, 1, 0, true, false)));
-    set_cls->giveAttr("union", new BoxedFunction(boxRTFunction((void*)setUnion, UNKNOWN, 1, 0, true, false)));
+    set_cls->giveAttr("update", new BoxedFunction(boxRTFunction((void*)setUpdate, NONE, 1, true, false)));
+    set_cls->giveAttr("union", new BoxedFunction(boxRTFunction((void*)setUnion, UNKNOWN, 1, true, false)));
     frozenset_cls->giveAttr("union", set_cls->getattr(internStringMortal("union")));
     set_cls->giveAttr("intersection",
-                      new BoxedFunction(boxRTFunction((void*)setIntersection, UNKNOWN, 1, 0, true, false)));
+                      new BoxedFunction(boxRTFunction((void*)setIntersection, UNKNOWN, 1, true, false)));
     frozenset_cls->giveAttr("intersection", set_cls->getattr(internStringMortal("intersection")));
     set_cls->giveAttr("intersection_update",
-                      new BoxedFunction(boxRTFunction((void*)setIntersectionUpdate, UNKNOWN, 1, 0, true, false)));
+                      new BoxedFunction(boxRTFunction((void*)setIntersectionUpdate, UNKNOWN, 1, true, false)));
     frozenset_cls->giveAttr("intersection_update", set_cls->getattr(internStringMortal("intersection_update")));
-    set_cls->giveAttr("difference", new BoxedFunction(boxRTFunction((void*)setDifference, UNKNOWN, 1, 0, true, false)));
+    set_cls->giveAttr("difference", new BoxedFunction(boxRTFunction((void*)setDifference, UNKNOWN, 1, true, false)));
     frozenset_cls->giveAttr("difference", set_cls->getattr(internStringMortal("difference")));
     set_cls->giveAttr("difference_update",
-                      new BoxedFunction(boxRTFunction((void*)setDifferenceUpdate, UNKNOWN, 1, 0, true, false)));
+                      new BoxedFunction(boxRTFunction((void*)setDifferenceUpdate, UNKNOWN, 1, true, false)));
     set_cls->giveAttr("issubset", new BoxedFunction(boxRTFunction((void*)setIssubset, UNKNOWN, 2)));
     frozenset_cls->giveAttr("issubset", set_cls->getattr(internStringMortal("issubset")));
     set_cls->giveAttr("issuperset", new BoxedFunction(boxRTFunction((void*)setIssuperset, UNKNOWN, 2)));

--- a/src/runtime/str.cpp
+++ b/src/runtime/str.cpp
@@ -2841,39 +2841,34 @@ void setupStr() {
     str_cls->giveAttr("istitle", new BoxedFunction(boxRTFunction((void*)strIsTitle, BOXED_BOOL, 1)));
     str_cls->giveAttr("isupper", new BoxedFunction(boxRTFunction((void*)strIsUpper, BOXED_BOOL, 1)));
 
-    str_cls->giveAttr("decode",
-                      new BoxedFunction(boxRTFunction((void*)strDecode, UNKNOWN, 3, 2, false, false), { 0, 0 }));
-    str_cls->giveAttr("encode",
-                      new BoxedFunction(boxRTFunction((void*)strEncode, UNKNOWN, 3, 2, false, false), { 0, 0 }));
+    str_cls->giveAttr("decode", new BoxedFunction(boxRTFunction((void*)strDecode, UNKNOWN, 3, false, false), { 0, 0 }));
+    str_cls->giveAttr("encode", new BoxedFunction(boxRTFunction((void*)strEncode, UNKNOWN, 3, false, false), { 0, 0 }));
 
     str_cls->giveAttr("lower", new BoxedFunction(boxRTFunction((void*)strLower, STR, 1)));
     str_cls->giveAttr("swapcase", new BoxedFunction(boxRTFunction((void*)strSwapcase, STR, 1)));
     str_cls->giveAttr("upper", new BoxedFunction(boxRTFunction((void*)strUpper, STR, 1)));
 
-    str_cls->giveAttr("strip",
-                      new BoxedFunction(boxRTFunction((void*)strStrip, UNKNOWN, 2, 1, false, false), { None }));
-    str_cls->giveAttr("lstrip",
-                      new BoxedFunction(boxRTFunction((void*)strLStrip, UNKNOWN, 2, 1, false, false), { None }));
-    str_cls->giveAttr("rstrip",
-                      new BoxedFunction(boxRTFunction((void*)strRStrip, UNKNOWN, 2, 1, false, false), { None }));
+    str_cls->giveAttr("strip", new BoxedFunction(boxRTFunction((void*)strStrip, UNKNOWN, 2, false, false), { None }));
+    str_cls->giveAttr("lstrip", new BoxedFunction(boxRTFunction((void*)strLStrip, UNKNOWN, 2, false, false), { None }));
+    str_cls->giveAttr("rstrip", new BoxedFunction(boxRTFunction((void*)strRStrip, UNKNOWN, 2, false, false), { None }));
 
     str_cls->giveAttr("capitalize", new BoxedFunction(boxRTFunction((void*)strCapitalize, STR, 1)));
     str_cls->giveAttr("title", new BoxedFunction(boxRTFunction((void*)strTitle, STR, 1)));
 
     str_cls->giveAttr("translate",
-                      new BoxedFunction(boxRTFunction((void*)strTranslate, STR, 3, 1, false, false), { NULL }));
+                      new BoxedFunction(boxRTFunction((void*)strTranslate, STR, 3, false, false), { NULL }));
 
     str_cls->giveAttr("__contains__", new BoxedFunction(boxRTFunction((void*)strContains, BOXED_BOOL, 2)));
 
     str_cls->giveAttr("startswith",
-                      new BoxedFunction(boxRTFunction((void*)strStartswith, BOXED_BOOL, 4, 2, 0, 0), { NULL, NULL }));
+                      new BoxedFunction(boxRTFunction((void*)strStartswith, BOXED_BOOL, 4, 0, 0), { NULL, NULL }));
     str_cls->giveAttr("endswith",
-                      new BoxedFunction(boxRTFunction((void*)strEndswith, BOXED_BOOL, 4, 2, 0, 0), { NULL, NULL }));
+                      new BoxedFunction(boxRTFunction((void*)strEndswith, BOXED_BOOL, 4, 0, 0), { NULL, NULL }));
 
     str_cls->giveAttr("partition", new BoxedFunction(boxRTFunction((void*)strPartition, UNKNOWN, 2)));
     str_cls->giveAttr("rpartition", new BoxedFunction(boxRTFunction((void*)strRpartition, UNKNOWN, 2)));
 
-    str_cls->giveAttr("format", new BoxedFunction(boxRTFunction((void*)strFormat, UNKNOWN, 1, 0, true, true)));
+    str_cls->giveAttr("format", new BoxedFunction(boxRTFunction((void*)strFormat, UNKNOWN, 1, true, true)));
 
     str_cls->giveAttr("__add__", new BoxedFunction(boxRTFunction((void*)strAdd, UNKNOWN, 2)));
     str_cls->giveAttr("__mod__", new BoxedFunction(boxRTFunction((void*)strMod, UNKNOWN, 2)));
@@ -2886,11 +2881,11 @@ void setupStr() {
     BoxedString* spaceChar = characters[' ' & UCHAR_MAX];
     assert(spaceChar);
     str_cls->giveAttr("ljust",
-                      new BoxedFunction(boxRTFunction((void*)strLjust, UNKNOWN, 3, 1, false, false), { spaceChar }));
+                      new BoxedFunction(boxRTFunction((void*)strLjust, UNKNOWN, 3, false, false), { spaceChar }));
     str_cls->giveAttr("rjust",
-                      new BoxedFunction(boxRTFunction((void*)strRjust, UNKNOWN, 3, 1, false, false), { spaceChar }));
+                      new BoxedFunction(boxRTFunction((void*)strRjust, UNKNOWN, 3, false, false), { spaceChar }));
     str_cls->giveAttr("center",
-                      new BoxedFunction(boxRTFunction((void*)strCenter, UNKNOWN, 3, 1, false, false), { spaceChar }));
+                      new BoxedFunction(boxRTFunction((void*)strCenter, UNKNOWN, 3, false, false), { spaceChar }));
 
     auto str_getitem = boxRTFunction((void*)strGetitem<CXX>, STR, 2, ParamNames::empty(), CXX);
     addRTFunction(str_getitem, (void*)strGetitem<CAPI>, STR, CAPI);
@@ -2901,14 +2896,14 @@ void setupStr() {
     str_cls->giveAttr("__iter__", new BoxedFunction(boxRTFunction((void*)strIter, typeFromClass(str_iterator_cls), 1)));
 
     str_cls->giveAttr("replace",
-                      new BoxedFunction(boxRTFunction((void*)strReplace, UNKNOWN, 4, 1, false, false), { boxInt(-1) }));
+                      new BoxedFunction(boxRTFunction((void*)strReplace, UNKNOWN, 4, false, false), { boxInt(-1) }));
 
     for (auto& md : string_methods) {
         str_cls->giveAttr(md.ml_name, new BoxedMethodDescriptor(&md, str_cls));
     }
 
     str_cls->giveAttr("__new__",
-                      new BoxedFunction(boxRTFunction((void*)strNew, UNKNOWN, 2, 1, false, false), { EmptyString }));
+                      new BoxedFunction(boxRTFunction((void*)strNew, UNKNOWN, 2, false, false), { EmptyString }));
 
     add_operators(str_cls);
     str_cls->freeze();
@@ -2923,8 +2918,7 @@ void setupStr() {
 
     basestring_cls->giveAttr("__doc__",
                              boxString("Type basestring cannot be instantiated; it is the base for str and unicode."));
-    basestring_cls->giveAttr("__new__",
-                             new BoxedFunction(boxRTFunction((void*)basestringNew, UNKNOWN, 1, 0, true, true)));
+    basestring_cls->giveAttr("__new__", new BoxedFunction(boxRTFunction((void*)basestringNew, UNKNOWN, 1, true, true)));
     basestring_cls->freeze();
 }
 

--- a/src/runtime/super.cpp
+++ b/src/runtime/super.cpp
@@ -204,7 +204,7 @@ void setupSuper() {
     super_cls->giveAttr("__repr__", new BoxedFunction(boxRTFunction((void*)superRepr, STR, 1)));
 
     super_cls->giveAttr("__init__",
-                        new BoxedFunction(boxRTFunction((void*)superInit, UNKNOWN, 3, 1, false, false), { NULL }));
+                        new BoxedFunction(boxRTFunction((void*)superInit, UNKNOWN, 3, false, false), { NULL }));
 
     super_cls->giveAttr("__thisclass__",
                         new BoxedMemberDescriptor(BoxedMemberDescriptor::OBJECT, offsetof(BoxedSuper, type)));

--- a/src/runtime/tuple.cpp
+++ b/src/runtime/tuple.cpp
@@ -577,8 +577,8 @@ void setupTuple() {
     tuple_iterator_cls = BoxedHeapClass::create(type_cls, object_cls, &BoxedTupleIterator::gcHandler, 0, 0,
                                                 sizeof(BoxedTupleIterator), false, "tuple");
 
-    tuple_cls->giveAttr("__new__", new BoxedFunction(boxRTFunction((void*)tupleNew, UNKNOWN, 1, 0, true, true)));
-    CLFunction* getitem = createRTFunction(2, 0, 0, 0);
+    tuple_cls->giveAttr("__new__", new BoxedFunction(boxRTFunction((void*)tupleNew, UNKNOWN, 1, true, true)));
+    CLFunction* getitem = createRTFunction(2, 0, 0);
     addRTFunction(getitem, (void*)tupleGetitemInt, UNKNOWN, std::vector<ConcreteCompilerType*>{ UNKNOWN, BOXED_INT });
     addRTFunction(getitem, (void*)tupleGetitemSlice, UNKNOWN, std::vector<ConcreteCompilerType*>{ UNKNOWN, SLICE });
     addRTFunction(getitem, (void*)tupleGetitem<CXX>, UNKNOWN, std::vector<ConcreteCompilerType*>{ UNKNOWN, UNKNOWN },
@@ -588,7 +588,7 @@ void setupTuple() {
     tuple_cls->giveAttr("__getitem__", new BoxedFunction(getitem));
 
     tuple_cls->giveAttr("__contains__", new BoxedFunction(boxRTFunction((void*)tupleContains, BOXED_BOOL, 2)));
-    tuple_cls->giveAttr("index", new BoxedFunction(boxRTFunction((void*)tupleIndex, BOXED_INT, 4, 2, false, false),
+    tuple_cls->giveAttr("index", new BoxedFunction(boxRTFunction((void*)tupleIndex, BOXED_INT, 4, false, false),
                                                    { boxInt(0), boxInt(std::numeric_limits<Py_ssize_t>::max()) }));
     tuple_cls->giveAttr("count", new BoxedFunction(boxRTFunction((void*)tupleCount, BOXED_INT, 2)));
 

--- a/src/runtime/types.h
+++ b/src/runtime/types.h
@@ -762,8 +762,8 @@ public:
     BoxedClosure* closure;
     Box* globals;
 
-    int ndefaults;
-    GCdArray* defaults;
+    BoxedTuple* defaults;
+    bool can_change_defaults;
 
     ICInvalidator dependent_ics;
 
@@ -774,7 +774,11 @@ public:
 
     BoxedFunctionBase(CLFunction* f);
     BoxedFunctionBase(CLFunction* f, std::initializer_list<Box*> defaults, BoxedClosure* closure = NULL,
-                      Box* globals = NULL);
+                      Box* globals = NULL, bool can_change_defaults = false);
+
+    ParamReceiveSpec getParamspec() {
+        return ParamReceiveSpec(f->num_args, defaults ? defaults->size() : 0, f->takes_varargs, f->takes_kwargs);
+    }
 };
 
 class BoxedFunction : public BoxedFunctionBase {
@@ -783,7 +787,7 @@ public:
 
     BoxedFunction(CLFunction* f);
     BoxedFunction(CLFunction* f, std::initializer_list<Box*> defaults, BoxedClosure* closure = NULL,
-                  Box* globals = NULL);
+                  Box* globals = NULL, bool can_change_defaults = false);
 
     DEFAULT_CLASS(function_cls);
 

--- a/test/tests/binops_subclass.py
+++ b/test/tests/binops_subclass.py
@@ -39,3 +39,13 @@ add(A(), B())
 add(A(), C())
 add(B(), B())
 add(B(), C())
+
+
+class Int(int):
+    def __add__(self, rhs):
+        print "Int.__add__", rhs
+        return int.__add__(self, rhs)
+    def __radd__(self, rhs):
+        print "Int.__radd__", rhs
+        return int.__radd__(self, rhs)
+print sum([Int(2)])

--- a/test/tests/defaults_changing.py
+++ b/test/tests/defaults_changing.py
@@ -1,0 +1,59 @@
+
+def func(a, b=1):
+    print a, b
+func(0)
+
+print func.func_defaults, func.__defaults__
+
+try:
+    func.func_defaults = [2]
+except TypeError as e:
+    print e
+
+print
+print "Changing the default value"
+func.func_defaults = (2,)
+func(0)
+
+print
+print "Clearing the default"
+func.func_defaults = ()
+try:
+    func(0)
+except TypeError as e:
+    print e
+
+func.__defaults__ = (1, 2)
+func()
+
+del func.__defaults__
+print "after del:", func.__defaults__
+try:
+    func(0)
+except TypeError as e:
+    print e
+
+# You can specify more defaults than arguments:
+func.func_defaults = (1, 2, 3, 4, 5)
+print "after extra defaults:", func.__defaults__
+func()
+
+func.func_defaults = None
+print "after setting to None:", func.__defaults__
+try:
+    func(0)
+except TypeError as e:
+    print e
+
+
+# Test setting it to a subclass of tuple:
+def f(a):
+    print a
+class MyTuple(tuple):
+    def __getitem__(self, idx):
+        print idx
+        return 1
+
+f.func_defaults = MyTuple((1, 2))
+print type(f.__defaults__)
+f()

--- a/test/tests/defaults_test.py
+++ b/test/tests/defaults_test.py
@@ -1,6 +1,3 @@
-# expected: fail
-# - with statements
-
 # Test for various defaults arguments in builtin functions:
 
 class ExpectationFailedException(Exception):
@@ -35,15 +32,6 @@ with expected_exception(KeyError):
 
 print min([1])
 print min([1], None)
-
-class Int(int):
-    def __add__(self, rhs):
-        print "Int.__add__", rhs
-        return int.__add__(self, rhs)
-    def __radd__(self, rhs):
-        print "Int.__radd__", rhs
-        return int.__radd__(self, rhs)
-print sum([Int(2)])
 
 with expected_exception(AttributeError):
     print getattr(object(), "")

--- a/test/unittests/analysis.cpp
+++ b/test/unittests/analysis.cpp
@@ -72,7 +72,7 @@ void doOsrTest(bool is_osr, bool i_maybe_undefined) {
     ScopeInfo* scope_info = scoping->getScopeInfoForNode(func);
     std::unique_ptr<SourceInfo> si(new SourceInfo(createModule(boxString("osr" + std::to_string((is_osr << 1) + i_maybe_undefined)),
                     fn.c_str()), scoping, future_flags, func, func->body, boxString(fn)));
-    CLFunction* clfunc = new CLFunction(0, 0, false, false, std::move(si));
+    CLFunction* clfunc = new CLFunction(0, false, false, std::move(si));
 
     CFG* cfg = computeCFG(clfunc->source.get(), func->body);
     std::unique_ptr<LivenessAnalysis> liveness = computeLivenessInfo(cfg);


### PR DESCRIPTION
We already supported changing the values, but not the number
of them.  The main trickiness here is
- We had been assuming that the number of defaults was immutable,
  so I had to find the places that we used it and add invalidation.
- We assumed that all functions based on the same source function would
  have the same number of defaults.

For the second part, I moved "num_defaults" from the CLFunction (our "code" object)
to the BoxedFunction (our "function" object), and then changed the users to pull
it from there.

Most of the changes here are a refactoring to remove the "num_defaults" argument to `boxRTFunction`.