### PR TITLE
Parser fix: call fclose

### DIFF
--- a/src/codegen/parser.cpp
+++ b/src/codegen/parser.cpp
@@ -1019,9 +1019,8 @@ AST_Module* parse_string(const char* code, FutureFlags inherited_flags) {
     inherited_flags &= ~(CO_NESTED | CO_FUTURE_DIVISION);
 
     if (ENABLE_CPYTHON_PARSER) {
-        RELEASE_ASSERT(!inherited_flags, "unimplemented");
         PyCompilerFlags cf;
-        cf.cf_flags = 0;
+        cf.cf_flags = inherited_flags;
         ArenaWrapper arena;
         assert(arena);
         const char* fn = "<string>";
@@ -1065,11 +1064,9 @@ AST_Module* parse_file(const char* fn, FutureFlags inherited_flags) {
     Timer _t("parsing");
 
     if (ENABLE_CPYTHON_PARSER) {
-        RELEASE_ASSERT(!inherited_flags, "unimplemented");
-
         FileHandle fp(fn, "r");
         PyCompilerFlags cf;
-        cf.cf_flags = 0;
+        cf.cf_flags = inherited_flags;
         ArenaWrapper arena;
         assert(arena);
         mod_ty mod = PyParser_ASTFromFile(fp, fn, Py_file_input, 0, 0, &cf, NULL, arena);
@@ -1153,11 +1150,9 @@ static std::vector<char> _reparse(const char* fn, const std::string& cache_fn, A
 
     if (ENABLE_CPYTHON_PARSER || ENABLE_PYPA_PARSER || inherited_flags) {
         if (ENABLE_CPYTHON_PARSER) {
-            RELEASE_ASSERT(!inherited_flags, "unimplemented");
-
             FileHandle fp(fn, "r");
             PyCompilerFlags cf;
-            cf.cf_flags = 0;
+            cf.cf_flags = inherited_flags;
             ArenaWrapper arena;
             assert(arena);
             mod_ty mod = PyParser_ASTFromFile(fp, fn, Py_file_input, 0, 0, &cf, NULL, arena);

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -803,6 +803,20 @@ public:
     operator PyArena*() const { return arena; }
 };
 
+class FileHandle {
+private:
+    FILE* file;
+
+public:
+    FileHandle(const char* fn, const char* mode) : file(fopen(fn, mode)) {}
+    ~FileHandle() {
+        if (file)
+            fclose(file);
+    }
+
+    operator FILE*() const { return file; }
+};
+
 // similar to Java's Array.binarySearch:
 // return values are either:
 //   >= 0 : the index where a given item was found


### PR DESCRIPTION
Add a FileHandle class for c++-style raii on FILE* objects.

Also, add support for using the cpython parser for parsing
strings (still only in -X mode).