### PR TITLE
typeLookup: guard on tp_version_tag instead of mro

### DIFF
--- a/from_cpython/Include/object.h
+++ b/from_cpython/Include/object.h
@@ -430,7 +430,9 @@ typedef PyObject *(*allocfunc)(PyTypeObject *, Py_ssize_t);
     destructor tp_del;\
                                                                                 \
     /* Type attribute cache version tag. Added in version 2.6 */\
-    unsigned int tp_version_tag;    \
+    /* Pyston change: change uint to 64bit uint
+    unsigned int tp_version_tag; */    \
+    PY_UINT64_T tp_version_tag;        \
 \
     /* Pyston changes: added these fields */ \
 

--- a/src/asm_writing/assembler.cpp
+++ b/src/asm_writing/assembler.cpp
@@ -127,6 +127,17 @@ void Assembler::emitInt(int64_t n, int bytes) {
     ASSERT(n == 0 || n == -1, "%ld", n);
 }
 
+void Assembler::emitUInt(uint64_t n, int bytes) {
+    assert(bytes > 0 && bytes <= 8);
+    if (bytes < 8)
+        assert(n < ((1UL << (8 * bytes))));
+
+    for (int i = 0; i < bytes; i++) {
+        emitByte(n & 0xff);
+        n >>= 8;
+    }
+    ASSERT(n == 0, "%lu", n);
+}
 void Assembler::emitRex(uint8_t rex) {
     emitByte(rex | 0x40);
 }
@@ -167,7 +178,7 @@ void Assembler::mov(Immediate val, Register dest, bool force_64bit_load) {
     if (rex)
         emitRex(rex);
     emitByte(0xb8 + dest_idx);
-    emitInt(val.val, force_64bit_load ? 8 : 4);
+    emitUInt(val.val, force_64bit_load ? 8 : 4);
 }
 
 void Assembler::movq(Immediate src, Indirect dest) {

--- a/src/asm_writing/assembler.h
+++ b/src/asm_writing/assembler.h
@@ -83,6 +83,7 @@ private:
 private:
     void emitByte(uint8_t b);
     void emitInt(int64_t n, int bytes);
+    void emitUInt(uint64_t n, int bytes);
     void emitRex(uint8_t rex);
     void emitModRM(uint8_t mod, uint8_t reg, uint8_t rm);
     void emitSIB(uint8_t scalebits, uint8_t index, uint8_t base);

--- a/src/asm_writing/rewriter.cpp
+++ b/src/asm_writing/rewriter.cpp
@@ -270,6 +270,11 @@ void Rewriter::assertArgsInPlace() {
 void RewriterVar::addGuard(uint64_t val) {
     STAT_TIMER(t0, "us_timer_rewriter", 10);
 
+    if (isConstant()) {
+        RELEASE_ASSERT(constant_value == val, "added guard which is always false");
+        return;
+    }
+
     RewriterVar* val_var = rewriter->loadConst(val);
     rewriter->addAction([=]() { rewriter->_addGuard(this, val_var); }, { this, val_var }, ActionType::GUARD);
 }


### PR DESCRIPTION
This if WIP but before spending more time on it I would like to get feedback on it.
This removes the guarding ```Box::getattr``` adds for types which have the ```HAVE_VERSION_TAG``` set (aka. all types except capi extensions types which are not part of pyston)
instead it guards on the ```tp_version_tag```. 
There is currently a problem that the version tags are only 32bit and can overflow. So in case they overflow we need some mechanism to invalidate all ICs....

Perf change of the last commit:
```
           django_template3.py             2.3s (4)             2.3s (4)  -1.2%
                 pyxl_bench.py             2.0s (4)             2.0s (4)  -2.4%
     sqlalchemy_imperative2.py             2.5s (4)             2.5s (4)  -2.6%
                       geomean                 2.3s                 2.2s  -2.1%
```