### PR TITLE
some long improvements

### DIFF
--- a/test/tests/long.py
+++ b/test/tests/long.py
@@ -122,3 +122,27 @@ a = 2389134823414823408429384238403228392384028439480234823
 print +a
 print +long.__new__(C, 5L)
 print type(+long.__new__(C, 5L))
+
+print((0L).bit_length())
+
+values = ['inf', '-inf', 'nan']
+
+for v in values:
+    try:
+        long(float(v))
+    except Exception as e:
+        print(e.message)
+
+
+class long2(long):
+    pass
+
+# Overflowing int conversion must return long not long subtype.
+x = long2(1L << 100)
+y = int(x)
+print(type(y))
+
+print(long(unicode("-3")))
+
+print(long(x=10))
+print(long(x="10", base=10))


### PR DESCRIPTION
The long constructor is far from complete. It block too many CPython tests. Just fix it along with other issues found in `test_long`. test_cpickle also blocked by it.

All these code are tested and passed in `test_long`. But not enabled `test_long` here. Because `mpz_get_d` use "round to zero", CPython need "round to nearest".