### PR TITLE
Use travis_wait to workaround the no output received error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,7 @@ before_script:
 
 script:
   - ccache -z
-  - ninja -j4 pyston check-deps && PYSTON_RUN_ARGS=G ctest --output-on-failure
+  - ninja -j4 pyston check-deps && PYSTON_RUN_ARGS=G travis_wait ctest --output-on-failure
   - ccache -s
   - if [ -n "$(git status --porcelain --untracked=no)" ]; then echo "test suite left the source directory dirty"; git status; false; fi
 


### PR DESCRIPTION
Fixes:
No output has been received in the last 10 minutes, this potentially indicates a stalled build or something wrong with the build itself.