### PR TITLE
Add signal support

### DIFF
--- a/from_cpython/Lib/test/test_signal.py
+++ b/from_cpython/Lib/test/test_signal.py
@@ -1,4 +1,3 @@
-# expected: fail
 import unittest
 from test import test_support
 from contextlib import closing
@@ -80,7 +79,8 @@ class InterProcessSignalTests(unittest.TestCase):
         # don't worry about re-setting the default handlers.
         signal.signal(signal.SIGHUP, self.handlerA)
         signal.signal(signal.SIGUSR1, self.handlerB)
-        signal.signal(signal.SIGUSR2, signal.SIG_IGN)
+        # Pyston change: pyston uses SIGUSR2 internally
+        # signal.signal(signal.SIGUSR2, signal.SIG_IGN)
         signal.signal(signal.SIGALRM, signal.default_int_handler)
 
         # Variables the signals will modify:
@@ -117,9 +117,11 @@ class InterProcessSignalTests(unittest.TestCase):
             if test_support.verbose:
                 print "HandlerBCalled exception caught"
 
-        child = ignoring_eintr(subprocess.Popen, ['kill', '-USR2', str(pid)])
-        if child:
-            self.wait(child)  # Nothing should happen.
+
+        # Pyston change: pyston uses SIGUSR2 internally
+        # child = ignoring_eintr(subprocess.Popen, ['kill', '-USR2', str(pid)])
+        # if child:
+        #     self.wait(child)  # Nothing should happen.
 
         try:
             signal.alarm(1)

--- a/from_cpython/Modules/signalmodule.c
+++ b/from_cpython/Modules/signalmodule.c
@@ -626,6 +626,9 @@ initsignal(void)
         old_siginthandler = PyOS_setsig(SIGINT, signal_handler);
     }
 
+    // Pyston change: let the GC scan the handlers
+    PyGC_AddPotentialRoot(Handlers, sizeof(Handlers));
+
 #ifdef SIGHUP
     x = PyInt_FromLong(SIGHUP);
     PyDict_SetItemString(d, "SIGHUP", x);
@@ -895,10 +898,6 @@ PyErr_CheckSignals(void)
     if (!is_tripped)
         return 0;
 
-    // Pyston change:
-    Py_FatalError("TODO");
-
-#if 0
     int i;
     PyObject *f;
 
@@ -943,7 +942,6 @@ PyErr_CheckSignals(void)
             Py_DECREF(result);
         }
     }
-#endif
 
     return 0;
 }

--- a/src/codegen/ast_interpreter.cpp
+++ b/src/codegen/ast_interpreter.cpp
@@ -922,43 +922,66 @@ Value ASTInterpreter::visit_stmt(AST_stmt* node) {
         printf("\n");
     }
 
