### PR TITLE
Some xrange improvments

### DIFF
--- a/from_cpython/Lib/test/test_xrange.py
+++ b/from_cpython/Lib/test/test_xrange.py
@@ -1,4 +1,3 @@
-# expected: fail
 # Python test set -- built-in functions
 
 import test.test_support, unittest


### PR DESCRIPTION
Some xrange improvments that make `test_xrange` pass

**Changes:**
- Implement `__reduce__` and `__repr__`
- Improve the argument check in `xrange`
- Improve the `xrangeiterator`.