### PR TITLE
Add more asserts to aggressively enforce return conventions

### DIFF
--- a/src/asm_writing/rewriter.h
+++ b/src/asm_writing/rewriter.h
@@ -277,6 +277,8 @@ public:
         assert(rewriter);
     }
 
+    Rewriter* getRewriter() { return rewriter; }
+
     friend class Rewriter;
     friend class JitFragmentWriter;
 };

--- a/src/runtime/builtin_modules/builtins.cpp
+++ b/src/runtime/builtin_modules/builtins.cpp
@@ -569,16 +569,15 @@ Box* getattrFuncInternal(BoxedFunctionBase* func, CallRewriteArgs* rewrite_args,
         GetattrRewriteArgs grewrite_args(rewrite_args->rewriter, rewrite_args->arg1, rewrite_args->destination);
         rtn = getattrInternal<CAPI>(obj, str, &grewrite_args);
         // TODO could make the return valid in the NOEXC_POSSIBLE case via a helper
-        if (!grewrite_args.out_success || grewrite_args.out_return_convention == GetattrRewriteArgs::NOEXC_POSSIBLE)
+        if (!grewrite_args.isSuccessful())
             rewrite_args = NULL;
         else {
-            if (!rtn && !PyErr_Occurred()) {
-                assert(grewrite_args.out_return_convention == GetattrRewriteArgs::NO_RETURN);
+            ReturnConvention return_convention;
+            std::tie(r_rtn, return_convention) = grewrite_args.getReturn();
+
+            // Convert to NOEXC_POSSIBLE:
+            if (return_convention == ReturnConvention::NO_RETURN)
                 r_rtn = rewrite_args->rewriter->loadConst(0);
-            } else {
-                assert(grewrite_args.out_return_convention == GetattrRewriteArgs::VALID_RETURN);
-                r_rtn = grewrite_args.out_rtn;
-            }
         }
     } else {
         rtn = getattrInternal<CAPI>(obj, str, NULL);
@@ -681,16 +680,15 @@ Box* hasattrFuncInternal(BoxedFunctionBase* func, CallRewriteArgs* rewrite_args,
     if (rewrite_args) {
         GetattrRewriteArgs grewrite_args(rewrite_args->rewriter, rewrite_args->arg1, rewrite_args->destination);
         rtn = getattrInternal<CAPI>(obj, str, &grewrite_args);
-        if (!grewrite_args.out_success || grewrite_args.out_return_convention == GetattrRewriteArgs::NOEXC_POSSIBLE)
+        if (!grewrite_args.isSuccessful())
             rewrite_args = NULL;
         else {
-            if (!rtn && !PyErr_Occurred()) {
-                assert(grewrite_args.out_return_convention == GetattrRewriteArgs::NO_RETURN);
+            ReturnConvention return_convention;
+            std::tie(r_rtn, return_convention) = grewrite_args.getReturn();
+
+            // Convert to NOEXC_POSSIBLE:
+            if (return_convention == ReturnConvention::NO_RETURN)
                 r_rtn = rewrite_args->rewriter->loadConst(0);
-            } else {
-                assert(grewrite_args.out_return_convention == GetattrRewriteArgs::VALID_RETURN);
-                r_rtn = grewrite_args.out_rtn;
-            }
         }
     } else {
         rtn = getattrInternal<CAPI>(obj, str, NULL);

--- a/src/runtime/classobj.cpp
+++ b/src/runtime/classobj.cpp
@@ -32,15 +32,20 @@ BoxedClass* classobj_cls, *instance_cls;
 
 static Box* classLookup(BoxedClassobj* cls, BoxedString* attr, GetattrRewriteArgs* rewrite_args = NULL) {
     if (rewrite_args)
-        assert(!rewrite_args->out_success);
+        assert(!rewrite_args->isSuccessful());
 
     Box* r = cls->getattr(attr, rewrite_args);
-    if (r)
+    if (r) {
+        if (rewrite_args)
+            rewrite_args->assertReturnConvention(ReturnConvention::HAS_RETURN);
         return r;
+    }
 
     if (rewrite_args) {
-        // abort rewriting because we currenly don't guard the particular 'bases' hierarchy
-        rewrite_args->out_success = false;
+        if (rewrite_args->isSuccessful()) {
+            rewrite_args->getReturn(); // just to make the asserts happy
+            rewrite_args->clearReturn();
+        }
         rewrite_args = NULL;
     }
 
@@ -328,62 +333,71 @@ Box* classobjRepr(Box* _obj) {
 
 // Analogous to CPython's instance_getattr2
 static Box* instanceGetattributeSimple(BoxedInstance* inst, BoxedString* attr_str,
-                                       GetattrRewriteArgs* rewriter_args = NULL) {
-    Box* r = inst->getattr(attr_str, rewriter_args);
-    if (r)
+                                       GetattrRewriteArgs* rewrite_args = NULL) {
+    Box* r = inst->getattr(attr_str, rewrite_args);
+    if (r) {
+        if (rewrite_args)
+            rewrite_args->assertReturnConvention(ReturnConvention::HAS_RETURN);
         return r;
+    }
 
     RewriterVar* r_inst = NULL;
     RewriterVar* r_inst_cls = NULL;
-    if (rewriter_args) {
-        if (!rewriter_args->out_success)
-            rewriter_args = NULL;
+    if (rewrite_args) {
+        if (!rewrite_args->isSuccessful())
+            rewrite_args = NULL;
         else {
-            rewriter_args->out_success = false;
-            r_inst = rewriter_args->obj;
+            rewrite_args->assertReturnConvention(ReturnConvention::NO_RETURN);
+            rewrite_args->clearReturn();
+
+            r_inst = rewrite_args->obj;
             r_inst_cls = r_inst->getAttr(offsetof(BoxedInstance, inst_cls));
         }
     }
-    GetattrRewriteArgs grewriter_inst_args(rewriter_args ? rewriter_args->rewriter : NULL, r_inst_cls,
-                                           rewriter_args ? rewriter_args->rewriter->getReturnDestination()
-                                                         : Location());
-    r = classLookup(inst->inst_cls, attr_str, rewriter_args ? &grewriter_inst_args : NULL);
-    if (!grewriter_inst_args.out_success)
-        rewriter_args = NULL;
-    else
-        assert(grewriter_inst_args.out_return_convention == GetattrRewriteArgs::VALID_RETURN);
+    GetattrRewriteArgs grewriter_inst_args(rewrite_args ? rewrite_args->rewriter : NULL, r_inst_cls,
+                                           rewrite_args ? rewrite_args->rewriter->getReturnDestination() : Location());
+    r = classLookup(inst->inst_cls, attr_str, rewrite_args ? &grewriter_inst_args : NULL);
+    if (!grewriter_inst_args.isSuccessful())
+        rewrite_args = NULL;
 
     if (r) {
         Box* rtn = processDescriptor(r, inst, inst->inst_cls);
-        if (rewriter_args) {
-            RewriterVar* r_rtn = rewriter_args->rewriter->call(true, (void*)processDescriptor,
-                                                               grewriter_inst_args.out_rtn, r_inst, r_inst_cls);
-            rewriter_args->out_rtn = r_rtn;
-            rewriter_args->out_success = true;
-            rewriter_args->out_return_convention = GetattrRewriteArgs::VALID_RETURN;
+        if (rewrite_args) {
+            RewriterVar* r_rtn = rewrite_args->rewriter->call(
+                true, (void*)processDescriptor, grewriter_inst_args.getReturn(ReturnConvention::HAS_RETURN), r_inst,
+                r_inst_cls);
+            rewrite_args->setReturn(r_rtn, ReturnConvention::HAS_RETURN);
         }
         return rtn;
     }
+
+    if (rewrite_args)
+        grewriter_inst_args.assertReturnConvention(ReturnConvention::NO_RETURN);
 
     return NULL;
 }
 
 static Box* instanceGetattributeWithFallback(BoxedInstance* inst, BoxedString* attr_str,
-                                             GetattrRewriteArgs* rewriter_args = NULL) {
-    Box* attr_obj = instanceGetattributeSimple(inst, attr_str, rewriter_args);
+                                             GetattrRewriteArgs* rewrite_args = NULL) {
+    Box* attr_obj = instanceGetattributeSimple(inst, attr_str, rewrite_args);
 
     if (attr_obj) {
+        if (rewrite_args && rewrite_args->isSuccessful())
+            rewrite_args->assertReturnConvention(
+                ReturnConvention::HAS_RETURN); // otherwise need to guard on the success
         return attr_obj;
     }
 
-    if (rewriter_args) {
-        if (!rewriter_args->out_success)
-            rewriter_args = NULL;
-        else
-            rewriter_args->out_success = false;
+    if (rewrite_args) {
+        if (!rewrite_args->isSuccessful())
+            rewrite_args = NULL;
+        else {
+            rewrite_args->assertReturnConvention(ReturnConvention::NO_RETURN);
+            rewrite_args->clearReturn();
+        }
 
         // abort rewriting for now
-        rewriter_args = NULL;
+        rewrite_args = NULL;
     }
 
     static BoxedString* getattr_str = internStringImmortal("__getattr__");
@@ -398,7 +412,7 @@ static Box* instanceGetattributeWithFallback(BoxedInstance* inst, BoxedString* a
 }
 
 static Box* _instanceGetattribute(Box* _inst, BoxedString* attr_str, bool raise_on_missing,
-                                  GetattrRewriteArgs* rewriter_args = NULL) {
+                                  GetattrRewriteArgs* rewrite_args = NULL) {
     RELEASE_ASSERT(_inst->cls == instance_cls, "");
     BoxedInstance* inst = static_cast<BoxedInstance*>(_inst);
 
@@ -411,7 +425,7 @@ static Box* _instanceGetattribute(Box* _inst, BoxedString* attr_str, bool raise_
             return inst->inst_cls;
     }
 
-    Box* attr = instanceGetattributeWithFallback(inst, attr_str, rewriter_args);
+    Box* attr = instanceGetattributeWithFallback(inst, attr_str, rewrite_args);
     if (attr) {
         return attr;
     } else if (!raise_on_missing) {

--- a/src/runtime/objmodel.h
+++ b/src/runtime/objmodel.h
@@ -141,8 +141,9 @@ enum LookupScope {
     INST_ONLY = 2,
     CLASS_OR_INST = 3,
 };
+struct CallattrRewriteArgs;
 template <ExceptionStyle S>
-Box* callattrInternal(Box* obj, BoxedString* attr, LookupScope, CallRewriteArgs* rewrite_args, ArgPassSpec argspec,
+Box* callattrInternal(Box* obj, BoxedString* attr, LookupScope, CallattrRewriteArgs* rewrite_args, ArgPassSpec argspec,
                       Box* arg1, Box* arg2, Box* arg3, Box** args,
                       const std::vector<BoxedString*>* keyword_names) noexcept(S == CAPI);
 extern "C" void delattr_internal(Box* obj, BoxedString* attr, bool allow_custom, DelattrRewriteArgs* rewrite_args);

--- a/src/runtime/types.cpp
+++ b/src/runtime/types.cpp
@@ -905,13 +905,12 @@ static Box* typeCallInner(CallRewriteArgs* rewrite_args, ArgPassSpec argspec, Bo
         GetattrRewriteArgs grewrite_args(rewrite_args->rewriter, r_ccls, rewrite_args->destination);
         // TODO: if tp_new != Py_CallPythonNew, call that instead?
         new_attr = typeLookup(cls, new_str, &grewrite_args);
+        assert(new_attr);
 
-        if (!grewrite_args.out_success)
+        if (!grewrite_args.isSuccessful())
             rewrite_args = NULL;
         else {
-            assert(new_attr);
-            assert(grewrite_args.out_return_convention = GetattrRewriteArgs::VALID_RETURN);
-            r_new = grewrite_args.out_rtn;
+            r_new = grewrite_args.getReturn(ReturnConvention::HAS_RETURN);
             r_new->addGuard((intptr_t)new_attr);
         }
 
@@ -1049,15 +1048,14 @@ static Box* typeCallInner(CallRewriteArgs* rewrite_args, ArgPassSpec argspec, Bo
             GetattrRewriteArgs grewrite_args(rewrite_args->rewriter, r_ccls, rewrite_args->destination);
             init_attr = typeLookup(cls, init_str, &grewrite_args);
 
-            if (!grewrite_args.out_success)
+            if (!grewrite_args.isSuccessful())
                 rewrite_args = NULL;
             else {
                 if (init_attr) {
-                    assert(grewrite_args.out_return_convention = GetattrRewriteArgs::VALID_RETURN);
-                    r_init = grewrite_args.out_rtn;
+                    r_init = grewrite_args.getReturn(ReturnConvention::HAS_RETURN);
                     r_init->addGuard((intptr_t)init_attr);
                 } else {
-                    assert(grewrite_args.out_return_convention = GetattrRewriteArgs::NO_RETURN);
+                    grewrite_args.assertReturnConvention(ReturnConvention::NO_RETURN);
                 }
             }
         } else {

--- a/test/tests/binop_guarding.py
+++ b/test/tests/binop_guarding.py
@@ -1,0 +1,25 @@
+class C(object):
+    def __add__(self, rhs):
+        if rhs == 50:
+            return NotImplemented
+        return 0
+
+    __eq__ = __add__
+
+def f():
+    c = C()
+    for i in xrange(100):
+        try:
+            print i, c + i
+        except TypeError as e:
+            print e
+f()
+
+def f2():
+    c = C()
+    for i in xrange(100):
+        try:
+            print i, c == i
+        except TypeError as e:
+            print e
+f2()


### PR DESCRIPTION
You can't get the return value from a RewriteArgs without
looking at the return convention.  Debug mode will check the
return convention during the execution of rewrites.

Split "VALID_RETURN" into "HAS_RETURN" and "CAPI_RETURN" since some
places used it to mean either.

Hopefully this helps keep things clean.  There are a lot of places that
were implictly assuming a certain return convention, but now that they
have to explicitly assume it, the issues are more obvious.  Plus
they will get checked in the debug builds.

Also tried to fix things up while going through and doing this refactoring;
I think I found a number of issues.