+    Value rtn;
     switch (node->type) {
         case AST_TYPE::Assert:
-            return visit_assert((AST_Assert*)node);
+            rtn = visit_assert((AST_Assert*)node);
+            ASTInterpreterJitInterface::pendingCallsCheckHelper();
+            break;
         case AST_TYPE::Assign:
-            return visit_assign((AST_Assign*)node);
+            rtn = visit_assign((AST_Assign*)node);
+            ASTInterpreterJitInterface::pendingCallsCheckHelper();
+            break;
         case AST_TYPE::Delete:
-            return visit_delete((AST_Delete*)node);
+            rtn = visit_delete((AST_Delete*)node);
+            ASTInterpreterJitInterface::pendingCallsCheckHelper();
+            break;
         case AST_TYPE::Exec:
-            return visit_exec((AST_Exec*)node);
+            rtn = visit_exec((AST_Exec*)node);
+            ASTInterpreterJitInterface::pendingCallsCheckHelper();
+            break;
         case AST_TYPE::Expr:
             // docstrings are str constant expression statements.
             // ignore those while interpreting.
-            if ((((AST_Expr*)node)->value)->type != AST_TYPE::Str)
-                return visit_expr((AST_Expr*)node);
+            if ((((AST_Expr*)node)->value)->type != AST_TYPE::Str) {
+                rtn = visit_expr((AST_Expr*)node);
+                ASTInterpreterJitInterface::pendingCallsCheckHelper();
+            }
             break;
         case AST_TYPE::Pass:
-            return Value(); // nothing todo
+            ASTInterpreterJitInterface::pendingCallsCheckHelper();
+            break; // nothing todo
         case AST_TYPE::Print:
-            return visit_print((AST_Print*)node);
+            rtn = visit_print((AST_Print*)node);
+            ASTInterpreterJitInterface::pendingCallsCheckHelper();
+            break;
         case AST_TYPE::Raise:
-            return visit_raise((AST_Raise*)node);
+            rtn = visit_raise((AST_Raise*)node);
+            ASTInterpreterJitInterface::pendingCallsCheckHelper();
+            break;
         case AST_TYPE::Return:
-            return visit_return((AST_Return*)node);
+            rtn = visit_return((AST_Return*)node);
+            ASTInterpreterJitInterface::pendingCallsCheckHelper();
+            break;
         case AST_TYPE::Global:
-            return visit_global((AST_Global*)node);
+            rtn = visit_global((AST_Global*)node);
+            ASTInterpreterJitInterface::pendingCallsCheckHelper();
+            break;
 
         // pseudo
         case AST_TYPE::Branch:
-            return visit_branch((AST_Branch*)node);
+            rtn = visit_branch((AST_Branch*)node);
+            break;
         case AST_TYPE::Jump:
-            return visit_jump((AST_Jump*)node);
+            rtn = visit_jump((AST_Jump*)node);
+            break;
         case AST_TYPE::Invoke:
-            return visit_invoke((AST_Invoke*)node);
+            rtn = visit_invoke((AST_Invoke*)node);
+            break;
         default:
             RELEASE_ASSERT(0, "not implemented");
     };
