### PR TITLE
add PyGC_AddPotentialRoot

### DIFF
--- a/from_cpython/Include/Python.h
+++ b/from_cpython/Include/Python.h
@@ -173,6 +173,7 @@ PyObject* PyGC_AddRoot(PyObject*) PYSTON_NOEXCEPT;
 // a temporary patching mechanism - we want to have a better way of dealing with such objects
 // in the future (even if it's an invalid use of CPython APIs).
 PyObject* PyGC_AddNonHeapRoot(PyObject* obj, int size) PYSTON_NOEXCEPT;
+void* PyGC_AddPotentialRoot(void* obj, int size) PYSTON_NOEXCEPT;
 
 // Pyston change : expose these type objects
 extern PyTypeObject Pattern_Type;

--- a/src/gc/collector.cpp
+++ b/src/gc/collector.cpp
@@ -311,7 +311,13 @@ void deregisterPermanentRoot(void* obj) {
 }
 
 void registerPotentialRootRange(void* start, void* end) {
-    potential_root_ranges.push_back(std::make_pair(start, end));
+    // only track void* aligned memory
+    uintptr_t end_int = (uintptr_t)end;
+    end_int = (end_int + (sizeof(void*) - 1)) & ~(sizeof(void*) - 1);
+    end_int -= end_int % sizeof(void*);
+
+    if (end_int > (uintptr_t)start)
+        potential_root_ranges.push_back(std::make_pair(start, (void*)end_int));
 }
 
 extern "C" PyObject* PyGC_AddRoot(PyObject* obj) noexcept {
@@ -327,6 +333,12 @@ extern "C" PyObject* PyGC_AddNonHeapRoot(PyObject* obj, int size) noexcept {
     if (obj) {
         registerNonheapRootObject(obj, size);
     }
+    return obj;
+}
+
+extern "C" void* PyGC_AddPotentialRoot(void* obj, int size) noexcept {
+    if (obj)
+        registerPotentialRootRange(obj, (char*)obj + size);
     return obj;
 }
 

--- a/src/runtime/import.cpp
+++ b/src/runtime/import.cpp
@@ -870,12 +870,8 @@ static void registerDataSegment(void* dl_handle) {
         gc::registerPotentialRootRange((void*)r.first, (void*)r.second);
     }
 
-    if (should_add_bss) {
-        // only track void* aligned memory
-        bss_start = (bss_start + (sizeof(void*) - 1)) & ~(sizeof(void*) - 1);
-        bss_end -= bss_end % sizeof(void*);
+    if (should_add_bss)
         gc::registerPotentialRootRange((void*)bss_start, (void*)bss_end);
-    }
 }
 
 BoxedModule* importCExtension(BoxedString* full_name, const std::string& last_name, const std::string& path) {


### PR DESCRIPTION
This function let's one register a potential root range from the CAPI
Was part of the unmerged #1026 but split out because #1029 requires it too.