### PR TITLE
LLVM tier: adjust num of IC slots depending on the num of times the IC got rewritten in the bjit tier

### DIFF
--- a/src/asm_writing/icinfo.cpp
+++ b/src/asm_writing/icinfo.cpp
@@ -367,4 +367,16 @@ void ICInfo::visitGCReferences(gc::GCVisitor* v) {
     }
 #endif
 }
+
+static llvm::DenseMap<AST*, ICInfo*> ics_by_ast_node;
+
+ICInfo* ICInfo::getICInfoForNode(AST* node) {
+    auto&& it = ics_by_ast_node.find(node);
+    if (it != ics_by_ast_node.end())
+        return it->second;
+    return NULL;
+}
+void ICInfo::associateNodeWithICInfo(AST* node) {
+    ics_by_ast_node[node] = this;
+}
 }

--- a/src/asm_writing/icinfo.h
+++ b/src/asm_writing/icinfo.h
@@ -147,9 +147,13 @@ public:
     // For use of the rewriter for computing aggressiveness:
     int percentMegamorphic() const { return times_rewritten * 100 / IC_MEGAMORPHIC_THRESHOLD; }
     int percentBackedoff() const { return retry_backoff; }
+    int timesRewritten() const { return times_rewritten; }
 
     friend class ICSlotRewrite;
     static void visitGCReferences(gc::GCVisitor* visitor);
+
+    static ICInfo* getICInfoForNode(AST* node);
+    void associateNodeWithICInfo(AST* node);
 };
 
 void registerGCTrackedICInfo(ICInfo* ic);

--- a/src/asm_writing/rewriter.h
+++ b/src/asm_writing/rewriter.h
@@ -318,7 +318,7 @@ public:
 
 class RewriterAction {
 public:
-    SmallFunction<48> action;
+    SmallFunction<56> action;
 
     template <typename F> RewriterAction(F&& action) : action(std::forward<F>(action)) {}
 

--- a/src/codegen/baseline_jit.h
+++ b/src/codegen/baseline_jit.h
@@ -191,6 +191,7 @@ private:
         uint8_t* end_addr;
         std::unique_ptr<ICSetupInfo> ic;
         StackInfo stack_info;
+        AST* node;
     };
 
     llvm::SmallVector<PPInfo, 8> pp_infos;
@@ -203,11 +204,11 @@ public:
     RewriterVar* imm(uint64_t val);
     RewriterVar* imm(void* val);
 
-    RewriterVar* emitAugbinop(RewriterVar* lhs, RewriterVar* rhs, int op_type);
-    RewriterVar* emitBinop(RewriterVar* lhs, RewriterVar* rhs, int op_type);
+    RewriterVar* emitAugbinop(AST_expr* node, RewriterVar* lhs, RewriterVar* rhs, int op_type);
+    RewriterVar* emitBinop(AST_expr* node, RewriterVar* lhs, RewriterVar* rhs, int op_type);
     RewriterVar* emitCallattr(AST_expr* node, RewriterVar* obj, BoxedString* attr, CallattrFlags flags,
                               const llvm::ArrayRef<RewriterVar*> args, std::vector<BoxedString*>* keyword_names);
-    RewriterVar* emitCompare(RewriterVar* lhs, RewriterVar* rhs, int op_type);
+    RewriterVar* emitCompare(AST_expr* node, RewriterVar* lhs, RewriterVar* rhs, int op_type);
     RewriterVar* emitCreateDict(const llvm::ArrayRef<RewriterVar*> keys, const llvm::ArrayRef<RewriterVar*> values);
     RewriterVar* emitCreateList(const llvm::ArrayRef<RewriterVar*> values);
     RewriterVar* emitCreateSet(const llvm::ArrayRef<RewriterVar*> values);
@@ -221,7 +222,7 @@ public:
     RewriterVar* emitGetBoxedLocals();
     RewriterVar* emitGetClsAttr(RewriterVar* obj, BoxedString* s);
     RewriterVar* emitGetGlobal(Box* global, BoxedString* s);
-    RewriterVar* emitGetItem(RewriterVar* value, RewriterVar* slice);
+    RewriterVar* emitGetItem(AST_expr* node, RewriterVar* value, RewriterVar* slice);
     RewriterVar* emitGetLocal(InternedString s, int vreg);
     RewriterVar* emitGetPystonIter(RewriterVar* v);
     RewriterVar* emitHasnext(RewriterVar* v);
@@ -249,7 +250,7 @@ public:
     void emitRaise0();
     void emitRaise3(RewriterVar* arg0, RewriterVar* arg1, RewriterVar* arg2);
     void emitReturn(RewriterVar* v);
