### PR TITLE
Add a clang libTooling example

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -356,10 +356,16 @@ else()
   add_custom_target(docs COMMAND ${CMAKE_COMMAND} -E echo "Can't create docs, doxygen not installed \(try sudo apt-get install doxygen grpahviz on Ubuntu and then rerun cmake\)" VERBATIM)
 endif()
 
-set(CMAKE_EXECUTABLE_FORMAT "ELF")
-install(TARGETS pyston DESTINATION ".")
+add_subdirectory(plugins/refcount_checker EXCLUDE_FROM_ALL)
+
+
+# CPack config.  I think this needs to come after any other code, since it will
+# look at whatever install targets have already been set up.
 
 set(CPACK_GENERATOR "TGZ")
+
+set(CMAKE_EXECUTABLE_FORMAT "ELF") # Otherwise cmake thinks this is a cross-compile
+install(TARGETS pyston DESTINATION ".")
 
 set(CPACK_PACKAGE_VERSION_MAJOR "0")
 set(CPACK_PACKAGE_VERSION_MINOR "4")
@@ -377,6 +383,7 @@ install(FILES test/lib/virtualenv/virtualenv_support/pip-6.0.8-py2.py3-none-any.
 install(FILES test/lib/virtualenv/virtualenv_support/setuptools-12.0.5-py2.py3-none-any.whl DESTINATION virtualenv/virtualenv_support)
 
 include(CPack)
+
 
 # last file added (need to change this if we add a file that is added via a glob):
 # from_cpython/Lib/test/test_zipimport.py

--- a/plugins/refcount_checker/CMakeLists.txt
+++ b/plugins/refcount_checker/CMakeLists.txt
@@ -1,0 +1,27 @@
+# from llvm-trunk/tools/clang/CMakeLists.txt:
+set(LLVM_RUNTIME_OUTPUT_INTDIR llvm/bin)
+set(LLVM_LIBRARY_OUTPUT_INTDIR llvm/lib${LLVM_LIBDIR_SUFFIX})
+
+# Pyston addition:
+include_directories("${DEPS_DIR}/llvm-trunk/tools/clang/include")
+include_directories("${CMAKE_BINARY_DIR}/llvm/tools/clang/include")
+
+# From llvm-trunk/tools/clang/tools/clang-check/CMakeLists.txt
+set(LLVM_LINK_COMPONENTS
+  Option
+  Support
+  )
+
+add_clang_executable(refcount_checker
+  refcount_checker.cpp
+  )
+
+target_link_libraries(refcount_checker
+  clangAST
+  clangBasic
+  clangDriver
+  clangFrontend
+  clangRewriteFrontend
+  clangStaticAnalyzerFrontend
+  clangTooling
+  )

--- a/plugins/refcount_checker/refcount_checker.cpp
+++ b/plugins/refcount_checker/refcount_checker.cpp
@@ -1,0 +1,28 @@
+// Declares clang::SyntaxOnlyAction.
+#include "clang/Frontend/FrontendActions.h"
+#include "clang/Tooling/CommonOptionsParser.h"
+#include "clang/Tooling/Tooling.h"
+// Declares llvm::cl::extrahelp.
+#include "llvm/Support/CommandLine.h"
+
+using namespace clang::tooling;
+using namespace llvm;
+
+// Apply a custom category to all command-line options so that they are the
+// only ones displayed.
+static cl::OptionCategory MyToolCategory("my-tool options");
+
+// CommonOptionsParser declares HelpMessage with a description of the common
+// command-line options related to the compilation database and input files.
+// It's nice to have this help message in all tools.
+static cl::extrahelp CommonHelp(CommonOptionsParser::HelpMessage);
+
+// A help message for this specific tool can be added afterwards.
+static cl::extrahelp MoreHelp("\nMore help text...");
+
+int main(int argc, const char **argv) {
+  CommonOptionsParser OptionsParser(argc, argv, MyToolCategory);
+  ClangTool Tool(OptionsParser.getCompilations(),
+                 OptionsParser.getSourcePathList());
+  return Tool.run(newFrontendActionFactory<clang::SyntaxOnlyAction>().get());
+}


### PR DESCRIPTION
Surprisingly hard to get the build to work.  I feel like no one must use
libTooling for out-of-tree projects.  Also, the binary can only be run from
the directory in which it would have been placed for an in-tree project.

It was going to be a refcount discipline checker, but I'm not sure that's
a good use of time right now.  I want to check it in though so that we have it.