### PR TITLE
Don't abort when generating a call of a known type which is not callable.

### DIFF
--- a/src/codegen/compvars.cpp
+++ b/src/codegen/compvars.cpp
@@ -352,18 +352,22 @@ public:
                     = var->getType()->getattrType(attr, true)->callType(ArgPassSpec(1), { SLICE }, NULL);
                 assert(return_type->getConcreteType() == return_type);
 
-                llvm::Value* cstart, *cstop;
-                cstart = slice_val.start ? slice_val.start->makeConverted(emitter, UNKNOWN)->getValue()
-                                         : getNullPtr(g.llvm_value_type_ptr);
-                cstop = slice_val.stop ? slice_val.stop->makeConverted(emitter, UNKNOWN)->getValue()
-                                       : getNullPtr(g.llvm_value_type_ptr);
+                if (return_type != UNDEF) {
+                    llvm::Value* cstart, *cstop;
+                    cstart = slice_val.start ? slice_val.start->makeConverted(emitter, UNKNOWN)->getValue()
+                                             : getNullPtr(g.llvm_value_type_ptr);
+                    cstop = slice_val.stop ? slice_val.stop->makeConverted(emitter, UNKNOWN)->getValue()
+                                           : getNullPtr(g.llvm_value_type_ptr);
 
-                llvm::Value* r
-                    = emitter.createCall3(info.unw_info, g.funcs.apply_slice, var->getValue(), cstart, cstop);
-                emitter.checkAndPropagateCapiException(info.unw_info, r, getNullPtr(g.llvm_value_type_ptr));
+                    llvm::Value* r
+                        = emitter.createCall3(info.unw_info, g.funcs.apply_slice, var->getValue(), cstart, cstop);
+                    emitter.checkAndPropagateCapiException(info.unw_info, r, getNullPtr(g.llvm_value_type_ptr));
 
-
-                return new ConcreteCompilerVariable(static_cast<ConcreteCompilerType*>(return_type), r, true);
+                    return new ConcreteCompilerVariable(static_cast<ConcreteCompilerType*>(return_type), r, true);
+                } else {
+                    // TODO: we could directly emit an exception if we know getitem is undefined but for now let it just
+                    // call the normal getitem which will raise the exception
+                }
             }
         }
 

--- a/src/codegen/compvars.h
+++ b/src/codegen/compvars.h
@@ -141,10 +141,7 @@ public:
     }
     virtual CompilerVariable* call(IREmitter& emitter, const OpInfo& info, VAR* var, struct ArgPassSpec argspec,
                                    const std::vector<CompilerVariable*>& args,
-                                   const std::vector<BoxedString*>* keyword_names) {
-        printf("call not defined for %s\n", debugName().c_str());
-        abort();
-    }
+                                   const std::vector<BoxedString*>* keyword_names);
     virtual CompilerVariable* len(IREmitter& emitter, const OpInfo& info, VAR* var) {
         printf("len not defined for %s\n", debugName().c_str());
         abort();
@@ -172,10 +169,7 @@ public:
         abort();
     }
     CompilerType* callType(struct ArgPassSpec argspec, const std::vector<CompilerType*>& arg_types,
-                           const std::vector<llvm::StringRef>* keyword_names) override {
-        printf("callType not defined for %s\n", debugName().c_str());
-        abort();
-    }
+                           const std::vector<llvm::StringRef>* keyword_names) override;
     BoxedClass* guaranteedClass() override {
         ASSERT((CompilerType*)getConcreteType() != this, "%s", debugName().c_str());
         return getConcreteType()->guaranteedClass();
@@ -486,6 +480,23 @@ std::vector<CompilerVariable*> _ValuedCompilerType<V>::unpack(IREmitter& emitter
 
     ConcreteCompilerVariable* converted = makeConverted(emitter, var, UNKNOWN);
     auto r = UNKNOWN->unpack(emitter, info, converted, num_into);
+    converted->decvref(emitter);
+    return r;
+}
+
+template <typename V>
+CompilerType* _ValuedCompilerType<V>::callType(struct ArgPassSpec argspec, const std::vector<CompilerType*>& arg_types,
+                                               const std::vector<llvm::StringRef>* keyword_names) {
+    return UNKNOWN;
+}
+
+template <typename V>
+CompilerVariable* _ValuedCompilerType<V>::call(IREmitter& emitter, const OpInfo& info, VAR* var,
+                                               struct ArgPassSpec argspec, const std::vector<CompilerVariable*>& args,
+                                               const std::vector<BoxedString*>* keyword_names) {
+    assert((CompilerType*)this != UNKNOWN);
+    ConcreteCompilerVariable* converted = makeConverted(emitter, var, UNKNOWN);
+    auto r = UNKNOWN->call(emitter, info, converted, argspec, args, keyword_names);
     converted->decvref(emitter);
     return r;
 }

--- a/test/tests/type_errors.py
+++ b/test/tests/type_errors.py
@@ -42,3 +42,24 @@ def f2():
 
 for i in xrange(100):
     f2()
+
+
+# make sure we don't abort when calling a type which is not callable
+def f(call):
+    i = 1
+    f = 1.0
+    l = 1l
+    s = "str"
+    t = (1,)
+    
+    if call:
+       i()
+       f()
+       l()
+       s()
+       t()
+try:
+    for i in range(10000):
+        f(i == 9999)
+except TypeError, e:
+    print e

--- a/test/tests/type_errors.py
+++ b/test/tests/type_errors.py
@@ -63,3 +63,27 @@ try:
         f(i == 9999)
 except TypeError, e:
     print e
+
+
+# make sure we don't abort when calling getitem
+def f(error):
+    i = 1
+    f = 1.0
+    l = 1l
+    
+    if error:
+       i[:]
+       f[:]
+       l[:]
+       i[1]
+       f[1]
+       l[1]
+       i[1:2]
+       f[1:2]
+       l[1:2]
+
+try:
+    for i in range(10000):
+        f(i == 9999)
+except TypeError as e:
+    print e


### PR DESCRIPTION
fixes #1046