### PR TITLE
Avoid creating most slice objects

### DIFF
--- a/src/codegen/compvars.h
+++ b/src/codegen/compvars.h
@@ -411,6 +411,8 @@ public:
 // Emit the test for whether one variable 'is' another one.
 ConcreteCompilerVariable* doIs(IREmitter& emitter, CompilerVariable* lhs, CompilerVariable* rhs, bool negate);
 
+ConcreteCompilerVariable* getNone();
+
 // These functions all return an INT variable, from either an unboxed representation (makeInt) or
 // a boxed representation (makeUnboxedInt)
 CompilerVariable* makeInt(int64_t);
@@ -429,6 +431,13 @@ ConcreteCompilerVariable* makeLong(Box*);
 ConcreteCompilerVariable* makePureImaginary(Box*);
 CompilerVariable* makeStr(BoxedString*);
 CompilerVariable* makeUnicode(Box*);
+
+struct UnboxedSlice {
+    CompilerVariable* start, *stop, *step;
+};
+CompilerVariable* makeSlice(CompilerVariable* start, CompilerVariable* stop, CompilerVariable* step);
+UnboxedSlice extractSlice(CompilerVariable* slice);
+
 #if 0
 CompilerVariable* makeUnicode(IREmitter& emitter, llvm::StringRef);
 #endif

