### PR TITLE
support inspecting exited frames (faster version)

### DIFF
--- a/from_cpython/Include/pystate.h
+++ b/from_cpython/Include/pystate.h
@@ -111,6 +111,8 @@ typedef struct _ts {
 } PyThreadState;
 #endif
 typedef struct _ts {
+    void* frame_info; // This points to top python FrameInfo object
+
     int recursion_depth;
     int gilstate_counter;
 

--- a/from_cpython/Lib/logging/__init__.py
+++ b/from_cpython/Lib/logging/__init__.py
@@ -71,9 +71,15 @@ else:
     _srcfile = __file__
 _srcfile = os.path.normcase(_srcfile)
 
-# pyston changes: we don't support tb_frame or f_back, so always use sys._getframe
-currentframe = lambda: sys._getframe(4)
-start_getframe = 4
+# next bit filched from 1.5.2's inspect.py
+def currentframe():
+    """Return the frame object for the caller's stack frame."""
+    try:
+        raise Exception
+    except:
+        return sys.exc_info()[2].tb_frame.f_back
+
+if hasattr(sys, '_getframe'): currentframe = lambda: sys._getframe(3)
 # done filching
 
 # _srcfile is only used in conjunction with sys._getframe().
@@ -1222,23 +1228,17 @@ class Logger(Filterer):
         Find the stack frame of the caller so that we can note the source
         file name, line number and function name.
         """
-
         f = currentframe()
-        # pyston change: we can't use f_back to walk back up the stack, so increment a counter of
-        # frames to skip and repeatedly call sys._getframe
-        fn = start_getframe
         #On some versions of IronPython, currentframe() returns None if
         #IronPython isn't run with -X:Frames.
-        #if f is not None:
-        #    f = f.f_back
+        if f is not None:
+            f = f.f_back
         rv = "(unknown file)", 0, "(unknown function)"
         while hasattr(f, "f_code"):
             co = f.f_code
             filename = os.path.normcase(co.co_filename)
             if filename == _srcfile:
-                fn += 1
-                f = sys._getframe(fn);
-                #f = f.f_back
+                f = f.f_back
                 continue
             rv = (co.co_filename, f.f_lineno, co.co_name)
             break

--- a/from_cpython/Lib/traceback.py
+++ b/from_cpython/Lib/traceback.py
@@ -1,8 +1,5 @@
 """Extract, format and print information about Python stack traces."""
 
-# This module has been heavily modified for Pyston, since we don't provide the
-# same traceback objects as CPython.
-
 import linecache
 import sys
 import types
@@ -59,20 +56,7 @@ def print_tb(tb, limit=None, file=None):
     if limit is None:
         if hasattr(sys, 'tracebacklimit'):
             limit = sys.tracebacklimit
-
     n = 0
-    # Pyston change:
-    for (filename, name, lineno) in tb.getLines():
-        if limit and n >= limit:
-            break
-
-        _print(file,
-               '  File "%s", line %d, in %s' % (filename, lineno, name))
-        linecache.checkcache(filename)
-        line = linecache.getline(filename, lineno, None)
-        if line: _print(file, '    ' + line.strip())
-        n = n+1
-    """
     while tb is not None and (limit is None or n < limit):
         f = tb.tb_frame
         lineno = tb.tb_lineno
@@ -86,7 +70,6 @@ def print_tb(tb, limit=None, file=None):
         if line: _print(file, '    ' + line.strip())
         tb = tb.tb_next
         n = n+1
-    """
 
 def format_tb(tb, limit = None):
     """A shorthand for 'format_list(extract_tb(tb, limit))'."""
@@ -108,18 +91,6 @@ def extract_tb(tb, limit = None):
             limit = sys.tracebacklimit
     list = []
     n = 0
-    # Pyston change:
-    for (filename, name, lineno) in tb.getLines():
-        if limit and n >= limit:
-            break
-
-        linecache.checkcache(filename)
-        line = linecache.getline(filename, lineno, None)
-        if line: line = line.strip()
-        else: line = None
-        list.append((filename, lineno, name, line))
-        n = n+1
-    """
     while tb is not None and (limit is None or n < limit):
         f = tb.tb_frame
         lineno = tb.tb_lineno
@@ -133,7 +104,6 @@ def extract_tb(tb, limit = None):
         list.append((filename, lineno, name, line))
         tb = tb.tb_next
         n = n+1
-    """
     return list
 
 
@@ -293,28 +263,19 @@ def print_stack(f=None, limit=None, file=None):
     arguments have the same meaning as for print_exception().
     """
     if f is None:
-        # Pyston change:
-        """
         try:
             raise ZeroDivisionError
         except ZeroDivisionError:
             f = sys.exc_info()[2].tb_frame.f_back
-        """
-        f = sys._getframe(1)
     print_list(extract_stack(f, limit), file)
 
 def format_stack(f=None, limit=None):
     """Shorthand for 'format_list(extract_stack(f, limit))'."""
-
     if f is None:
-        # Pyston change:
-        """
         try:
             raise ZeroDivisionError
         except ZeroDivisionError:
             f = sys.exc_info()[2].tb_frame.f_back
-        """
-        f = sys._getframe(1)
     return format_list(extract_stack(f, limit))
 
 def extract_stack(f=None, limit = None):
@@ -326,16 +287,11 @@ def extract_stack(f=None, limit = None):
     line number, function name, text), and the entries are in order
     from oldest to newest stack frame.
     """
-
     if f is None:
-        # Pyston change:
-        """
         try:
             raise ZeroDivisionError
         except ZeroDivisionError:
             f = sys.exc_info()[2].tb_frame.f_back
