### PR TITLE
Fix build error caused by missing 'override's.

### DIFF
--- a/src/asm_writing/rewriter.h
+++ b/src/asm_writing/rewriter.h
@@ -596,7 +596,7 @@ public:
 
     void addDependenceOn(ICInvalidator&);
 
-    void gc_visit(gc::GCVisitor* visitor);
+    void gc_visit(gc::GCVisitor* visitor) override;
 
     static Rewriter* createRewriter(void* rtn_addr, int num_args, const char* debug_name);
 

--- a/src/codegen/compvars.cpp
+++ b/src/codegen/compvars.cpp
@@ -1619,7 +1619,7 @@ private:
 public:
     PhonyUnboxedType(llvm::Type* t, CompilerType* usable_type) : t(t), usable_type(usable_type) {}
 
-    std::string debugName() { return "phony(" + ConcreteCompilerType::debugName() + ")"; }
+    std::string debugName() override { return "phony(" + ConcreteCompilerType::debugName() + ")"; }
 
     CompilerType* getUsableType() override { return usable_type; }
 
@@ -2778,7 +2778,7 @@ public:
     void drop(IREmitter& emitter, VAR* var) override {}
     void grab(IREmitter& emitter, VAR* var) override {}
 
-    void assertMatches(UnboxedSlice slice) {}
+    void assertMatches(UnboxedSlice slice) override {}
 
     int numFrameArgs() override { RELEASE_ASSERT(0, "unboxed slice should never get serialized"); }
 


### PR DESCRIPTION
Got a couple build errors when building pyston in my clean Ubuntu 15.10 installation.
Adding the missing 'override's fixes them.