### PR TITLE
object cache: hash IR before running any opt passes

### DIFF
--- a/src/codegen/codegen.h
+++ b/src/codegen/codegen.h
@@ -31,6 +31,8 @@ class TargetMachine;
 
 namespace pyston {
 
+class PystonObjectCache;
+
 class FunctionAddressRegistry {
 private:
     struct FuncInfo {
@@ -62,6 +64,7 @@ struct GlobalState {
     CompiledFunction* cur_cf;
     llvm::TargetMachine* tm;
     llvm::ExecutionEngine* engine;
+    PystonObjectCache* object_cache;
 
     std::vector<llvm::JITEventListener*> jit_listeners;
 


### PR DESCRIPTION
This lets us to skip running the opt passes when we find a cached object file.
This has the disadvantage that opt passes are not allowed to call embedRelocatablePtr()
but has the advantage that we could do more costly optimizations in the future without hurting the perf on the second run.

```
                                   upstream/master:  origin/cache_optim:
           django_template3.py             2.4s (4)             2.2s (4)  -4.5%
                 pyxl_bench.py             2.0s (4)             1.9s (4)  -3.8%
     sqlalchemy_imperative2.py             2.5s (4)             2.4s (4)  -3.4%
                       geomean                 2.3s                 2.2s  -3.9%
```