### PR TITLE
use a template to remove rewriter checks inside our most important runtime funcs

### DIFF
--- a/src/capi/abstract.cpp
+++ b/src/capi/abstract.cpp
@@ -758,7 +758,7 @@ exit:
 }
 
 extern "C" Py_ssize_t PyObject_Size(PyObject* o) noexcept {
-    BoxedInt* r = lenInternal<ExceptionStyle::CAPI>(o, NULL);
+    BoxedInt* r = lenInternal<ExceptionStyle::CAPI, NOT_REWRITABLE>(o, NULL);
     if (!r)
         return -1;
     return r->n;
@@ -2252,7 +2252,7 @@ extern "C" PyObject* PyNumber_Int(PyObject* o) noexcept {
     // Pyston change: this should be an optimization
     // PyObject* trunc_func = PyObject_GetAttrString(o, "__trunc__");
     static BoxedString* trunc_str = internStringImmortal("__trunc__");
-    PyObject* trunc_func = getattrInternal<ExceptionStyle::CAPI>(o, trunc_str, NULL);
+    PyObject* trunc_func = getattrInternal<ExceptionStyle::CAPI>(o, trunc_str);
 
     if (trunc_func) {
         PyObject* truncated = PyEval_CallObject(trunc_func, NULL);

--- a/src/capi/object.cpp
+++ b/src/capi/object.cpp
@@ -486,7 +486,7 @@ extern "C" int PyObject_GenericSetAttr(PyObject* obj, PyObject* name, PyObject* 
         if (value == NULL)
             delattrGeneric(obj, str, NULL);
         else
-            setattrGeneric(obj, str, value, NULL);
+            setattrGeneric<NOT_REWRITABLE>(obj, str, value, NULL);
     } catch (ExcInfo e) {
         setCAPIException(e);
         return -1;
@@ -534,7 +534,7 @@ extern "C" int PyObject_SetAttrString(PyObject* v, const char* name, PyObject* w
 
 extern "C" PyObject* PyObject_GetAttrString(PyObject* o, const char* attr) noexcept {
     try {
-        Box* r = getattrInternal<ExceptionStyle::CXX>(o, internStringMortal(attr), NULL);
+        Box* r = getattrInternal<ExceptionStyle::CXX>(o, internStringMortal(attr));
         if (!r)
             PyErr_Format(PyExc_AttributeError, "'%.50s' object has no attribute '%.400s'", o->cls->tp_name, attr);
         return r;

--- a/src/capi/typeobject.h
+++ b/src/capi/typeobject.h
@@ -55,7 +55,7 @@ PyObject* tp_new_wrapper(PyTypeObject* self, BoxedTuple* args, Box* kwds) noexce
 int slot_tp_init(PyObject* self, PyObject* args, PyObject* kwds) noexcept;
 
 class GetattrRewriteArgs;
-template <ExceptionStyle S>
+template <ExceptionStyle S, Rewritable rewritable>
 Box* slotTpGetattrHookInternal(Box* self, BoxedString* attr, GetattrRewriteArgs* rewrite_args) noexcept(S == CAPI);
 }
 

--- a/src/codegen/compvars.cpp
+++ b/src/codegen/compvars.cpp
@@ -1563,7 +1563,7 @@ public:
     CompilerType* getattrType(BoxedString* attr, bool cls_only) override {
         // Any changes here need to be mirrored in getattr()
         if (canStaticallyResolveGetattrs()) {
-            Box* rtattr = typeLookup(cls, attr, nullptr);
+            Box* rtattr = typeLookup(cls, attr);
             if (rtattr == NULL)
                 return UNDEF;
 
@@ -1588,7 +1588,7 @@ public:
                               bool cls_only) override {
         // Any changes here need to be mirrored in getattrType()
         if (canStaticallyResolveGetattrs()) {
-            Box* rtattr = typeLookup(cls, attr, nullptr);
+            Box* rtattr = typeLookup(cls, attr);
             if (rtattr == NULL) {
                 ExceptionStyle exception_style = info.preferredExceptionStyle();
                 llvm::Value* raise_func = exception_style == CXX ? g.funcs.raiseAttributeErrorStr

--- a/src/core/cfg.cpp
+++ b/src/core/cfg.cpp
@@ -2625,7 +2625,7 @@ CFG* computeCFG(SourceInfo* source, std::vector<AST_stmt*> body) {
 
         if (source->scoping->areGlobalsFromModule()) {
             static BoxedString* name_str = internStringImmortal("__name__");
-            Box* module_name = source->parent_module->getattr(name_str, NULL);
+            Box* module_name = source->parent_module->getattr(name_str);
             assert(module_name->cls == str_cls);
             module_assign->value = new AST_Str(static_cast<BoxedString*>(module_name)->s());
         } else {

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -51,6 +51,11 @@ enum ExceptionStyle {
     CXX,
 };
 
+enum Rewritable {
+    REWRITABLE,
+    NOT_REWRITABLE,
+};
+
 template <typename T> struct ExceptionSwitchable {
 public:
     T capi_val;
@@ -545,8 +550,9 @@ public:
 
     // getattr() does the equivalent of PyDict_GetItem(obj->dict, attr): it looks up the attribute's value on the
     // object's attribute storage. it doesn't look at other objects or do any descriptor logic.
+    template <Rewritable rewritable = REWRITABLE>
     Box* getattr(BoxedString* attr, GetattrRewriteArgs* rewrite_args);
-    Box* getattr(BoxedString* attr) { return getattr(attr, NULL); }
+    Box* getattr(BoxedString* attr) { return getattr<NOT_REWRITABLE>(attr, NULL); }
     bool hasattr(BoxedString* attr) { return getattr(attr) != NULL; }
     void delattr(BoxedString* attr, DelattrRewriteArgs* rewrite_args);
 

--- a/src/runtime/builtin_modules/builtins.cpp
+++ b/src/runtime/builtin_modules/builtins.cpp
@@ -83,7 +83,7 @@ extern "C" Box* vars(Box* obj) {
         return fastLocalsToBoxedLocals();
 
     static BoxedString* dict_str = internStringImmortal("__dict__");
-    Box* rtn = getattrInternal<ExceptionStyle::CAPI>(obj, dict_str, NULL);
+    Box* rtn = getattrInternal<ExceptionStyle::CAPI>(obj, dict_str);
     if (!rtn)
         raiseExcHelper(TypeError, "vars() argument must have __dict__ attribute");
     return rtn;
@@ -580,7 +580,7 @@ Box* getattrFuncInternal(BoxedFunctionBase* func, CallRewriteArgs* rewrite_args,
                 r_rtn = rewrite_args->rewriter->loadConst(0);
         }
     } else {
-        rtn = getattrInternal<CAPI>(obj, str, NULL);
+        rtn = getattrInternal<CAPI>(obj, str);
     }
 
     if (rewrite_args) {
@@ -691,7 +691,7 @@ Box* hasattrFuncInternal(BoxedFunctionBase* func, CallRewriteArgs* rewrite_args,
                 r_rtn = rewrite_args->rewriter->loadConst(0);
         }
     } else {
-        rtn = getattrInternal<CAPI>(obj, str, NULL);
+        rtn = getattrInternal<CAPI>(obj, str);
     }
 
     if (rewrite_args) {
@@ -1252,7 +1252,7 @@ Box* ellipsisRepr(Box* self) {
     return boxString("Ellipsis");
 }
 Box* divmod(Box* lhs, Box* rhs) {
-    return binopInternal(lhs, rhs, AST_TYPE::DivMod, false, NULL);
+    return binopInternal<NOT_REWRITABLE>(lhs, rhs, AST_TYPE::DivMod, false, NULL);
 }
 
 Box* powFunc(Box* x, Box* y, Box* z) {
@@ -1326,7 +1326,7 @@ Box* getreversed(Box* o) {
         return r;
 
     static BoxedString* getitem_str = internStringImmortal("__getitem__");
-    if (!typeLookup(o->cls, getitem_str, NULL)) {
+    if (!typeLookup(o->cls, getitem_str)) {
         raiseExcHelper(TypeError, "'%s' object is not iterable", getTypeName(o));
     }
     int64_t len = unboxedLen(o); // this will throw an exception if __len__ isn't there

--- a/src/runtime/capi.cpp
+++ b/src/runtime/capi.cpp
@@ -220,7 +220,7 @@ extern "C" PyObject* PyObject_GetAttr(PyObject* o, PyObject* attr) noexcept {
     BoxedString* s = static_cast<BoxedString*>(attr);
     internStringMortalInplace(s);
 
-    Box* r = getattrInternal<ExceptionStyle::CAPI>(o, s, NULL);
+    Box* r = getattrInternal<ExceptionStyle::CAPI>(o, s);
 
     if (!r && !PyErr_Occurred()) {
         PyErr_Format(PyExc_AttributeError, "'%.50s' object has no attribute '%.400s'", o->cls->tp_name,
@@ -234,7 +234,7 @@ extern "C" PyObject* PyObject_GenericGetAttr(PyObject* o, PyObject* name) noexce
     try {
         BoxedString* s = static_cast<BoxedString*>(name);
         internStringMortalInplace(s);
-        Box* r = getattrInternalGeneric<false>(o, s, NULL, false, false, NULL, NULL);
+        Box* r = getattrInternalGeneric<false, NOT_REWRITABLE>(o, s, NULL, false, false, NULL, NULL);
         if (!r)
             PyErr_Format(PyExc_AttributeError, "'%.50s' object has no attribute '%.400s'", o->cls->tp_name,
                          PyString_AS_STRING(name));
@@ -458,7 +458,7 @@ done:
 
 
 extern "C" PyObject* PyObject_GetItem(PyObject* o, PyObject* key) noexcept {
-    return getitemInternal<ExceptionStyle::CAPI>(o, key, NULL);
+    return getitemInternal<ExceptionStyle::CAPI>(o, key);
 }
 
 extern "C" int PyObject_SetItem(PyObject* o, PyObject* key, PyObject* v) noexcept {
@@ -580,11 +580,11 @@ extern "C" int PyObject_Not(PyObject* o) noexcept {
 
 extern "C" PyObject* PyObject_Call(PyObject* callable_object, PyObject* args, PyObject* kw) noexcept {
     if (kw)
-        return runtimeCallInternal<ExceptionStyle::CAPI>(callable_object, NULL, ArgPassSpec(0, 0, true, true), args, kw,
-                                                         NULL, NULL, NULL);
+        return runtimeCallInternal<ExceptionStyle::CAPI, NOT_REWRITABLE>(
+            callable_object, NULL, ArgPassSpec(0, 0, true, true), args, kw, NULL, NULL, NULL);
     else
-        return runtimeCallInternal<ExceptionStyle::CAPI>(callable_object, NULL, ArgPassSpec(0, 0, true, false), args,
-                                                         NULL, NULL, NULL, NULL);
+        return runtimeCallInternal<ExceptionStyle::CAPI, NOT_REWRITABLE>(
+            callable_object, NULL, ArgPassSpec(0, 0, true, false), args, NULL, NULL, NULL, NULL);
 }
 
 extern "C" int PyObject_GetBuffer(PyObject* obj, Py_buffer* view, int flags) noexcept {

--- a/src/runtime/complex.cpp
+++ b/src/runtime/complex.cpp
@@ -842,7 +842,8 @@ template <ExceptionStyle S> static Box* try_special_method(Box* self) noexcept(S
 
     static BoxedString* float_str = internStringImmortal("__float__");
     if (PyObject_HasAttr((PyObject*)self, float_str)) {
-        Box* r_f = callattrInternal<S>(self, float_str, CLASS_ONLY, NULL, ArgPassSpec(0), NULL, NULL, NULL, NULL, NULL);
+        Box* r_f = callattrInternal<S, NOT_REWRITABLE>(self, float_str, CLASS_ONLY, NULL, ArgPassSpec(0), NULL, NULL,
+                                                       NULL, NULL, NULL);
         if (!PyFloat_Check(r_f)) {
             if (S == CAPI) {
                 if (!PyErr_Occurred())
@@ -857,8 +858,8 @@ template <ExceptionStyle S> static Box* try_special_method(Box* self) noexcept(S
 
     static BoxedString* complex_str = internStringImmortal("__complex__");
     if (PyObject_HasAttr((PyObject*)self, complex_str)) {
-        Box* r
-            = callattrInternal<S>(self, complex_str, CLASS_OR_INST, NULL, ArgPassSpec(0), NULL, NULL, NULL, NULL, NULL);
+        Box* r = callattrInternal<S, NOT_REWRITABLE>(self, complex_str, CLASS_OR_INST, NULL, ArgPassSpec(0), NULL, NULL,
+                                                     NULL, NULL, NULL);
         if (!r) {
             if (S == CAPI) {
                 if (!PyErr_Occurred())

--- a/src/runtime/descr.cpp
+++ b/src/runtime/descr.cpp
@@ -47,7 +47,7 @@ static void propertyDocCopy(BoxedProperty* prop, Box* fget) {
 
     static BoxedString* doc_str = internStringImmortal("__doc__");
     try {
-        get_doc = getattrInternal<ExceptionStyle::CXX>(fget, doc_str, NULL);
+        get_doc = getattrInternal<ExceptionStyle::CXX>(fget, doc_str);
     } catch (ExcInfo e) {
         if (!e.matches(Exception)) {
             throw e;

--- a/src/runtime/dict.cpp
+++ b/src/runtime/dict.cpp
@@ -327,12 +327,12 @@ extern "C" PyObject* PyDict_GetItem(PyObject* dict, PyObject* key) noexcept {
         /* preserve the existing exception */
         PyObject* err_type, *err_value, *err_tb;
         PyErr_Fetch(&err_type, &err_value, &err_tb);
-        Box* b = getitemInternal<CAPI>(dict, key, NULL);
+        Box* b = getitemInternal<CAPI>(dict, key);
         /* ignore errors */
         PyErr_Restore(err_type, err_value, err_tb);
         return b;
     } else {
-        Box* b = getitemInternal<CAPI>(dict, key, NULL);
+        Box* b = getitemInternal<CAPI>(dict, key);
         if (b == NULL)
             PyErr_Clear();
         return b;
@@ -691,7 +691,7 @@ Box* dictUpdate(BoxedDict* self, BoxedTuple* args, BoxedDict* kwargs) {
     if (args->size()) {
         Box* arg = args->elts[0];
         static BoxedString* keys_str = internStringImmortal("keys");
-        if (getattrInternal<ExceptionStyle::CXX>(arg, keys_str, NULL)) {
+        if (getattrInternal<ExceptionStyle::CXX>(arg, keys_str)) {
             dictMerge(self, arg);
         } else {
             dictMergeFromSeq2(self, arg);

--- a/src/runtime/float.cpp
+++ b/src/runtime/float.cpp
@@ -794,7 +794,8 @@ template <ExceptionStyle S> static BoxedFloat* _floatNew(Box* a) noexcept(S == C
         return res;
     } else {
         static BoxedString* float_str = internStringImmortal("__float__");
-        Box* r = callattrInternal<S>(a, float_str, CLASS_ONLY, NULL, ArgPassSpec(0), NULL, NULL, NULL, NULL, NULL);
+        Box* r = callattrInternal<S, NOT_REWRITABLE>(a, float_str, CLASS_ONLY, NULL, ArgPassSpec(0), NULL, NULL, NULL,
+                                                     NULL, NULL);
 
         if (!r) {
             if (S == CAPI) {

--- a/src/runtime/import.cpp
+++ b/src/runtime/import.cpp
@@ -381,7 +381,7 @@ static Box* importSub(const std::string& name, BoxedString* full_name, Box* pare
         path_list = NULL;
     } else {
         static BoxedString* path_str = internStringImmortal("__path__");
-        path_list = static_cast<BoxedList*>(getattrInternal<ExceptionStyle::CXX>(parent_module, path_str, NULL));
+        path_list = static_cast<BoxedList*>(getattrInternal<ExceptionStyle::CXX>(parent_module, path_str));
         if (path_list == NULL || path_list->cls != list_cls) {
             return None;
         }
@@ -558,7 +558,7 @@ static void ensureFromlist(Box* module, Box* fromlist, std::string& buf, bool re
     static BoxedString* path_str = internStringImmortal("__path__");
     Box* pathlist = NULL;
     try {
-        pathlist = getattrInternal<ExceptionStyle::CXX>(module, path_str, NULL);
+        pathlist = getattrInternal<ExceptionStyle::CXX>(module, path_str);
     } catch (ExcInfo e) {
         if (!e.matches(AttributeError))
             throw e;
@@ -580,14 +580,14 @@ static void ensureFromlist(Box* module, Box* fromlist, std::string& buf, bool re
                 continue;
 
             static BoxedString* all_str = internStringImmortal("__all__");
-            Box* all = getattrInternal<ExceptionStyle::CXX>(module, all_str, NULL);
+            Box* all = getattrInternal<ExceptionStyle::CXX>(module, all_str);
             if (all) {
                 ensureFromlist(module, all, buf, true);
             }
             continue;
         }
 
-        Box* attr = getattrInternal<ExceptionStyle::CXX>(module, s, NULL);
+        Box* attr = getattrInternal<ExceptionStyle::CXX>(module, s);
         if (attr != NULL)
             continue;
 

--- a/src/runtime/list.cpp
+++ b/src/runtime/list.cpp
@@ -837,7 +837,7 @@ private:
 public:
     PyCmpComparer(Box* cmp) : cmp(cmp) {}
     bool operator()(Box* lhs, Box* rhs) {
-        Box* r = runtimeCallInternal<CXX>(cmp, NULL, ArgPassSpec(2), lhs, rhs, NULL, NULL, NULL);
+        Box* r = runtimeCallInternal<CXX, NOT_REWRITABLE>(cmp, NULL, ArgPassSpec(2), lhs, rhs, NULL, NULL, NULL);
         if (!PyInt_Check(r))
             raiseExcHelper(TypeError, "comparison function must return int, not %.200s", r->cls->tp_name);
         return static_cast<BoxedInt*>(r)->n < 0;
@@ -1141,7 +1141,7 @@ Box* _listCmp(BoxedList* lhs, BoxedList* rhs, AST_TYPE::AST_TYPE op_type) {
         } else if (op_type == AST_TYPE::NotEq) {
             return boxBool(true);
         } else {
-            Box* r = compareInternal(lhs->elts->elts[i], rhs->elts->elts[i], op_type, NULL);
+            Box* r = compareInternal<NOT_REWRITABLE>(lhs->elts->elts[i], rhs->elts->elts[i], op_type, NULL);
             return r;
         }
     }

--- a/src/runtime/super.cpp
+++ b/src/runtime/super.cpp
@@ -127,7 +127,7 @@ Box* superGetattribute(Box* _s, Box* _attr) {
         }
     }
 
-    Box* r = typeLookup(s->cls, attr, NULL);
+    Box* r = typeLookup(s->cls, attr);
     // TODO implement this
     RELEASE_ASSERT(r, "should call the equivalent of objectGetattr here");
     return processDescriptor(r, s, s->cls);

--- a/src/runtime/types.cpp
+++ b/src/runtime/types.cpp
@@ -770,8 +770,8 @@ static Box* objectNewNoArgs(BoxedClass* cls) noexcept {
 #ifndef NDEBUG
     static BoxedString* new_str = internStringImmortal("__new__");
     static BoxedString* init_str = internStringImmortal("__init__");
-    assert(typeLookup(cls, new_str, NULL) == typeLookup(object_cls, new_str, NULL)
-           && typeLookup(cls, init_str, NULL) != typeLookup(object_cls, init_str, NULL));
+    assert(typeLookup(cls, new_str) == typeLookup(object_cls, new_str)
+           && typeLookup(cls, init_str) != typeLookup(object_cls, init_str));
 #endif
     return new (cls) Box();
 }
@@ -934,7 +934,7 @@ static Box* typeCallInner(CallRewriteArgs* rewrite_args, ArgPassSpec argspec, Bo
             }
         }
     } else {
-        new_attr = typeLookup(cls, new_str, NULL);
+        new_attr = typeLookup(cls, new_str);
         try {
             if (new_attr->cls != function_cls) // optimization
                 new_attr = processDescriptor(new_attr, None, cls);
@@ -982,7 +982,7 @@ static Box* typeCallInner(CallRewriteArgs* rewrite_args, ArgPassSpec argspec, Bo
     static std::vector<Box*> class_making_news;
     if (class_making_news.empty()) {
         for (BoxedClass* allowed_cls : { object_cls, enumerate_cls, xrange_cls, tuple_cls, list_cls, dict_cls }) {
-            auto new_obj = typeLookup(allowed_cls, new_str, NULL);
+            auto new_obj = typeLookup(allowed_cls, new_str);
             gc::registerPermanentRoot(new_obj, /* allow_duplicates= */ true);
             class_making_news.push_back(new_obj);
         }
@@ -1062,7 +1062,7 @@ static Box* typeCallInner(CallRewriteArgs* rewrite_args, ArgPassSpec argspec, Bo
                 }
             }
         } else {
-            init_attr = typeLookup(cls, init_str, NULL);
+            init_attr = typeLookup(cls, init_str);
         }
     }
 
@@ -1112,7 +1112,8 @@ static Box* typeCallInner(CallRewriteArgs* rewrite_args, ArgPassSpec argspec, Bo
             if (new_npassed_args >= 4)
                 srewrite_args.args = rewrite_args->args;
 
-            made = runtimeCallInternal<S>(new_attr, &srewrite_args, new_argspec, cls, arg2, arg3, args, keyword_names);
+            made = runtimeCallInternal<S, REWRITABLE>(new_attr, &srewrite_args, new_argspec, cls, arg2, arg3, args,
+                                                      keyword_names);
             if (!made) {
                 assert(S == CAPI);
 
@@ -1135,7 +1136,8 @@ static Box* typeCallInner(CallRewriteArgs* rewrite_args, ArgPassSpec argspec, Bo
             made = objectNewNoArgs(cls);
             assert(made);
         } else
-            made = runtimeCallInternal<S>(new_attr, NULL, new_argspec, cls, arg2, arg3, args, keyword_names);
+            made = runtimeCallInternal<S, NOT_REWRITABLE>(new_attr, NULL, new_argspec, cls, arg2, arg3, args,
+                                                          keyword_names);
 
         if (!made) {
             assert(S == CAPI);
@@ -1248,8 +1250,8 @@ static Box* typeCallInner(CallRewriteArgs* rewrite_args, ArgPassSpec argspec, Bo
                 srewrite_args.args_guarded = rewrite_args->args_guarded;
                 srewrite_args.func_guarded = true;
 
-                initrtn
-                    = runtimeCallInternal<S>(init_attr, &srewrite_args, argspec, made, arg2, arg3, args, keyword_names);
+                initrtn = runtimeCallInternal<S, REWRITABLE>(init_attr, &srewrite_args, argspec, made, arg2, arg3, args,
+                                                             keyword_names);
 
                 if (!srewrite_args.out_success) {
                     rewrite_args = NULL;
@@ -1258,7 +1260,8 @@ static Box* typeCallInner(CallRewriteArgs* rewrite_args, ArgPassSpec argspec, Bo
                     rewrite_args->rewriter->call(true, (void*)assertInitNone, srewrite_args.out_rtn);
                 }
             } else {
-                initrtn = runtimeCallInternal<S>(init_attr, NULL, argspec, made, arg2, arg3, args, keyword_names);
+                initrtn = runtimeCallInternal<S, NOT_REWRITABLE>(init_attr, NULL, argspec, made, arg2, arg3, args,
+                                                                 keyword_names);
             }
 
             if (!initrtn) {
@@ -1823,7 +1826,8 @@ extern "C" Box* sliceNew(Box* cls, Box* start, Box* stop, Box** args) {
 
 static Box* instancemethodCall(BoxedInstanceMethod* self, Box* args, Box* kwargs) {
     // Not the most effficient, but it works:
-    return runtimeCallInternal<CXX>(self, NULL, ArgPassSpec(0, 0, true, true), args, kwargs, NULL, NULL, NULL);
+    return runtimeCallInternal<CXX, NOT_REWRITABLE>(self, NULL, ArgPassSpec(0, 0, true, true), args, kwargs, NULL, NULL,
+                                                    NULL);
     // TODO add a tpp_call
 }
 
@@ -1872,7 +1876,7 @@ static Box* instancemethodRepr(Box* b) {
     const char* sfuncname = "?", * sklassname = "?";
 
     static BoxedString* name_str = internStringImmortal("__name__");
-    funcname = getattrInternal<CXX>(func, name_str, NULL);
+    funcname = getattrInternal<CXX>(func, name_str);
 
     if (funcname != NULL) {
         if (!PyString_Check(funcname)) {
@@ -1884,7 +1888,7 @@ static Box* instancemethodRepr(Box* b) {
     if (klass == NULL) {
         klassname = NULL;
     } else {
-        klassname = getattrInternal<CXX>(klass, name_str, NULL);
+        klassname = getattrInternal<CXX>(klass, name_str);
         if (klassname != NULL) {
             if (!PyString_Check(klassname)) {
                 klassname = NULL;
@@ -1916,7 +1920,7 @@ Box* instancemethodEq(BoxedInstanceMethod* self, Box* rhs) {
             return boxBool(true);
         } else {
             if (self->obj != NULL && rhs_im->obj != NULL) {
-                return compareInternal(self->obj, rhs_im->obj, AST_TYPE::Eq, NULL);
+                return compareInternal<NOT_REWRITABLE>(self->obj, rhs_im->obj, AST_TYPE::Eq, NULL);
             } else {
                 return boxBool(false);
             }
@@ -2325,8 +2329,8 @@ public:
 
         if (self->isDictBacked()) {
             static BoxedString* setitem_str = internStringImmortal("__setitem__");
-            return callattrInternal<CXX>(self->getDictBacking(), setitem_str, LookupScope::CLASS_ONLY, NULL,
-                                         ArgPassSpec(2), _key, value, NULL, NULL, NULL);
+            return callattrInternal<CXX, NOT_REWRITABLE>(self->getDictBacking(), setitem_str, LookupScope::CLASS_ONLY,
+                                                         NULL, ArgPassSpec(2), _key, value, NULL, NULL, NULL);
         }
 
         assert(_key->cls == str_cls);
@@ -2362,8 +2366,9 @@ public:
 
         if (self->isDictBacked()) {
             static BoxedString* setdefault_str = internStringImmortal("setdefault");
-            return callattrInternal<CXX>(self->getDictBacking(), setdefault_str, LookupScope::CLASS_ONLY, NULL,
-                                         ArgPassSpec(2), _key, value, NULL, NULL, NULL);
+            return callattrInternal<CXX, NOT_REWRITABLE>(self->getDictBacking(), setdefault_str,
+                                                         LookupScope::CLASS_ONLY, NULL, ArgPassSpec(2), _key, value,
+                                                         NULL, NULL, NULL);
         }
 
         assert(_key->cls == str_cls);
@@ -2649,8 +2654,8 @@ public:
 
         if (self->isDictBacked()) {
             static BoxedString* iter_str = internStringImmortal("__iter__");
-            return callattrInternal<CXX>(self->getDictBacking(), iter_str, LookupScope::CLASS_ONLY, NULL,
-                                         ArgPassSpec(0), NULL, NULL, NULL, NULL, NULL);
+            return callattrInternal<CXX, NOT_REWRITABLE>(self->getDictBacking(), iter_str, LookupScope::CLASS_ONLY,
+                                                         NULL, ArgPassSpec(0), NULL, NULL, NULL, NULL, NULL);
         }
 
         return new AttrWrapperIter(self);
@@ -2664,8 +2669,8 @@ public:
         BoxedDict* dict = (BoxedDict*)AttrWrapper::copy(_self);
         assert(dict->cls == dict_cls);
         static BoxedString* eq_str = internStringImmortal("__eq__");
-        return callattrInternal<CXX>(dict, eq_str, LookupScope::CLASS_ONLY, NULL, ArgPassSpec(1), _other, NULL, NULL,
-                                     NULL, NULL);
+        return callattrInternal<CXX, NOT_REWRITABLE>(dict, eq_str, LookupScope::CLASS_ONLY, NULL, ArgPassSpec(1),
+                                                     _other, NULL, NULL, NULL, NULL);
     }
 
     static Box* ne(Box* _self, Box* _other) { return eq(_self, _other) == True ? False : True; }
@@ -2840,7 +2845,7 @@ Box* objectSetattr(Box* obj, Box* attr, Box* value) {
     }
 
     BoxedString* attr_str = static_cast<BoxedString*>(attr);
-    setattrGeneric(obj, attr_str, value, NULL);
+    setattrGeneric<NOT_REWRITABLE>(obj, attr_str, value, NULL);
     return None;
 }
 


### PR DESCRIPTION
use a template to remove rewriter checks inside our most important runtime funcs when we know that the rewrite_args are NULL.
This is similar to #657 but uses a template arg. (as long as we only have two template args I think the are fine to use ... three would be bad :-D)
I looked at the assembly which clang generated and it's able to remove all rewriter specific code just by setting the ```rewriter_args``` to NULL in the beginning of the function.

Sadly this touches quite a lot of lines but I don't think the change is likely to introduce any bug because of this assert I added ```if (rewritable == NOT_REWRITABLE) {       assert(!rewrite_args); ```
```
                                origin/rewritable~:   origin/rewritable:
           django_template3.py             2.7s (4)             2.7s (4)  -1.3%
                 pyxl_bench.py             2.2s (4)             2.2s (4)  -1.7%
     sqlalchemy_imperative2.py             2.7s (4)             2.6s (4)  -2.4%
                       geomean                 2.5s                 2.5s  -1.8%
```