### PR TITLE
some improvements in intNew

### DIFF
--- a/test/tests/intmethods.py
+++ b/test/tests/intmethods.py
@@ -164,3 +164,16 @@ print(-max_int / 5)
 print(max_int / 7)
 print(-max_int / 7)
 print(max_int / -7)
+
+try:
+    int(x=10, base=16)
+except TypeError as e:
+    print(e.message)
+
+if sys.version_info >= (2, 7, 6):
+    try:
+        int(base=16)
+    except TypeError as e:
+        print(e.message)
+else:
+    print("int() missing string argument")


### PR DESCRIPTION
After some investigation of the new added CPython tests. Some of them related to the long constructer. 

eg:
- Need to handle unicode string in `long()`; 
- Get correct error type and error message in long constructor. 
- etc...

When I fix it. I found our int constructor has same issue. So I make some improvements. The `test_long` need some discuss. So I create this PR first.

Changes:

This patch reorganize the error check in `_intNew`, and remove some unnessary or dead code.