### PR TITLE
Some fix of Ellpisis

### DIFF
--- a/src/codegen/ast_interpreter.cpp
+++ b/src/codegen/ast_interpreter.cpp
@@ -99,6 +99,7 @@ private:
 
     Value visit_attribute(AST_Attribute* node);
     Value visit_dict(AST_Dict* node);
+    Value visit_ellipsis(AST_Ellipsis* node);
     Value visit_expr(AST_expr* node);
     Value visit_expr(AST_Expr* node);
     Value visit_extslice(AST_ExtSlice* node);
@@ -549,7 +550,7 @@ Value ASTInterpreter::visit_slice(AST_slice* node) {
         case AST_TYPE::ExtSlice:
             return visit_extslice(static_cast<AST_ExtSlice*>(node));
         case AST_TYPE::Ellipsis:
-            RELEASE_ASSERT(0, "not implemented");
+            return visit_ellipsis(static_cast<AST_Ellipsis*>(node));
             break;
         case AST_TYPE::Index:
             return visit_index(static_cast<AST_Index*>(node));
@@ -560,7 +561,12 @@ Value ASTInterpreter::visit_slice(AST_slice* node) {
     }
     return Value();
 }
-
+Value ASTInterpreter::visit_ellipsis(AST_Ellipsis* node)
+{
+     Value v;
+     v.o = createEllipsis();
+     return v;
+}
 Value ASTInterpreter::visit_slice(AST_Slice* node) {
     Value lower = node->lower ? visit_expr(node->lower) : getNone();
     Value upper = node->upper ? visit_expr(node->upper) : getNone();

--- a/src/codegen/ast_interpreter.cpp
+++ b/src/codegen/ast_interpreter.cpp
@@ -561,11 +561,10 @@ Value ASTInterpreter::visit_slice(AST_slice* node) {
     }
     return Value();
 }
