### PR TITLE
Cleanup the __str__, __repr__ support and let they handle unicode strings

### DIFF
--- a/from_cpython/Objects/floatobject.c
+++ b/from_cpython/Objects/floatobject.c
@@ -388,7 +388,7 @@ float_repr(PyFloatObject *v)
     return float_str_or_repr(v, 0, 'r');
 }
 
-static PyObject *
+PyObject *
 float_str(PyFloatObject *v)
 {
     return float_str_or_repr(v, PyFloat_STR_PRECISION, 'g');

--- a/src/capi/typeobject.cpp
+++ b/src/capi/typeobject.cpp
@@ -632,22 +632,33 @@ extern "C" int _PyObject_SlotCompare(PyObject* self, PyObject* other) noexcept {
 static PyObject* slot_tp_repr(PyObject* self) noexcept {
     STAT_TIMER(t0, "us_timer_slot_tprepr", SLOT_AVOIDABILITY(self));
 
-    try {
-        return repr(self);
-    } catch (ExcInfo e) {
-        setCAPIException(e);
-        return NULL;
+    PyObject* func, *res;
+    static PyObject* repr_str;
+
+    func = lookup_method(self, "__repr__", &repr_str);
+    if (func != NULL) {
+        res = PyEval_CallObject(func, NULL);
+        Py_DECREF(func);
+        return res;
     }
+    PyErr_Clear();
+    return PyString_FromFormat("<%s object at %p>", Py_TYPE(self)->tp_name, self);
 }
 
 static PyObject* slot_tp_str(PyObject* self) noexcept {
     STAT_TIMER(t0, "us_timer_slot_tpstr", SLOT_AVOIDABILITY(self));
 
-    try {
-        return str(self);
-    } catch (ExcInfo e) {
-        setCAPIException(e);
-        return NULL;
+    PyObject* func, *res;
+    static PyObject* str_str;
+
+    func = lookup_method(self, "__str__", &str_str);
+    if (func != NULL) {
+        res = PyEval_CallObject(func, NULL);
+        Py_DECREF(func);
+        return res;
+    } else {
+        PyErr_Clear();
+        return slot_tp_repr(self);
     }
 }
 

--- a/src/codegen/parser.cpp
+++ b/src/codegen/parser.cpp
@@ -1074,9 +1074,9 @@ AST_Module* parse_file(const char* fn, FutureFlags inherited_flags) {
 
 const char* getMagic() {
     if (ENABLE_PYPA_PARSER)
-        return "a\ncN";
+        return "a\ncO";
     else
-        return "a\ncn";
+        return "a\nco";
 }
 
 #define MAGIC_STRING_LENGTH 4

--- a/src/codegen/pypa-parser.cpp
+++ b/src/codegen/pypa-parser.cpp
@@ -1169,6 +1169,7 @@ static AST_Module* parse_with_reader(std::unique_ptr<pypa::Reader> reader, Futur
     pypa::AstModulePtr module;
     pypa::ParserOptions options;
 
+    options.perform_inline_optimizations = true;
     options.printerrors = false;
     options.python3allowed = false;
     options.python3only = false;

--- a/src/codegen/runtime_hooks.cpp
+++ b/src/codegen/runtime_hooks.cpp
@@ -221,8 +221,6 @@ void initGlobalFuncs(GlobalState& g) {
     GET(importFrom);
     GET(importStar);
     GET(repr);
-    GET(str);
-    GET(strOrUnicode);
     GET(exceptionMatches);
     GET(yield);
     GET(getiterHelper);

--- a/src/codegen/runtime_hooks.h
+++ b/src/codegen/runtime_hooks.h
@@ -37,8 +37,7 @@ struct GlobalFuncs {
         *createGenerator, *createSet;
     llvm::Value* getattr, *getattr_capi, *setattr, *delattr, *delitem, *delGlobal, *nonzero, *binop, *compare,
         *augbinop, *unboxedLen, *getitem, *getitem_capi, *getclsattr, *getGlobal, *setitem, *unaryop, *import,
-        *importFrom, *importStar, *repr, *str, *strOrUnicode, *exceptionMatches, *yield, *getiterHelper, *hasnext,
-        *setGlobal;
+        *importFrom, *importStar, *repr, *exceptionMatches, *yield, *getiterHelper, *hasnext, *setGlobal;
 
     llvm::Value* unpackIntoArray, *raiseAttributeError, *raiseAttributeErrorStr, *raiseAttributeErrorCapi,
         *raiseAttributeErrorStrCapi, *raiseNotIterableError, *raiseIndexErrorStr, *raiseIndexErrorStrCapi,

--- a/src/runtime/float.cpp
+++ b/src/runtime/float.cpp
@@ -33,6 +33,7 @@ extern "C" PyObject* float_as_integer_ratio(PyObject* v, PyObject* unused) noexc
 extern "C" PyObject* float_is_integer(PyObject* v) noexcept;
 extern "C" PyObject* float__format__(PyObject* v) noexcept;
 extern "C" PyObject* float_pow(PyObject* v, PyObject* w, PyObject* z) noexcept;
+extern "C" PyObject* float_str(PyObject* v) noexcept;
 extern "C" int float_pow_unboxed(double iv, double iw, double* res) noexcept;
 
 namespace pyston {
@@ -1704,6 +1705,7 @@ void setupFloat() {
 
     floatFormatInit();
 
+    float_cls->tp_str = float_str;
     float_cls->tp_as_number->nb_power = float_pow;
 }
 

--- a/src/runtime/inline/link_forcer.cpp
+++ b/src/runtime/inline/link_forcer.cpp
@@ -115,7 +115,6 @@ void force() {
     FORCE(printExprHelper);
     FORCE(printHelper);
 
-    FORCE(strOrUnicode);
     FORCE(printFloat);
     FORCE(listAppendInternal);
     FORCE(getSysStdout);

--- a/src/runtime/objmodel.h
+++ b/src/runtime/objmodel.h
@@ -73,9 +73,6 @@ extern "C" Box* callattrCapi(Box*, BoxedString*, CallattrFlags, Box*, Box*, Box*
                              const std::vector<BoxedString*>*) noexcept;
 extern "C" BoxedString* str(Box* obj);
 extern "C" BoxedString* repr(Box* obj);
-extern "C" BoxedString* reprOrNull(Box* obj); // similar to repr, but returns NULL on exception
-extern "C" BoxedString* strOrNull(Box* obj);  // similar to str, but returns NULL on exception
-extern "C" Box* strOrUnicode(Box* obj);
 extern "C" bool exceptionMatches(Box* obj, Box* cls);
 extern "C" BoxedInt* hash(Box* obj);
 extern "C" int64_t hashUnboxed(Box* obj);

--- a/src/runtime/str.cpp
+++ b/src/runtime/str.cpp
@@ -1278,8 +1278,9 @@ extern "C" Box* strLen(BoxedString* self) {
     return boxInt(self->size());
 }
 
-extern "C" Box* strStr(BoxedString* self) {
-    assert(PyString_Check(self));
+extern "C" Box* str_str(Box* _self) noexcept {
+    assert(PyString_Check(_self));
+    BoxedString* self = (BoxedString*)_self;
 
     if (self->cls == str_cls)
         return self;
@@ -2854,7 +2855,7 @@ void setupStr() {
                                                                         ParamNames::empty(), CAPI)));
 
     str_cls->giveAttr("__len__", new BoxedFunction(boxRTFunction((void*)strLen, BOXED_INT, 1)));
-    str_cls->giveAttr("__str__", new BoxedFunction(boxRTFunction((void*)strStr, STR, 1)));
+    str_cls->giveAttr("__str__", new BoxedFunction(boxRTFunction((void*)str_str, STR, 1)));
     str_cls->giveAttr("__repr__", new BoxedFunction(boxRTFunction((void*)strRepr, STR, 1)));
     str_cls->giveAttr("__hash__", new BoxedFunction(boxRTFunction((void*)strHash, UNKNOWN, 1)));
     str_cls->giveAttr("__nonzero__", new BoxedFunction(boxRTFunction((void*)strNonzero, BOXED_BOOL, 1)));
@@ -2935,6 +2936,7 @@ void setupStr() {
     str_cls->freeze();
 
     str_cls->tp_repr = str_repr;
+    str_cls->tp_str = str_str;
     str_cls->tp_iter = (decltype(str_cls->tp_iter))strIter;
     str_cls->tp_hash = (hashfunc)str_hash;
     str_cls->tp_as_sequence->sq_length = str_length;

--- a/src/runtime/types.cpp
+++ b/src/runtime/types.cpp
@@ -1613,12 +1613,8 @@ extern "C" Box* boxUnboundInstanceMethod(Box* func, Box* type) {
     return new BoxedInstanceMethod(NULL, func, type);
 }
 
-extern "C" BoxedString* noneRepr(Box* v) {
+extern "C" Box* none_repr(Box* v) noexcept {
     return boxString("None");
-}
-
-extern "C" Box* noneHash(Box* v) {
-    return boxInt(819239); // chosen randomly
 }
 
 extern "C" Box* noneNonzero(Box* v) {
@@ -3867,11 +3863,12 @@ void setupRuntime() {
     type_cls->tpp_call.capi_val = &typeTppCall<CAPI>;
     type_cls->tpp_call.cxx_val = &typeTppCall<CXX>;
 
-    none_cls->giveAttr("__repr__", new BoxedFunction(boxRTFunction((void*)noneRepr, STR, 1)));
+    none_cls->giveAttr("__repr__", new BoxedFunction(boxRTFunction((void*)none_repr, STR, 1)));
     none_cls->giveAttr("__nonzero__", new BoxedFunction(boxRTFunction((void*)noneNonzero, BOXED_BOOL, 1)));
     none_cls->giveAttr("__doc__", None);
     none_cls->tp_hash = (hashfunc)_Py_HashPointer;
     none_cls->freeze();
+    none_cls->tp_repr = none_repr;
 
     module_cls->giveAttr("__init__",
                          new BoxedFunction(boxRTFunction((void*)moduleInit, UNKNOWN, 3, false, false), { NULL }));

--- a/test/tests/unicode_test.py
+++ b/test/tests/unicode_test.py
@@ -166,3 +166,12 @@ class C(object):
 
 print type(unicode(C()))
 print unicode("test", encoding="UTF-8")
+
+class CStr(object):
+    def __str__(self):
+        return u"\u20ac"
+class CRepr(object):
+    def __repr__(self):
+        return u"\u20ac"
+print "%s %s" % (CStr(), CRepr())
+


### PR DESCRIPTION
- switch to use cpythons repr handling - while I don't think python explicitly allows returning anything other than a string from ```__repr__``` and ```__str__``` cpython and pypy support it for string formats and we support it now too.
- enable libpypas optimizations which often let us omit an unary neg op when encountering something like ```-1```.

```
                                   upstream/master:  origin/str_cleanup:
           django_template3.py             2.2s (4)             2.2s (4)  -0.7%
                 pyxl_bench.py             1.9s (4)             1.9s (4)  -1.5%
     sqlalchemy_imperative2.py             2.4s (4)             2.4s (4)  -0.4%
                       geomean                 2.2s                 2.1s  -0.9%

```