### PR TITLE
Misc optimizations for pyxl2

### DIFF
--- a/from_cpython/Objects/stringobject.c
+++ b/from_cpython/Objects/stringobject.c
@@ -402,3 +402,538 @@ done:
     Py_XDECREF(tmp);
     return result;
 }
+
+/* find and count characters and substrings */
+
+#define findchar(target, target_len, c)                         \
+  ((char *)memchr((const void *)(target), c, target_len))
+
+/* String ops must return a string.  */
+/* If the object is subclass of string, create a copy */
+Py_LOCAL(PyStringObject *)
+return_self(PyStringObject *self)
+{
+    if (PyString_CheckExact(self)) {
+        Py_INCREF(self);
+        return self;
+    }
+    return (PyStringObject *)PyString_FromStringAndSize(
+        PyString_AS_STRING(self),
+        PyString_GET_SIZE(self));
+}
+
+Py_LOCAL_INLINE(Py_ssize_t)
+countchar(const char *target, Py_ssize_t target_len, char c, Py_ssize_t maxcount)
+{
+    Py_ssize_t count=0;
+    const char *start=target;
+    const char *end=target+target_len;
+
+    while ( (start=findchar(start, end-start, c)) != NULL ) {
+        count++;
+        if (count >= maxcount)
+            break;
+        start += 1;
+    }
+    return count;
+}
+
+/* Algorithms for different cases of string replacement */
+
+/* len(self)>=1, from="", len(to)>=1, maxcount>=1 */
+Py_LOCAL(PyStringObject *)
+replace_interleave(PyStringObject *self,
+                   const char *to_s, Py_ssize_t to_len,
+                   Py_ssize_t maxcount)
+{
+    char *self_s, *result_s;
+    Py_ssize_t self_len, result_len;
+    Py_ssize_t count, i, product;
+    PyStringObject *result;
+
+    self_len = PyString_GET_SIZE(self);
+
+    /* 1 at the end plus 1 after every character */
+    count = self_len+1;
+    if (maxcount < count)
+        count = maxcount;
+
+    /* Check for overflow */
+    /*   result_len = count * to_len + self_len; */
+    product = count * to_len;
+    if (product / to_len != count) {
+        PyErr_SetString(PyExc_OverflowError,
+                        "replace string is too long");
+        return NULL;
+    }
+    result_len = product + self_len;
+    if (result_len < 0) {
+        PyErr_SetString(PyExc_OverflowError,
+                        "replace string is too long");
+        return NULL;
+    }
+
+    if (! (result = (PyStringObject *)
+                     PyString_FromStringAndSize(NULL, result_len)) )
+        return NULL;
+
+    self_s = PyString_AS_STRING(self);
+    result_s = PyString_AS_STRING(result);
+
+    /* TODO: special case single character, which doesn't need memcpy */
+
+    /* Lay the first one down (guaranteed this will occur) */
+    Py_MEMCPY(result_s, to_s, to_len);
+    result_s += to_len;
+    count -= 1;
+
+    for (i=0; i<count; i++) {
+        *result_s++ = *self_s++;
+        Py_MEMCPY(result_s, to_s, to_len);
+        result_s += to_len;
+    }
+
+    /* Copy the rest of the original string */
+    Py_MEMCPY(result_s, self_s, self_len-i);
+
+    return result;
+}
+
+/* Special case for deleting a single character */
+/* len(self)>=1, len(from)==1, to="", maxcount>=1 */
+Py_LOCAL(PyStringObject *)
+replace_delete_single_character(PyStringObject *self,
+                                char from_c, Py_ssize_t maxcount)
+{
+    char *self_s, *result_s;
+    char *start, *next, *end;
+    Py_ssize_t self_len, result_len;
+    Py_ssize_t count;
+    PyStringObject *result;
+
+    self_len = PyString_GET_SIZE(self);
+    self_s = PyString_AS_STRING(self);
+
+    count = countchar(self_s, self_len, from_c, maxcount);
+    if (count == 0) {
+        return return_self(self);
+    }
+
+    result_len = self_len - count;  /* from_len == 1 */
+    assert(result_len>=0);
+
+    if ( (result = (PyStringObject *)
+                    PyString_FromStringAndSize(NULL, result_len)) == NULL)
+        return NULL;
+    result_s = PyString_AS_STRING(result);
+
+    start = self_s;
+    end = self_s + self_len;
+    while (count-- > 0) {
+        next = findchar(start, end-start, from_c);
+        if (next == NULL)
+            break;
+        Py_MEMCPY(result_s, start, next-start);
+        result_s += (next-start);
+        start = next+1;
+    }
+    Py_MEMCPY(result_s, start, end-start);
+
+    return result;
+}
+
+/* len(self)>=1, len(from)>=2, to="", maxcount>=1 */
+
+Py_LOCAL(PyStringObject *)
+replace_delete_substring(PyStringObject *self,
+                         const char *from_s, Py_ssize_t from_len,
+                         Py_ssize_t maxcount) {
+    char *self_s, *result_s;
+    char *start, *next, *end;
+    Py_ssize_t self_len, result_len;
+    Py_ssize_t count, offset;
+    PyStringObject *result;
+
+    self_len = PyString_GET_SIZE(self);
+    self_s = PyString_AS_STRING(self);
+
+    count = stringlib_count(self_s, self_len,
+                            from_s, from_len,
+                            maxcount);
+
+    if (count == 0) {
+        /* no matches */
+        return return_self(self);
+    }
+
+    result_len = self_len - (count * from_len);
+    assert (result_len>=0);
+
+    if ( (result = (PyStringObject *)
+          PyString_FromStringAndSize(NULL, result_len)) == NULL )
+        return NULL;
+
+    result_s = PyString_AS_STRING(result);
+
+    start = self_s;
+    end = self_s + self_len;
+    while (count-- > 0) {
+        offset = stringlib_find(start, end-start,
+                                from_s, from_len,
+                                0);
+        if (offset == -1)
+            break;
+        next = start + offset;
+
+        Py_MEMCPY(result_s, start, next-start);
+
+        result_s += (next-start);
+        start = next+from_len;
+    }
+    Py_MEMCPY(result_s, start, end-start);
+    return result;
+}
+
+/* len(self)>=1, len(from)==len(to)==1, maxcount>=1 */
+Py_LOCAL(PyStringObject *)
+replace_single_character_in_place(PyStringObject *self,
+                                  char from_c, char to_c,
+                                  Py_ssize_t maxcount)
+{
+    char *self_s, *result_s, *start, *end, *next;
+    Py_ssize_t self_len;
+    PyStringObject *result;
+
+    /* The result string will be the same size */
+    self_s = PyString_AS_STRING(self);
+    self_len = PyString_GET_SIZE(self);
+
+    next = findchar(self_s, self_len, from_c);
+
+    if (next == NULL) {
+        /* No matches; return the original string */
+        return return_self(self);
+    }
+
+    /* Need to make a new string */
+    result = (PyStringObject *) PyString_FromStringAndSize(NULL, self_len);
+    if (result == NULL)
+        return NULL;
+    result_s = PyString_AS_STRING(result);
+    Py_MEMCPY(result_s, self_s, self_len);
+
+    /* change everything in-place, starting with this one */
+    start =  result_s + (next-self_s);
+    *start = to_c;
+    start++;
+    end = result_s + self_len;
+
+    while (--maxcount > 0) {
+        next = findchar(start, end-start, from_c);
+        if (next == NULL)
+            break;
+        *next = to_c;
+        start = next+1;
+    }
+
+    return result;
+}
+
+/* len(self)>=1, len(from)==len(to)>=2, maxcount>=1 */
+Py_LOCAL(PyStringObject *)
+replace_substring_in_place(PyStringObject *self,
+                           const char *from_s, Py_ssize_t from_len,
+                           const char *to_s, Py_ssize_t to_len,
+                           Py_ssize_t maxcount)
+{
+    char *result_s, *start, *end;
+    char *self_s;
+    Py_ssize_t self_len, offset;
+    PyStringObject *result;
+
+    /* The result string will be the same size */
+
+    self_s = PyString_AS_STRING(self);
+    self_len = PyString_GET_SIZE(self);
+
+    offset = stringlib_find(self_s, self_len,
+                            from_s, from_len,
+                            0);
+    if (offset == -1) {
+        /* No matches; return the original string */
+        return return_self(self);
+    }
+
+    /* Need to make a new string */
+    result = (PyStringObject *) PyString_FromStringAndSize(NULL, self_len);
+    if (result == NULL)
+        return NULL;
+    result_s = PyString_AS_STRING(result);
+    Py_MEMCPY(result_s, self_s, self_len);
+
+    /* change everything in-place, starting with this one */
+    start =  result_s + offset;
+    Py_MEMCPY(start, to_s, from_len);
+    start += from_len;
+    end = result_s + self_len;
+
+    while ( --maxcount > 0) {
+        offset = stringlib_find(start, end-start,
+                                from_s, from_len,
+                                0);
+        if (offset==-1)
+            break;
+        Py_MEMCPY(start+offset, to_s, from_len);
+        start += offset+from_len;
+    }
+
+    return result;
+}
+
+/* len(self)>=1, len(from)==1, len(to)>=2, maxcount>=1 */
+Py_LOCAL(PyStringObject *)
+replace_single_character(PyStringObject *self,
+                         char from_c,
+                         const char *to_s, Py_ssize_t to_len,
+                         Py_ssize_t maxcount)
+{
+    char *self_s, *result_s;
+    char *start, *next, *end;
+    Py_ssize_t self_len, result_len;
+    Py_ssize_t count, product;
+    PyStringObject *result;
+
+    self_s = PyString_AS_STRING(self);
+    self_len = PyString_GET_SIZE(self);
+
+    count = countchar(self_s, self_len, from_c, maxcount);
+    if (count == 0) {
+        /* no matches, return unchanged */
+        return return_self(self);
+    }
+
+    /* use the difference between current and new, hence the "-1" */
+    /*   result_len = self_len + count * (to_len-1)  */
+    product = count * (to_len-1);
+    if (product / (to_len-1) != count) {
+        PyErr_SetString(PyExc_OverflowError, "replace string is too long");
+        return NULL;
+    }
+    result_len = self_len + product;
+    if (result_len < 0) {
+        PyErr_SetString(PyExc_OverflowError, "replace string is too long");
+        return NULL;
+    }
+
+    if ( (result = (PyStringObject *)
+          PyString_FromStringAndSize(NULL, result_len)) == NULL)
+        return NULL;
+    result_s = PyString_AS_STRING(result);
+
+    start = self_s;
+    end = self_s + self_len;
+    while (count-- > 0) {
+        next = findchar(start, end-start, from_c);
+        if (next == NULL)
+            break;
+
+        if (next == start) {
+            /* replace with the 'to' */
+            Py_MEMCPY(result_s, to_s, to_len);
+            result_s += to_len;
+            start += 1;
+        } else {
+            /* copy the unchanged old then the 'to' */
+            Py_MEMCPY(result_s, start, next-start);
+            result_s += (next-start);
+            Py_MEMCPY(result_s, to_s, to_len);
+            result_s += to_len;
+            start = next+1;
+        }
+    }
+    /* Copy the remainder of the remaining string */
+    Py_MEMCPY(result_s, start, end-start);
+
+    return result;
+}
+
+/* len(self)>=1, len(from)>=2, len(to)>=2, maxcount>=1 */
+Py_LOCAL(PyStringObject *)
+replace_substring(PyStringObject *self,
+                  const char *from_s, Py_ssize_t from_len,
+                  const char *to_s, Py_ssize_t to_len,
+                  Py_ssize_t maxcount) {
+    char *self_s, *result_s;
+    char *start, *next, *end;
+    Py_ssize_t self_len, result_len;
+    Py_ssize_t count, offset, product;
+    PyStringObject *result;
+
+    self_s = PyString_AS_STRING(self);
+    self_len = PyString_GET_SIZE(self);
+
+    count = stringlib_count(self_s, self_len,
+                            from_s, from_len,
+                            maxcount);
+
+    if (count == 0) {
+        /* no matches, return unchanged */
+        return return_self(self);
+    }
+
+    /* Check for overflow */
+    /*    result_len = self_len + count * (to_len-from_len) */
+    product = count * (to_len-from_len);
+    if (product / (to_len-from_len) != count) {
+        PyErr_SetString(PyExc_OverflowError, "replace string is too long");
+        return NULL;
+    }
+    result_len = self_len + product;
+    if (result_len < 0) {
+        PyErr_SetString(PyExc_OverflowError, "replace string is too long");
+        return NULL;
+    }
+
+    if ( (result = (PyStringObject *)
+          PyString_FromStringAndSize(NULL, result_len)) == NULL)
+        return NULL;
+    result_s = PyString_AS_STRING(result);
+
+    start = self_s;
+    end = self_s + self_len;
+    while (count-- > 0) {
+        offset = stringlib_find(start, end-start,
+                                from_s, from_len,
+                                0);
+        if (offset == -1)
+            break;
+        next = start+offset;
+        if (next == start) {
+            /* replace with the 'to' */
+            Py_MEMCPY(result_s, to_s, to_len);
+            result_s += to_len;
+            start += from_len;
+        } else {
+            /* copy the unchanged old then the 'to' */
+            Py_MEMCPY(result_s, start, next-start);
+            result_s += (next-start);
+            Py_MEMCPY(result_s, to_s, to_len);
+            result_s += to_len;
+            start = next+from_len;
+        }
+    }
+    /* Copy the remainder of the remaining string */
+    Py_MEMCPY(result_s, start, end-start);
+
+    return result;
+}
+
+
+Py_LOCAL(PyStringObject *)
+replace(PyStringObject *self,
+    const char *from_s, Py_ssize_t from_len,
+    const char *to_s, Py_ssize_t to_len,
+    Py_ssize_t maxcount)
+{
+    if (maxcount < 0) {
+        maxcount = PY_SSIZE_T_MAX;
+    } else if (maxcount == 0 || PyString_GET_SIZE(self) == 0) {
+        /* nothing to do; return the original string */
+        return return_self(self);
+    }
+
+    if (maxcount == 0 ||
+        (from_len == 0 && to_len == 0)) {
+        /* nothing to do; return the original string */
+        return return_self(self);
+    }
+
+    /* Handle zero-length special cases */
+
+    if (from_len == 0) {
+        /* insert the 'to' string everywhere.   */
+        /*    >>> "Python".replace("", ".")     */
+        /*    '.P.y.t.h.o.n.'                   */
+        return replace_interleave(self, to_s, to_len, maxcount);
+    }
+
+    /* Except for "".replace("", "A") == "A" there is no way beyond this */
+    /* point for an empty self string to generate a non-empty string */
+    /* Special case so the remaining code always gets a non-empty string */
+    if (PyString_GET_SIZE(self) == 0) {
+        return return_self(self);
+    }
+
+    if (to_len == 0) {
+        /* delete all occurances of 'from' string */
+        if (from_len == 1) {
+            return replace_delete_single_character(
+                self, from_s[0], maxcount);
+        } else {
+            return replace_delete_substring(self, from_s, from_len, maxcount);
+        }
+    }
+
+    /* Handle special case where both strings have the same length */
+
+    if (from_len == to_len) {
+        if (from_len == 1) {
+            return replace_single_character_in_place(
+                self,
+                from_s[0],
+                to_s[0],
+                maxcount);
+        } else {
+            return replace_substring_in_place(
+                self, from_s, from_len, to_s, to_len, maxcount);
+        }
+    }
+
+    /* Otherwise use the more generic algorithms */
+    if (from_len == 1) {
+        return replace_single_character(self, from_s[0],
+                                        to_s, to_len, maxcount);
+    } else {
+        /* len('from')>=2, len('to')>=1 */
+        return replace_substring(self, from_s, from_len, to_s, to_len, maxcount);
+    }
+}
+
+PyObject* string_replace(PyStringObject *self, PyObject *args)
+{
+    Py_ssize_t count = -1;
+    PyObject *from, *to;
+    const char *from_s, *to_s;
+    Py_ssize_t from_len, to_len;
+
+    if (!PyArg_ParseTuple(args, "OO|n:replace", &from, &to, &count))
+        return NULL;
+
+    if (PyString_Check(from)) {
+        from_s = PyString_AS_STRING(from);
+        from_len = PyString_GET_SIZE(from);
+    }
+#ifdef Py_USING_UNICODE
+    if (PyUnicode_Check(from))
+        return PyUnicode_Replace((PyObject *)self,
+                                 from, to, count);
+#endif
+    else if (PyObject_AsCharBuffer(from, &from_s, &from_len))
+        return NULL;
+
+    if (PyString_Check(to)) {
+        to_s = PyString_AS_STRING(to);
+        to_len = PyString_GET_SIZE(to);
+    }
+#ifdef Py_USING_UNICODE
+    else if (PyUnicode_Check(to))
+        return PyUnicode_Replace((PyObject *)self,
+                                 from, to, count);
+#endif
+    else if (PyObject_AsCharBuffer(to, &to_s, &to_len))
+        return NULL;
+
+    return (PyObject *)replace((PyStringObject *) self,
+                               from_s, from_len,
+                               to_s, to_len, count);
+}

