### PR TITLE
Tuple and list calling order fixing.

### DIFF
--- a/src/runtime/list.cpp
+++ b/src/runtime/list.cpp
@@ -691,11 +691,15 @@ extern "C" int PyList_Insert(PyObject* op, Py_ssize_t where, PyObject* newitem) 
 }
 
 Box* listMul(BoxedList* self, Box* rhs) {
-    static BoxedString* index_str = internStringImmortal("__index__");
+    Py_ssize_t n;
 
-    Py_ssize_t n = PyNumber_AsSsize_t(rhs, PyExc_IndexError);
-    if (n == -1 && PyErr_Occurred())
-        throwCAPIException();
+    if (PyIndex_Check(rhs)) {
+        n = PyNumber_AsSsize_t(rhs, PyExc_OverflowError);
+        if (n == -1 && PyErr_Occurred())
+            throwCAPIException();
+    } else {
+        return NotImplemented;
+    }
 
     int s = self->size;
 
@@ -715,11 +719,15 @@ Box* listMul(BoxedList* self, Box* rhs) {
 }
 
 Box* listImul(BoxedList* self, Box* rhs) {
-    static BoxedString* index_str = internStringImmortal("__index__");
+    Py_ssize_t n;
 
-    Py_ssize_t n = PyNumber_AsSsize_t(rhs, PyExc_IndexError);
-    if (n == -1 && PyErr_Occurred())
-        throwCAPIException();
+    if (PyIndex_Check(rhs)) {
+        n = PyNumber_AsSsize_t(rhs, PyExc_OverflowError);
+        if (n == -1 && PyErr_Occurred())
+            throwCAPIException();
+    } else {
+        return NotImplemented;
+    }
 
     int s = self->size;
 

--- a/src/runtime/tuple.cpp
+++ b/src/runtime/tuple.cpp
@@ -169,16 +169,7 @@ Box* tupleAdd(BoxedTuple* self, Box* rhs) {
     return rtn;
 }
 
-Box* tupleMul(BoxedTuple* self, Box* rhs) {
-    Py_ssize_t n;
-    if (PyIndex_Check(rhs)) {
-        n = PyNumber_AsSsize_t(rhs, PyExc_OverflowError);
-        if (n == -1 && PyErr_Occurred())
-            throwCAPIException();
-    } else {
-        raiseExcHelper(TypeError, "can't multiply sequence by non-int of type '%s'", getTypeName(rhs));
-    }
-
+Box* tupleMulInt(BoxedTuple* self, int n) {
     int s = self->size();
 
     if (n < 0)
@@ -194,6 +185,19 @@ Box* tupleMul(BoxedTuple* self, Box* rhs) {
             rtn_i += s;
         }
         return rtn;
+    }
+}
+
+Box* tupleMul(BoxedTuple* self, Box* rhs) {
+    Py_ssize_t n;
+
+    if (PyIndex_Check(rhs)) {
+        n = PyNumber_AsSsize_t(rhs, PyExc_OverflowError);
+        if (n == -1 && PyErr_Occurred())
+            throwCAPIException();
+        return tupleMulInt(self, n);
+    } else {
+        return NotImplemented;
     }
 }
 
@@ -690,8 +694,8 @@ void setupTuple() {
 
     // Return type is UNKNOWN as it could be NotImplemented.
     tuple_cls->giveAttr("__add__", new BoxedFunction(FunctionMetadata::create((void*)tupleAdd, UNKNOWN, 2)));
-    tuple_cls->giveAttr("__mul__", new BoxedFunction(FunctionMetadata::create((void*)tupleMul, BOXED_TUPLE, 2)));
-    tuple_cls->giveAttr("__rmul__", new BoxedFunction(FunctionMetadata::create((void*)tupleMul, BOXED_TUPLE, 2)));
+    tuple_cls->giveAttr("__mul__", new BoxedFunction(FunctionMetadata::create((void*)tupleMul, UNKNOWN, 2)));
+    tuple_cls->giveAttr("__rmul__", new BoxedFunction(FunctionMetadata::create((void*)tupleMul, UNKNOWN, 2)));
 
     tuple_cls->giveAttr("__getnewargs__", new BoxedFunction(FunctionMetadata::create((void*)tuple_getnewargs, UNKNOWN,
                                                                                      1, ParamNames::empty(), CAPI)));

--- a/test/tests/list.py
+++ b/test/tests/list.py
@@ -219,3 +219,19 @@ try:
     RaisingCmp() in [1, 2, 3]
 except ZeroDivisionError as e:
     print e
+
+class D(object):
+    def __rmul__(self, other):
+        return other * 2
+
+d = D()
+
+try:
+    print([1, 2] * 3.5)
+except TypeError as e:
+    print(type(e))
+
+try:
+    print([1, 2] * d)
+except TypeError as e:
+    print(type(e))

--- a/test/tests/tuples.py
+++ b/test/tests/tuples.py
@@ -239,3 +239,24 @@ class C(object):
     def __repr__(self):
         return repr(self.t)
 print repr(C())
+
+try:
+    (1, 2) + "a"
+except TypeError as e:
+    print(type(e))
+
+class D(object):
+    def __rmul__(self, other):
+        return other * 2
+
+d = D()
+
+try:
+    print((1, 2) * 3.5)
+except TypeError as e:
+    print(type(e))
+
+try:
+    print((1, 2) * d)
+except TypeError as e:
+    print(e.message)


### PR DESCRIPTION
For `tuple.__add__`, if we throw an exception in our `tuple.__add__`, we won't bother checking for an `__radd__`. So before throw exception, I call `__radd__` first. If both return `NotImplemented`. Throw an exception.

For `list.__mul__`. Before throw `TypeError, XXX object cannot be interpreted as an index`., I check the argument type whether is `int` or `long` first. If not, throw `TypeError, can't multiply sequence by non-int of type XXX`. This may not the correct solution, but the behavior is more like CPython.