-Value ASTInterpreter::visit_ellipsis(AST_Ellipsis* node)
-{
-     Value v;
-     v.o = createEllipsis();
-     return v;
+Value ASTInterpreter::visit_ellipsis(AST_Ellipsis* node) {
+    Value v;
+    v.o = createEllipsis();
+    return v;
 }
 Value ASTInterpreter::visit_slice(AST_Slice* node) {
     Value lower = node->lower ? visit_expr(node->lower) : getNone();

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -788,7 +788,8 @@ int binarySearch(T needle, RandomAccessIterator start, RandomAccessIterator end,
     int l = 0;
     int r = end - start - 1;
     while (l <= r) {
-        int mid = l + (r - l) / 2;
+        //prevent overflow while calculating mid value
+        int mid = (l & r) + ((l ^ r) >> 1);;
         auto mid_item = *(start + mid);
         int c = cmp(needle, mid_item);
         if (c < 0)

--- a/src/runtime/builtin_modules/builtins.cpp
+++ b/src/runtime/builtin_modules/builtins.cpp
@@ -1528,7 +1528,6 @@ void setupBuiltins() {
                                    "Built-in functions, exceptions, and other objects.\n\nNoteworthy: None is "
                                    "the `nil' object; Ellipsis represents `...' in slices.");
 
-    BoxedClass* ellipsis_cls = BoxedClass::create(type_cls, object_cls, NULL, 0, 0, sizeof(Box), false, "ellipsis");
     Ellipsis = new (ellipsis_cls) Box();
     assert(Ellipsis->cls);
     gc::registerPermanentRoot(Ellipsis);

--- a/src/runtime/types.cpp
+++ b/src/runtime/types.cpp
@@ -1480,6 +1480,13 @@ void BoxedSlice::gcHandler(GCVisitor* v, Box* b) {
     v->visit(&sl->step);
 }
 
+void BoxedEllipsis::gcHandler(GCVisitor* v, Box* b){
+     assert(b->cls == ellipsis_cls);
+  
+     Box::gcHandler(v, b);
+
+}
+
 static int call_gc_visit(PyObject* val, void* arg) {
     if (val) {
         GCVisitor* v = static_cast<GCVisitor*>(arg);
@@ -1512,7 +1519,7 @@ void BoxedClosure::gcHandler(GCVisitor* v, Box* b) {
 
 extern "C" {
 BoxedClass* object_cls, *type_cls, *none_cls, *bool_cls, *int_cls, *float_cls,
-    * str_cls = NULL, *function_cls, *instancemethod_cls, *list_cls, *slice_cls, *module_cls, *dict_cls, *tuple_cls,
+    * str_cls = NULL, *function_cls, *instancemethod_cls, *list_cls, *ellipsis_cls, *slice_cls, *module_cls, *dict_cls, *tuple_cls,
       *file_cls, *member_descriptor_cls, *closure_cls, *generator_cls, *complex_cls, *basestring_cls, *property_cls,
       *staticmethod_cls, *classmethod_cls, *attrwrapper_cls, *pyston_getset_cls, *capi_getset_cls,
       *builtin_function_or_method_cls, *attrwrapperiter_cls, *set_cls, *frozenset_cls;
@@ -1752,6 +1759,10 @@ extern "C" Box* createSlice(Box* start, Box* stop, Box* step) {
     return rtn;
 }
 
+extern "C" Box* createEllipsis(){
+    BoxedEllipsis* rtn = new BoxedEllipsis();
+    return rtn;
+}
 extern "C" BoxedClosure* createClosure(BoxedClosure* parent_closure, size_t n) {
     if (parent_closure)
         assert(parent_closure->cls == closure_cls);
@@ -1767,6 +1778,11 @@ extern "C" Box* sliceNew(Box* cls, Box* start, Box* stop, Box** args) {
     if (stop == NULL)
         return createSlice(None, start, None);
     return createSlice(start, stop, step);
+}
+
+extern "C" Box* ellipsisNew(Box* cls){
+    RELEASE_ASSERT(cls == ellipsis_cls, "");
+    return createEllipsis();
 }
 
 static Box* instancemethodCall(BoxedInstanceMethod* self, Box* args, Box* kwargs) {
@@ -1879,6 +1895,11 @@ Box* sliceRepr(BoxedSlice* self) {
     BoxedString* stop = static_cast<BoxedString*>(repr(self->stop));
     BoxedString* step = static_cast<BoxedString*>(repr(self->step));
     return boxStringTwine(llvm::Twine("slice(") + start->s() + ", " + stop->s() + ", " + step->s() + ")");
+}
+
+Box* ellipsisRepr(BoxedEllipsis* self)
+{
+    return boxStringTwine(llvm::Twine("Ellipsis"));
 }
 
 Box* sliceHash(BoxedSlice* self) {
@@ -3685,6 +3706,7 @@ void setupRuntime() {
                                             offsetof(BoxedInstanceMethod, in_weakreflist), sizeof(BoxedInstanceMethod),
                                             false, "instancemethod");
 
+    ellipsis_cls = BoxedClass::create(type_cls, object_cls, &BoxedEllipsis::gcHandler, 0, 0, sizeof(BoxedEllipsis), false, "Ellipsis");
     slice_cls
         = BoxedClass::create(type_cls, object_cls, &BoxedSlice::gcHandler, 0, 0, sizeof(BoxedSlice), false, "slice");
     set_cls = BoxedClass::create(type_cls, object_cls, &BoxedSet::gcHandler, 0, offsetof(BoxedSet, weakreflist),
@@ -3855,6 +3877,10 @@ void setupRuntime() {
 
     instancemethod_cls->giveAttr("im_class", new BoxedMemberDescriptor(BoxedMemberDescriptor::OBJECT,
                                                                        offsetof(BoxedInstanceMethod, im_class), true));
+
+    ellipsis_cls->giveAttr("__repr__", new BoxedFunction(boxRTFunction((void*)ellipsisRepr, STR, 1)));
+    //ellipsis_cls->giveAttr("__getitem__", new BoxedFunction(ellipsis_getitem));
+    ellipsis_cls->freeze();
 
     slice_cls->giveAttr("__new__",
                         new BoxedFunction(boxRTFunction((void*)sliceNew, UNKNOWN, 4, false, false), { NULL, None }));

--- a/src/runtime/types.cpp
+++ b/src/runtime/types.cpp
@@ -1490,11 +1490,10 @@ void BoxedSlice::gcHandler(GCVisitor* v, Box* b) {
     v->visit(&sl->step);
 }
 
-void BoxedEllipsis::gcHandler(GCVisitor* v, Box* b){
-     assert(b->cls == ellipsis_cls);
-  
-     Box::gcHandler(v, b);
+void BoxedEllipsis::gcHandler(GCVisitor* v, Box* b) {
+    assert(b->cls == ellipsis_cls);
 
+    Box::gcHandler(v, b);
 }
 
 static int call_gc_visit(PyObject* val, void* arg) {
@@ -1529,9 +1528,9 @@ void BoxedClosure::gcHandler(GCVisitor* v, Box* b) {
 
 extern "C" {
 BoxedClass* object_cls, *type_cls, *none_cls, *bool_cls, *int_cls, *float_cls,
-    * str_cls = NULL, *function_cls, *instancemethod_cls, *list_cls, *ellipsis_cls, *slice_cls, *module_cls, *dict_cls, *tuple_cls,
-      *file_cls, *member_descriptor_cls, *closure_cls, *generator_cls, *complex_cls, *basestring_cls, *property_cls,
-      *staticmethod_cls, *classmethod_cls, *attrwrapper_cls, *pyston_getset_cls, *capi_getset_cls,
+    * str_cls = NULL, *function_cls, *instancemethod_cls, *list_cls, *ellipsis_cls, *slice_cls, *module_cls, *dict_cls,
+      *tuple_cls, *file_cls, *member_descriptor_cls, *closure_cls, *generator_cls, *complex_cls, *basestring_cls,
+      *property_cls, *staticmethod_cls, *classmethod_cls, *attrwrapper_cls, *pyston_getset_cls, *capi_getset_cls,
       *builtin_function_or_method_cls, *attrwrapperiter_cls, *set_cls, *frozenset_cls;
 
 BoxedTuple* EmptyTuple;
@@ -1787,7 +1786,7 @@ extern "C" Box* createSlice(Box* start, Box* stop, Box* step) {
     return rtn;
 }
 
-extern "C" Box* createEllipsis(){
+extern "C" Box* createEllipsis() {
     BoxedEllipsis* rtn = new BoxedEllipsis();
     return rtn;
 }
@@ -1808,7 +1807,7 @@ extern "C" Box* sliceNew(Box* cls, Box* start, Box* stop, Box** args) {
     return createSlice(start, stop, step);
 }
 
-extern "C" Box* ellipsisNew(Box* cls){
+extern "C" Box* ellipsisNew(Box* cls) {
     RELEASE_ASSERT(cls == ellipsis_cls, "");
     return createEllipsis();
 }
@@ -1925,8 +1924,7 @@ Box* sliceRepr(BoxedSlice* self) {
     return boxStringTwine(llvm::Twine("slice(") + start->s() + ", " + stop->s() + ", " + step->s() + ")");
 }
 
-Box* ellipsisRepr(BoxedEllipsis* self)
-{
+Box* ellipsisRepr(BoxedEllipsis* self) {
     return boxStringTwine(llvm::Twine("Ellipsis"));
 }
 
@@ -3777,7 +3775,8 @@ void setupRuntime() {
                                             offsetof(BoxedInstanceMethod, in_weakreflist), sizeof(BoxedInstanceMethod),
                                             false, "instancemethod");
 
-    ellipsis_cls = BoxedClass::create(type_cls, object_cls, &BoxedEllipsis::gcHandler, 0, 0, sizeof(BoxedEllipsis), false, "ellipsis");
+    ellipsis_cls = BoxedClass::create(type_cls, object_cls, &BoxedEllipsis::gcHandler, 0, 0, sizeof(BoxedEllipsis),
+                                      false, "ellipsis");
     slice_cls
         = BoxedClass::create(type_cls, object_cls, &BoxedSlice::gcHandler, 0, 0, sizeof(BoxedSlice), false, "slice");
     set_cls = BoxedClass::create(type_cls, object_cls, &BoxedSet::gcHandler, 0, offsetof(BoxedSet, weakreflist),
@@ -3951,7 +3950,7 @@ void setupRuntime() {
                                                                        offsetof(BoxedInstanceMethod, im_class), true));
 
     ellipsis_cls->giveAttr("__repr__", new BoxedFunction(boxRTFunction((void*)ellipsisRepr, STR, 1)));
-    
+
     ellipsis_cls->freeze();
 
     slice_cls->giveAttr("__new__",

--- a/src/runtime/types.cpp
+++ b/src/runtime/types.cpp
@@ -3777,7 +3777,7 @@ void setupRuntime() {
                                             offsetof(BoxedInstanceMethod, in_weakreflist), sizeof(BoxedInstanceMethod),
                                             false, "instancemethod");
 
-    ellipsis_cls = BoxedClass::create(type_cls, object_cls, &BoxedEllipsis::gcHandler, 0, 0, sizeof(BoxedEllipsis), false, "Ellipsis");
+    ellipsis_cls = BoxedClass::create(type_cls, object_cls, &BoxedEllipsis::gcHandler, 0, 0, sizeof(BoxedEllipsis), false, "ellipsis");
     slice_cls
         = BoxedClass::create(type_cls, object_cls, &BoxedSlice::gcHandler, 0, 0, sizeof(BoxedSlice), false, "slice");
     set_cls = BoxedClass::create(type_cls, object_cls, &BoxedSet::gcHandler, 0, offsetof(BoxedSet, weakreflist),
@@ -3951,7 +3951,7 @@ void setupRuntime() {
                                                                        offsetof(BoxedInstanceMethod, im_class), true));
 
     ellipsis_cls->giveAttr("__repr__", new BoxedFunction(boxRTFunction((void*)ellipsisRepr, STR, 1)));
-    //ellipsis_cls->giveAttr("__getitem__", new BoxedFunction(ellipsis_getitem));
+    
     ellipsis_cls->freeze();
 
     slice_cls->giveAttr("__new__",

--- a/src/runtime/types.h
+++ b/src/runtime/types.h
@@ -484,10 +484,10 @@ public:
 
 class BoxedEllipsis : public Box {
 public:
-   BoxedEllipsis() __attribute__((visibility("default"))) {}
-   
-   DEFAULT_CLASS_SIMPLE(ellipsis_cls);
-   static void gcHandler(GCVisitor* v, Box* b);
+    BoxedEllipsis() __attribute__((visibility("default"))) {}
+
+    DEFAULT_CLASS_SIMPLE(ellipsis_cls);
+    static void gcHandler(GCVisitor* v, Box* b);
 };
 
 class BoxedList : public Box {

--- a/src/runtime/types.h
+++ b/src/runtime/types.h
@@ -41,6 +41,7 @@ class BoxedFile;
 class BoxedClosure;
 class BoxedGenerator;
 class BoxedLong;
+class BoxedEllipsis;
 
 void setupInt();
 void teardownInt();
@@ -71,6 +72,7 @@ void setupDescr();
 void teardownDescr();
 void setupCode();
 void setupFrame();
+void setupEllipsis();
 
 void setupSys();
 void setupBuiltins();
@@ -89,7 +91,7 @@ extern "C" BoxedString* EmptyString;
 
 extern "C" {
 extern BoxedClass* object_cls, *type_cls, *bool_cls, *int_cls, *long_cls, *float_cls, *str_cls, *function_cls,
-    *none_cls, *instancemethod_cls, *list_cls, *slice_cls, *module_cls, *dict_cls, *tuple_cls, *file_cls,
+    *none_cls, *instancemethod_cls, *list_cls, *slice_cls, *ellipsis_cls, *module_cls, *dict_cls, *tuple_cls, *file_cls,
     *enumerate_cls, *xrange_cls, *member_descriptor_cls, *method_cls, *closure_cls, *generator_cls, *complex_cls,
     *basestring_cls, *property_cls, *staticmethod_cls, *classmethod_cls, *attrwrapper_cls, *pyston_getset_cls,
     *capi_getset_cls, *builtin_function_or_method_cls, *set_cls, *frozenset_cls, *code_cls, *frame_cls, *capifunc_cls,
@@ -167,6 +169,7 @@ extern "C" CLFunction* unboxCLFunction(Box* b);
 extern "C" Box* createUserClass(BoxedString* name, Box* base, Box* attr_dict);
 extern "C" double unboxFloat(Box* b);
 extern "C" Box* createDict();
+extern "C" Box* createEllipsis();
 extern "C" Box* createList();
 extern "C" Box* createSlice(Box* start, Box* stop, Box* step);
 extern "C" Box* createTuple(int64_t nelts, Box** elts);
@@ -471,6 +474,14 @@ public:
     static GCdArray* realloc(GCdArray* array, int capacity) {
         return (GCdArray*)gc::gc_realloc(array, capacity * sizeof(Box*) + sizeof(GCdArray));
     }
+};
+
+class BoxedEllipsis : public Box {
+public:
+   BoxedEllipsis() __attribute__((visibility("default"))) {}
+   
+   DEFAULT_CLASS_SIMPLE(ellipsis_cls);
+   static void gcHandler(GCVisitor* v, Box* b);
 };
 
 class BoxedList : public Box {

--- a/test/tests/ellipsis_getname.py
+++ b/test/tests/ellipsis_getname.py
@@ -1,0 +1,16 @@
+# expected: fail
+# - print x[...] should be "Ellipsis" but not yet implemented..
+class TestEllipsis(object):
+   def __getitem__(self, item):
+      if item is Ellipsis:
+         return "Ellipsis"
+      else:
+         return "return %r items" % item
+
+print Ellipsis
+v = Ellipsis
+print v
+print type(v)
+x = TestEllipsis()
+print x[2]
+print x[...]


### PR DESCRIPTION
* prevent overflow while calculating mid value (src/core/types.h)
*  some fix of Ellipsis
*  add Ellipsis test

before fixing  code
```
class TestEllipsis(object):
   def __getitem__(self, item):
      if item is Ellipsis:
         return "Ellipsis"
      else:
         return "return %r items" % item

print Ellipsis
v = Ellipsis
print v
print type(v)
x = TestEllipsis()
print x[2]
print x[...]
```
results as 

```
<ellipsis object at 0x127000c4a8>
<ellipsis object at 0x127000c4a8>
<type 'ellipsis'>
return 2 items
../../src/codegen/ast_interpreter.cpp:552: pyston::Value pyston::<anonymous namespace>::ASTInterpreter::visit_slice(pyston::AST_slice *): Assertion `0' failed: not implemented
Someone called abort!
Traceback (most recent call last):
  File "ellipsis_getname.py", line 16, in <module>:
    print x[...]
```

but now 

```
Ellipsis
Ellipsis
<type 'ellipsis'>
return 2 items
return Ellipsis items  ==> this should be Ellipsis it will fix at future..
```
