### PR TITLE
Micro optimization on 'gc_invalidateOrderedFinalizerList'

### DIFF
--- a/src/gc/collector.cpp
+++ b/src/gc/collector.cpp
@@ -47,7 +47,7 @@ FILE* trace_fp;
 std::deque<Box*> pending_finalization_list;
 std::deque<PyWeakReference*> weakrefs_needing_callback_list;
 
-std::list<Box*> objects_with_ordered_finalizers;
+std::vector<Box*> objects_with_ordered_finalizers;
 
 static std::unordered_set<void*> roots;
 static std::vector<std::pair<void*, void*>> potential_root_ranges;
@@ -379,18 +379,19 @@ void invalidateOrderedFinalizerList() {
     static StatCounter sc_us("us_gc_invalidate_ordered_finalizer_list");
     Timer _t("invalidateOrderedFinalizerList", /*min_usec=*/10000);
 
-    for (auto iter = objects_with_ordered_finalizers.begin(); iter != objects_with_ordered_finalizers.end();) {
-        Box* box = *iter;
+    auto needToRemove = [](Box* box) -> bool {
         GCAllocation* al = GCAllocation::fromUserData(box);
-
         if (!hasOrderedFinalizer(box->cls) || hasFinalized(al)) {
-            // Cleanup.
             GC_TRACE_LOG("Removing %p from objects_with_ordered_finalizers\n", box);
-            iter = objects_with_ordered_finalizers.erase(iter);
+            return true;
         } else {
-            ++iter;
+            return false;
         }
-    }
+    };
+
+    objects_with_ordered_finalizers.erase(
+        std::remove_if(objects_with_ordered_finalizers.begin(), objects_with_ordered_finalizers.end(), needToRemove),
+        objects_with_ordered_finalizers.end());
 
     long us = _t.end();
     sc_us.log(us);


### PR DESCRIPTION
Make it better performance using std::vector instead of std::list

```
Comparing to '['baseline']'
              pyston (calibration)                      :   0.66s baseline: 0.66 ( -0.2%)
              pyston django_template3_10x.py            :   8.98s baseline: 9.10 ( -1.3%)
              pyston pyxl_bench_10x.py                  :   7.45s baseline: 7.39 (  0.8%)
              pyston sqlalchemy_imperative2_10x.py      :  10.43s baseline: 10.47 ( -0.4%)
              pyston django_template3.py                :   1.60s baseline: 1.64 ( -2.2%)
              pyston pyxl_bench.py                      :   1.00s baseline: 1.02 ( -1.1%)
              pyston pyxl_bench2.py                     :   0.73s baseline: 0.72 (  1.6%)
              pyston sqlalchemy_imperative2.py          :   1.44s baseline: 1.46 ( -1.1%)
              pyston pyxl_bench2_10x.py                 :   6.18s baseline: 6.15 (  0.4%)
              pyston (geomean-8ce1)                     :   8.87s baseline: 8.90 ( -0.3%)
```

and also on this code (monty-hall-problem code)
it result to improve speed noticeably on us_gc_invalidate_ordered_finalizer_list time (26 -> 8 on pyston_release)
```python
import random
def populate_doors(): # put a car behind one door
	door=['goat', 'goat', 'goat']
	door[random.randint(0,2)]='car'
	return door
wins = 0
losses = 0
# playing the game 100,000 times:
for x in range(100000):
	doors=populate_doors()
	first_choice=random.randint(0,2) # choose a random door
	for y in range(3): # reveal first losing, unchosen door
		if doors[y] != 'car' and y != first_choice:
			doors[y] = 'out'
			break
	if doors[first_choice] == 'car':
		losses = losses + 1 # contestant switched to losing door
	else:
		wins = wins + 1 # contestant switched to winning door
print "All choices were switched."
print "Wins:", wins
print "Losses:", losses
``` 

