### PR TITLE
Fix crash inside BoxedGenerator::gcHandler

### DIFF
--- a/src/runtime/generator.cpp
+++ b/src/runtime/generator.cpp
@@ -436,11 +436,12 @@ void BoxedGenerator::gcHandler(GCVisitor* v, Box* b) {
         v->visit(&g->arg2);
     if (num_args >= 3)
         v->visit(&g->arg3);
-    if (g->args)
+    if (g->args) {
         v->visit(&g->args);
-    if (num_args > 3)
-        v->visitPotentialRange(reinterpret_cast<void**>(&g->args->elts[0]),
-                               reinterpret_cast<void**>(&g->args->elts[num_args - 3]));
+        if (num_args > 3)
+            v->visitPotentialRange(reinterpret_cast<void**>(&g->args->elts[0]),
+                                   reinterpret_cast<void**>(&g->args->elts[num_args - 3]));
+    }
     if (g->returnValue)
         v->visit(&g->returnValue);
     if (g->exception.type)


### PR DESCRIPTION
This could happen when we trigger a collection inside the BoxedGenerator constructor when allocating space for the args array.
In this case it would not be set but we would dereference the memory.