### PR TITLE
Try to fix set-dtor segfault

### DIFF
--- a/src/runtime/set.cpp
+++ b/src/runtime/set.cpp
@@ -664,7 +664,8 @@ done:
 } // namespace set
 
 void BoxedSet::dealloc(Box* b) noexcept {
-    assert(PyAnySet_Check(b));
+    // Unfortunately, this assert requires accessing the type object, which might have been freed already:
+    // assert(PyAnySet_Check(b));
     static_cast<BoxedSet*>(b)->s.freeAllMemory();
 }
 

--- a/src/runtime/types.h
+++ b/src/runtime/types.h
@@ -209,7 +209,7 @@ public:
 
     // A "safe" tp_dealloc destructor/finalizer is one we believe:
     //  1) Can be called at any point after the object is dead.
-    //      (implies it's references could be finalized already)
+    //      (implies it's references could be finalized already, including its class)
     //  2) Won't take a lot of time to run.
     //  3) Won't take up a lot of memory (requiring another GC run).
     //  4) Won't resurrect itself.


### PR DESCRIPTION
The issue is that the set destructor, which is marked as "safe",
will try to access the type object.  But a safe destructor is not
allowed to assume that any objects are alive, including its own class.

We do actually force the class to be alive during a safe destructor,
but the tp_mro field was not so lucky.  We could try to address this by
saying again that types have ordered finalizers, which will cause them
to also keep their references alive.  But this doesn't completely work
since it will cause issues with objects that have actual ordered finalizers.

So for now, just remove type-check from the destructor.