### PR TITLE
Reenable unboxed values

### DIFF
--- a/src/analysis/type_analysis.cpp
+++ b/src/analysis/type_analysis.cpp
@@ -197,7 +197,7 @@ private:
         }
     }
 
-    void* visit_ellipsis(AST_Ellipsis* node) override { return ELLIPSIS; }
+    void* visit_ellipsis(AST_Ellipsis* node) override { return typeFromClass(ellipsis_cls); }
 
     void* visit_attribute(AST_Attribute* node) override {
         CompilerType* t = getType(node->value);

--- a/src/analysis/type_analysis.cpp
+++ b/src/analysis/type_analysis.cpp
@@ -62,10 +62,8 @@ static CompilerType* unboxedType(ConcreteCompilerType* t) {
         return BOOL;
     if (t == BOXED_INT)
         return INT;
-#if ENABLE_UNBOXED_VALUES
     if (t == BOXED_FLOAT)
         return FLOAT;
-#endif
     return t;
 }
 

--- a/src/codegen/compvars.cpp
+++ b/src/codegen/compvars.cpp
@@ -155,7 +155,7 @@ public:
         return var->getValue()->func->call(emitter, info, new_argspec, new_args, keyword_names);
     }
 
-    bool canConvertTo(ConcreteCompilerType* other_type) override { return other_type == UNKNOWN; }
+    bool canConvertTo(CompilerType* other_type) override { return other_type == UNKNOWN; }
     ConcreteCompilerType* getConcreteType() override { return typeFromClass(instancemethod_cls); }
     ConcreteCompilerType* getBoxType() override { return getConcreteType(); }
     ConcreteCompilerVariable* makeConverted(IREmitter& emitter, VAR* var, ConcreteCompilerType* other_type) override {
@@ -324,7 +324,7 @@ public:
         abort();
     }
 