-    void emitSetAttr(RewriterVar* obj, BoxedString* s, RewriterVar* attr);
+    void emitSetAttr(AST_expr* node, RewriterVar* obj, BoxedString* s, RewriterVar* attr);
     void emitSetBlockLocal(InternedString s, RewriterVar* v);
     void emitSetCurrentInst(AST_stmt* node);
     void emitSetExcInfo(RewriterVar* type, RewriterVar* value, RewriterVar* traceback);
@@ -274,7 +275,7 @@ private:
 #endif
 
     RewriterVar* emitPPCall(void* func_addr, llvm::ArrayRef<RewriterVar*> args, int num_slots, int slot_size,
-                            TypeRecorder* type_recorder = NULL);
+                            AST* ast_node = NULL, TypeRecorder* type_recorder = NULL);
 
     static void assertNameDefinedHelper(const char* id);
     static Box* callattrHelper(Box* obj, BoxedString* attr, CallattrFlags flags, TypeRecorder* type_recorder,
@@ -294,7 +295,7 @@ private:
     void _emitJump(CFGBlock* b, RewriterVar* block_next, int& size_of_exit_to_interp);
     void _emitOSRPoint(RewriterVar* result, RewriterVar* node_var);
     void _emitPPCall(RewriterVar* result, void* func_addr, llvm::ArrayRef<RewriterVar*> args, int num_slots,
-                     int slot_size);
+                     int slot_size, AST* ast_node);
     void _emitRecordType(RewriterVar* type_recorder_var, RewriterVar* obj_cls_var);
     void _emitReturn(RewriterVar* v);
     void _emitSideExit(RewriterVar* var, RewriterVar* val_constant, CFGBlock* next_block, RewriterVar* false_path);

