### PR TITLE
Fix a rare 'assert R11 is not used' crash

### DIFF
--- a/src/asm_writing/rewriter.h
+++ b/src/asm_writing/rewriter.h
@@ -489,7 +489,8 @@ protected:
     void _slowpathJump(bool condition_eq);
     void _trap();
     void _loadConst(RewriterVar* result, int64_t val);
-    void _setupCall(bool has_side_effects, llvm::ArrayRef<RewriterVar*> args, llvm::ArrayRef<RewriterVar*> args_xmm);
+    void _setupCall(bool has_side_effects, llvm::ArrayRef<RewriterVar*> args, llvm::ArrayRef<RewriterVar*> args_xmm,
+                    Location preserve = Location::any());
     void _call(RewriterVar* result, bool has_side_effects, void* func_addr, llvm::ArrayRef<RewriterVar*> args,
                llvm::ArrayRef<RewriterVar*> args_xmm);
     void _add(RewriterVar* result, RewriterVar* a, int64_t b, Location dest);


### PR DESCRIPTION
I think it's because the initial allocation of it fails.  This only shows
up in the debug build of lxml_test, which doesn't get tested through CI.