-    return Value();
+    return rtn;
 }
 
 Value ASTInterpreter::visit_return(AST_Return* node) {
@@ -1650,6 +1673,11 @@ Box* ASTInterpreterJitInterface::landingpadHelper(void* _interpreter) {
     Box* rtn = BoxedTuple::create({ type, value, traceback });
     last_exception = ExcInfo(NULL, NULL, NULL);
     return rtn;
+}
+
+void ASTInterpreterJitInterface::pendingCallsCheckHelper() {
+    if (unlikely(_pendingcalls_to_do))
+        makePendingCalls();
 }
 
 Box* ASTInterpreterJitInterface::setExcInfoHelper(void* _interpreter, Box* type, Box* value, Box* traceback) {

--- a/src/codegen/ast_interpreter.h
+++ b/src/codegen/ast_interpreter.h
@@ -45,6 +45,7 @@ struct ASTInterpreterJitInterface {
     static Box* derefHelper(void* interp, InternedString s);
     static Box* doOSRHelper(void* interp, AST_Jump* node);
     static Box* landingpadHelper(void* interp);
+    static void pendingCallsCheckHelper();
     static Box* setExcInfoHelper(void* interp, Box* type, Box* value, Box* traceback);
     static void setLocalClosureHelper(void* interp, long vreg, InternedString id, Box* v);
     static Box* uncacheExcInfoHelper(void* interp);

--- a/src/codegen/baseline_jit.h
+++ b/src/codegen/baseline_jit.h
@@ -246,6 +246,7 @@ public:
     void emitExec(RewriterVar* code, RewriterVar* globals, RewriterVar* locals, FutureFlags flags);
     void emitJump(CFGBlock* b);
     void emitOSRPoint(AST_Jump* node);
+    void emitPendingCallsCheck();
     void emitPrint(RewriterVar* dest, RewriterVar* var, bool nl);
     void emitRaise0();
     void emitRaise3(RewriterVar* arg0, RewriterVar* arg1, RewriterVar* arg2);

--- a/src/codegen/entry.cpp
+++ b/src/codegen/entry.cpp
@@ -378,16 +378,6 @@ static void handle_sigprof_investigate_stattimer(int signum) {
 }
 #endif
 
-static void handle_sigint(int signum) {
-    assert(signum == SIGINT);
-    // TODO: this should set a flag saying a KeyboardInterrupt is pending.
-    // For now, just call abort(), so that we get a traceback at least.
-    fprintf(stderr, "SIGINT!\n");
-    joinRuntime();
-    Stats::dump(false);
-    abort();
-}
-
 void initCodegen() {
     llvm::InitializeNativeTarget();
     llvm::InitializeNativeTargetAsmPrinter();
@@ -481,9 +471,8 @@ void initCodegen() {
 
     setupRuntime();
 
-    // signal(SIGFPE, &handle_sigfpe);
-    signal(SIGUSR1, &handle_sigusr1);
-    signal(SIGINT, &handle_sigint);
+// signal(SIGFPE, &handle_sigfpe);
+// signal(SIGUSR1, &handle_sigusr1);
 
 #if ENABLE_SAMPLING_PROFILER
     struct itimerval prof_timer;

--- a/src/codegen/runtime_hooks.cpp
+++ b/src/codegen/runtime_hooks.cpp
@@ -200,6 +200,7 @@ void initGlobalFuncs(GlobalState& g) {
     GET(createSet);
     GET(initFrame);
     GET(deinitFrame);
+    GET(makePendingCalls);
 
     GET(getattr);
     GET(getattr_capi);

--- a/src/codegen/runtime_hooks.h
+++ b/src/codegen/runtime_hooks.h
@@ -34,7 +34,7 @@ struct GlobalFuncs {
 
     llvm::Value* boxInt, *unboxInt, *boxFloat, *unboxFloat, *createFunctionFromMetadata, *getFunctionMetadata,
         *boxInstanceMethod, *boxBool, *unboxBool, *createTuple, *createDict, *createList, *createSlice,
-        *createUserClass, *createClosure, *createGenerator, *createSet, *initFrame, *deinitFrame;
+        *createUserClass, *createClosure, *createGenerator, *createSet, *initFrame, *deinitFrame, *makePendingCalls;
     llvm::Value* getattr, *getattr_capi, *setattr, *delattr, *delitem, *delGlobal, *nonzero, *binop, *compare,
         *augbinop, *unboxedLen, *getitem, *getitem_capi, *getclsattr, *getGlobal, *setitem, *unaryop, *import,
         *importFrom, *importStar, *repr, *exceptionMatches, *yield, *getiterHelper, *hasnext, *setGlobal, *apply_slice;

--- a/src/core/threading.cpp
+++ b/src/core/threading.cpp
@@ -497,8 +497,12 @@ static void* find_stack() {
     return NULL; /* not found =^P */
 }
 
+static long main_thread_id;
+
 void registerMainThread() {
     LOCK_REGION(&threading_lock);
+
+    main_thread_id = pthread_self();
 
     assert(!current_internal_thread_state);
     current_internal_thread_state = new ThreadStateInternal(find_stack(), pthread_self(), &cur_thread_state);
@@ -522,6 +526,10 @@ void finishMainThread() {
     current_internal_thread_state->assertNoGenerators();
 
     // TODO maybe this is the place to wait for non-daemon threads?
+}
+
+bool isMainThread() {
+    return pthread_self() == main_thread_id;
 }
 
 

--- a/src/core/threading.h
+++ b/src/core/threading.h
@@ -51,6 +51,8 @@ intptr_t start_thread(void* (*start_func)(Box*, Box*, Box*), Box* arg1, Box* arg
 void registerMainThread();
 void finishMainThread();
 
+bool isMainThread();
+
 // Hook for the GC; will visit all the threads (including the current one), visiting their
 // stacks and thread-local PyThreadState objects
 void visitAllStacks(gc::GCVisitor* v);

--- a/src/runtime/capi.cpp
+++ b/src/runtime/capi.cpp
@@ -17,6 +17,7 @@
 #include <string.h>
 
 #include "Python.h"
+#include "pythread.h"
 
 #include "codegen/cpython_ast.h"
 #include "grammar.h"
@@ -1547,9 +1548,126 @@ extern "C" PyOS_sighandler_t PyOS_setsig(int sig, PyOS_sighandler_t handler) noe
 #endif
 }
 
+static PyThread_type_lock pending_lock = 0; /* for pending calls */
+
+/* The WITH_THREAD implementation is thread-safe.  It allows
+   scheduling to be made from any thread, and even from an executing
+   callback.
+ */
+
+#define NPENDINGCALLS 32
+static struct {
+    int (*func)(void*);
+    void* arg;
+} pendingcalls[NPENDINGCALLS];
+static int pendingfirst = 0;
+static int pendinglast = 0;
+// Pyston change
+// static volatile int pendingcalls_to_do = 1; /* trigger initialization of lock */
+extern "C" {
+volatile int _pendingcalls_to_do = 1;
+}
+static char pendingbusy = 0;
+
 extern "C" int Py_AddPendingCall(int (*func)(void*), void* arg) noexcept {
-    fatalOrError(PyExc_NotImplementedError, "unimplemented");
-    return -1;
+    int i, j, result = 0;
+    PyThread_type_lock lock = pending_lock;
+
+    /* try a few times for the lock.  Since this mechanism is used
+     * for signal handling (on the main thread), there is a (slim)
+     * chance that a signal is delivered on the same thread while we
+     * hold the lock during the Py_MakePendingCalls() function.
+     * This avoids a deadlock in that case.
+     * Note that signals can be delivered on any thread.  In particular,
+     * on Windows, a SIGINT is delivered on a system-created worker
+     * thread.
+     * We also check for lock being NULL, in the unlikely case that
+     * this function is called before any bytecode evaluation takes place.
+     */
+    if (lock != NULL) {
+        for (i = 0; i < 100; i++) {
+            if (PyThread_acquire_lock(lock, NOWAIT_LOCK))
+                break;
+        }
+        if (i == 100)
+            return -1;
+    }
+
+    i = pendinglast;
+    j = (i + 1) % NPENDINGCALLS;
+    if (j == pendingfirst) {
+        result = -1; /* Queue full */
+    } else {
+        pendingcalls[i].func = func;
+        pendingcalls[i].arg = arg;
+        pendinglast = j;
+    }
+    /* signal main loop */
+    // Pyston change: we don't have a _Py_Ticker
+    // _Py_Ticker = 0;
+
+    _pendingcalls_to_do = 1;
+    if (lock != NULL)
+        PyThread_release_lock(lock);
+    return result;
+}
+
+extern "C" int Py_MakePendingCalls(void) noexcept {
+    int i;
+    int r = 0;
+
+    if (!pending_lock) {
+        /* initial allocation of the lock */
+        pending_lock = PyThread_allocate_lock();
+        if (pending_lock == NULL)
+            return -1;
+
+        // Pyston change: we could potentialy store a python object inside the arg field
+        PyGC_AddPotentialRoot(pendingcalls, sizeof(pendingcalls));
+    }
+
+    /* only service pending calls on main thread */
+    // Pyston change:
+    // if (main_thread && PyThread_get_thread_ident() != main_thread)
+    if (!threading::isMainThread())
+        return 0;
+    /* don't perform recursive pending calls */
+    if (pendingbusy)
+        return 0;
+    pendingbusy = 1;
+    /* perform a bounded number of calls, in case of recursion */
+    for (i = 0; i < NPENDINGCALLS; i++) {
+        int j;
+        int (*func)(void*);
+        void* arg = NULL;
+
+        /* pop one item off the queue while holding the lock */
+        PyThread_acquire_lock(pending_lock, WAIT_LOCK);
+        j = pendingfirst;
+        if (j == pendinglast) {
+            func = NULL; /* Queue empty */
+        } else {
+            func = pendingcalls[j].func;
+            arg = pendingcalls[j].arg;
+            pendingfirst = (j + 1) % NPENDINGCALLS;
+        }
+        _pendingcalls_to_do = pendingfirst != pendinglast;
+        PyThread_release_lock(pending_lock);
+        /* having released the lock, perform the callback */
+        if (func == NULL)
+            break;
+        r = func(arg);
+        if (r)
+            break;
+    }
+    pendingbusy = 0;
+    return r;
+}
+
+extern "C" void makePendingCalls() {
+    int ret = Py_MakePendingCalls();
+    if (ret != 0)
+        throwCAPIException();
 }
 
 extern "C" PyObject* _PyImport_FixupExtension(char* name, char* filename) noexcept {
@@ -1714,6 +1832,16 @@ extern "C" PyThreadState* PyEval_SaveThread(void) noexcept {
 extern "C" void PyEval_RestoreThread(PyThreadState* tstate) noexcept {
     RELEASE_ASSERT(tstate == PyThreadState_GET(), "");
     endAllowThreads();
+}
+
+extern "C" struct _frame* PyEval_GetFrame(void) noexcept {
+    Box* frame = NULL;
+    try {
+        frame = getFrame(0);
+    } catch (ExcInfo) {
+        RELEASE_ASSERT(0, "untested");
+    }
+    return (struct _frame*)frame;
 }
 
 extern "C" char* PyModule_GetName(PyObject* m) noexcept {

--- a/src/runtime/inline/link_forcer.cpp
+++ b/src/runtime/inline/link_forcer.cpp
@@ -74,6 +74,7 @@ void force() {
     FORCE(decodeUTF8StringPtr);
     FORCE(initFrame);
     FORCE(deinitFrame);
+    FORCE(makePendingCalls);
 
     FORCE(getattr);
     FORCE(getattr_capi);

--- a/src/runtime/types.h
+++ b/src/runtime/types.h
@@ -170,6 +170,7 @@ extern "C" Box* createDict();
 extern "C" Box* createList();
 extern "C" Box* createSlice(Box* start, Box* stop, Box* step);
 extern "C" Box* createTuple(int64_t nelts, Box** elts);
+extern "C" void makePendingCalls();
 
 Box* objectStr(Box*);
 Box* objectRepr(Box*);
@@ -1181,6 +1182,8 @@ inline Box*& getArg(int idx, Box*& arg1, Box*& arg2, Box*& arg3, Box** args) {
         return arg3;
     return args[idx - 3];
 }
+
+extern "C" volatile int _pendingcalls_to_do;
 }
 
 #endif

--- a/test/CPYTHON_TEST_NOTES.md
+++ b/test/CPYTHON_TEST_NOTES.md
@@ -183,7 +183,6 @@ test_scope              eval of code object from existing function (not currentl
 test_scriptpackages     [unknown]
 test_shelve             [unknown]
 test_shlex              [unknown]
-test_signal             [unknown]
 test_site               [unknown]
 test_smtpnet            [unknown]
 test_socketserver       [unknown]

--- a/test/tests/signal_test.py
+++ b/test/tests/signal_test.py
@@ -6,3 +6,23 @@ for k in sorted(dir(signal)):
     print k, getattr(signal, k)
 
 print hasattr(signal, "alarm")
+
+
+import time
+import signal
+
+def sig_handler(signum, stack):
+    print "inside sig_handler"
+    import sys, traceback
+    traceback.print_stack(stack)
+    sys.exit(0)
+
+def f(lst):
+    signal.signal(signal.SIGALRM, sig_handler)
+    signal.setitimer(signal.ITIMER_REAL, 2, 1)
+    for x in lst:
+        time.sleep(x)  #1
+        time.sleep(x)  #2
+
+f([0] * 100 + [10])
+assert False, "shuld not get executed"


### PR DESCRIPTION
We check for signals on most calls to runtime functions in the llvm tier and the bjit and inside the interpreter on some additional places, because checking on every bytecode is a too large slowdown (>10%).
I don't like that there is different behavior between the different tiers but it was the best result I could accomplish.
This patch does more checks than pypy does see: https://bitbucket.org/pypy/pypy/issues/1841/signal-check-only-in-jump_absolute-when

I think the perf regression is not nice but I think we could accept it:
```
           django_template3.py             2.1s (6)             2.2s (4)  +2.8%
                 pyxl_bench.py             1.8s (6)             1.8s (4)  +4.2%
     sqlalchemy_imperative2.py             2.2s (6)             2.3s (4)  +3.0%
                pyxl_bench2.py             1.1s (6)             1.1s (4)  +0.8%
       django_template3_10x.py            13.9s (6)            14.3s (4)  +2.8%
             pyxl_bench_10x.py            13.5s (6)            13.8s (4)  +2.0%
 sqlalchemy_imperative2_10x.py            16.9s (6)            17.3s (4)  +2.7%
            pyxl_bench2_10x.py             9.3s (6)             9.3s (4)  +0.1%
                       geomean                 4.8s                 4.9s  +2.3%
```
I tried generating better code in the bjit (e.g. directly emitting the check or creating a special function which does the pendingCalls check with a special calling convention which does not modify any regs but nothing improved the perf...)

For fun I tried disabling the ticker check which get executed on every bytecode in cpython and saw about a 3.5% perf improvement there...

On additional not nice thing is that this currently does not add checks inside the llvm codegen if the called function is a capi function...