--- a/src/codegen/compvars.cpp
+++ b/src/codegen/compvars.cpp
@@ -259,7 +259,7 @@ public:
         // converted->getValue()->dump(); llvm::errs() << '\n';
         bool do_patchpoint = ENABLE_ICSETATTRS;
         if (do_patchpoint) {
-            ICSetupInfo* pp = createSetattrIC(info.getTypeRecorder());
+            ICSetupInfo* pp = createSetattrIC(info.getTypeRecorder(), info.getBJitICInfo());
 
             std::vector<llvm::Value*> llvm_args;
             llvm_args.push_back(var->getValue());
@@ -374,7 +374,7 @@ public:
         bool do_patchpoint = ENABLE_ICGETITEMS;
         llvm::Value* rtn;
         if (do_patchpoint) {
-            ICSetupInfo* pp = createGetitemIC(info.getTypeRecorder());
+            ICSetupInfo* pp = createGetitemIC(info.getTypeRecorder(), info.getBJitICInfo());
 
             std::vector<llvm::Value*> llvm_args;
             llvm_args.push_back(var->getValue());
@@ -471,7 +471,7 @@ public:
         }
 
         if (do_patchpoint) {
-            ICSetupInfo* pp = createBinexpIC(info.getTypeRecorder());
+            ICSetupInfo* pp = createBinexpIC(info.getTypeRecorder(), info.getBJitICInfo());
 
             std::vector<llvm::Value*> llvm_args;
             llvm_args.push_back(var->getValue());
@@ -554,7 +554,7 @@ CompilerVariable* UnknownType::getattr(IREmitter& emitter, const OpInfo& info, C
 
     bool do_patchpoint = ENABLE_ICGETATTRS;
     if (do_patchpoint) {
-        ICSetupInfo* pp = createGetattrIC(info.getTypeRecorder());
+        ICSetupInfo* pp = createGetattrIC(info.getTypeRecorder(), info.getBJitICInfo());
 
         std::vector<llvm::Value*> llvm_args;
         llvm_args.push_back(var->getValue());
@@ -650,7 +650,7 @@ static ConcreteCompilerVariable* _call(IREmitter& emitter, const OpInfo& info, l
     if (do_patchpoint) {
         assert(func_addr);
 
-        ICSetupInfo* pp = createCallsiteIC(info.getTypeRecorder(), args.size());
+        ICSetupInfo* pp = createCallsiteIC(info.getTypeRecorder(), args.size(), info.getBJitICInfo());
 
         llvm::Value* uncasted = emitter.createIC(pp, func_addr, llvm_args, info.unw_info, target_exception_style);
 

--- a/src/codegen/irgen.h
+++ b/src/codegen/irgen.h
@@ -141,14 +141,16 @@ class OpInfo {
 private:
     const EffortLevel effort;
     TypeRecorder* const type_recorder;
+    ICInfo* bjit_ic_info;
 
 public:
     const UnwindInfo unw_info;
 
-    OpInfo(EffortLevel effort, TypeRecorder* type_recorder, const UnwindInfo& unw_info)
-        : effort(effort), type_recorder(type_recorder), unw_info(unw_info) {}
+    OpInfo(EffortLevel effort, TypeRecorder* type_recorder, const UnwindInfo& unw_info, ICInfo* bjit_ic_info)
+        : effort(effort), type_recorder(type_recorder), bjit_ic_info(bjit_ic_info), unw_info(unw_info) {}
 
     TypeRecorder* getTypeRecorder() const { return type_recorder; }
+    ICInfo* getBJitICInfo() const { return bjit_ic_info; }
 
     ExceptionStyle preferredExceptionStyle() const { return unw_info.preferredExceptionStyle(); }
 };

--- a/src/codegen/irgen/irgenerator.cpp
+++ b/src/codegen/irgen/irgenerator.cpp
@@ -20,6 +20,7 @@
 #include "analysis/function_analysis.h"
 #include "analysis/scoping_analysis.h"
 #include "analysis/type_analysis.h"
+#include "asm_writing/icinfo.h"
 #include "codegen/codegen.h"
 #include "codegen/compvars.h"
 #include "codegen/irgen.h"
@@ -596,10 +597,12 @@ private:
             type_recorder = NULL;
         }
 
-        return OpInfo(irstate->getEffortLevel(), type_recorder, unw_info);
+        return OpInfo(irstate->getEffortLevel(), type_recorder, unw_info, ICInfo::getICInfoForNode(ast));
     }
 
-    OpInfo getEmptyOpInfo(const UnwindInfo& unw_info) { return OpInfo(irstate->getEffortLevel(), NULL, unw_info); }
+    OpInfo getEmptyOpInfo(const UnwindInfo& unw_info) {
+        return OpInfo(irstate->getEffortLevel(), NULL, unw_info, NULL);
+    }
 
     void createExprTypeGuard(llvm::Value* check_val, AST* node, llvm::Value* node_value, AST_stmt* current_statement) {
         assert(check_val->getType() == g.i1);

--- a/src/codegen/patchpoints.h
+++ b/src/codegen/patchpoints.h
@@ -152,16 +152,17 @@ public:
                                    TypeRecorder* type_recorder);
 };
 
+class ICInfo;
 ICSetupInfo* createGenericIC(TypeRecorder* type_recorder, bool has_return_value, int size);
-ICSetupInfo* createCallsiteIC(TypeRecorder* type_recorder, int num_args);
+ICSetupInfo* createCallsiteIC(TypeRecorder* type_recorder, int num_args, ICInfo* bjit_ic_info);
 ICSetupInfo* createGetGlobalIC(TypeRecorder* type_recorder);
-ICSetupInfo* createGetattrIC(TypeRecorder* type_recorder);
-ICSetupInfo* createSetattrIC(TypeRecorder* type_recorder);
+ICSetupInfo* createGetattrIC(TypeRecorder* type_recorder, ICInfo* bjit_ic_info);
+ICSetupInfo* createSetattrIC(TypeRecorder* type_recorder, ICInfo* bjit_ic_info);
 ICSetupInfo* createDelattrIC(TypeRecorder* type_recorder);
-ICSetupInfo* createGetitemIC(TypeRecorder* type_recorder);
+ICSetupInfo* createGetitemIC(TypeRecorder* type_recorder, ICInfo* bjit_ic_info);
 ICSetupInfo* createSetitemIC(TypeRecorder* type_recorder);
 ICSetupInfo* createDelitemIC(TypeRecorder* type_recorder);
-ICSetupInfo* createBinexpIC(TypeRecorder* type_recorder);
+ICSetupInfo* createBinexpIC(TypeRecorder* type_recorder, ICInfo* bjit_ic_info);
 ICSetupInfo* createNonzeroIC(TypeRecorder* type_recorder);
 ICSetupInfo* createHasnextIC(TypeRecorder* type_recorder);
 


### PR DESCRIPTION
I chose IC slot size heuristic just by running a few times the benchmarks and taking the best one, we may want to adjust it later.
```
           django_template3.py             2.2s (6)             2.2s (2)  -0.5%
                 pyxl_bench.py             1.9s (6)             1.8s (2)  -3.8%
     sqlalchemy_imperative2.py             2.3s (6)             2.3s (2)  -1.3%
                pyxl_bench2.py             1.5s (6)             1.3s (2)  -14.5%
       django_template3_10x.py            14.3s (6)            14.2s (2)  -0.5%
             pyxl_bench_10x.py            14.7s (6)            13.9s (2)  -5.4%
 sqlalchemy_imperative2_10x.py            18.1s (6)            17.4s (2)  -3.4%
            pyxl_bench2_10x.py            13.8s (6)            11.6s (2)  -15.9%
                       geomean                 5.4s                 5.1s  -5.9%
```