### PR TITLE
Get more of the sqlalchemy tests working

### DIFF
--- a/src/core/from_llvm/DenseMap.h
+++ b/src/core/from_llvm/DenseMap.h
@@ -600,6 +600,14 @@ public:
     this->insert(I, E);
   }
 
+  // Pyston addition:
+  // Frees all dynamically-allocated memory, but leaves the DenseMap in a valid state.
+  void freeAllMemory() {
+    this->destroyAll();
+    operator delete(Buckets);
+    init(0);
+  }
+
   ~DenseMap() {
     this->destroyAll();
     operator delete(Buckets);

--- a/src/core/from_llvm/DenseSet.h
+++ b/src/core/from_llvm/DenseSet.h
@@ -81,6 +81,12 @@ public:
     TheMap.clear();
   }
 
+  // Pyston addition:
+  // Frees all dynamically-allocated memory, but leaves the DenseSet in a valid state.
+  void freeAllMemory() {
+    TheMap.freeAllMemory();
+  }
+
   /// Return 1 if the specified key is in the set, 0 otherwise.
   size_type count(const ValueT &V) const {
     return TheMap.count(V);

--- a/src/runtime/builtin_modules/thread.cpp
+++ b/src/runtime/builtin_modules/thread.cpp
@@ -161,6 +161,7 @@ public:
             PyThread_release_lock(self->lock_lock);
 
             PyThread_free_lock(self->lock_lock);
+            self->lock_lock = NULL;
         }
     }
 

--- a/src/runtime/classobj.cpp
+++ b/src/runtime/classobj.cpp
@@ -1055,13 +1055,15 @@ static PyObject* instance_index(PyObject* self) noexcept {
     return res;
 }
 
-static void instance_dealloc(Box* _inst) {
+static void instance_dealloc(Box* _inst) noexcept {
     RELEASE_ASSERT(_inst->cls == instance_cls, "");
     BoxedInstance* inst = static_cast<BoxedInstance*>(_inst);
 
     // Note that trying to call __del__ as a finalizer does not fallback to
     // __getattr__ unlike other attributes (like __index__). This is CPython's behavior.
     static BoxedString* del_str = internStringImmortal("__del__");
+
+    // TODO: any exceptions here should get caught + printed, instead of causing a std::terminate:
     Box* func = instanceGetattributeSimple(inst, del_str);
     if (func)
         runtimeCall(func, ArgPassSpec(0), NULL, NULL, NULL, NULL, NULL);

--- a/src/runtime/dict.cpp
+++ b/src/runtime/dict.cpp
@@ -771,7 +771,7 @@ static Box* dict_repr(PyObject* self) noexcept {
 
 void BoxedDict::dealloc(Box* b) noexcept {
     assert(PyDict_Check(b));
-    static_cast<BoxedDict*>(b)->d.~DictMap();
+    static_cast<BoxedDict*>(b)->d.freeAllMemory();
 }
 
 void setupDict() {

--- a/src/runtime/set.cpp
+++ b/src/runtime/set.cpp
@@ -587,7 +587,7 @@ extern "C" PyObject* PyFrozenSet_New(PyObject* iterable) noexcept {
 
 void BoxedSet::dealloc(Box* b) noexcept {
     assert(PyAnySet_Check(b));
-    static_cast<BoxedSet*>(b)->s.~Set();
+    static_cast<BoxedSet*>(b)->s.freeAllMemory();
 }
 
 using namespace pyston::set;

--- a/src/runtime/types.cpp
+++ b/src/runtime/types.cpp
@@ -1770,8 +1770,9 @@ extern "C" Box* sliceNew(Box* cls, Box* start, Box* stop, Box** args) {
 }
 
 static Box* instancemethodCall(BoxedInstanceMethod* self, Box* args, Box* kwargs) {
-    RELEASE_ASSERT(self->cls == instancemethod_cls, "");
-    Py_FatalError("unimplemented");
+    // Not the most effficient, but it works:
+    return runtimeCallInternal<CXX>(self, NULL, ArgPassSpec(0, 0, true, true), args, kwargs, NULL, NULL, NULL);
+    // TODO add a tpp_call
 }
 
 Box* instancemethodGet(BoxedInstanceMethod* self, Box* obj, Box* type) {

--- a/test/tests/instance_methods.py
+++ b/test/tests/instance_methods.py
@@ -43,3 +43,5 @@ def f(m):
 
 f(C.foo)
 f(C().foo)
+
+C().foo.__call__()


### PR DESCRIPTION
by expanding our test harness to be closer to how the tests get
run under pytest (which we don't support yet)

Also fix a couple minor things that this turned up.  There is a lot more
to be found here: the new harness supports many more of the sqlalchemy
tests, a number of which aren't working for us.  Also there is some
sort of issue with the current tests that we run, since repeating the tests
multiple times will end up crashing.