-    ConcreteCompilerVariable* len(IREmitter& emitter, const OpInfo& info, ConcreteCompilerVariable* var) override {
+    CompilerVariable* len(IREmitter& emitter, const OpInfo& info, ConcreteCompilerVariable* var) override {
         bool do_patchpoint = ENABLE_ICGENERICS;
         llvm::Value* rtn;
         if (do_patchpoint) {
@@ -338,7 +338,7 @@ public:
             rtn = emitter.createCall(info.unw_info, g.funcs.unboxedLen, var->getValue());
         }
         assert(rtn->getType() == g.i64);
-        return new ConcreteCompilerVariable(INT, rtn, true);
+        return makeInt(rtn);
     }
 
     CompilerVariable* getitem(IREmitter& emitter, const OpInfo& info, ConcreteCompilerVariable* var,
@@ -849,7 +849,7 @@ public:
 
     ConcreteCompilerType* getBoxType() override { return UNKNOWN; }
 
-    bool canConvertTo(ConcreteCompilerType* other_type) override { return other_type == UNKNOWN; }
+    bool canConvertTo(CompilerType* other_type) override { return other_type == UNKNOWN; }
 
     CompilerType* getattrType(BoxedString* attr, bool cls_only) override { return UNDEF; }
 
@@ -901,7 +901,7 @@ public:
 
             Sig* type_sig = new Sig();
             auto paramspec = rtfunc->getParamspec();
-            type_sig->rtn_type = fspec->rtn_type;
+            type_sig->rtn_type = fspec->rtn_type->getUsableType();
             type_sig->ndefaults = paramspec.num_defaults;
             type_sig->takes_varargs = paramspec.takes_varargs;
             type_sig->takes_kwargs = paramspec.takes_kwargs;
@@ -928,20 +928,143 @@ public:
     int numFrameArgs() override { abort(); }
 };
 
-class IntType : public ConcreteCompilerType {
+template <typename T> struct UnboxedVal {
+    T val;
+    ConcreteCompilerVariable* boxed;
+
+    UnboxedVal(T val, ConcreteCompilerVariable* boxed) : val(std::move(val)), boxed(boxed) {}
+};
+
+// XXX: make this a over a unique_ptr<UnboxedVal>
+template <typename T, typename D> class UnboxedType : public ValuedCompilerType<std::shared_ptr<UnboxedVal<T>>> {
+public:
+    // Subclasses need to implement:
+    //   _makeConverted
+    //   _dup
+    //   _drop
+    //   _numFrameArgs
+    //   _serializeToFrame
+    //   _deserializeFromFrame
+    typedef UnboxedVal<T> Unboxed;
+    typedef typename ValuedCompilerType<std::shared_ptr<UnboxedVal<T>>>::VAR VAR;
+
+    void drop(IREmitter& emitter, VAR* var) override final {
+        auto v = var->getValue();
+        if (v->boxed)
+            v->boxed->decvref(emitter);
+        static_cast<D*>(this)->_drop(emitter, v->val);
+    }
+
+    void grab(IREmitter& emitter, VAR* var) override final { RELEASE_ASSERT(0, ""); }
+
+    void assertMatches(std::shared_ptr<Unboxed> val) override final {
+        static_cast<D*>(this)->_assertMatches(val->val);
+        assert(!val->boxed || val->boxed->getType() == static_cast<D*>(this)->getBoxType());
+    }
+
+    CompilerVariable* dup(VAR* var, DupCache& cache) override final {
+        CompilerVariable*& rtn = cache[var];
+
+        if (rtn == NULL) {
+            auto orig_v = var->getValue();
+
+            T val_duped = static_cast<D*>(this)->_dup(orig_v->val, cache);
+
+            CompilerVariable* box_duped = orig_v->boxed ? orig_v->boxed->dup(cache) : NULL;
+            assert(!box_duped || box_duped->getType() == box_duped->getType()->getBoxType());
+
+            auto val = std::make_shared<Unboxed>( std::move(val_duped), static_cast<ConcreteCompilerVariable*>(box_duped) );
+            rtn = new VAR(this, val,
+                          var->isGrabbed());
+            while (rtn->getVrefs() < var->getVrefs())
+                rtn->incvref();
+        }
+        return rtn;
+    }
+
+    bool canConvertTo(CompilerType* other_type) override final {
+        return (other_type == this || other_type == UNKNOWN || other_type == this->getBoxType());
+    }
+
+    ConcreteCompilerVariable* makeConverted(IREmitter& emitter, VAR* var,
+                                            ConcreteCompilerType* other_type) override final {
+        assert(canConvertTo(other_type));
+
+        auto val = var->getValue();
+        ConcreteCompilerVariable* boxed = val->boxed;
+
+        if (!boxed) {
+            boxed = static_cast<D*>(this)->_makeConverted(emitter, val->val, this->getBoxType());
+            ASSERT(boxed->getType() == this->getBoxType(), "%s %s", boxed->getType()->debugName().c_str(),
+                   this->getBoxType()->debugName().c_str());
+
+            val->boxed = boxed;
+        }
+
+        if (boxed->getType() != other_type) {
+            assert(other_type == UNKNOWN);
+            return boxed->makeConverted(emitter, other_type);
+        }
+
+        boxed->incvref();
+        return boxed;
+    }
+
+    // Serialization strategy is a bit silly for now: we will emit a bool saying whether we emitted the
+    // boxed or unboxed value.  There's no reason that has to be in the serialization though (it could
+    // be in the metadata), and we shouldn't have to pad the smaller version to the size of the larger one.
+    int numFrameArgs() override final {
+        return 1 + std::max(static_cast<D*>(this)->_numFrameArgs(), this->getBoxType()->numFrameArgs());
+    }
+
+    void serializeToFrame(VAR* var, std::vector<llvm::Value*>& stackmap_args) override final {
+        auto v = var->getValue();
+
+        int total_args = numFrameArgs();
+        int needed_args = stackmap_args.size() + total_args;
+
+        if (v->boxed) {
+            stackmap_args.push_back(getConstantInt(1, g.i64));
+            v->boxed->serializeToFrame(stackmap_args);
+        } else {
+            stackmap_args.push_back(getConstantInt(0, g.i64));
+            static_cast<D*>(this)->_serializeToFrame(v->val, stackmap_args);
+        }
+
+        while (stackmap_args.size() < needed_args)
+            stackmap_args.push_back(getConstantInt(0, g.i64));
+    }
+
+    Box* deserializeFromFrame(const FrameVals& vals) override final {
+        assert(vals.size() == numFrameArgs());
+
+
+        bool is_boxed = vals[0];
+
+        if (is_boxed) {
+            // TODO: inefficient
+            FrameVals sub_vals(vals.begin() + 1, vals.begin() + 1 + this->getBoxType()->numFrameArgs());
+            return this->getBoxType()->deserializeFromFrame(sub_vals);
+        } else {
+            FrameVals sub_vals(vals.begin() + 1, vals.begin() + 1 + static_cast<D*>(this)->_numFrameArgs());
+            return static_cast<D*>(this)->_deserializeFromFrame(sub_vals);
+        }
+    }
+};
+
+class IntType : public UnboxedType<llvm::Value*, IntType> {
 public:
     IntType() {}
 
-    llvm::Type* llvmType() override { return g.i64; }
+    void _drop(IREmitter& emitter, llvm::Value* v) {}
 
-    bool isFitBy(BoxedClass* c) override { return false; }
+    llvm::Value* _dup(llvm::Value* v, DupCache& cache) { return v; }
 
-    void drop(IREmitter& emitter, ConcreteCompilerVariable* var) override {
-        // pass
-    }
-    void grab(IREmitter& emitter, ConcreteCompilerVariable* var) override {
-        // pass
-    }
+    void _assertMatches(llvm::Value* v) { assert(v->getType() == g.i64); }
+
+    ConcreteCompilerType* getConcreteType() override { return BOXED_INT; }
+
+    std::string debugName() override { return "int"; }
 
     CompilerType* getattrType(BoxedString* attr, bool cls_only) override {
         /*
@@ -993,8 +1116,8 @@ public:
         return BOXED_INT->getattrType(attr, cls_only);
     }
 
-    CompilerVariable* callattr(IREmitter& emitter, const OpInfo& info, ConcreteCompilerVariable* var, BoxedString* attr,
-                               CallattrFlags flags, const std::vector<CompilerVariable*>& args,
+    CompilerVariable* callattr(IREmitter& emitter, const OpInfo& info, VAR* var, BoxedString* attr, CallattrFlags flags,
+                               const std::vector<CompilerVariable*>& args,
                                const std::vector<BoxedString*>* keyword_names) override {
         ConcreteCompilerVariable* converted = var->makeConverted(emitter, BOXED_INT);
         CompilerVariable* rtn = converted->callattr(emitter, info, attr, flags, args, keyword_names);
@@ -1002,7 +1125,7 @@ public:
         return rtn;
     }
 
-    CompilerVariable* getattr(IREmitter& emitter, const OpInfo& info, ConcreteCompilerVariable* var, BoxedString* attr,
+    CompilerVariable* getattr(IREmitter& emitter, const OpInfo& info, VAR* var, BoxedString* attr,
                               bool cls_only) override {
         ConcreteCompilerVariable* converted = var->makeConverted(emitter, BOXED_INT);
         CompilerVariable* rtn = converted->getattr(emitter, info, attr, cls_only);
@@ -1024,24 +1147,16 @@ public:
         call.setDoesNotReturn();
     }
 
-    ConcreteCompilerVariable* makeConverted(IREmitter& emitter, ConcreteCompilerVariable* var,
-                                            ConcreteCompilerType* other_type) override {
-        if (other_type == this) {
-            var->incvref();
-            return var;
-        } else if (other_type == UNKNOWN || other_type == BOXED_INT) {
-            llvm::Value* unboxed = var->getValue();
-            llvm::Value* boxed;
-            if (llvm::ConstantInt* llvm_val = llvm::dyn_cast<llvm::ConstantInt>(unboxed)) {
-                boxed = embedRelocatablePtr(emitter.getIntConstant(llvm_val->getSExtValue()), g.llvm_value_type_ptr);
-            } else {
-                boxed = emitter.getBuilder()->CreateCall(g.funcs.boxInt, var->getValue());
-            }
-            return new ConcreteCompilerVariable(other_type, boxed, true);
+    ConcreteCompilerVariable* _makeConverted(IREmitter& emitter, llvm::Value* unboxed,
+                                             ConcreteCompilerType* other_type) {
+        assert(other_type == BOXED_INT);
+        llvm::Value* boxed;
+        if (llvm::ConstantInt* llvm_val = llvm::dyn_cast<llvm::ConstantInt>(unboxed)) {
+            boxed = embedRelocatablePtr(emitter.getIntConstant(llvm_val->getSExtValue()), g.llvm_value_type_ptr);
         } else {
-            printf("Don't know how to convert i64 to %s\n", other_type->debugName().c_str());
-            abort();
+            boxed = emitter.getBuilder()->CreateCall(g.funcs.boxInt, unboxed);
         }
+        return new ConcreteCompilerVariable(other_type, boxed, true);
     }
 
     CompilerVariable* getitem(IREmitter& emitter, const OpInfo& info, VAR* var, CompilerVariable* slice) override {
@@ -1051,21 +1166,21 @@ public:
         return rtn;
     }
 
-    ConcreteCompilerVariable* len(IREmitter& emitter, const OpInfo& info, VAR* var) override {
+    CompilerVariable* len(IREmitter& emitter, const OpInfo& info, VAR* var) override {
         llvm::CallSite call
             = emitter.createCall(info.unw_info, g.funcs.raiseNotIterableError, embedConstantPtr("int", g.i8_ptr));
         call.setDoesNotReturn();
-        return new ConcreteCompilerVariable(INT, llvm::UndefValue::get(g.i64), true);
+        return makeInt(llvm::UndefValue::get(g.i64));
     }
 
-    ConcreteCompilerVariable* nonzero(IREmitter& emitter, const OpInfo& info, ConcreteCompilerVariable* var) override {
-        llvm::Value* cmp = emitter.getBuilder()->CreateICmpNE(var->getValue(), llvm::ConstantInt::get(g.i64, 0, false));
+    ConcreteCompilerVariable* nonzero(IREmitter& emitter, const OpInfo& info, VAR* var) override {
+        llvm::Value* cmp
+            = emitter.getBuilder()->CreateICmpNE(var->getValue()->val, llvm::ConstantInt::get(g.i64, 0, false));
         return boolFromI1(emitter, cmp);
     }
 
-    ConcreteCompilerVariable* unaryop(IREmitter& emitter, const OpInfo& info, ConcreteCompilerVariable* var,
-                                      AST_TYPE::AST_TYPE op_type) override {
-        llvm::Value* unboxed = var->getValue();
+    CompilerVariable* unaryop(IREmitter& emitter, const OpInfo& info, VAR* var, AST_TYPE::AST_TYPE op_type) override {
+        llvm::Value* unboxed = var->getValue()->val;
         if (op_type == AST_TYPE::USub) {
             if (llvm::ConstantInt* llvm_val = llvm::dyn_cast<llvm::ConstantInt>(unboxed)) {
                 int64_t val = llvm_val->getSExtValue();
@@ -1092,10 +1207,8 @@ public:
                 if (op_type == AST_TYPE::IsNot || op_type == AST_TYPE::Is)
                     return makeBool(op_type == AST_TYPE::IsNot);
 
-                ConcreteCompilerVariable* converted_left = var->makeConverted(emitter, INT);
-                llvm::Value* conv = emitter.getBuilder()->CreateSIToFP(converted_left->getValue(), g.double_);
-                converted_left->decvref(emitter);
-                converted_left = new ConcreteCompilerVariable(FLOAT, conv, true);
+                llvm::Value* conv = emitter.getBuilder()->CreateSIToFP(var->getValue()->val, g.double_);
+                auto converted_left = new ConcreteCompilerVariable(FLOAT, conv, true);
                 return converted_left->binexp(emitter, info, rhs, op_type, exp_type);
             }
 
@@ -1105,7 +1218,8 @@ public:
             return rtn;
         }
 
-        ConcreteCompilerVariable* converted_right = rhs->makeConverted(emitter, INT);
+        assert(rhs->getType() == INT);
+        llvm::Value* right_val = static_cast<VAR*>(rhs)->getValue()->val;
         llvm::Value* v;
         /*if (op_type == AST_TYPE::Mod) {
             v = emitter.createCall2(info.unw_info, g.funcs.mod_i64_i64, var->getValue(), converted_right->getValue())
@@ -1178,14 +1292,10 @@ public:
                     abort();
                     break;
             }
-            v = emitter.getBuilder()->CreateICmp(cmp_pred, var->getValue(), converted_right->getValue());
+            v = emitter.getBuilder()->CreateICmp(cmp_pred, var->getValue()->val, right_val);
         }
-        converted_right->decvref(emitter);
-        if (v->getType() == g.i64) {
-            return new ConcreteCompilerVariable(INT, v, true);
-        } else {
-            return boolFromI1(emitter, v);
-        }
+        assert(v->getType() == g.i1);
+        return boolFromI1(emitter, v);
     }
 
     CompilerVariable* contains(IREmitter& emitter, const OpInfo& info, VAR* var, CompilerVariable* lhs) override {
@@ -1197,16 +1307,36 @@ public:
 
     ConcreteCompilerType* getBoxType() override { return BOXED_INT; }
 
-    Box* deserializeFromFrame(const FrameVals& vals) override {
+    int _numFrameArgs() { return 1; }
+
+    Box* _deserializeFromFrame(const FrameVals& vals) {
         assert(vals.size() == 1);
 
         return boxInt(vals[0]);
     }
-} _INT;
-ConcreteCompilerType* INT = &_INT;
 
-ConcreteCompilerVariable* makeInt(int64_t n) {
-    return new ConcreteCompilerVariable(INT, llvm::ConstantInt::get(g.i64, n, true), true);
+    void _serializeToFrame(llvm::Value* val, std::vector<llvm::Value*>& stackmap_args) { stackmap_args.push_back(val); }
+} _INT;
+CompilerType* INT = &_INT;
+
+CompilerVariable* makeInt(llvm::Value* n) {
+    assert(n->getType() == g.i64);
+    return new IntType::VAR(&_INT, std::make_shared<IntType::Unboxed>(n, nullptr), true);
+}
+
+CompilerVariable* makeInt(int64_t n) {
+    return makeInt(llvm::ConstantInt::get(g.i64, n, true));
+}
+
+CompilerVariable* makeUnboxedInt(IREmitter& emitter, ConcreteCompilerVariable* v) {
+    assert(v->getType() == BOXED_INT);
+    llvm::Value* unboxed = emitter.getBuilder()->CreateCall(g.funcs.unboxInt, v->getValue());
+    return new IntType::VAR(&_INT, std::make_shared<IntType::Unboxed>( unboxed, v ), true);
+}
+
+CompilerVariable* makeUnboxedInt(IREmitter& emitter, llvm::Value* v) {
+    assert(v->getType() == g.llvm_value_type_ptr);
+    return makeUnboxedInt(emitter, new ConcreteCompilerVariable(BOXED_INT, v, false));
 }
 
 class FloatType : public ConcreteCompilerType {
@@ -1234,7 +1364,7 @@ public:
 
             AbstractFunctionType::Sig* int_sig = new AbstractFunctionType::Sig();
             int_sig->rtn_type = FLOAT;
-            int_sig->arg_types.push_back(INT);
+            int_sig->arg_types.push_back(UNBOXED_INT);
             sigs.push_back(int_sig);
 
             AbstractFunctionType::Sig* unknown_sig = new AbstractFunctionType::Sig();
@@ -1316,8 +1446,8 @@ public:
         return boolFromI1(emitter, cmp);
     }
 
-    ConcreteCompilerVariable* unaryop(IREmitter& emitter, const OpInfo& info, ConcreteCompilerVariable* var,
-                                      AST_TYPE::AST_TYPE op_type) override {
+    CompilerVariable* unaryop(IREmitter& emitter, const OpInfo& info, ConcreteCompilerVariable* var,
+                              AST_TYPE::AST_TYPE op_type) override {
         ConcreteCompilerVariable* converted = var->makeConverted(emitter, BOXED_FLOAT);
         auto rtn = converted->unaryop(emitter, info, op_type);
         converted->decvref(emitter);
@@ -1347,9 +1477,9 @@ public:
             if (op_type == AST_TYPE::IsNot || op_type == AST_TYPE::Is)
                 return makeBool(op_type == AST_TYPE::IsNot);
 
-            converted_right = rhs->makeConverted(emitter, INT);
-            llvm::Value* conv = emitter.getBuilder()->CreateSIToFP(converted_right->getValue(), g.double_);
-            converted_right->decvref(emitter);
+            assert(rhs->getType() == INT);
+            llvm::Value* right_val = static_cast<IntType::VAR*>(rhs)->getValue()->val;
+            llvm::Value* conv = emitter.getBuilder()->CreateSIToFP(right_val, g.double_);
             converted_right = new ConcreteCompilerVariable(FLOAT, conv, true);
         }
 
@@ -1460,6 +1590,27 @@ public:
     }
 } _FLOAT;
 ConcreteCompilerType* FLOAT = &_FLOAT;
+
+class PhonyUnboxedType : public ConcreteCompilerType {
+private:
+    llvm::Type* t;
+    CompilerType* usable_type;
+
+public:
+    PhonyUnboxedType(llvm::Type* t, CompilerType* usable_type) : t(t), usable_type(usable_type) {}
+
+    std::string debugName() { return "phony(" + ConcreteCompilerType::debugName() + ")"; }
+
+    CompilerType* getUsableType() override {
+        return usable_type;
+    }
+
+    llvm::Type* llvmType() override { return t; }
+
+    Box* deserializeFromFrame(const FrameVals& vals) override { RELEASE_ASSERT(0, "unavailable for phony types"); }
+};
+
+ConcreteCompilerType* UNBOXED_INT = new PhonyUnboxedType(llvm::Type::getInt64Ty(llvm::getGlobalContext()), INT);
 
 ConcreteCompilerVariable* makeFloat(double d) {
     return new ConcreteCompilerVariable(FLOAT, llvm::ConstantFP::get(g.double_, d), true);
@@ -1638,11 +1789,11 @@ public:
         return rtn;
     }
 
-    ConcreteCompilerVariable* tryCallattrConstant(IREmitter& emitter, const OpInfo& info, ConcreteCompilerVariable* var,
-                                                  BoxedString* attr, bool clsonly, ArgPassSpec argspec,
-                                                  const std::vector<CompilerVariable*>& args,
-                                                  const std::vector<BoxedString*>* keyword_names,
-                                                  bool* no_attribute = NULL, ExceptionStyle exception_style = CXX) {
+    CompilerVariable* tryCallattrConstant(IREmitter& emitter, const OpInfo& info, ConcreteCompilerVariable* var,
+                                          BoxedString* attr, bool clsonly, ArgPassSpec argspec,
+                                          const std::vector<CompilerVariable*>& args,
+                                          const std::vector<BoxedString*>* keyword_names, bool* no_attribute = NULL,
+                                          ExceptionStyle exception_style = CXX) {
         if (!canStaticallyResolveGetattrs())
             return NULL;
 
@@ -1770,27 +1921,28 @@ public:
         ConcreteCompilerVariable* rtn = _call(emitter, info, linked_function, cf->exception_style, cf->code, other_args,
                                               argspec, new_args, keyword_names, cf->spec->rtn_type);
         assert(rtn->getType() == cf->spec->rtn_type);
-        assert(rtn->getType() != UNDEF);
+        ConcreteCompilerType* rtn_type = rtn->getType();
+
+        assert(rtn_type != UNDEF);
 
         // We should provide unboxed versions of these rather than boxing then unboxing:
         // TODO is it more efficient to unbox here, or should we leave it boxed?
-        if (cf->spec->rtn_type == BOXED_BOOL) {
+        if (rtn_type == BOXED_BOOL) {
             llvm::Value* unboxed = emitter.getBuilder()->CreateCall(g.funcs.unboxBool, rtn->getValue());
             return boolFromI1(emitter, unboxed);
         }
-#if ENABLE_UNBOXED_VALUES
-        if (cf->spec->rtn_type == BOXED_INT) {
-            llvm::Value* unboxed = emitter.getBuilder()->CreateCall(g.funcs.unboxInt, rtn->getValue());
-            return new ConcreteCompilerVariable(INT, unboxed, true);
+        if (rtn_type == BOXED_INT) {
+            return makeUnboxedInt(emitter, rtn);
         }
-        if (cf->spec->rtn_type == BOXED_FLOAT) {
+        if (rtn_type == UNBOXED_INT) {
+            return makeInt(rtn->getValue());
+        }
+#if ENABLE_UNBOXED_VALUES
+        if (rtn_type == BOXED_FLOAT) {
             llvm::Value* unboxed = emitter.getBuilder()->CreateCall(g.funcs.unboxFloat, rtn->getValue());
             return new ConcreteCompilerVariable(FLOAT, unboxed, true);
         }
-        assert(cf->spec->rtn_type != BOXED_INT);
-        assert(cf->spec->rtn_type != BOXED_FLOAT);
 #endif
-        ASSERT(cf->spec->rtn_type != BOXED_BOOL, "%p", cf->code);
 
         return rtn;
     }
@@ -1800,8 +1952,8 @@ public:
                                const std::vector<BoxedString*>* keyword_names) override {
         ExceptionStyle exception_style = info.preferredExceptionStyle();
 
-        ConcreteCompilerVariable* called_constant = tryCallattrConstant(
-            emitter, info, var, attr, flags.cls_only, flags.argspec, args, keyword_names, NULL, exception_style);
+        CompilerVariable* called_constant = tryCallattrConstant(emitter, info, var, attr, flags.cls_only, flags.argspec,
+                                                                args, keyword_names, NULL, exception_style);
 
         if (called_constant)
             return called_constant;
@@ -1827,7 +1979,7 @@ public:
 
                 bool no_attribute = false;
 
-                ConcreteCompilerVariable* called_constant
+                CompilerVariable* called_constant
                     = tryCallattrConstant(emitter, info, var, left_side_name, true, ArgPassSpec(1, 0, 0, 0),
                                           { converted_rhs }, NULL, &no_attribute);
 
@@ -1863,8 +2015,8 @@ public:
 
         ExceptionStyle exception_style = info.preferredExceptionStyle();
 
-        ConcreteCompilerVariable* called_constant = tryCallattrConstant(
-            emitter, info, var, attr, true, ArgPassSpec(1, 0, 0, 0), { slice }, NULL, &no_attribute, exception_style);
+        CompilerVariable* called_constant = tryCallattrConstant(emitter, info, var, attr, true, ArgPassSpec(1, 0, 0, 0),
+                                                                { slice }, NULL, &no_attribute, exception_style);
 
         if (no_attribute) {
             assert(called_constant->getType() == UNDEF);
@@ -1886,9 +2038,9 @@ public:
         return UNKNOWN->getPystonIter(emitter, info, var);
     }
 
-    ConcreteCompilerVariable* len(IREmitter& emitter, const OpInfo& info, VAR* var) override {
+    CompilerVariable* len(IREmitter& emitter, const OpInfo& info, VAR* var) override {
         static BoxedString* attr = internStringImmortal("__len__");
-        ConcreteCompilerVariable* called_constant
+        CompilerVariable* called_constant
             = tryCallattrConstant(emitter, info, var, attr, true, ArgPassSpec(0, 0, 0, 0), {}, NULL);
         if (called_constant)
             return called_constant;
@@ -1896,13 +2048,13 @@ public:
         return UNKNOWN->len(emitter, info, var);
     }
 
-    ConcreteCompilerVariable* nonzero(IREmitter& emitter, const OpInfo& info, ConcreteCompilerVariable* var) override {
+    CompilerVariable* nonzero(IREmitter& emitter, const OpInfo& info, ConcreteCompilerVariable* var) override {
         if (cls == None->cls)
             return makeBool(false);
 
         static BoxedString* attr = internStringImmortal("__nonzero__");
         bool no_attribute = false;
-        ConcreteCompilerVariable* called_constant
+        CompilerVariable* called_constant
             = tryCallattrConstant(emitter, info, var, attr, true, ArgPassSpec(0, 0, 0, 0), {}, NULL, &no_attribute);
 
         // TODO: if no_attribute, we could optimize by continuing the dispatch process and trying
@@ -1922,12 +2074,12 @@ public:
         return UNKNOWN->nonzero(emitter, info, var);
     }
 
-    ConcreteCompilerVariable* unaryop(IREmitter& emitter, const OpInfo& info, ConcreteCompilerVariable* var,
-                                      AST_TYPE::AST_TYPE op_type) override {
+    CompilerVariable* unaryop(IREmitter& emitter, const OpInfo& info, ConcreteCompilerVariable* var,
+                              AST_TYPE::AST_TYPE op_type) override {
         BoxedString* attr = getOpName(op_type);
 
         bool no_attribute = false;
-        ConcreteCompilerVariable* called_constant
+        CompilerVariable* called_constant
             = tryCallattrConstant(emitter, info, var, attr, true, ArgPassSpec(0, 0, 0, 0), {}, NULL, &no_attribute);
 
         if (called_constant && !no_attribute)
@@ -1936,10 +2088,10 @@ public:
         return UNKNOWN->unaryop(emitter, info, var, op_type);
     }
 
-    ConcreteCompilerVariable* hasnext(IREmitter& emitter, const OpInfo& info, ConcreteCompilerVariable* var) override {
+    CompilerVariable* hasnext(IREmitter& emitter, const OpInfo& info, ConcreteCompilerVariable* var) override {
         static BoxedString* attr = internStringImmortal("__hasnext__");
 
-        ConcreteCompilerVariable* called_constant
+        CompilerVariable* called_constant
             = tryCallattrConstant(emitter, info, var, attr, true, ArgPassSpec(0, 0, 0, 0), {}, NULL, NULL);
 
         if (called_constant)
@@ -2068,7 +2220,7 @@ public:
         return new ConcreteCompilerVariable(other_type, boxed, true);
     }
 
-    bool canConvertTo(ConcreteCompilerType* other) override { return (other == STR || other == UNKNOWN); }
+    bool canConvertTo(CompilerType* other) override { return (other == STR || other == UNKNOWN); }
 
     CompilerVariable* getattr(IREmitter& emitter, const OpInfo& info, VAR* var, BoxedString* attr,
                               bool cls_only) override {
@@ -2181,7 +2333,7 @@ public:
         return var;
     }
 
-    bool canConvertTo(ConcreteCompilerType* other_type) override {
+    bool canConvertTo(CompilerType* other_type) override {
         return (other_type == UNKNOWN || other_type == BOXED_BOOL || other_type == BOOL);
     }
 
@@ -2266,114 +2418,6 @@ ConcreteCompilerVariable* doIs(IREmitter& emitter, CompilerVariable* lhs, Compil
     return boolFromI1(emitter, cmp);
 }
 
-template <typename T> struct UnboxedVal {
-    T val;
-    ConcreteCompilerVariable* boxed;
-};
-
-template <typename T, typename D> class UnboxedType : public ValuedCompilerType<UnboxedVal<T>*> {
-public:
-    typedef UnboxedVal<T> Unboxed;
-    typedef typename ValuedCompilerType<UnboxedVal<T>*>::VAR VAR;
-
-    void drop(IREmitter& emitter, VAR* var) override final {
-        Unboxed* v = var->getValue();
-        if (v->boxed)
-            v->boxed->decvref(emitter);
-        static_cast<D*>(this)->_drop(emitter, v->val);
-    }
-
-    void grab(IREmitter& emitter, VAR* var) override final { RELEASE_ASSERT(0, ""); }
-
-    CompilerVariable* dup(VAR* var, DupCache& cache) override final {
-        CompilerVariable*& rtn = cache[var];
-
-        if (rtn == NULL) {
-            Unboxed* orig_v = var->getValue();
-
-            T val_duped = static_cast<D*>(this)->_dup(orig_v->val, cache);
-
-            CompilerVariable* box_duped = orig_v->boxed ? orig_v->boxed->dup(cache) : NULL;
-            assert(!box_duped || box_duped->getType() == box_duped->getType()->getBoxType());
-
-            rtn = new VAR(this, new Unboxed{ std::move(val_duped), static_cast<ConcreteCompilerVariable*>(box_duped) },
-                          var->isGrabbed());
-            while (rtn->getVrefs() < var->getVrefs())
-                rtn->incvref();
-        }
-        return rtn;
-    }
-
-    bool canConvertTo(ConcreteCompilerType* other_type) override final {
-        return (other_type == UNKNOWN || other_type == this->getBoxType());
-    }
-
-    ConcreteCompilerVariable* makeConverted(IREmitter& emitter, VAR* var,
-                                            ConcreteCompilerType* other_type) override final {
-        assert(canConvertTo(other_type));
-
-        Unboxed* val = var->getValue();
-        ConcreteCompilerVariable* boxed = val->boxed;
-
-        if (!boxed) {
-            boxed = static_cast<D*>(this)->_makeConverted(emitter, val->val, this->getBoxType());
-            ASSERT(boxed->getType() == this->getBoxType(), "%s %s", boxed->getType()->debugName().c_str(),
-                   this->getBoxType()->debugName().c_str());
-
-            val->boxed = boxed;
-        }
-
-        if (boxed->getType() != other_type) {
-            assert(other_type == UNKNOWN);
-            return boxed->makeConverted(emitter, other_type);
-        }
-
-        boxed->incvref();
-        return boxed;
-    }
-
-    // Serialization strategy is a bit silly for now: we will emit a bool saying whether we emitted the
-    // boxed or unboxed value.  There's no reason that has to be in the serialization though (it could
-    // be in the metadata), and we shouldn't have to pad the smaller version to the size of the larger one.
-    int numFrameArgs() override final {
-        return 1 + std::max(static_cast<D*>(this)->_numFrameArgs(), this->getBoxType()->numFrameArgs());
-    }
-
-    void serializeToFrame(VAR* var, std::vector<llvm::Value*>& stackmap_args) override final {
-        Unboxed* v = var->getValue();
-
-        int total_args = numFrameArgs();
-        int needed_args = stackmap_args.size() + total_args;
-
-        if (v->boxed) {
-            stackmap_args.push_back(getConstantInt(1, g.i64));
-            v->boxed->serializeToFrame(stackmap_args);
-        } else {
-            stackmap_args.push_back(getConstantInt(0, g.i64));
-            static_cast<D*>(this)->_serializeToFrame(v->val, stackmap_args);
-        }
-
-        while (stackmap_args.size() < needed_args)
-            stackmap_args.push_back(getConstantInt(0, g.i64));
-    }
-
-    Box* deserializeFromFrame(const FrameVals& vals) override final {
-        assert(vals.size() == numFrameArgs());
-
-
-        bool is_boxed = vals[0];
-
-        if (is_boxed) {
-            // TODO: inefficient
-            FrameVals sub_vals(vals.begin() + 1, vals.begin() + 1 + this->getBoxType()->numFrameArgs());
-            return this->getBoxType()->deserializeFromFrame(sub_vals);
-        } else {
-            FrameVals sub_vals(vals.begin() + 1, vals.begin() + 1 + static_cast<D*>(this)->_numFrameArgs());
-            return static_cast<D*>(this)->_deserializeFromFrame(sub_vals);
-        }
-    }
-};
-
 ConcreteCompilerType* BOXED_TUPLE;
 class TupleType : public UnboxedType<const std::vector<CompilerVariable*>, TupleType> {
 private:
@@ -2395,11 +2439,11 @@ private:
 public:
     typedef const std::vector<CompilerVariable*> VEC;
 
-    void assertMatches(Unboxed* v) override {
-        assert(v->val.size() == elt_types.size());
+    void _assertMatches(const VEC& v) {
+        assert(v.size() == elt_types.size());
 
-        for (int i = 0; i < v->val.size(); i++) {
-            assert((v->val)[i]->getType() == elt_types[i]);
+        for (int i = 0; i < v.size(); i++) {
+            assert(v[i]->getType() == elt_types[i]);
         }
     }
 
@@ -2466,7 +2510,7 @@ public:
             assert(v->getType() == g.i64);
             if (llvm::ConstantInt* ci = llvm::dyn_cast<llvm::ConstantInt>(v)) {
                 int64_t i = ci->getSExtValue();
-                Unboxed* v = var->getValue();
+                auto v = var->getValue();
                 const VEC* elts = &v->val;
                 if (i >= 0 && i < elts->size()) {
                     CompilerVariable* rtn = (*elts)[i];
@@ -2500,8 +2544,8 @@ public:
         return rtn;
     }
 
-    ConcreteCompilerVariable* len(IREmitter& emitter, const OpInfo& info, VAR* var) override {
-        return new ConcreteCompilerVariable(INT, getConstantInt(var->getValue()->val.size(), g.i64), true);
+    CompilerVariable* len(IREmitter& emitter, const OpInfo& info, VAR* var) override {
+        return makeInt(var->getValue()->val.size());
     }
 
     CompilerType* getattrType(BoxedString* attr, bool cls_only) override {
@@ -2539,9 +2583,9 @@ public:
 
             {
                 CompilerVariable* eq = converted_lhs->binexp(emitter, info, e, AST_TYPE::Eq, Compare);
-                ConcreteCompilerVariable* eq_nonzero = eq->nonzero(emitter, info);
+                CompilerVariable* eq_nonzero = eq->nonzero(emitter, info);
                 assert(eq_nonzero->getType() == BOOL);
-                llvm::Value* raw = i1FromBool(emitter, eq_nonzero);
+                llvm::Value* raw = i1FromBool(emitter, static_cast<ConcreteCompilerVariable*>(eq_nonzero));
 
                 phi_incoming.push_back(std::make_pair(emitter.currentBasicBlock(), getConstantInt(1, g.i1)));
                 llvm::BasicBlock* new_bb = emitter.createBasicBlock();
@@ -2640,7 +2684,7 @@ CompilerVariable* makeTuple(const std::vector<CompilerVariable*>& elts) {
     }
     TupleType* type = TupleType::make(elt_types);
 
-    auto alloc_var = new TupleType::Unboxed({ elts, NULL });
+    auto alloc_var = std::make_shared<TupleType::Unboxed>(elts, nullptr);
     return new TupleType::VAR(type, alloc_var, true);
 }
 
@@ -2715,7 +2759,7 @@ public:
 
     CompilerType* getattrType(BoxedString* attr, bool cls_only) override { return UNDEF; }
 
-    bool canConvertTo(ConcreteCompilerType* other_type) override { return true; }
+    bool canConvertTo(CompilerType* other_type) override { return true; }
 
     BoxedClass* guaranteedClass() override { return NULL; }
 

--- a/src/codegen/compvars.cpp
+++ b/src/codegen/compvars.cpp
@@ -2127,7 +2127,7 @@ public:
     }
 };
 std::unordered_map<BoxedClass*, NormalObjectType*> NormalObjectType::made;
-ConcreteCompilerType* STR, *BOXED_INT, *BOXED_FLOAT, *BOXED_BOOL, *NONE, *ELLIPSIS;
+ConcreteCompilerType* STR, *BOXED_INT, *BOXED_FLOAT, *BOXED_BOOL, *NONE;
 
 class ClosureType : public ConcreteCompilerType {
 public:

--- a/src/codegen/compvars.h
+++ b/src/codegen/compvars.h
@@ -47,7 +47,7 @@ public:
     virtual std::string debugName() = 0;
     virtual ConcreteCompilerType* getConcreteType() = 0;
     virtual ConcreteCompilerType* getBoxType() = 0;
-    virtual bool canConvertTo(ConcreteCompilerType* other_type) = 0;
+    virtual bool canConvertTo(CompilerType* other_type) = 0;
     virtual CompilerType* getattrType(BoxedString* attr, bool cls_only) = 0;
     virtual CompilerType* getPystonIterType();
     virtual Result hasattr(BoxedString* attr);
@@ -58,6 +58,13 @@ public:
     virtual Box* deserializeFromFrame(const FrameVals& vals) = 0;
     virtual int numFrameArgs() = 0;
     virtual std::vector<CompilerType*> unpackTypes(int num_into);
+
+    // Some types are not "usable" even if they are "concrete".  Concrete means that it's possible to
+    // represent the value as an llvm::Value*; usable means that we are allowed to use it as a variable's
+    // type.  Some concrete types are not usable; for example unboxed ints are concrete (can be represented
+    // as an i64) but are not usable, since we need to use the form that remembers what it gets boxed to.
+    virtual CompilerType* getUsableType() { return this; }
+    bool isUsable() { return this == getUsableType(); }
 };
 
 typedef std::unordered_map<CompilerVariable*, CompilerVariable*> DupCache;
@@ -94,7 +101,7 @@ public:
         printf("grab not defined for %s\n", debugName().c_str());
         abort();
     }
-    bool canConvertTo(ConcreteCompilerType* other_type) override {
+    bool canConvertTo(CompilerType* other_type) override {
         printf("canConvertTo not defined for %s\n", debugName().c_str());
         abort();
     }
@@ -102,13 +109,12 @@ public:
         printf("makeConverted not defined for %s\n", debugName().c_str());
         abort();
     }
-    virtual ConcreteCompilerVariable* nonzero(IREmitter& emitter, const OpInfo& info, VAR* var) {
+    virtual CompilerVariable* nonzero(IREmitter& emitter, const OpInfo& info, VAR* var) {
         printf("nonzero not defined for %s\n", debugName().c_str());
         abort();
     }
-    virtual ConcreteCompilerVariable* unaryop(IREmitter& emitter, const OpInfo& info, VAR* var,
-                                              AST_TYPE::AST_TYPE op_type);
-    virtual ConcreteCompilerVariable* hasnext(IREmitter& emitter, const OpInfo& info, VAR* var) {
+    virtual CompilerVariable* unaryop(IREmitter& emitter, const OpInfo& info, VAR* var, AST_TYPE::AST_TYPE op_type);
+    virtual CompilerVariable* hasnext(IREmitter& emitter, const OpInfo& info, VAR* var) {
         printf("hasnext not defined for %s\n", debugName().c_str());
         abort();
     }
@@ -139,7 +145,7 @@ public:
         printf("call not defined for %s\n", debugName().c_str());
         abort();
     }
-    virtual ConcreteCompilerVariable* len(IREmitter& emitter, const OpInfo& info, VAR* var) {
+    virtual CompilerVariable* len(IREmitter& emitter, const OpInfo& info, VAR* var) {
         printf("len not defined for %s\n", debugName().c_str());
         abort();
     }
@@ -202,7 +208,7 @@ public:
 
     CompilerVariable* dup(ConcreteCompilerVariable* v, DupCache& cache) override;
     ConcreteCompilerType* getConcreteType() override { return this; }
-    bool canConvertTo(ConcreteCompilerType* other_type) override { return other_type == this || other_type == UNKNOWN; }
+    bool canConvertTo(CompilerType* other_type) override { return other_type == this || other_type == UNKNOWN; }
     ConcreteCompilerVariable* makeConverted(IREmitter& emitter, ConcreteCompilerVariable* var,
                                             ConcreteCompilerType* other_type) override;
     void serializeToFrame(VAR* var, std::vector<llvm::Value*>& stackmap_args) override;
@@ -261,14 +267,14 @@ public:
     virtual CompilerType* getType() = 0;
     virtual ConcreteCompilerType* getConcreteType() = 0;
     virtual ConcreteCompilerType* getBoxType() = 0;
-    virtual bool canConvertTo(ConcreteCompilerType* other_type) = 0;
+    virtual bool canConvertTo(CompilerType* other_type) = 0;
     virtual ConcreteCompilerVariable* makeConverted(IREmitter& emitter, ConcreteCompilerType* other_type) = 0;
     virtual llvm::Value* makeClassCheck(IREmitter& emitter, BoxedClass* cls) = 0;
     virtual BoxedClass* guaranteedClass() = 0;
 
-    virtual ConcreteCompilerVariable* nonzero(IREmitter& emitter, const OpInfo& info) = 0;
-    virtual ConcreteCompilerVariable* unaryop(IREmitter& emitter, const OpInfo& info, AST_TYPE::AST_TYPE op_type) = 0;
-    virtual ConcreteCompilerVariable* hasnext(IREmitter& emitter, const OpInfo& info) = 0;
+    virtual CompilerVariable* nonzero(IREmitter& emitter, const OpInfo& info) = 0;
+    virtual CompilerVariable* unaryop(IREmitter& emitter, const OpInfo& info, AST_TYPE::AST_TYPE op_type) = 0;
+    virtual CompilerVariable* hasnext(IREmitter& emitter, const OpInfo& info) = 0;
     virtual CompilerVariable* getattr(IREmitter& emitter, const OpInfo& info, BoxedString* attr, bool cls_only) = 0;
     virtual void setattr(IREmitter& emitter, const OpInfo& info, BoxedString* attr, CompilerVariable* v) = 0;
     virtual void delattr(IREmitter& emitter, const OpInfo& info, BoxedString* attr) = 0;
@@ -278,7 +284,7 @@ public:
     virtual CompilerVariable* call(IREmitter& emitter, const OpInfo& info, struct ArgPassSpec argspec,
                                    const std::vector<CompilerVariable*>& args,
                                    const std::vector<BoxedString*>* keyword_names) = 0;
-    virtual ConcreteCompilerVariable* len(IREmitter& emitter, const OpInfo& info) = 0;
+    virtual CompilerVariable* len(IREmitter& emitter, const OpInfo& info) = 0;
     virtual CompilerVariable* getitem(IREmitter& emitter, const OpInfo& info, CompilerVariable*) = 0;
     virtual CompilerVariable* getPystonIter(IREmitter& emitter, const OpInfo& info) = 0;
     virtual CompilerVariable* binexp(IREmitter& emitter, const OpInfo& info, CompilerVariable* rhs,
@@ -330,19 +336,19 @@ public:
         return rtn;
     }
 
-    bool canConvertTo(ConcreteCompilerType* other_type) override { return type->canConvertTo(other_type); }
+    bool canConvertTo(CompilerType* other_type) override { return type->canConvertTo(other_type); }
     ConcreteCompilerVariable* makeConverted(IREmitter& emitter, ConcreteCompilerType* other_type) override {
         ConcreteCompilerVariable* rtn = type->makeConverted(emitter, this, other_type);
         ASSERT(rtn->getType() == other_type, "%s", type->debugName().c_str());
         return rtn;
     }
-    ConcreteCompilerVariable* nonzero(IREmitter& emitter, const OpInfo& info) override {
+    CompilerVariable* nonzero(IREmitter& emitter, const OpInfo& info) override {
         return type->nonzero(emitter, info, this);
     }
-    ConcreteCompilerVariable* unaryop(IREmitter& emitter, const OpInfo& info, AST_TYPE::AST_TYPE op_type) override {
+    CompilerVariable* unaryop(IREmitter& emitter, const OpInfo& info, AST_TYPE::AST_TYPE op_type) override {
         return type->unaryop(emitter, info, this, op_type);
     }
-    ConcreteCompilerVariable* hasnext(IREmitter& emitter, const OpInfo& info) override {
+    CompilerVariable* hasnext(IREmitter& emitter, const OpInfo& info) override {
         return type->hasnext(emitter, info, this);
     }
     CompilerVariable* getattr(IREmitter& emitter, const OpInfo& info, BoxedString* attr, bool cls_only) override {
@@ -366,9 +372,7 @@ public:
                            const std::vector<BoxedString*>* keyword_names) override {
         return type->call(emitter, info, this, argspec, args, keyword_names);
     }
-    ConcreteCompilerVariable* len(IREmitter& emitter, const OpInfo& info) override {
-        return type->len(emitter, info, this);
-    }
+    CompilerVariable* len(IREmitter& emitter, const OpInfo& info) override { return type->len(emitter, info, this); }
     CompilerVariable* getitem(IREmitter& emitter, const OpInfo& info, CompilerVariable* slice) override {
         return type->getitem(emitter, info, this, slice);
     }
@@ -407,8 +411,14 @@ public:
 // Emit the test for whether one variable 'is' another one.
 ConcreteCompilerVariable* doIs(IREmitter& emitter, CompilerVariable* lhs, CompilerVariable* rhs, bool negate);
 
+// These functions all return an INT variable, from either an unboxed representation (makeInt) or
+// a boxed representation (makeUnboxedInt)
+CompilerVariable* makeInt(int64_t);
+CompilerVariable* makeInt(llvm::Value*);
+CompilerVariable* makeUnboxedInt(IREmitter&, ConcreteCompilerVariable*);
+CompilerVariable* makeUnboxedInt(IREmitter&, llvm::Value*);
+
 ConcreteCompilerVariable* makeBool(bool);
-ConcreteCompilerVariable* makeInt(int64_t);
 ConcreteCompilerVariable* makeFloat(double);
 ConcreteCompilerVariable* makeLong(Box*);
 ConcreteCompilerVariable* makePureImaginary(Box*);
@@ -447,8 +457,8 @@ CompilerVariable* _ValuedCompilerType<V>::contains(IREmitter& emitter, const OpI
 }
 
 template <typename V>
-ConcreteCompilerVariable* _ValuedCompilerType<V>::unaryop(IREmitter& emitter, const OpInfo& info, VAR* var,
-                                                          AST_TYPE::AST_TYPE op_type) {
+CompilerVariable* _ValuedCompilerType<V>::unaryop(IREmitter& emitter, const OpInfo& info, VAR* var,
+                                                  AST_TYPE::AST_TYPE op_type) {
     ConcreteCompilerVariable* converted = makeConverted(emitter, var, getBoxType());
     auto r = UNKNOWN->unaryop(emitter, info, converted, op_type);
     converted->decvref(emitter);

--- a/src/codegen/compvars.h
+++ b/src/codegen/compvars.h
@@ -418,8 +418,13 @@ CompilerVariable* makeInt(llvm::Value*);
 CompilerVariable* makeUnboxedInt(IREmitter&, ConcreteCompilerVariable*);
 CompilerVariable* makeUnboxedInt(IREmitter&, llvm::Value*);
 
+// Same for floats:
+CompilerVariable* makeFloat(llvm::Value*);
+CompilerVariable* makeFloat(double);
+CompilerVariable* makeUnboxedFloat(IREmitter&, ConcreteCompilerVariable*);
+CompilerVariable* makeUnboxedFloat(IREmitter&, llvm::Value*);
+
 ConcreteCompilerVariable* makeBool(bool);
-ConcreteCompilerVariable* makeFloat(double);
 ConcreteCompilerVariable* makeLong(Box*);
 ConcreteCompilerVariable* makePureImaginary(Box*);
 CompilerVariable* makeStr(BoxedString*);

--- a/src/codegen/irgen/irgenerator.cpp
+++ b/src/codegen/irgen/irgenerator.cpp
@@ -1521,13 +1521,9 @@ private:
         if (t == BOXED_INT) {
             return makeUnboxedInt(emitter, v);
         }
-#if ENABLE_UNBOXED_VALUES
         if (t == BOXED_FLOAT) {
-            llvm::Value* unboxed = emitter.getBuilder()->CreateCall(g.funcs.unboxFloat, v);
-            ConcreteCompilerVariable* rtn = new ConcreteCompilerVariable(FLOAT, unboxed, true);
-            return rtn;
+            return makeUnboxedFloat(emitter, v);
         }
-#endif
         if (t == BOXED_BOOL) {
             llvm::Value* unboxed = emitter.getBuilder()->CreateCall(g.funcs.unboxBool, v);
             return boolFromI1(emitter, unboxed);
@@ -2211,10 +2207,8 @@ private:
             converted_args.push_back(var);
 
             assert(var->getType() != BOXED_INT);
-#if ENABLE_UNBOXED_VALUES
             assert(var->getType() != BOXED_FLOAT
                    && "should probably unbox it, but why is it boxed in the first place?");
-#endif
 
             // This line can never get hit right now for the same reason that the variables must already be
             // concrete,
@@ -2672,9 +2666,6 @@ public:
 
         ASSERT(var->getType()->isUsable(), "%s", name.c_str());
 
-#if ENABLE_UNBOXED_VALUES
-        assert(var->getType() != BOXED_FLOAT);
-#endif
         CompilerVariable*& cur = symbol_table[name];
         assert(cur == NULL);
         cur = var;

--- a/src/codegen/irgen/irgenerator.cpp
+++ b/src/codegen/irgen/irgenerator.cpp
@@ -799,7 +799,7 @@ private:
                 assert(node->args.size() == 1);
                 CompilerVariable* obj = evalExpr(node->args[0], unw_info);
 
-                ConcreteCompilerVariable* rtn = obj->nonzero(emitter, getOpInfoForNode(node, unw_info));
+                CompilerVariable* rtn = obj->nonzero(emitter, getOpInfoForNode(node, unw_info));
                 obj->decvref(emitter);
                 return rtn;
             }
@@ -807,7 +807,7 @@ private:
                 assert(node->args.size() == 1);
                 CompilerVariable* obj = evalExpr(node->args[0], unw_info);
 
-                ConcreteCompilerVariable* rtn = obj->hasnext(emitter, getOpInfoForNode(node, unw_info));
+                CompilerVariable* rtn = obj->hasnext(emitter, getOpInfoForNode(node, unw_info));
                 obj->decvref(emitter);
                 return rtn;
             }
@@ -1348,18 +1348,18 @@ private:
         CompilerVariable* operand = evalExpr(node->operand, unw_info);
 
         if (node->op_type == AST_TYPE::Not) {
-            ConcreteCompilerVariable* rtn = operand->nonzero(emitter, getOpInfoForNode(node, unw_info));
+            CompilerVariable* rtn = operand->nonzero(emitter, getOpInfoForNode(node, unw_info));
             operand->decvref(emitter);
 
             assert(rtn->getType() == BOOL);
-            llvm::Value* v = i1FromBool(emitter, rtn);
+            llvm::Value* v = i1FromBool(emitter, static_cast<ConcreteCompilerVariable*>(rtn));
             assert(v->getType() == g.i1);
 
             llvm::Value* negated = emitter.getBuilder()->CreateNot(v);
             rtn->decvref(emitter);
             return boolFromI1(emitter, negated);
         } else {
-            ConcreteCompilerVariable* rtn = operand->unaryop(emitter, getOpInfoForNode(node, unw_info), node->op_type);
+            CompilerVariable* rtn = operand->unaryop(emitter, getOpInfoForNode(node, unw_info), node->op_type);
             operand->decvref(emitter);
             return rtn;
         }
@@ -1517,13 +1517,11 @@ private:
     }
 
     // Note: the behavior of this function must match type_analysis.cpp:unboxedType()
-    ConcreteCompilerVariable* unboxVar(ConcreteCompilerType* t, llvm::Value* v, bool grabbed) {
-#if ENABLE_UNBOXED_VALUES
+    CompilerVariable* unboxVar(ConcreteCompilerType* t, llvm::Value* v, bool grabbed) {
         if (t == BOXED_INT) {
-            llvm::Value* unboxed = emitter.getBuilder()->CreateCall(g.funcs.unboxInt, v);
-            ConcreteCompilerVariable* rtn = new ConcreteCompilerVariable(INT, unboxed, true);
-            return rtn;
+            return makeUnboxedInt(emitter, v);
         }
+#if ENABLE_UNBOXED_VALUES
         if (t == BOXED_FLOAT) {
             llvm::Value* unboxed = emitter.getBuilder()->CreateCall(g.funcs.unboxFloat, v);
             ConcreteCompilerVariable* rtn = new ConcreteCompilerVariable(FLOAT, unboxed, true);
@@ -1548,7 +1546,7 @@ private:
 
             ConcreteCompilerType* speculated_type = typeFromClass(speculated_class);
             if (VERBOSITY("irgen") >= 2) {
-                printf("Speculating that %s is actually %s, at ", rtn->getConcreteType()->debugName().c_str(),
+                printf("Speculating that %s is actually %s, at ", rtn->getType()->debugName().c_str(),
                        speculated_type->debugName().c_str());
                 fflush(stdout);
                 print_ast(node);
@@ -1580,6 +1578,7 @@ private:
         }
 
         assert(rtn);
+        assert(rtn->getType()->isUsable());
 
         return rtn;
     }
@@ -1728,6 +1727,7 @@ private:
     void _doSet(InternedString name, CompilerVariable* val, const UnwindInfo& unw_info) {
         assert(name.s() != "None");
         assert(name.s() != FRAME_INFO_PTR_NAME);
+        assert(val->getType()->isUsable());
 
         auto scope_info = irstate->getScopeInfo();
         ScopeInfo::VarScopeType vst = scope_info->getScopeTypeOfName(name);
@@ -2210,8 +2210,8 @@ private:
             ConcreteCompilerVariable* var = p.second->makeConverted(emitter, p.second->getConcreteType());
             converted_args.push_back(var);
 
+            assert(var->getType() != BOXED_INT);
 #if ENABLE_UNBOXED_VALUES
-            assert(var->getType() != BOXED_INT && "should probably unbox it, but why is it boxed in the first place?");
             assert(var->getType() != BOXED_FLOAT
                    && "should probably unbox it, but why is it boxed in the first place?");
 #endif
@@ -2438,13 +2438,13 @@ private:
 
     void loadArgument(InternedString name, ConcreteCompilerType* t, llvm::Value* v, const UnwindInfo& unw_info) {
         assert(name.s() != FRAME_INFO_PTR_NAME);
-        ConcreteCompilerVariable* var = unboxVar(t, v, false);
+        CompilerVariable* var = unboxVar(t, v, false);
         _doSet(name, var, unw_info);
         var->decvref(emitter);
     }
 
     void loadArgument(AST_expr* name, ConcreteCompilerType* t, llvm::Value* v, const UnwindInfo& unw_info) {
-        ConcreteCompilerVariable* var = unboxVar(t, v, false);
+        CompilerVariable* var = unboxVar(t, v, false);
         _doSet(name, var, unw_info);
         var->decvref(emitter);
     }
@@ -2467,6 +2467,7 @@ private:
         std::map<InternedString, CompilerVariable*> sorted_symbol_table(symbol_table.begin(), symbol_table.end());
         for (const auto& p : sorted_symbol_table) {
             assert(p.first.s() != FRAME_INFO_PTR_NAME);
+            assert(p.second->getType()->isUsable());
             if (allowableFakeEndingSymbol(p.first))
                 continue;
 
@@ -2483,6 +2484,7 @@ private:
             } else if (irstate->getPhis()->isRequiredAfter(p.first, myblock)) {
                 assert(scope_info->getScopeTypeOfName(p.first) != ScopeInfo::VarScopeType::GLOBAL);
                 ConcreteCompilerType* phi_type = types->getTypeAtBlockEnd(p.first, myblock);
+                assert(phi_type->isUsable());
                 // printf("Converting %s from %s to %s\n", p.first.c_str(),
                 // p.second->getType()->debugName().c_str(), phi_type->debugName().c_str());
                 // printf("have to convert %s from %s to %s\n", p.first.c_str(),
@@ -2533,6 +2535,7 @@ private:
             } else {
                 // printf("no st entry, setting undefined\n");
                 ConcreteCompilerType* phi_type = types->getTypeAtBlockEnd(*it, myblock);
+                assert(phi_type->isUsable());
                 cur = new ConcreteCompilerVariable(phi_type, llvm::UndefValue::get(phi_type->llvmType()), true);
                 _setFake(defined_name, makeBool(0));
             }
@@ -2553,7 +2556,7 @@ public:
             pp->addFrameVar(PASSED_GLOBALS_NAME, UNKNOWN);
         }
 
-        assert(INT->llvmType() == g.i64);
+        assert(UNBOXED_INT->llvmType() == g.i64);
         if (ENABLE_JIT_OBJECT_CACHE) {
             llvm::Value* v;
             if (current_stmt)
@@ -2565,7 +2568,7 @@ public:
             stackmap_args.push_back(getConstantInt((uint64_t)current_stmt, g.i64));
         }
 
-        pp->addFrameVar("!current_stmt", INT);
+        pp->addFrameVar("!current_stmt", UNBOXED_INT);
 
         if (ENABLE_FRAME_INTROSPECTION) {
             // TODO: don't need to use a sorted symbol table if we're explicitly recording the names!
@@ -2599,6 +2602,10 @@ public:
 
         // This should have been consumed:
         assert(incoming_exc_state.empty());
+
+        for (auto&& p : symbol_table) {
+            ASSERT(p.second->getType()->isUsable(), "%s", p.first.c_str());
+        }
 
         if (myblock->successors.size() == 0) {
             for (auto& p : *st) {
@@ -2645,6 +2652,7 @@ public:
                 } else {
                     ending_type = types->getTypeAtBlockEnd(it->first, myblock);
                 }
+                assert(ending_type->isUsable());
                 //(*phi_st)[it->first] = it->second->makeConverted(emitter, it->second->getConcreteType());
                 // printf("%s %p %d\n", it->first.c_str(), it->second, it->second->getVrefs());
                 (*phi_st)[it->first] = it->second->split(emitter)->makeConverted(emitter, ending_type);
@@ -2661,8 +2669,10 @@ public:
         assert(name.s() != FRAME_INFO_PTR_NAME);
         ASSERT(irstate->getScopeInfo()->getScopeTypeOfName(name) != ScopeInfo::VarScopeType::GLOBAL, "%s",
                name.c_str());
+
+        ASSERT(var->getType()->isUsable(), "%s", name.c_str());
+
 #if ENABLE_UNBOXED_VALUES
-        assert(var->getType() != BOXED_INT);
         assert(var->getType() != BOXED_FLOAT);
 #endif
         CompilerVariable*& cur = symbol_table[name];
@@ -2675,7 +2685,9 @@ public:
         DupCache cache;
         for (SymbolTable::iterator it = st->begin(); it != st->end(); ++it) {
             // printf("Copying in %s: %p, %d\n", it->first.c_str(), it->second, it->second->getVrefs());
+            // printf("Copying in %s, a %s\n", it->first.c_str(), it->second->getType()->debugName().c_str());
             symbol_table[it->first] = it->second->dup(cache);
+            assert(symbol_table[it->first]->getType()->isUsable());
             // printf("got: %p, %d\n", symbol_table[it->first], symbol_table[it->first]->getVrefs());
         }
     }

--- a/src/core/options.h
+++ b/src/core/options.h
@@ -51,12 +51,6 @@ extern bool ENABLE_ICS, ENABLE_ICGENERICS, ENABLE_ICGETITEMS, ENABLE_ICSETITEMS,
 extern bool BOOLS_AS_I64;
 
 #define ENABLE_SAMPLING_PROFILER 0
-
-// Our current implementation of unbox values has some minor compatibility issues, where it can
-// change the apparent id() / is-equality of a boxed value (by inserting extra unbox+box pairs).
-// I think it can be rescued (we need the unboxed compilertype to remember the boxed value),
-// but for now it's just turned off with this flag.
-#define ENABLE_UNBOXED_VALUES 0
 }
 }
 

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -93,8 +93,8 @@ template <class V> class ValuedCompilerType;
 typedef ValuedCompilerType<llvm::Value*> ConcreteCompilerType;
 ConcreteCompilerType* typeFromClass(BoxedClass*);
 
-extern ConcreteCompilerType* UNBOXED_INT, *BOXED_INT, *LONG, *UNBOXED_FLOAT, *BOXED_FLOAT, *UNKNOWN, *BOOL, *STR, *NONE, *LIST,
-    *SLICE, *ELLIPSIS, *MODULE, *DICT, *BOOL, *BOXED_BOOL, *BOXED_TUPLE, *SET, *FROZENSET, *CLOSURE, *GENERATOR,
+extern ConcreteCompilerType* UNBOXED_INT, *BOXED_INT, *LONG, *UNBOXED_FLOAT, *BOXED_FLOAT, *UNKNOWN, *BOOL, *STR, *NONE,
+    *LIST, *SLICE, *MODULE, *DICT, *BOOL, *BOXED_BOOL, *BOXED_TUPLE, *SET, *FROZENSET, *CLOSURE, *GENERATOR,
     *BOXED_COMPLEX, *FRAME_INFO;
 extern CompilerType* UNDEF, *INT, *FLOAT;
 

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -93,10 +93,10 @@ template <class V> class ValuedCompilerType;
 typedef ValuedCompilerType<llvm::Value*> ConcreteCompilerType;
 ConcreteCompilerType* typeFromClass(BoxedClass*);
 
-extern ConcreteCompilerType* INT, *BOXED_INT, *LONG, *FLOAT, *BOXED_FLOAT, *UNKNOWN, *BOOL, *STR, *NONE, *LIST, *SLICE,*ELLIPSIS,
-    *MODULE, *DICT, *BOOL, *BOXED_BOOL, *BOXED_TUPLE, *SET, *FROZENSET, *CLOSURE, *GENERATOR, *BOXED_COMPLEX,
-    *FRAME_INFO;
-extern CompilerType* UNDEF;
+extern ConcreteCompilerType* UNBOXED_INT, *BOXED_INT, *LONG, *FLOAT, *BOXED_FLOAT, *UNKNOWN, *BOOL, *STR, *NONE, *LIST,
+    *SLICE, *ELLIPSIS, *MODULE, *DICT, *BOOL, *BOXED_BOOL, *BOXED_TUPLE, *SET, *FROZENSET, *CLOSURE, *GENERATOR,
+    *BOXED_COMPLEX, *FRAME_INFO;
+extern CompilerType* UNDEF, *INT;
 
 class CompilerVariable;
 template <class V> class ValuedCompilerVariable;

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -93,10 +93,10 @@ template <class V> class ValuedCompilerType;
 typedef ValuedCompilerType<llvm::Value*> ConcreteCompilerType;
 ConcreteCompilerType* typeFromClass(BoxedClass*);
 
-extern ConcreteCompilerType* UNBOXED_INT, *BOXED_INT, *LONG, *FLOAT, *BOXED_FLOAT, *UNKNOWN, *BOOL, *STR, *NONE, *LIST,
+extern ConcreteCompilerType* UNBOXED_INT, *BOXED_INT, *LONG, *UNBOXED_FLOAT, *BOXED_FLOAT, *UNKNOWN, *BOOL, *STR, *NONE, *LIST,
     *SLICE, *ELLIPSIS, *MODULE, *DICT, *BOOL, *BOXED_BOOL, *BOXED_TUPLE, *SET, *FROZENSET, *CLOSURE, *GENERATOR,
     *BOXED_COMPLEX, *FRAME_INFO;
-extern CompilerType* UNDEF, *INT;
+extern CompilerType* UNDEF, *INT, *FLOAT;
 
 class CompilerVariable;
 template <class V> class ValuedCompilerVariable;

--- a/src/runtime/builtin_modules/builtins.cpp
+++ b/src/runtime/builtin_modules/builtins.cpp
@@ -1524,12 +1524,16 @@ Box* builtinFormat(Box* value, Box* format_spec) {
     return res;
 }
 
+extern "C" {
+BoxedClass* ellipsis_cls;
+}
+
 void setupBuiltins() {
     builtins_module = createModule(boxString("__builtin__"), NULL,
                                    "Built-in functions, exceptions, and other objects.\n\nNoteworthy: None is "
                                    "the `nil' object; Ellipsis represents `...' in slices.");
 
-    BoxedClass* ellipsis_cls = BoxedClass::create(type_cls, object_cls, NULL, 0, 0, sizeof(Box), false, "ellipsis");
+    ellipsis_cls = BoxedClass::create(type_cls, object_cls, NULL, 0, 0, sizeof(Box), false, "ellipsis");
     ellipsis_cls->giveAttr("__repr__", new BoxedFunction(boxRTFunction((void*)ellipsisRepr, STR, 1)));
     Ellipsis = new (ellipsis_cls) Box();
     assert(Ellipsis->cls);

--- a/src/runtime/inline/xrange.cpp
+++ b/src/runtime/inline/xrange.cpp
@@ -270,7 +270,7 @@ void setupXrange() {
         "__iter__", new BoxedFunction(boxRTFunction((void*)xrangeIterIter, typeFromClass(xrange_iterator_cls), 1)));
     xrange_iterator_cls->giveAttr("__hasnext__", new BoxedFunction(hasnext));
 
-    CLFunction* next = boxRTFunction((void*)BoxedXrangeIterator::xrangeIteratorNextUnboxed, INT, 1);
+    CLFunction* next = boxRTFunction((void*)BoxedXrangeIterator::xrangeIteratorNextUnboxed, UNBOXED_INT, 1);
     addRTFunction(next, (void*)BoxedXrangeIterator::xrangeIteratorNext, BOXED_INT);
     xrange_iterator_cls->giveAttr("next", new BoxedFunction(next));
 

--- a/test/tests/int_ids.py
+++ b/test/tests/int_ids.py
@@ -42,6 +42,14 @@ def f4(a, b):
 for i in xrange(11000):
     f4(1000, 1000)
 
+def f6():
+    for i in xrange(11000):
+        a = b = 1000
+        if True:
+            pass
+        f4(a, b)
+f6()
+
 
 # This applies to other data types as well.  (maybe should call this test file something else)
 def ident(x):
@@ -49,7 +57,7 @@ def ident(x):
 
 def f5():
     t = (1, 2, 3)
-    print ident(t) is t
+    assert ident(t) is t
 
 for i in xrange(10):
     f5()


### PR DESCRIPTION
Feels like more work than it was worth:
```
           django_template3.py             2.2s (2)             2.2s (2)  -0.1%
                 pyxl_bench.py             2.0s (2)             1.9s (2)  -3.6%
     sqlalchemy_imperative2.py             2.4s (2)             2.4s (2)  +0.0%
       django_template3_10x.py            14.3s (2)            14.4s (2)  +0.9%
             pyxl_bench_10x.py            15.4s (2)            15.1s (2)  -2.5%
 sqlalchemy_imperative2_10x.py            18.5s (2)            18.8s (2)  +1.3%
                       geomean                 6.0s                 5.9s  -0.7%
```

For now unboxed values can't get passed between BBs (compiler types don't have a hook to specify how to phi themselves, but that shouldn't be too hard to add if we need it).  Even with this limitation we seem to get most (but not all) of the benefit.

I think there's still some cases that this is missing, but after working on this for a few days I think it's time to check in what's working and I'll just fix any issues if we notice any.