### PR TITLE
implement PyObject_AsWriteBuffer

### DIFF
--- a/src/capi/abstract.cpp
+++ b/src/capi/abstract.cpp
@@ -605,6 +605,32 @@ extern "C" int PyObject_AsReadBuffer(PyObject* obj, const void** buffer, Py_ssiz
     return 0;
 }
 
+extern "C" int PyObject_AsWriteBuffer(PyObject* obj, void** buffer, Py_ssize_t* buffer_len) noexcept {
+    PyBufferProcs* pb;
+    void* pp;
+    Py_ssize_t len;
+
+    if (obj == NULL || buffer == NULL || buffer_len == NULL) {
+        null_error();
+        return -1;
+    }
+    pb = obj->cls->tp_as_buffer;
+    if (pb == NULL || pb->bf_getwritebuffer == NULL || pb->bf_getsegcount == NULL) {
+        PyErr_SetString(PyExc_TypeError, "expected a writeable buffer object");
+        return -1;
+    }
+    if ((*pb->bf_getsegcount)(obj, NULL) != 1) {
+        PyErr_SetString(PyExc_TypeError, "expected a single-segment buffer object");
+        return -1;
+    }
+    len = (*pb->bf_getwritebuffer)(obj, 0, &pp);
+    if (len < 0)
+        return -1;
+    *buffer = pp;
+    *buffer_len = len;
+    return 0;
+}
+
 static PyObject* call_function_tail(PyObject* callable, PyObject* args) {
     PyObject* retval;
 

--- a/src/capi/object.cpp
+++ b/src/capi/object.cpp
@@ -564,10 +564,6 @@ extern "C" int PyObject_HasAttrString(PyObject* v, const char* name) noexcept {
     return 0;
 }
 
-extern "C" int PyObject_AsWriteBuffer(PyObject* obj, void** buffer, Py_ssize_t* buffer_len) noexcept {
-    Py_FatalError("unimplemented");
-}
-
 // I'm not sure how we can support this one:
 extern "C" PyObject** _PyObject_GetDictPtr(PyObject* obj) noexcept {
     fatalOrError(PyExc_NotImplementedError, "unimplemented");

--- a/test/tests/multiprocessing_ctypes_test.py
+++ b/test/tests/multiprocessing_ctypes_test.py
@@ -1,5 +1,3 @@
-# expected: fail
-# - relies on ctypes
 
 import multiprocessing
 


### PR DESCRIPTION
To make `run_multiprocessing_ctypes_test` and `run_test_sqlite.SqliteTypeTest.CheckBlob` pass. Just copied Python's `PyObject_AsWriteBuffer` with little modify.

And I think `PyObject_AsWriteBuffer` is better written in `abstract.cpp`, but somehow it exits in `object.cpp`, maybe by mistake, so I changed this, or maybe threre were some reasons I don't know?