### PR TITLE
add m2crypto test + fix missing stuff

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,7 @@ addons:
     - libxml2-dev 
     - libxslt1-dev
     - libssl-dev
+    - swig
 
 before_install:
   - if [ "$CC" = "clang" ]; then export CC="clang-3.5" CXX="clang++-3.5"; fi

--- a/from_cpython/Include/code.h
+++ b/from_cpython/Include/code.h
@@ -91,6 +91,9 @@ PyCode_NewEmpty(const char *filename, const char *funcname, int firstlineno) PYS
    use PyFrame_GetLineNumber() instead. */
 PyAPI_FUNC(int) PyCode_Addr2Line(PyCodeObject *, int) PYSTON_NOEXCEPT;
 
+// Pyston addition:
+PyAPI_FUNC(int) PyCode_GetArgCount(PyCodeObject *) PYSTON_NOEXCEPT;
+
 /* for internal use only */
 #define _PyCode_GETCODEPTR(co, pp) \
 	((*Py_TYPE((co)->co_code)->tp_as_buffer->bf_getreadbuffer) \

--- a/src/runtime/classobj.cpp
+++ b/src/runtime/classobj.cpp
@@ -148,12 +148,6 @@ Box* classobjNew(Box* _cls, Box* _name, Box* _bases, Box** _args) {
         made->setattr(s, p.second, NULL);
     }
 
-    // Note: make sure to do this after assigning the attrs, since it will overwrite any defined __name__
-    static BoxedString* name_str = internStringImmortal("__name__");
-    static BoxedString* bases_str = internStringImmortal("__bases__");
-    made->setattr(name_str, name, NULL);
-    made->setattr(bases_str, bases, NULL);
-
     return made;
 }
 

--- a/src/runtime/code.cpp
+++ b/src/runtime/code.cpp
@@ -110,6 +110,11 @@ extern "C" PyCodeObject* PyCode_New(int, int, int, int, PyObject*, PyObject*, Py
     RELEASE_ASSERT(0, "not implemented");
 }
 
