### PR TITLE
Ellipsis implementation

### DIFF
--- a/src/analysis/type_analysis.cpp
+++ b/src/analysis/type_analysis.cpp
@@ -196,6 +196,8 @@ private:
         }
     }
 
+    void* visit_ellipsis(AST_Ellipsis* node) override { return ELLIPSIS; }
+
     void* visit_attribute(AST_Attribute* node) override {
         CompilerType* t = getType(node->value);
         CompilerType* rtn = t->getattrType(node->attr, false);

--- a/src/codegen/ast_interpreter.cpp
+++ b/src/codegen/ast_interpreter.cpp
@@ -99,6 +99,7 @@ private:
 
     Value visit_attribute(AST_Attribute* node);
     Value visit_dict(AST_Dict* node);
+    Value visit_ellipsis(AST_Ellipsis* node);
     Value visit_expr(AST_expr* node);
     Value visit_expr(AST_Expr* node);
     Value visit_extslice(AST_ExtSlice* node);
@@ -549,7 +550,7 @@ Value ASTInterpreter::visit_slice(AST_slice* node) {
         case AST_TYPE::ExtSlice:
             return visit_extslice(static_cast<AST_ExtSlice*>(node));
         case AST_TYPE::Ellipsis:
-            RELEASE_ASSERT(0, "not implemented");
+            return visit_ellipsis(static_cast<AST_Ellipsis*>(node));
             break;
         case AST_TYPE::Index:
             return visit_index(static_cast<AST_Index*>(node));
@@ -559,6 +560,10 @@ Value ASTInterpreter::visit_slice(AST_slice* node) {
             RELEASE_ASSERT(0, "Attempt to handle invalid slice type");
     }
     return Value();
+}
+
+Value ASTInterpreter::visit_ellipsis(AST_Ellipsis* node) {
+    return Value(Ellipsis, jit ? jit->imm(Ellipsis) : NULL);
 }
 
 Value ASTInterpreter::visit_slice(AST_Slice* node) {

--- a/src/codegen/compvars.cpp
+++ b/src/codegen/compvars.cpp
@@ -1966,7 +1966,7 @@ public:
     }
 };
 std::unordered_map<BoxedClass*, NormalObjectType*> NormalObjectType::made;
-ConcreteCompilerType* STR, *BOXED_INT, *BOXED_FLOAT, *BOXED_BOOL, *NONE;
+ConcreteCompilerType* STR, *BOXED_INT, *BOXED_FLOAT, *BOXED_BOOL, *NONE, *ELLIPSIS;
 
 class ClosureType : public ConcreteCompilerType {
 public:

--- a/src/codegen/irgen/irgenerator.cpp
+++ b/src/codegen/irgen/irgenerator.cpp
@@ -1073,6 +1073,11 @@ private:
         return rtn;
     }
 
