### PR TITLE
Add a check to make sure users don't request custom __builtins__

### DIFF
--- a/src/codegen/irgen/hooks.cpp
+++ b/src/codegen/irgen/hooks.cpp
@@ -561,8 +561,14 @@ static void pickGlobalsAndLocals(Box*& globals, Box*& locals) {
         Box* globals_dict = globals;
         if (globals->cls == module_cls)
             globals_dict = globals->getAttrWrapper();
-        if (PyDict_GetItemString(globals_dict, "__builtins__") == NULL)
+
+        auto requested_builtins = PyDict_GetItemString(globals_dict, "__builtins__");
+        if (requested_builtins == NULL)
             PyDict_SetItemString(globals_dict, "__builtins__", builtins_module);
+        else
+            RELEASE_ASSERT(requested_builtins == builtins_module
+                               || requested_builtins == builtins_module->getAttrWrapper(),
+                           "we don't support overriding __builtins__");
     }
 }
 

--- a/test/extra/babel.patch
+++ b/test/extra/babel.patch
@@ -1,0 +1,13 @@
+diff --git a/babel/messages/extract.py b/babel/messages/extract.py
+index 2f8084a..22fc289 100644
+--- a/babel/messages/extract.py
++++ b/babel/messages/extract.py
+@@ -421,7 +421,7 @@ def extract_python(fileobj, keywords, comment_tags, options):
+                 # https://sourceforge.net/tracker/?func=detail&atid=355470&
+                 # aid=617979&group_id=5470
+                 value = eval('# coding=%s\n%s' % (str(encoding), value),
+-                             {'__builtins__':{}}, {})
++                             {}, {})
+                 if PY2 and not isinstance(value, text_type):
+                     value = value.decode(encoding)
+                 buf.append(value)

--- a/test/extra/babel_test.py
+++ b/test/extra/babel_test.py
@@ -12,6 +12,9 @@ NOSETESTS_EXE = os.path.abspath(os.path.join(ENV_NAME, "bin", "nosetests"))
 packages = ["nose==1.3.7", "pytz==2015.4", "-e", "git+http://github.com/mitsuhiko/babel.git@1.3#egg=Babel"]
 create_virtenv(ENV_NAME, packages, force_create = True)
 
+PATCH_FILE = os.path.abspath(os.path.join(os.path.dirname(__file__), "babel.patch"))
+subprocess.check_call(["patch", "-p1", "--input=" + PATCH_FILE], cwd=BABEL_DIR)
+
 subprocess.check_call([PYTHON_EXE, "setup.py", "import_cldr"], cwd=BABEL_DIR)
 subprocess.check_call([PYTHON_EXE, "setup.py", "build"], cwd=BABEL_DIR)
 subprocess.check_call([PYTHON_EXE, "setup.py", "install"], cwd=BABEL_DIR)

--- a/test/tests/builtins.py
+++ b/test/tests/builtins.py
@@ -129,3 +129,11 @@ print format(5.011111111111, '+.6')
 print format("abc", '')
 
 print '{n}'.format(n=None)
+
+# Thankfully, setting __builtins__ has no effect:
+__builtins__ = {'zzz': 2}
+try:
+    print zzz
+    assert 0
+except NameError as e:
+    print "caught NameError"


### PR DESCRIPTION
We don't support that, and hopefully we don't have to.  CPython seems
pretty inconsistent about it and PyPy doesn't support it.