### PR TITLE
pyxl_bench allocation reductions

### DIFF
--- a/from_cpython/Modules/_sre.c
+++ b/from_cpython/Modules/_sre.c
@@ -3538,13 +3538,12 @@ _pair(Py_ssize_t i1, Py_ssize_t i2)
 }
 
 static PyObject*
-match_span(MatchObject* self, PyObject* args)
+match_span(MatchObject* self, PyObject* index_)
 {
     Py_ssize_t index;
 
-    PyObject* index_ = Py_False; /* zero */
-    if (!PyArg_UnpackTuple(args, "span", 0, 1, &index_))
-        return NULL;
+    if (!index_)
+        index_ = Py_False; /* zero */
 
     index = match_getindex(self, index_);
 
@@ -3682,7 +3681,7 @@ static PyMethodDef match_methods[] = {
     {"group", (PyCFunction) match_group, METH_VARARGS, match_group_doc},
     {"start", (PyCFunction) match_start, METH_VARARGS, match_start_doc},
     {"end", (PyCFunction) match_end, METH_VARARGS, match_end_doc},
-    {"span", (PyCFunction) match_span, METH_VARARGS, match_span_doc},
+    {"span", (PyCFunction) match_span, METH_O | METH_D1, match_span_doc},
     {"groups", (PyCFunction) match_groups, METH_VARARGS|METH_KEYWORDS,
         match_groups_doc},
     {"groupdict", (PyCFunction) match_groupdict, METH_VARARGS|METH_KEYWORDS,

--- a/from_cpython/Modules/cStringIO.c
+++ b/from_cpython/Modules/cStringIO.c
@@ -685,11 +685,8 @@ newIobject(PyObject *s) {
   PyObject *args;
   int result;
 
-  args = Py_BuildValue("(O)", s);
-  if (args == NULL)
-      return NULL;
-  result = PyArg_ParseTuple(args, "s*:StringIO", &buf);
-  Py_DECREF(args);
+  // Pyston change:
+  result = PyArg_ParseSingle(s, 1, "StringIO", "s*", &buf);
   if (!result)
       return NULL;
 
@@ -714,11 +711,7 @@ PyDoc_STRVAR(IO_StringIO__doc__,
 "StringIO([s]) -- Return a StringIO-like stream for reading or writing");
 
 static PyObject *
-IO_StringIO(PyObject *self, PyObject *args) {
-  PyObject *s=0;
-
-  if (!PyArg_UnpackTuple(args, "StringIO", 0, 1, &s)) return NULL;
-
+IO_StringIO(PyObject *self, PyObject *s) {
   if (s) return newIobject(s);
   return newOobject(128);
 }
@@ -727,7 +720,7 @@ IO_StringIO(PyObject *self, PyObject *args) {
 
 static struct PyMethodDef IO_methods[] = {
   {"StringIO",  (PyCFunction)IO_StringIO,
-   METH_VARARGS,        IO_StringIO__doc__},
+   /* Pyston change: */ METH_O | METH_D1,        IO_StringIO__doc__},
   {NULL,                NULL}           /* sentinel */
 };
 

--- a/from_cpython/Modules/cStringIO.c
+++ b/from_cpython/Modules/cStringIO.c
@@ -222,12 +222,13 @@ IO_creadline(PyObject *self, char **output) {
 }
 
 static PyObject *
-IO_readline(IOobject *self, PyObject *args) {
+IO_readline(IOobject *self, PyObject *m_obj) {
     int n, m=-1;
     char *output;
 
-    if (args)
-        if (!PyArg_ParseTuple(args, "|i:readline", &m)) return NULL;
+    // Pyston change:
+    if (m_obj)
+        if (!PyArg_ParseSingle(m_obj, 1, "readline", "i", &m)) return NULL;
 
     if( (n=IO_creadline((PyObject*)self,&output)) < 0) return NULL;
     if (m >= 0 && m < n) {
@@ -514,7 +515,7 @@ static struct PyMethodDef O_methods[] = {
   {"getvalue",  (PyCFunction)IO_getval,   METH_VARARGS, IO_getval__doc__},
   {"isatty",    (PyCFunction)IO_isatty,   METH_NOARGS,  IO_isatty__doc__},
   {"read",      (PyCFunction)IO_read,     METH_VARARGS, IO_read__doc__},
-  {"readline",  (PyCFunction)IO_readline, METH_VARARGS, IO_readline__doc__},
+  {"readline",  (PyCFunction)IO_readline, /* Pyston change: */ METH_O | METH_D1, IO_readline__doc__},
   {"readlines", (PyCFunction)IO_readlines,METH_VARARGS, IO_readlines__doc__},
   {"reset",     (PyCFunction)IO_reset,    METH_NOARGS,  IO_reset__doc__},
   {"seek",      (PyCFunction)IO_seek,     METH_VARARGS, IO_seek__doc__},
@@ -621,7 +622,7 @@ static struct PyMethodDef I_methods[] = {
   {"getvalue",  (PyCFunction)IO_getval,   METH_VARARGS, IO_getval__doc__},
   {"isatty",    (PyCFunction)IO_isatty,   METH_NOARGS,  IO_isatty__doc__},
   {"read",      (PyCFunction)IO_read,     METH_VARARGS, IO_read__doc__},
-  {"readline",  (PyCFunction)IO_readline, METH_VARARGS, IO_readline__doc__},
+  {"readline",  (PyCFunction)IO_readline, /* Pyston change: */ METH_O | METH_D1, IO_readline__doc__},
   {"readlines", (PyCFunction)IO_readlines,METH_VARARGS, IO_readlines__doc__},
   {"reset",     (PyCFunction)IO_reset,    METH_NOARGS,  IO_reset__doc__},
   {"seek",      (PyCFunction)IO_seek,     METH_VARARGS, IO_seek__doc__},

--- a/from_cpython/Python/getargs.c
+++ b/from_cpython/Python/getargs.c
@@ -569,8 +569,7 @@ float_argument_error(PyObject *arg)
         return 0;
 }
 
-int _PyArg_ParseSingle_SizeT(PyObject* obj, int arg_idx, const char* fname, const char* format, ...) {
-    va_list va;
+int vgetsingle(PyObject* obj, int arg_idx, const char* fname, const char* format, va_list *v_pa, int flags) {
     char* msg;
     char msgbuf[256];
 
@@ -582,9 +581,7 @@ int _PyArg_ParseSingle_SizeT(PyObject* obj, int arg_idx, const char* fname, cons
     assert(format[1] != '*'); // would need to pass a non-null freelist
     assert(format[0] != 'e'); // would need to pass a non-null freelist
 
-    va_start(va, format);
-    msg = convertsimple(obj, &format, &va, FLAG_SIZE_T, msgbuf, sizeof(msgbuf), NULL);
-    va_end(va);
+    msg = convertsimple(obj, &format, v_pa, flags, msgbuf, sizeof(msgbuf), NULL);
 
     if (msg) {
         int levels[1];
@@ -596,6 +593,26 @@ int _PyArg_ParseSingle_SizeT(PyObject* obj, int arg_idx, const char* fname, cons
     // Should have consumed the entire format string:
     assert(format[0] == '\0');
     return 1;
+}
+
+int PyArg_ParseSingle(PyObject* obj, int arg_idx, const char* fname, const char* format, ...) {
+    va_list va;
+    va_start(va, format);
+
+    int r = vgetsingle(obj, arg_idx, fname, format, &va, 0);
+
+    va_end(va);
+    return r;
+}
+
+int _PyArg_ParseSingle_SizeT(PyObject* obj, int arg_idx, const char* fname, const char* format, ...) {
+    va_list va;
+    va_start(va, format);
+
+    int r = vgetsingle(obj, arg_idx, fname, format, &va, FLAG_SIZE_T);
+
+    va_end(va);
+    return r;
 }
 
 /* Convert a non-tuple argument.  Return NULL if conversion went OK,

--- a/src/capi/modsupport.cpp
+++ b/src/capi/modsupport.cpp
@@ -423,8 +423,6 @@ extern "C" PyObject* Py_InitModule4(const char* name, PyMethodDef* methods, cons
     Box* passthrough = static_cast<Box*>(self);
 
     while (methods && methods->ml_name) {
-        RELEASE_ASSERT((methods->ml_flags & (~(METH_VARARGS | METH_KEYWORDS | METH_NOARGS | METH_O))) == 0, "%d",
-                       methods->ml_flags);
         module->giveAttr(methods->ml_name, new BoxedCApiFunction(methods, passthrough, boxString(name)));
 
         methods++;

--- a/src/runtime/objmodel.cpp
+++ b/src/runtime/objmodel.cpp
@@ -3559,7 +3559,20 @@ void rearrangeArgumentsInternal(ParamReceiveSpec paramspec, const ParamNames* pa
             }
         }
 
-        Box* ovarargs = BoxedTuple::create(unused_positional.size(), unused_positional.data());
+        Box* ovarargs;
+        if (argspec.num_args == 0 && paramspec.num_args == 0 && (!varargs || varargs->cls == tuple_cls)) {
+            // We probably could have cut out a lot more of the overhead in this case:
+            assert(varargs_size == unused_positional.size());
+
+            if (!varargs)
+                ovarargs = EmptyTuple;
+            else
+                ovarargs = varargs;
+        } else {
+            ovarargs = BoxedTuple::create(unused_positional.size(), unused_positional.data());
+        }
+        assert(ovarargs->cls == tuple_cls);
+
         getArg(varargs_idx, oarg1, oarg2, oarg3, oargs) = ovarargs;
     } else if (unused_positional.size()) {
         raiseExcHelper(TypeError, "%s() takes at most %d argument%s (%ld given)", func_name_cb(), paramspec.num_args,

--- a/src/runtime/str.cpp
+++ b/src/runtime/str.cpp
@@ -1867,7 +1867,8 @@ Box* strReplace(Box* _self, Box* _old, Box* _new, Box** _args) {
     std::string s = self->s();
 
     bool single_char = old->size() == 1;
-    for (int num_replaced = 0; num_replaced < max_replaces || max_replaces < 0; ++num_replaced) {
+    int num_replaced = 0;
+    for (; num_replaced < max_replaces || max_replaces < 0; ++num_replaced) {
         if (single_char)
             start_pos = s.find(old->s()[0], start_pos);
         else
@@ -1878,6 +1879,10 @@ Box* strReplace(Box* _self, Box* _old, Box* _new, Box** _args) {
         s.replace(start_pos, old->size(), new_->s());
         start_pos += new_->size(); // Handles case where 'to' is a substring of 'from'
     }
+
+    if (num_replaced == 0 && self->cls == str_cls)
+        return self;
+
     return boxString(s);
 }
 


### PR DESCRIPTION
Other than the slices change, didn't find a whole lot; this PR reduces the number of collections by 2%.

Doesn't seem to have that much of an overall effect but I think it's still a good change:
```
           django_template3.py             2.1s (4)             2.1s (2)  +0.1%
                 pyxl_bench.py             1.8s (4)             1.8s (2)  +0.2%
     sqlalchemy_imperative2.py             2.3s (4)             2.3s (2)  +0.3%
       django_template3_10x.py            13.6s (4)            13.7s (2)  +0.4%
             pyxl_bench_10x.py            14.5s (4)            14.3s (2)  -1.3%
 sqlalchemy_imperative2_10x.py            17.1s (4)            17.1s (2)  -0.2%
                       geomean                 5.6s                 5.6s  -0.1%
```