### PR TITLE
Fix #599 by allowing subclasses of string and unicode in sys.path

### DIFF
--- a/src/runtime/import.cpp
+++ b/src/runtime/import.cpp
@@ -222,8 +222,15 @@ SearchResult findModule(const std::string& name, BoxedString* full_name, BoxedLi
     llvm::SmallString<128> joined_path;
     for (int i = 0; i < path_list->size; i++) {
         Box* _p = path_list->elts->elts[i];
-        if (_p->cls != str_cls)
+        if (isSubclass(_p->cls, unicode_cls)) {
+            _p = PyUnicode_AsEncodedString(_p, Py_FileSystemDefaultEncoding, NULL);
+            if (_p == NULL) {
+                continue;
+            }
+        }
+        if (!isSubclass(_p->cls, str_cls)) {
             continue;
+        }
         BoxedString* p = static_cast<BoxedString*>(_p);
 
         joined_path.clear();
@@ -686,7 +693,7 @@ static int isdir(const char* path) {
 Box* nullImporterInit(Box* self, Box* _path) {
     RELEASE_ASSERT(self->cls == null_importer_cls, "");
 
-    if (_path->cls != str_cls)
+    if (!isSubclass(_path->cls, str_cls))
         raiseExcHelper(TypeError, "must be string, not %s", getTypeName(_path));
 
     BoxedString* path = (BoxedString*)_path;

--- a/test/tests/sys_path_str.py
+++ b/test/tests/sys_path_str.py
@@ -1,0 +1,3 @@
+import sys
+sys.path.append("test_package")
+import import_target

--- a/test/tests/sys_path_str_subclass.py
+++ b/test/tests/sys_path_str_subclass.py
@@ -1,0 +1,6 @@
+import sys
+class TestClass(str):
+    pass
+t = TestClass("test_package")
+sys.path.append(t)
+import import_target

--- a/test/tests/sys_path_unicode.py
+++ b/test/tests/sys_path_unicode.py
@@ -1,0 +1,3 @@
+import sys
+sys.path.append(u"test_package")
+import import_target

--- a/test/tests/sys_path_unicode_subclass.py
+++ b/test/tests/sys_path_unicode_subclass.py
@@ -1,0 +1,6 @@
+import sys
+class TestClass(unicode):
+    pass
+t = TestClass("test_package")
+sys.path.append(t)
+import import_target


### PR DESCRIPTION
I use isSubclass check if a given entry in `sys.path` is subclass of `str` or `unicode` and tried to allow both situations. If it is `unicode`, I also convert it to `str` with `PyUnicode_AsEncodedString()` with `Py_FileSystemDefaultEncoding `.

I also modified `nullImporterInit` to make it accept subclasses of `str`.