-        """
-        f = sys._getframe(1)
     if limit is None:
         if hasattr(sys, 'tracebacklimit'):
             limit = sys.tracebacklimit
@@ -361,6 +317,4 @@ def tb_lineno(tb):
 
     Obsolete in 2.3.
     """
-
-    raise NotImplementedError("This function is currently not implemented in Pyston")
     return tb.tb_lineno

--- a/src/codegen/ast_interpreter.h
+++ b/src/codegen/ast_interpreter.h
@@ -76,12 +76,8 @@ Box* astInterpretFunctionEval(FunctionMetadata* cf, Box* globals, Box* boxedLoca
 Box* astInterpretDeopt(FunctionMetadata* cf, AST_expr* after_expr, AST_stmt* enclosing_stmt, Box* expr_val,
                        FrameStackState frame_state);
 
-FunctionMetadata* getMDForInterpretedFrame(void* frame_ptr);
 struct FrameInfo;
 FrameInfo* getFrameInfoForInterpretedFrame(void* frame_ptr);
-
-BoxedDict* localsForInterpretedFrame(Box** vregs, CFG* cfg);
-BoxedDict* localsForInterpretedFrame(void* frame_ptr);
 
 // Executes the equivalent of CPython's PRINT_EXPR opcode (call sys.displayhook)
 extern "C" void printExprHelper(Box* b);

--- a/src/codegen/irgen/irgenerator.h
+++ b/src/codegen/irgen/irgenerator.h
@@ -158,8 +158,7 @@ public:
     virtual void run(const CFGBlock* block) = 0; // primary entry point
     virtual EndingState getEndingSymbolTable() = 0;
     virtual void doSafePoint(AST_stmt* next_statement) = 0;
-    virtual void addFrameStackmapArgs(PatchpointInfo* pp, AST_stmt* current_stmt,
-                                      std::vector<llvm::Value*>& stackmap_args) = 0;
+    virtual void addFrameStackmapArgs(PatchpointInfo* pp, std::vector<llvm::Value*>& stackmap_args) = 0;
     virtual void addOutgoingExceptionState(ExceptionState exception_state) = 0;
     virtual void setIncomingExceptionState(llvm::SmallVector<ExceptionState, 2> exc_state) = 0;
     virtual llvm::BasicBlock* getCXXExcDest(llvm::BasicBlock* final_dest) = 0;

--- a/src/codegen/runtime_hooks.cpp
+++ b/src/codegen/runtime_hooks.cpp
@@ -198,6 +198,8 @@ void initGlobalFuncs(GlobalState& g) {
     GET(createClosure);
     GET(createGenerator);
     GET(createSet);
+    GET(initFrame);
+    GET(deinitFrame);
 
     GET(getattr);
     GET(getattr_capi);

--- a/src/codegen/runtime_hooks.h
+++ b/src/codegen/runtime_hooks.h
@@ -34,7 +34,7 @@ struct GlobalFuncs {
 
     llvm::Value* boxInt, *unboxInt, *boxFloat, *unboxFloat, *createFunctionFromMetadata, *getFunctionMetadata,
         *boxInstanceMethod, *boxBool, *unboxBool, *createTuple, *createDict, *createList, *createSlice,
-        *createUserClass, *createClosure, *createGenerator, *createSet;
+        *createUserClass, *createClosure, *createGenerator, *createSet, *initFrame, *deinitFrame;
     llvm::Value* getattr, *getattr_capi, *setattr, *delattr, *delitem, *delGlobal, *nonzero, *binop, *compare,
         *augbinop, *unboxedLen, *getitem, *getitem_capi, *getclsattr, *getGlobal, *setitem, *unaryop, *import,
         *importFrom, *importStar, *repr, *exceptionMatches, *yield, *getiterHelper, *hasnext, *setGlobal, *apply_slice;

--- a/src/codegen/unwinding.cpp
+++ b/src/codegen/unwinding.cpp
@@ -353,11 +353,6 @@ public:
     }
 
     AST_stmt* getCurrentStatement() {
-        if (id.type == PythonFrameId::COMPILED) {
-            auto locations = findLocations("!current_stmt");
-            if (locations.size() == 1)
-                return reinterpret_cast<AST_stmt*>(readLocation(locations[0]));
-        }
         assert(getFrameInfo()->stmt);
         return getFrameInfo()->stmt;
     }

--- a/src/codegen/unwinding.h
+++ b/src/codegen/unwinding.h
@@ -80,20 +80,7 @@ public:
     FrameInfo* getFrameInfo();
     bool exists() { return impl.get() != NULL; }
     AST_stmt* getCurrentStatement();
-    Box* fastLocalsToBoxedLocals();
     Box* getGlobalsDict();
-
-    // Gets the "current version" of this frame: if the frame has executed since
-    // the iterator was obtained, the methods may return old values. This returns
-    // an updated copy that returns the updated values.
-    // The "current version" will live at the same stack location, but any other
-    // similarities need to be verified by the caller, ie it is up to the caller
-    // to determine that we didn't leave and reenter the stack frame.
-    // This function can only be called from the thread that created this object.
-    PythonFrameIterator getCurrentVersion();
-
-    // Assuming this is a valid frame iterator, return the next frame back (ie older).
-    PythonFrameIterator back();
 
     PythonFrameIterator(PythonFrameIterator&& rhs);
     void operator=(PythonFrameIterator&& rhs);
@@ -101,7 +88,7 @@ public:
     ~PythonFrameIterator();
 };
 
-PythonFrameIterator getPythonFrame(int depth);
+FrameInfo* getPythonFrameInfo(int depth);
 
 // Fetches a writeable pointer to the frame-local excinfo object,
 // calculating it if necessary (from previous frames).

--- a/src/core/threading.cpp
+++ b/src/core/threading.cpp
@@ -38,7 +38,7 @@ std::unordered_set<PerThreadSetBase*> PerThreadSetBase::all_instances;
 
 extern "C" {
 __thread PyThreadState cur_thread_state
-    = { 0, 1, NULL, NULL, NULL, NULL }; // not sure if we need to explicitly request zero-initialization
+    = { NULL, 0, 1, NULL, NULL, NULL, NULL }; // not sure if we need to explicitly request zero-initialization
 }
 
 PthreadFastMutex threading_lock;

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -893,14 +893,16 @@ struct FrameInfo {
     BoxedClosure* passed_closure;
 
     Box** vregs;
-    // Current statement
-    // Caution the llvm tier only updates this information on direct external calls but not for patchpoints.
-    // This means if a patchpoint "current_stmt" info is available it must be used instead of this field.
-    AST_stmt* stmt;
+    AST_stmt* stmt; // current statement
     // This is either a module or a dict
     Box* globals;
 
-    FrameInfo(ExcInfo exc) : exc(exc), boxedLocals(NULL), frame_obj(0), passed_closure(0), vregs(0), stmt(0), globals(0) {}
+    FrameInfo* back;
+    FunctionMetadata* md;
+
+    Box* updateBoxedLocals();
+
+    FrameInfo(ExcInfo exc) : exc(exc), boxedLocals(NULL), frame_obj(0), passed_closure(0), vregs(0), stmt(0), globals(0), back(0), md(0) {}
 
     void gcVisit(GCVisitor* visitor);
 };

--- a/src/runtime/exceptions.cpp
+++ b/src/runtime/exceptions.cpp
@@ -51,7 +51,7 @@ void raiseSyntaxError(const char* msg, int lineno, int col_offset, llvm::StringR
     } else {
         // This is more like how the parser handles it:
         exc = runtimeCall(SyntaxError, ArgPassSpec(1), boxString(msg), NULL, NULL, NULL, NULL);
-        tb = new BoxedTraceback(LineInfo(lineno, col_offset, boxString(file), boxString(func)), None);
+        tb = new BoxedTraceback(LineInfo(lineno, col_offset, boxString(file), boxString(func)), None, getFrame(0));
     }
 
     assert(!PyErr_Occurred());
@@ -299,7 +299,7 @@ bool exceptionAtLineCheck() {
 
 void exceptionAtLine(LineInfo line_info, Box** traceback) {
     if (exceptionAtLineCheck())
-        BoxedTraceback::here(line_info, traceback);
+        BoxedTraceback::here(line_info, traceback, getFrame((FrameInfo*)cur_thread_state.frame_info));
 }
 
 void startReraise() {

--- a/src/runtime/frame.cpp
+++ b/src/runtime/frame.cpp
@@ -30,25 +30,24 @@ BoxedClass* frame_cls;
 class BoxedFrame : public Box {
 private:
     // Call boxFrame to get a BoxedFrame object.
-    BoxedFrame(PythonFrameIterator it) __attribute__((visibility("default")))
-    : it(std::move(it)), thread_id(PyThread_get_thread_ident()) {}
+    BoxedFrame(FrameInfo* frame_info) __attribute__((visibility("default")))
+    : frame_info(frame_info), _back(NULL), _code(NULL), _globals(NULL), _locals(NULL), _stmt(NULL) {
+        assert(frame_info);
+    }
 
 public:
-    PythonFrameIterator it;
-    long thread_id;
+    FrameInfo* frame_info;
 
-    Box* _globals;
+    Box* _back;
     Box* _code;
+    Box* _globals;
+    Box* _locals;
 
-    void update() {
-        // This makes sense as an exception, but who knows how the user program would react
-        // (it might swallow it and do something different)
-        RELEASE_ASSERT(thread_id == PyThread_get_thread_ident(),
-                       "frame objects can only be accessed from the same thread");
-        PythonFrameIterator new_it = it.getCurrentVersion();
-        RELEASE_ASSERT(new_it.exists() && new_it.getFrameInfo()->frame_obj == this, "frame has exited");
-        it = std::move(new_it);
-    }
+    AST_stmt* _stmt;
+
+
+    bool hasExited() const { return frame_info == NULL; }
+
 
     // cpython frame objects have the following attributes
 
@@ -82,84 +81,117 @@ public:
 
         auto f = static_cast<BoxedFrame*>(b);
 
+        v->visit(&f->_back);
         v->visit(&f->_code);
         v->visit(&f->_globals);
-    }
-
-    static void simpleDestructor(Box* b) {
-        auto f = static_cast<BoxedFrame*>(b);
-
-        f->it.~PythonFrameIterator();
+        v->visit(&f->_locals);
     }
 
     static Box* code(Box* obj, void*) {
         auto f = static_cast<BoxedFrame*>(obj);
+
+        if (!f->_code)
+            f->_code = (Box*)f->frame_info->md->getCode();
         return f->_code;
     }
 
     static Box* locals(Box* obj, void*) {
         auto f = static_cast<BoxedFrame*>(obj);
-        f->update();
-        return f->it.fastLocalsToBoxedLocals();
+
+        if (f->hasExited())
+            return f->_locals;
+        return f->frame_info->updateBoxedLocals();
     }
 
     static Box* globals(Box* obj, void*) {
         auto f = static_cast<BoxedFrame*>(obj);
+
+        if (!f->_globals) {
+            f->_globals = f->frame_info->globals;
+            if (f->_globals && PyModule_Check(f->_globals))
+                f->_globals = f->_globals->getAttrWrapper();
+        }
         return f->_globals;
     }
 
     static Box* back(Box* obj, void*) {
         auto f = static_cast<BoxedFrame*>(obj);
-        f->update();
 
-        PythonFrameIterator it = f->it.back();
-        if (!it.exists())
-            return None;
-        return BoxedFrame::boxFrame(std::move(it));
+        if (!f->_back) {
+            if (!f->frame_info->back)
+                f->_back = None;
+            else
+                f->_back = BoxedFrame::boxFrame(f->frame_info->back);
+        }
+        return f->_back;
     }
 
     static Box* lineno(Box* obj, void*) {
         auto f = static_cast<BoxedFrame*>(obj);
-        f->update();
-        AST_stmt* stmt = f->it.getCurrentStatement();
+
+        if (f->hasExited())
+            return boxInt(f->_stmt->lineno);
+
+        AST_stmt* stmt = f->frame_info->stmt;
         return boxInt(stmt->lineno);
+    }
+
+    void handleFrameExit() {
+        if (hasExited())
+            return;
+
+        _back = back(this, NULL);
+        _code = code(this, NULL);
+        _globals = globals(this, NULL);
+        _locals = locals(this, NULL);
+        _stmt = frame_info->stmt;
+
+        frame_info = NULL; // this means exited == true
+        assert(hasExited());
     }
 
     DEFAULT_CLASS(frame_cls);
 
-    static Box* boxFrame(PythonFrameIterator it) {
-        FrameInfo* fi = it.getFrameInfo();
-        if (fi->frame_obj == NULL) {
-            auto md = it.getMD();
-            Box* globals = it.getGlobalsDict();
-            BoxedFrame* f = fi->frame_obj = new BoxedFrame(std::move(it));
-            f->_globals = globals;
-            f->_code = (Box*)md->getCode();
-        }
-
+    static Box* boxFrame(FrameInfo* fi) {
+        if (fi->frame_obj == NULL)
+            fi->frame_obj = new BoxedFrame(fi);
+        assert(fi->frame_obj->cls == frame_cls);
         return fi->frame_obj;
     }
 };
 
-Box* getFrame(int depth) {
-    auto it = getPythonFrame(depth);
-    if (!it.exists())
-        return NULL;
 
-    return BoxedFrame::boxFrame(std::move(it));
+Box* getFrame(FrameInfo* frame_info) {
+    return BoxedFrame::boxFrame(frame_info);
+}
+
+Box* getFrame(int depth) {
+    FrameInfo* frame_info = getPythonFrameInfo(depth);
+    if (!frame_info)
+        return NULL;
+    return BoxedFrame::boxFrame(frame_info);
+}
+
+void frameInvalidateBack(BoxedFrame* frame) {
+    RELEASE_ASSERT(!frame->hasExited(), "should not happen");
+    frame->_back = NULL;
+}
+
+extern "C" void initFrame(FrameInfo* frame_info) {
+    frame_info->back = (FrameInfo*)(cur_thread_state.frame_info);
+    cur_thread_state.frame_info = frame_info;
+}
+
+extern "C" void deinitFrame(FrameInfo* frame_info) {
+    cur_thread_state.frame_info = frame_info->back;
+    BoxedFrame* frame = frame_info->frame_obj;
+    if (frame)
+        frame->handleFrameExit();
 }
 
 extern "C" int PyFrame_GetLineNumber(PyFrameObject* _f) noexcept {
-    // TODO remove this when we are able to introspect exited frames:
-    // We check if the frame exited and only return the correct line number when it is still available.
-    // Because of a limitation in out current frame introspection we can also not inspect OSRed frames.
-    BoxedFrame* f = (BoxedFrame*)_f;
-    PythonFrameIterator new_it = f->it.getCurrentVersion();
-    if (new_it.exists() && new_it.getFrameInfo()->frame_obj == f) {
-        BoxedInt* lineno = (BoxedInt*)BoxedFrame::lineno((Box*)f, NULL);
-        return lineno->n;
-    }
-    return -1;
+    BoxedInt* lineno = (BoxedInt*)BoxedFrame::lineno((Box*)_f, NULL);
+    return lineno->n;
 }
 
 extern "C" PyObject* PyFrame_GetGlobals(PyFrameObject* f) noexcept {
@@ -173,7 +205,6 @@ extern "C" PyFrameObject* PyFrame_ForStackLevel(int stack_level) noexcept {
 void setupFrame() {
     frame_cls = BoxedClass::create(type_cls, object_cls, &BoxedFrame::gchandler, 0, 0, sizeof(BoxedFrame), false,
                                    "frame", false);
-    frame_cls->tp_dealloc = BoxedFrame::simpleDestructor;
     frame_cls->has_safe_tp_dealloc = true;
 
     frame_cls->giveAttrDescriptor("f_code", BoxedFrame::code, NULL);

--- a/src/runtime/inline/link_forcer.cpp
+++ b/src/runtime/inline/link_forcer.cpp
@@ -72,6 +72,8 @@ void force() {
     FORCE(createPureImaginary);
     FORCE(createSet);
     FORCE(decodeUTF8StringPtr);
+    FORCE(initFrame);
+    FORCE(deinitFrame);
 
     FORCE(getattr);
     FORCE(getattr_capi);

--- a/src/runtime/traceback.h
+++ b/src/runtime/traceback.h
@@ -27,19 +27,26 @@ class GCVisitor;
 extern "C" BoxedClass* traceback_cls;
 class BoxedTraceback : public Box {
 public:
-    Box* tb_next;
     LineInfo line;
-    Box* py_lines;
-    BoxedTraceback(LineInfo line, Box* tb_next) : tb_next(tb_next), line(std::move(line)), py_lines(NULL) {}
+    Box* tb_next;
+    Box* tb_frame;
+
+    BoxedTraceback(LineInfo line, Box* tb_next, Box* tb_frame)
+        : line(std::move(line)), tb_next(tb_next), tb_frame(tb_frame) {
+        if (!tb_frame)
+            this->tb_frame = None;
+        else
+            assert(tb_frame->cls == frame_cls);
+    }
 
     DEFAULT_CLASS(traceback_cls);
 
-    static Box* getLines(Box* b);
+    static Box* lineno(Box* obj, void*);
 
     static void gcHandler(gc::GCVisitor* v, Box* b);
 
     // somewhat equivalent to PyTraceBack_Here
-    static void here(LineInfo lineInfo, Box** tb);
+    static void here(LineInfo lineInfo, Box** tb, Box* frame);
 };
 
 void printTraceback(Box* b);

--- a/src/runtime/types.cpp
+++ b/src/runtime/types.cpp
@@ -105,6 +105,9 @@ void FrameInfo::gcVisit(GCVisitor* visitor) {
     visitor->visit(&exc.type);
     visitor->visit(&exc.value);
     visitor->visit(&frame_obj);
+
+    if (back)
+        ((FrameInfo*)back)->gcVisit(visitor);
 }
 
 // Analogue of PyType_GenericAlloc (default tp_alloc), but should only be used for Pyston classes!

--- a/src/runtime/types.h
+++ b/src/runtime/types.h
@@ -1041,6 +1041,7 @@ public:
 
     struct Context* context, *returnContext;
     void* stack_begin;
+    FrameInfo* top_caller_frame_info;
 
 #if STAT_TIMERS
     StatTimer* prev_stack;
@@ -1146,7 +1147,11 @@ Box* codeForFunction(BoxedFunction*);
 Box* codeForFunctionMetadata(FunctionMetadata*);
 FunctionMetadata* metadataFromCode(Box* code);
 
+Box* getFrame(FrameInfo* frame_info);
 Box* getFrame(int depth);
+void frameInvalidateBack(BoxedFrame* frame);
+extern "C" void deinitFrame(FrameInfo* frame_info);
+extern "C" void initFrame(FrameInfo* frame_info);
 
 inline BoxedString* boxString(llvm::StringRef s) {
     if (s.size() <= 1) {

--- a/test/tests/generator_threads2.py
+++ b/test/tests/generator_threads2.py
@@ -1,0 +1,31 @@
+import threading
+import traceback, sys
+
+def exc():
+    1/0
+
+def G():
+    traceback.print_stack(limit=2)
+    yield 1
+    traceback.print_stack(limit=2)
+    yield 2
+    exc()
+
+def f1(x):
+    print x.next()
+def f2(x):
+    print x.next()
+def f3(x):
+    try:
+        print x.next()
+    except:
+        print "exc"
+        traceback.print_tb(sys.exc_info()[2])
+def run(nthreads=4):
+    g = G()
+    def t(f):
+        return threading.Thread(target=f, args=(g,))
+    for t in [t(f1), t(f2), t(f3)]:
+        t.start()
+        t.join()
+run()

--- a/test/tests/sys_getframe_exited.py
+++ b/test/tests/sys_getframe_exited.py
@@ -1,9 +1,16 @@
-# expected: fail
-# - we don't (yet?) support looking at frame objects after
-#   their frame has exited
 import sys
 def f():
+    var = 42
     return sys._getframe(0)
 
 fr = f()
 print fr.f_locals
+
+
+def f():
+    var = 0
+    fr = sys._getframe(0)
+    var += 1
+    return fr
+fr = f()
+print fr.f_locals["var"]


### PR DESCRIPTION
This replaces #1007 with a faster approach (I leave it up until this one is merged).

add frame intospection for exited frames
this works by copying the last locals state into the BoxedFrame when we exit a function.
As a perf improvement we only create BoxedFrames if _getframe got called or an exception got thrown.

It turned out that our python frame retrieving / updating code was really slow (using libunwind) I replaced it now with
a approach which manually keeps track of the python frames (calling initFrame/deinitFrame every time a functions gets called / exits).
Sadly we can't inline this functions in the llvm tier currently because it uses thread local storage which the JIT does not support.
But I have a prototype which works around the issue with inline asm.
We also store now always the current stmt inside the FrameInfo and in addition the FunctionMetadata.
This made it possible to switch away from libunwind frame introspection for most cases (except deopt and c++ unwinding where we need to access all register)

I think we can further improve the patch in several ways:
 - only copying the vregs array instead of generating the dict which takes more time (because of space overhead and hashing?).
 - refcounting should remove uneccesarry locals updating when no one keeps track of the BoxedFrame anymore.
 - switch to cpythons traceback implementation


```
                                   upstream/master:  origin/exited_fram:
           django_template3.py             2.1s (4)             2.2s (4)  +4.4%
                 pyxl_bench.py             1.8s (4)             1.9s (4)  +5.8%
     sqlalchemy_imperative2.py             2.2s (4)             2.3s (4)  +1.1%
                pyxl_bench2.py             1.1s (4)             1.1s (4)  +6.7%
       django_template3_10x.py            13.8s (4)            14.7s (4)  +6.5%
             pyxl_bench_10x.py            13.3s (4)            14.4s (4)  +8.7%
 sqlalchemy_imperative2_10x.py            17.0s (4)            17.6s (4)  +3.5%
            pyxl_bench2_10x.py             9.0s (4)             9.6s (4)  +6.8%
                       geomean                 4.7s                 5.0s  +5.4%
```