--- a/from_cpython/Objects/stringobject.c
+++ b/from_cpython/Objects/stringobject.c
@@ -899,14 +899,19 @@ replace(PyStringObject *self,
     }
 }
 
-PyObject* string_replace(PyStringObject *self, PyObject *args)
+// Pyston change: don't use varags calling convention
+// PyObject* string_replace(PyStringObject *self, PyObject *args)
+PyObject* string_replace(PyStringObject *self, PyObject *from, PyObject* to, PyObject** args)
 {
+    PyObject* _count = args[0];
     Py_ssize_t count = -1;
-    PyObject *from, *to;
     const char *from_s, *to_s;
     Py_ssize_t from_len, to_len;
 
-    if (!PyArg_ParseTuple(args, "OO|n:replace", &from, &to, &count))
+    // Pyston change: don't use varags calling convention
+    // if (!PyArg_ParseTuple(args, "OO|n:replace", &from, &to, &count))
+    //    return NULL;
+    if (_count && !PyArg_ParseSingle(_count, 3, "replace", "n", &count))
         return NULL;
 
     if (PyString_Check(from)) {

--- a/src/capi/typeobject.h
+++ b/src/capi/typeobject.h
@@ -56,7 +56,8 @@ int slot_tp_init(PyObject* self, PyObject* args, PyObject* kwds) noexcept;
 
 class GetattrRewriteArgs;
 template <ExceptionStyle S, Rewritable rewritable>
-Box* slotTpGetattrHookInternal(Box* self, BoxedString* attr, GetattrRewriteArgs* rewrite_args) noexcept(S == CAPI);
+Box* slotTpGetattrHookInternal(Box* self, BoxedString* attr, GetattrRewriteArgs* rewrite_args, bool for_call,
+                               Box** bind_obj_out, RewriterVar** r_bind_obj_out) noexcept(S == CAPI);
 }
 
 #endif

--- a/src/gc/heap.cpp
+++ b/src/gc/heap.cpp
@@ -357,6 +357,8 @@ GCAllocation* SmallArena::realloc(GCAllocation* al, size_t bytes) {
 #else
     memcpy(rtn, al, std::min(bytes, size));
 #endif
+    if (bytesAllocatedSinceCollection > size)
+        bytesAllocatedSinceCollection -= size;
 
     free(al);
     return rtn;
@@ -772,6 +774,9 @@ GCAllocation* LargeArena::realloc(GCAllocation* al, size_t bytes) {
     GCAllocation* rtn = heap->alloc(bytes);
     memcpy(rtn, al, std::min(bytes, obj->size));
 
+    if (bytesAllocatedSinceCollection > size)
+        bytesAllocatedSinceCollection -= size;
+
     _freeLargeObj(obj);
     return rtn;
 }
@@ -993,6 +998,9 @@ GCAllocation* HugeArena::realloc(GCAllocation* al, size_t bytes) {
 
     GCAllocation* rtn = heap->alloc(bytes);
     memcpy(rtn, al, std::min(bytes, obj->size));
+
+    if (bytesAllocatedSinceCollection > obj->size)
+        bytesAllocatedSinceCollection -= obj->size;
 
     _freeHugeObj(obj);
     return rtn;

--- a/src/runtime/objmodel.cpp
+++ b/src/runtime/objmodel.cpp
@@ -1561,7 +1561,8 @@ Box* getattrInternalEx(Box* obj, BoxedString* attr, GetattrRewriteArgs* rewrite_
             STAT_TIMER(t0, "us_timer_slowpath_tpgetattro", 10);
 
             if (obj->cls->tp_getattro == slot_tp_getattr_hook) {
-                return slotTpGetattrHookInternal<S, rewritable>(obj, attr, rewrite_args);
+                return slotTpGetattrHookInternal<S, rewritable>(obj, attr, rewrite_args, for_call, bind_obj_out,
+                                                                r_bind_obj_out);
             } else if (obj->cls->tp_getattro == instance_getattro) {
                 return instanceGetattroInternal<S>(obj, attr, rewrite_args);
             } else if (obj->cls->tp_getattro == type_getattro) {

--- a/src/runtime/str.cpp
+++ b/src/runtime/str.cpp
@@ -2780,7 +2780,7 @@ static PyMethodDef string_methods[] = {
     { "rindex", (PyCFunction)string_rindex, METH_VARARGS, NULL },
     { "rfind", (PyCFunction)string_rfind, METH_VARARGS, NULL },
     { "expandtabs", (PyCFunction)string_expandtabs, METH_VARARGS, NULL },
-    { "replace", (PyCFunction)string_replace, METH_VARARGS, NULL },
+    { "replace", (PyCFunction)string_replace, METH_O3 | METH_D1, NULL },
     { "splitlines", (PyCFunction)string_splitlines, METH_VARARGS, NULL },
     { "zfill", (PyCFunction)string_zfill, METH_VARARGS, NULL },
     { "__format__", (PyCFunction)string__format__, METH_VARARGS, NULL },

--- a/src/runtime/str.cpp
+++ b/src/runtime/str.cpp
@@ -42,6 +42,7 @@ extern "C" PyObject* string_find(PyStringObject* self, PyObject* args) noexcept;
 extern "C" PyObject* string_index(PyStringObject* self, PyObject* args) noexcept;
 extern "C" PyObject* string_rindex(PyStringObject* self, PyObject* args) noexcept;
 extern "C" PyObject* string_rfind(PyStringObject* self, PyObject* args) noexcept;
+extern "C" PyObject* string_replace(PyStringObject* self, PyObject* args) noexcept;
 extern "C" PyObject* string_splitlines(PyStringObject* self, PyObject* args) noexcept;
 extern "C" PyObject* string__format__(PyObject* self, PyObject* args) noexcept;
 
@@ -1839,53 +1840,6 @@ extern "C" PyObject* _PyString_Join(PyObject* sep, PyObject* x) noexcept {
     return string_join((PyStringObject*)sep, x);
 }
 
-Box* strReplace(Box* _self, Box* _old, Box* _new, Box** _args) {
-    if (!PyString_Check(_self))
-        raiseExcHelper(TypeError, "descriptor 'replace' requires a 'str' object but received a '%s'",
-                       getTypeName(_self));
-    BoxedString* self = static_cast<BoxedString*>(_self);
-
-#ifdef Py_USING_UNICODE
-    if (PyUnicode_Check(_old) || PyUnicode_Check(_new))
-        return PyUnicode_Replace((PyObject*)self, _old, _new, -1 /*count*/);
-#endif
-
-    if (!PyString_Check(_old))
-        raiseExcHelper(TypeError, "expected a character buffer object");
-    BoxedString* old = static_cast<BoxedString*>(_old);
-
-    if (!PyString_Check(_new))
-        raiseExcHelper(TypeError, "expected a character buffer object");
-    BoxedString* new_ = static_cast<BoxedString*>(_new);
-
-    Box* _maxreplace = _args[0];
-    if (!PyInt_Check(_maxreplace))
-        raiseExcHelper(TypeError, "an integer is required");
-
-    int max_replaces = static_cast<BoxedInt*>(_maxreplace)->n;
-    size_t start_pos = 0;
-    std::string s = self->s();
-
-    bool single_char = old->size() == 1;
-    int num_replaced = 0;
-    for (; num_replaced < max_replaces || max_replaces < 0; ++num_replaced) {
-        if (single_char)
-            start_pos = s.find(old->s()[0], start_pos);
-        else
-            start_pos = s.find(old->s(), start_pos);
-
-        if (start_pos == std::string::npos)
-            break;
-        s.replace(start_pos, old->size(), new_->s());
-        start_pos += new_->size(); // Handles case where 'to' is a substring of 'from'
-    }
-
-    if (num_replaced == 0 && self->cls == str_cls)
-        return self;
-
-    return boxString(s);
-}
-
 Box* strPartition(BoxedString* self, BoxedString* sep) {
     RELEASE_ASSERT(PyString_Check(self), "");
     RELEASE_ASSERT(PyString_Check(sep), "");
@@ -2826,6 +2780,7 @@ static PyMethodDef string_methods[] = {
     { "rindex", (PyCFunction)string_rindex, METH_VARARGS, NULL },
     { "rfind", (PyCFunction)string_rfind, METH_VARARGS, NULL },
     { "expandtabs", (PyCFunction)string_expandtabs, METH_VARARGS, NULL },
+    { "replace", (PyCFunction)string_replace, METH_VARARGS, NULL },
     { "splitlines", (PyCFunction)string_splitlines, METH_VARARGS, NULL },
     { "zfill", (PyCFunction)string_zfill, METH_VARARGS, NULL },
     { "__format__", (PyCFunction)string__format__, METH_VARARGS, NULL },
@@ -2926,9 +2881,6 @@ void setupStr() {
     str_cls->giveAttr("__getslice__", new BoxedFunction(boxRTFunction((void*)strGetslice, STR, 3)));
 
     str_cls->giveAttr("__iter__", new BoxedFunction(boxRTFunction((void*)strIter, typeFromClass(str_iterator_cls), 1)));
-
-    str_cls->giveAttr("replace",
-                      new BoxedFunction(boxRTFunction((void*)strReplace, UNKNOWN, 4, false, false), { boxInt(-1) }));
 
     for (auto& md : string_methods) {
         str_cls->giveAttr(md.ml_name, new BoxedMethodDescriptor(&md, str_cls));


### PR DESCRIPTION
Please take a look at the the individual commits to figure out whats changed.
The switch from 4byte to a 2byte unicode type changed a lot of the unicode functions names so it maybe a good idea to regenerate the section ordering file but I was not sure with which perf sample I have to run it.
```
                                   upstream/master:        origin/pyxl2:
           django_template3.py             2.2s (4)             2.1s (2)  -1.8%
                 pyxl_bench.py             1.8s (4)             1.8s (2)  +1.3%
     sqlalchemy_imperative2.py             2.3s (4)             2.3s (2)  +0.7%
                pyxl_bench2.py             1.3s (4)             1.1s (2)  -19.5%
       django_template3_10x.py            14.1s (4)            13.6s (2)  -3.7%
             pyxl_bench_10x.py            13.9s (4)            14.2s (2)  +1.6%
 sqlalchemy_imperative2_10x.py            17.6s (4)            17.9s (2)  +1.4%
            pyxl_bench2_10x.py            11.8s (4)             9.1s (2)  -22.6%
                       geomean                 5.1s                 4.8s  -5.8%
```

