### PR TITLE
make platform test pass

### DIFF
--- a/from_cpython/Lib/test/test_platform.py
+++ b/from_cpython/Lib/test/test_platform.py
@@ -1,4 +1,3 @@
-# expected: fail
 import sys
 import os
 import unittest

--- a/src/runtime/builtin_modules/sys.cpp
+++ b/src/runtime/builtin_modules/sys.cpp
@@ -649,6 +649,7 @@ void setupSys() {
 
     sys_module->giveAttr("version", boxString(generateVersionString()));
     sys_module->giveAttr("hexversion", boxInt(PY_VERSION_HEX));
+    sys_module->giveAttr("subversion", BoxedTuple::create({ boxString("Pyston"), boxString(""), boxString("") }));
     sys_module->giveAttr("maxint", boxInt(PYSTON_INT_MAX));
     sys_module->giveAttr("maxsize", boxInt(PY_SSIZE_T_MAX));
 

--- a/test/tests/sys_test.py
+++ b/test/tests/sys_test.py
@@ -11,6 +11,8 @@ print type(sys.maxsize)
 print sys.stdout is sys.__stdout__
 print sys.stderr is sys.__stderr__
 print sys.stdin is sys.__stdin__
+print type(sys.subversion)
+print len(sys.subversion)
 
 try:
     1/0


### PR DESCRIPTION
`make run_test_platform` is just to pass with one error, pyston have no `sys.subversion`.

In [this document](https://docs.python.org/2/library/sys.html#sys.subversion), `sys.subversion` is just a placeholder, so implement it as const value.

Or maybe we should modify the test just ignore it?