### PR TITLE
llvm tier: reduce scratch size

### DIFF
--- a/src/codegen/patchpoints.h
+++ b/src/codegen/patchpoints.h
@@ -129,7 +129,7 @@ public:
     const std::vector<FrameVarInfo>& getFrameVars() { return frame_vars; }
 
     int scratchStackmapArg() { return 0; }
-    int scratchSize() { return 80 + MAX_FRAME_SPILLS * sizeof(void*); }
+    int scratchSize() { return isDeopt() ? MAX_FRAME_SPILLS * sizeof(void*) : 96; }
     bool isDeopt() const { return icinfo ? icinfo->isDeopt() : false; }
     bool isFrameInfoStackmap() const { return is_frame_info_stackmap; }
     int numFrameSpillsSupported() const { return isDeopt() ? MAX_FRAME_SPILLS : 0; }


### PR DESCRIPTION
With the new frame introspection we don't need to save additional space for spilling vars which live in regs (except for deopts).
And for deopts we will never need more scratch than the one required for spilling the args.
```
                                   upstream/master:     origin/pp_stack:
           django_template3.py             2.1s (2)             2.1s (2)  -0.4%
                 pyxl_bench.py             1.8s (2)             1.8s (2)  +0.2%
     sqlalchemy_imperative2.py             2.2s (2)             2.2s (2)  -0.4%
                pyxl_bench2.py             1.1s (2)             1.1s (2)  -1.1%
       django_template3_10x.py            14.0s (2)            13.9s (2)  -0.6%
             pyxl_bench_10x.py            13.7s (2)            13.6s (2)  -1.0%
 sqlalchemy_imperative2_10x.py            16.9s (2)            17.0s (2)  +0.3%
            pyxl_bench2_10x.py             9.3s (2)             9.2s (2)  -0.8%
                       geomean                 4.8s                 4.8s  -0.5%
```