+    ConcreteCompilerVariable* getEllipsis() {
+        llvm::Constant* ellipsis = embedRelocatablePtr(Ellipsis, g.llvm_value_type_ptr, "cEllipsis");
+        auto ellipsis_cls = Ellipsis->cls;
+        return new ConcreteCompilerVariable(typeFromClass(ellipsis_cls), ellipsis, false);
+    }
     ConcreteCompilerVariable* getNone() {
         llvm::Constant* none = embedRelocatablePtr(None, g.llvm_value_type_ptr, "cNone");
         return new ConcreteCompilerVariable(typeFromClass(none_cls), none, false);
@@ -1590,6 +1595,9 @@ private:
         switch (node->type) {
             case AST_TYPE::ExtSlice:
                 rtn = evalExtSlice(ast_cast<AST_ExtSlice>(node), unw_info);
+                break;
+            case AST_TYPE::Ellipsis:
+                rtn = getEllipsis();
                 break;
             case AST_TYPE::Index:
                 rtn = evalIndex(ast_cast<AST_Index>(node), unw_info);

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -88,7 +88,7 @@ template <class V> class ValuedCompilerType;
 typedef ValuedCompilerType<llvm::Value*> ConcreteCompilerType;
 ConcreteCompilerType* typeFromClass(BoxedClass*);
 
-extern ConcreteCompilerType* INT, *BOXED_INT, *LONG, *FLOAT, *BOXED_FLOAT, *UNKNOWN, *BOOL, *STR, *NONE, *LIST, *SLICE,
+extern ConcreteCompilerType* INT, *BOXED_INT, *LONG, *FLOAT, *BOXED_FLOAT, *UNKNOWN, *BOOL, *STR, *NONE, *LIST, *SLICE,*ELLIPSIS,
     *MODULE, *DICT, *BOOL, *BOXED_BOOL, *BOXED_TUPLE, *SET, *FROZENSET, *CLOSURE, *GENERATOR, *BOXED_COMPLEX,
     *FRAME_INFO;
 extern CompilerType* UNDEF;

--- a/src/runtime/builtin_modules/builtins.cpp
+++ b/src/runtime/builtin_modules/builtins.cpp
@@ -1250,6 +1250,9 @@ extern "C" PyObject* PyEval_GetBuiltins(void) noexcept {
     return builtins_module;
 }
 
+Box* ellipsisRepr(Box* self) {
+    return boxString("Ellipsis");
+}
 Box* divmod(Box* lhs, Box* rhs) {
     return binopInternal(lhs, rhs, AST_TYPE::DivMod, false, NULL);
 }
@@ -1529,6 +1532,7 @@ void setupBuiltins() {
                                    "the `nil' object; Ellipsis represents `...' in slices.");
 
     BoxedClass* ellipsis_cls = BoxedClass::create(type_cls, object_cls, NULL, 0, 0, sizeof(Box), false, "ellipsis");
+    ellipsis_cls->giveAttr("__repr__", new BoxedFunction(boxRTFunction((void*)ellipsisRepr, STR, 1)));
     Ellipsis = new (ellipsis_cls) Box();
     assert(Ellipsis->cls);
     gc::registerPermanentRoot(Ellipsis);

--- a/src/runtime/types.h
+++ b/src/runtime/types.h
@@ -128,7 +128,7 @@ extern BoxedClass* object_cls, *type_cls, *bool_cls, *int_cls, *long_cls, *float
 extern std::vector<BoxedClass*> exception_types;
 
 extern "C" {
-extern Box* None, *NotImplemented, *True, *False;
+extern Box* None, *NotImplemented, *True, *False, *Ellipsis;
 }
 extern "C" {
 extern Box* repr_obj, *len_obj, *hash_obj, *range_obj, *abs_obj, *min_obj, *max_obj, *open_obj, *id_obj, *chr_obj,

--- a/test/tests/ellipsis.py
+++ b/test/tests/ellipsis.py
@@ -1,3 +1,2 @@
-
 print type(Ellipsis)
 print type(Ellipsis).__base__

--- a/test/tests/ellipsis_more_test.py
+++ b/test/tests/ellipsis_more_test.py
@@ -1,0 +1,14 @@
+class TestEllipsis(object):
+   def __getitem__(self, item):
+      if item is Ellipsis:
+         return "Ellipsis"
+      else:
+         return "return %r items" % item
+
+print Ellipsis
+v = Ellipsis
+print v
+print type(v)
+x = TestEllipsis()
+print x[2]
+print x[...]


### PR DESCRIPTION
*  some fix of Ellipsis
*  test more about Ellipsis
```
class TestEllipsis(object):
   def __getitem__(self, item):
      if item is Ellipsis:
         return "Ellipsis"
      else:
         return "return %r items" % item

print Ellipsis
v = Ellipsis
print v
print type(v)
x = TestEllipsis()
print x[2]
print x[...]
```
results as 

```
<ellipsis object at 0x127000c4a8>
<ellipsis object at 0x127000c4a8>
<type 'ellipsis'>
return 2 items
../../src/codegen/ast_interpreter.cpp:552: pyston::Value pyston::<anonymous namespace>::ASTInterpreter::visit_slice(pyston::AST_slice *): Assertion `0' failed: not implemented
Someone called abort!
Traceback (most recent call last):
  File "ellipsis_getname.py", line 16, in <module>:
    print x[...]
```

but now 

```
Ellipsis
Ellipsis
<type 'ellipsis'>
return 2 items
Ellipsis
```

it fully passed