### PR TITLE
Support CMake 3.3+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,6 +112,7 @@ add_custom_target(gitsubmodules DEPENDS ${CMAKE_BINARY_DIR}/gitmodules)
 
 # jemalloc
 ExternalProject_Add(libjemalloc
+                    BUILD_BYPRODUCTS ${CMAKE_BINARY_DIR}/jemalloc/lib/libjemalloc.a
                     PREFIX jemalloc-build
                     SOURCE_DIR ${CMAKE_SOURCE_DIR}/build_deps/jemalloc
                     DEPENDS gitsubmodules
@@ -124,8 +125,8 @@ ExternalProject_Add(libjemalloc
                     LOG_INSTALL ON)
 
 #
-# CMake (<3.3) has no way of knowing that an ExternalProject creates specific output files.  This is a problem for ninja,
-# which will not know how to build the generated file.
+# CMake (<3.3) does not support BUILD_BYPRODUCTS.
+# This is a problem for ninja, which will not know how to build the generated file.
 # Here are a couple hacks to get around it:
 #
 # Add a copy step.  This just hides the dependency but it seems to work.


### PR DESCRIPTION
I guess our hack for pre-3.3 doesn't work in 3.3, but thankfully
we can include both the pre-3.3 workaround and the actual 3.3+ fix,
and it looks like cmake will end up doing the right thing in both cases.

Fixes #996 and #1002