### PR TITLE
__new__ is supposed to become a staticmethod

### DIFF
--- a/src/runtime/descr.cpp
+++ b/src/runtime/descr.cpp
@@ -673,6 +673,10 @@ void BoxedWrapperObject::gcHandler(GCVisitor* v, Box* _o) {
     v->visit(&o->obj);
 }
 
+extern "C" PyObject* PyStaticMethod_New(PyObject* callable) noexcept {
+    return new BoxedStaticmethod(callable);
+}
+
 void setupDescr() {
     member_descriptor_cls->giveAttr("__get__", new BoxedFunction(boxRTFunction((void*)memberGet, UNKNOWN, 3)));
     member_descriptor_cls->freeze();

--- a/test/tests/defaults_changing.py
+++ b/test/tests/defaults_changing.py
@@ -57,3 +57,17 @@ class MyTuple(tuple):
 f.func_defaults = MyTuple((1, 2))
 print type(f.__defaults__)
 f()
+
+
+class C(object):
+    def __new__(cls, arg):
+        print arg
+        return object.__new__(cls)
+
+    def foo(self, arg):
+        print arg
+
+print type(C.__new__), type(C.__dict__['__new__'])
+
+C.__new__.__defaults__ = (1,)
+print type(C())


### PR DESCRIPTION
This seems to not matter very much, but it means that
Cls.__new__ is a the original function, instead of an
unbound instance method.