### PR TITLE
Changing the INSTALLING instructions. 

### DIFF
--- a/docs/INSTALLING.md
+++ b/docs/INSTALLING.md
@@ -32,8 +32,8 @@ sudo yum install git make cmake clang gcc gcc-c++ ccache ninja-build xz-devel au
 ```
 git clone https://github.com/dropbox/pyston.git ~/pyston
 
-git clone git://github.com/llvm-mirror/llvm.git ~/pyston_deps/llvm-trunk
-git clone git://github.com/llvm-mirror/clang.git ~/pyston_deps/llvm-trunk/tools/clang
+git clone git@github.com:llvm-mirror/llvm.git ~/pyston_deps/llvm-trunk
+git clone git@github.com:llvm-mirror/clang.git ~/pyston_deps/llvm-trunk/tools/clang
 
 git config --global user.email "you@example.com"
 git config --global user.name "Your Name"

--- a/docs/INSTALLING.md
+++ b/docs/INSTALLING.md
@@ -32,8 +32,8 @@ sudo yum install git make cmake clang gcc gcc-c++ ccache ninja-build xz-devel au
 ```
 git clone https://github.com/dropbox/pyston.git ~/pyston
 
-git clone git@github.com:llvm-mirror/llvm.git ~/pyston_deps/llvm-trunk
-git clone git@github.com:llvm-mirror/clang.git ~/pyston_deps/llvm-trunk/tools/clang
+git clone https://github.com/llvm-mirror/llvm.git ~/pyston_deps/llvm-trunk
+git clone https://github.com/llvm-mirror/clang.git ~/pyston_deps/llvm-trunk/tools/clang
 
 git config --global user.email "you@example.com"
 git config --global user.name "Your Name"


### PR DESCRIPTION
In the section "Building and testing" of INSTALLING.md, have commands to clone the clang and the llvm repositories, but the links are broken.