--- a/src/codegen/runtime_hooks.cpp
+++ b/src/codegen/runtime_hooks.cpp
@@ -225,6 +225,7 @@ void initGlobalFuncs(GlobalState& g) {
     GET(yield);
     GET(getiterHelper);
     GET(hasnext);
+    GET(apply_slice);
 
     GET(unpackIntoArray);
     GET(raiseAttributeError);

--- a/src/codegen/runtime_hooks.h
+++ b/src/codegen/runtime_hooks.h
@@ -37,7 +37,7 @@ struct GlobalFuncs {
         *createGenerator, *createSet;
     llvm::Value* getattr, *getattr_capi, *setattr, *delattr, *delitem, *delGlobal, *nonzero, *binop, *compare,
         *augbinop, *unboxedLen, *getitem, *getitem_capi, *getclsattr, *getGlobal, *setitem, *unaryop, *import,
-        *importFrom, *importStar, *repr, *exceptionMatches, *yield, *getiterHelper, *hasnext, *setGlobal;
+        *importFrom, *importStar, *repr, *exceptionMatches, *yield, *getiterHelper, *hasnext, *setGlobal, *apply_slice;
 
     llvm::Value* unpackIntoArray, *raiseAttributeError, *raiseAttributeErrorStr, *raiseAttributeErrorCapi,
         *raiseAttributeErrorStrCapi, *raiseNotIterableError, *raiseIndexErrorStr, *raiseIndexErrorStrCapi,

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -96,7 +96,7 @@ ConcreteCompilerType* typeFromClass(BoxedClass*);
 extern ConcreteCompilerType* UNBOXED_INT, *BOXED_INT, *LONG, *UNBOXED_FLOAT, *BOXED_FLOAT, *UNKNOWN, *BOOL, *STR, *NONE,
     *LIST, *SLICE, *MODULE, *DICT, *BOOL, *BOXED_BOOL, *BOXED_TUPLE, *SET, *FROZENSET, *CLOSURE, *GENERATOR,
     *BOXED_COMPLEX, *FRAME_INFO;
-extern CompilerType* UNDEF, *INT, *FLOAT;
+extern CompilerType* UNDEF, *INT, *FLOAT, *UNBOXED_SLICE;
 
 class CompilerVariable;
 template <class V> class ValuedCompilerVariable;

--- a/src/runtime/inline/link_forcer.cpp
+++ b/src/runtime/inline/link_forcer.cpp
@@ -100,6 +100,7 @@ void force() {
     FORCE(yield);
     FORCE(getiterHelper);
     FORCE(hasnext);
+    FORCE(apply_slice);
 
     FORCE(unpackIntoArray);
     FORCE(raiseAttributeError);

--- a/src/runtime/objmodel.h
+++ b/src/runtime/objmodel.h
@@ -88,6 +88,7 @@ extern "C" Box* getitem(Box* value, Box* slice);
 extern "C" Box* getitem_capi(Box* value, Box* slice) noexcept;
 extern "C" void setitem(Box* target, Box* slice, Box* value);
 extern "C" void delitem(Box* target, Box* slice);
+extern "C" PyObject* apply_slice(PyObject* u, PyObject* v, PyObject* w) noexcept;
 extern "C" Box* getclsattr(Box* obj, BoxedString* attr);
 extern "C" Box* getclsattrMaybeNonstring(Box* obj, Box* attr);
 extern "C" Box* unaryop(Box* operand, int op_type);

--- a/test/extra/pyopenssl_test.py
+++ b/test/extra/pyopenssl_test.py
@@ -10,5 +10,12 @@ PYOPENSSL_DIR = os.path.abspath(os.path.join(ENV_NAME, "site-packages", "OpenSSL
 packages = ["nose==1.3.7", "pycparser==2.13", "cryptography==1.0.1", "pyopenssl==0.15.1", "pyasn1==0.1.7", "idna==2.0", "six==1.9.0", "enum34==1.0.4", "ipaddress==1.0.14", "cffi==1.1.0"]
 create_virtenv(ENV_NAME, packages, force_create = True)
 
+# This particular test is bad; it depends on certain implementation details of the openssl library
+# it's linked against.  It fails in cpython and for other people as well
+# https://www.mail-archive.com/ports@openbsd.org/msg52063.html
+import subprocess
+subprocess.check_call(["sed", "-i", 's/\\(def test_digest.*\\)/\\1\\n        return/',
+    os.path.join(PYOPENSSL_DIR, "test", "test_crypto.py")])
+
 expected = [{'ran': 247, 'errors': 2}]
 run_test([NOSETESTS_EXE], cwd=PYOPENSSL_DIR, expected=expected)

--- a/test/tests/slice.py
+++ b/test/tests/slice.py
@@ -163,9 +163,9 @@ print unicodestr[-2:]
 # Calling the slice operator directly does not have the same behavior
 # as using the slice notation []. Namely, it will not modify negative
 # indices.
-print numbers.__getslice__(0, -1);
-print letters.__getslice__(0, -1);
-print unicodestr.__getslice__(0, -1);
+print numbers.__getslice__(0, -1)
+print letters.__getslice__(0, -1)
+print unicodestr.__getslice__(0, -1)
 
 # Other
 class C(object):
@@ -188,3 +188,9 @@ C()[:,:]
 C()[1:2,3:4]
 C()[1:2:3,3:4:5]
 
+# Regression test:
+def f(i):
+    for j in [1, 2, 3][::2]:
+        pass
+for i in xrange(100000):
+    f(i)


### PR DESCRIPTION
We've been allocating slice objects for slicing operations, but
CPython's internal slice methods already take separate start+stop
arguments.  So if we see a slice, instead of creating the slice
and sending it off to getitem, try calling PySequence_GetSlice.

This will be slower for classes with user-defined __getitem__
functions that can handle slices; we can fix that by adding rewriting
to this new endpoint, but it seems to not matter too much right now.

```
           django_template3.py             2.4s (4)             2.4s (4)  +0.5%
                 pyxl_bench.py             2.1s (2)             2.1s (2)  +0.8%
     sqlalchemy_imperative2.py             2.5s (2)             2.5s (2)  -0.3%
       django_template3_10x.py            14.8s (2)            14.8s (2)  +0.2%
             pyxl_bench_10x.py            15.7s (2)            15.1s (2)  -3.6%
 sqlalchemy_imperative2_10x.py            18.7s (2)            18.5s (2)  -0.9%
                       geomean                 6.2s                 6.1s  -0.6%
```