+extern "C" int PyCode_GetArgCount(PyCodeObject* op) noexcept {
+    RELEASE_ASSERT(PyCode_Check((Box*)op), "");
+    return unboxInt(BoxedCode::argcount((Box*)op, NULL));
+}
+
 void setupCode() {
     code_cls = BoxedClass::create(type_cls, object_cls, &BoxedCode::gcHandler, 0, 0, sizeof(BoxedCode), false, "code");
 

--- a/src/runtime/import.cpp
+++ b/src/runtime/import.cpp
@@ -614,6 +614,15 @@ extern "C" PyObject* PyImport_ImportModule(const char* name) noexcept {
     return PyImport_Import(boxString(name));
 }
 
+extern "C" PyObject* PyImport_GetModuleDict(void) noexcept {
+    try {
+        return getSysModulesDict();
+    } catch (ExcInfo e) {
+        setCAPIException(e);
+        return NULL;
+    }
+}
+
 /* Get the module object corresponding to a module name.
    First check the modules dictionary if there's one there,
    if not, create a new one and insert it in the modules dictionary.

--- a/src/runtime/types.cpp
+++ b/src/runtime/types.cpp
@@ -463,6 +463,9 @@ void BoxedFunction::gcHandler(GCVisitor* v, Box* b) {
         v->visit(&f->globals);
 
     v->visit(&f->defaults);
+
+    if (f->f && f->f->source && f->f->source->parent_module)
+        v->visit(&f->f->source->parent_module);
 }
 
 BoxedBuiltinFunctionOrMethod::BoxedBuiltinFunctionOrMethod(CLFunction* f, const char* name, const char* doc)
@@ -1683,6 +1686,15 @@ static Box* functionCode(Box* self, void*) {
     assert(self->cls == function_cls);
     BoxedFunction* func = static_cast<BoxedFunction*>(self);
     return codeForFunction(func);
+}
+
+extern "C" PyObject* PyFunction_GetCode(PyObject* func) noexcept {
+    try {
+        return functionCode((Box*)func, NULL);
+    } catch (ExcInfo e) {
+        setCAPIException(e);
+        return NULL;
+    }
 }
 
 static void functionSetCode(Box* self, Box* v, void*) {

--- a/test/extra/M2Crypto_patch.patch
+++ b/test/extra/M2Crypto_patch.patch
@@ -1,0 +1,23 @@
+diff -ur M2Crypto-0.21.1.orig/SWIG/_lib.i ./SWIG/_lib.i
+--- M2Crypto-0.21.1/SWIG/_lib.i	2011-01-15 19:10:06.000000000 +0000
++++ ./SWIG/_lib.i	2015-09-25 12:41:17.184659427 +0100
+@@ -110,12 +110,16 @@
+         PyCodeObject *code;
+         func = PyMethod_Function(ssl_verify_cb_func);
+         code = (PyCodeObject *) PyFunction_GetCode(func);
+-        if (code && code->co_argcount == 3) { /* XXX Python internals */
++        // Pyston change
++        //if (code && code->co_argcount == 3) { /* XXX Python internals */
++        if (code && PyCode_GetArgCount(code) == 3) {
+             new_style_callback = 1;
+         }
+     } else if (PyFunction_Check(ssl_verify_cb_func)) {
+         PyCodeObject *code = (PyCodeObject *) PyFunction_GetCode(ssl_verify_cb_func);
+-        if (code && code->co_argcount == 2) { /* XXX Python internals */
++        // Pyston change
++        //if (code && code->co_argcount == 2) { /* XXX Python internals */
++        if (code && PyCode_GetArgCount(code) == 2) {
+             new_style_callback = 1;
+         }    
+     } else {
+

--- a/test/extra/M2Crypto_test.py
+++ b/test/extra/M2Crypto_test.py
@@ -1,0 +1,49 @@
+import os, sys, subprocess, shutil
+sys.path.append(os.path.dirname(__file__) + "/../lib")
+
+from test_helper import create_virtenv, run_test
+
+ENV_NAME = "M2Crypto_test_env_" + os.path.basename(sys.executable)
+SRC_DIR = os.path.abspath(os.path.join(ENV_NAME, "src"))
+PYTHON_EXE = os.path.abspath(os.path.join(ENV_NAME, "bin", "python"))
+
+def install_and_test_lxml():
+    shutil.rmtree(SRC_DIR, ignore_errors=True)
+    os.makedirs(SRC_DIR)
+
+    url = "https://pypi.python.org/packages/source/M/M2Crypto/M2Crypto-0.21.1.tar.gz"
+    subprocess.check_call(["wget", url], cwd=SRC_DIR)
+    subprocess.check_call(["tar", "-zxf", "M2Crypto-0.21.1.tar.gz"], cwd=SRC_DIR)
+    M2CRYPTO_DIR = os.path.abspath(os.path.join(SRC_DIR, "M2Crypto-0.21.1"))
+
+    url = "http://archive.ubuntu.com/ubuntu/pool/main/m/m2crypto/m2crypto_0.21.1-3ubuntu5.debian.tar.gz"
+    subprocess.check_call(["wget", url], cwd=M2CRYPTO_DIR)
+    subprocess.check_call(["tar", "-zxf", "m2crypto_0.21.1-3ubuntu5.debian.tar.gz"], cwd=M2CRYPTO_DIR)
+
+    debian_patches = ("0001-Import-inspect-in-urllib-2.patch",
+                      "0002-Disable-SSLv2_method-when-disabled-in-OpenSSL-iself-.patch",
+                      "0003-Look-for-OpenSSL-headers-in-usr-include-DEB_HOST_MUL.patch",
+                      "skip_sslv2_tests.patch",
+                      "fix_testsuite_ftbfs.patch",
+                      "fix_testsuite_tls1.2.patch",
+                      "fix_testsuite_sha256.patch")	
+
+    for patch in debian_patches:
+        PATCH_FILE = os.path.abspath(os.path.join(M2CRYPTO_DIR, "debian", "patches", patch))
+        subprocess.check_call(["patch", "-p1", "--input=" + PATCH_FILE], cwd=M2CRYPTO_DIR)
+
+    PATCH_FILE = os.path.abspath(os.path.join(os.path.dirname(__file__), "M2Crypto_patch.patch"))
+    subprocess.check_call(["patch", "-p1", "--input=" + PATCH_FILE], cwd=M2CRYPTO_DIR)
+
+    env = os.environ
+    # M2Crypto can't find the opensslconf without this
+    env["DEB_HOST_MULTIARCH"] = "/usr/include/x86_64-linux-gnu"
+    # SWIG does not work with pyston if this define is not set
+    env["CFLAGS"] = "-DSWIG_PYTHON_SLOW_GETSET_THIS" 
+    subprocess.check_call([PYTHON_EXE, "setup.py", "install"], cwd=M2CRYPTO_DIR, env=env)
+
+    expected = [{'ran': 235, 'failures': 1, 'errors': 7, 'skipped': 2}]
+    run_test([PYTHON_EXE, "setup.py", "test"], cwd=M2CRYPTO_DIR, expected=expected)
+   
+create_virtenv(ENV_NAME, None, force_create = True)
+install_and_test_lxml()

--- a/test/extra/pyopenssl_test.py
+++ b/test/extra/pyopenssl_test.py
@@ -10,5 +10,5 @@ PYOPENSSL_DIR = os.path.abspath(os.path.join(ENV_NAME, "site-packages", "OpenSSL
 packages = ["nose==1.3.7", "pycparser==2.13", "cryptography==1.0.1", "pyopenssl==0.15.1", "pyasn1==0.1.7", "idna==2.0", "six==1.9.0", "enum34==1.0.4", "ipaddress==1.0.14", "cffi==1.1.0"]
 create_virtenv(ENV_NAME, packages, force_create = True)
 
-expected = [{'ran': 247, 'errors': 2, 'failures': 0}]
+expected = [{'ran': 247, 'errors': 2}]
 run_test([NOSETESTS_EXE], cwd=PYOPENSSL_DIR, expected=expected)

--- a/test/lib/test_helper.py
+++ b/test/lib/test_helper.py
@@ -40,31 +40,12 @@ def parse_output(output):
         m = re.match("Ran (\d+) tests in", l)
         if m:
             result.append({"ran": int(m.group(1))})
-
-        m = re.match("FAILED \(failures=(\d+), errors=(\d+)\)", l)
-        if m:
-            d = result[-1]
-            assert d.keys() == ["ran"]
-            d['failures'] = int(m.group(1))
-            d['errors'] = int(m.group(2))
-        m = re.match("FAILED \(errors=(\d+), failures=(\d+)\)", l)
-        if m:
-            d = result[-1]
-            assert d.keys() == ["ran"]
-            d['failures'] = int(m.group(2))
-            d['errors'] = int(m.group(1))
-        m = re.match("FAILED \(failures=(\d+)\)", l)
-        if m:
-            d = result[-1]
-            assert d.keys() == ["ran"]
-            d['failures'] = int(m.group(1))
-            d['errors'] = 0
-        m = re.match("FAILED \(errors=(\d+)\)", l)
-        if m:
-            d = result[-1]
-            assert d.keys() == ["ran"]
-            d['failures'] = 0
-            d['errors'] = int(m.group(1))
+            continue
+        for res_type in ("errors", "failures", "skipped"):
+	    m = re.match("FAILED \(.*%s=(\d+).*\)" % res_type, l)
+	    if m:
+	        result[-1][res_type] = int(m.group(1))
+	
     return result
 
 def run_test(cmd, cwd, expected, env = None):

--- a/test/tests/oldstyle_classes.py
+++ b/test/tests/oldstyle_classes.py
@@ -1,7 +1,7 @@
 class C():
     pass
 
-print C, type(C)
+print C, type(C), sorted(dir(C))
 print map(str, C.__bases__), C.__name__
 print type(C())
 


### PR DESCRIPTION
- oldstyle classed don't add ```__bases__``` and ```__name__``` as attributes to their dict instead the intercept them with ```__getattribute__```
- it was possible to encounter a crash when importing a module and then deleting the entry from sys.modules and calling the function from the other module
```python
import gc, sys
def get_func():
 from t2 import f2
 print f2()
 del sys.modules["t2"]
 return f2
f = get_func()
gc.collect()
print f.__globals__ # <-- crashes here sometimes
f()                 # <-- this hits sometimes a release assert
```
- add a Pyston specific ```PyCode_GetArgCount``` instead of directly accessing ```code->co_argcount```
- In order to not have to patch swig for pyston I set the missing define ```SWIG_PYTHON_SLOW_GETSET_THIS``` with the ```CFLAGS``` environment variable