### PR TITLE
Allow subclassing classmethod and staticmethod

### DIFF
--- a/src/runtime/descr.cpp
+++ b/src/runtime/descr.cpp
@@ -186,7 +186,7 @@ static Box* propertyDeleter(Box* self, Box* obj) {
 }
 
 static Box* staticmethodInit(Box* _self, Box* f) {
-    RELEASE_ASSERT(_self->cls == staticmethod_cls, "");
+    RELEASE_ASSERT(isSubclass(_self->cls, staticmethod_cls), "");
     BoxedStaticmethod* self = static_cast<BoxedStaticmethod*>(_self);
     self->sm_callable = f;
 
@@ -194,7 +194,7 @@ static Box* staticmethodInit(Box* _self, Box* f) {
 }
 
 static Box* staticmethodGet(Box* self, Box* obj, Box* type) {
-    RELEASE_ASSERT(self->cls == staticmethod_cls, "");
+    RELEASE_ASSERT(isSubclass(self->cls, staticmethod_cls), "");
 
     BoxedStaticmethod* sm = static_cast<BoxedStaticmethod*>(self);
 
@@ -210,7 +210,7 @@ extern "C" PyObject* PyClassMethod_New(PyObject* callable) noexcept {
 }
 
 static Box* classmethodInit(Box* _self, Box* f) {
-    RELEASE_ASSERT(_self->cls == classmethod_cls, "");
+    RELEASE_ASSERT(isSubclass(_self->cls, classmethod_cls), "");
     BoxedClassmethod* self = static_cast<BoxedClassmethod*>(_self);
     self->cm_callable = f;
 
@@ -218,7 +218,7 @@ static Box* classmethodInit(Box* _self, Box* f) {
 }
 
 static Box* classmethodGet(Box* self, Box* obj, Box* type) {
-    RELEASE_ASSERT(self->cls == classmethod_cls, "");
+    RELEASE_ASSERT(isSubclass(self->cls, classmethod_cls), "");
 
     BoxedClassmethod* cm = static_cast<BoxedClassmethod*>(self);
 

--- a/test/tests/static_class_methods.py
+++ b/test/tests/static_class_methods.py
@@ -24,3 +24,21 @@ def g(cls, a, b, c, d):
 
 f.__get__(c, C)(17, 18, 19, 20)
 g.__get__(c, C)(21, 22, 23, 24)
+
+
+class classonlymethod(classmethod):
+    def __get__(self, instance, owner):
+        if instance is not None:
+            raise AttributeError("This method is available only on the class, not on instances.")
+        return super(classonlymethod, self).__get__(instance, owner)
+
+class C(object):
+    @classonlymethod
+    def f(cls):
+        print "f called"
+C.f()
+try:
+    C().f()
+except AttributeError, e:
+    print e
+


### PR DESCRIPTION
fixes #1033
I think there are more of this still around, at some point we should audit all this ```cls ==``` checks.