### PR TITLE
Use our interned ints more often (especially for constants specified inside the source)

### DIFF
--- a/src/runtime/builtin_modules/builtins.cpp
+++ b/src/runtime/builtin_modules/builtins.cpp
@@ -355,13 +355,13 @@ extern "C" Box* ord(Box* obj) {
         size = PyString_GET_SIZE(obj);
         if (size == 1) {
             ord = (long)((unsigned char)*PyString_AS_STRING(obj));
-            return new BoxedInt(ord);
+            return boxInt(ord);
         }
     } else if (PyByteArray_Check(obj)) {
         size = PyByteArray_GET_SIZE(obj);
         if (size == 1) {
             ord = (long)((unsigned char)*PyByteArray_AS_STRING(obj));
-            return new BoxedInt(ord);
+            return boxInt(ord);
         }
 
 #ifdef Py_USING_UNICODE
@@ -369,7 +369,7 @@ extern "C" Box* ord(Box* obj) {
         size = PyUnicode_GET_SIZE(obj);
         if (size == 1) {
             ord = (long)*PyUnicode_AS_UNICODE(obj);
-            return new BoxedInt(ord);
+            return boxInt(ord);
         }
 #endif
     } else {
@@ -1972,9 +1972,9 @@ void setupBuiltins() {
     FunctionMetadata* import_func
         = FunctionMetadata::create((void*)bltinImport, UNKNOWN, 5, false, false,
                                    ParamNames({ "name", "globals", "locals", "fromlist", "level" }, "", ""));
-    builtins_module->giveAttr("__import__", new BoxedBuiltinFunctionOrMethod(import_func, "__import__",
-                                                                             { None, None, None, new BoxedInt(-1) },
-                                                                             NULL, import_doc));
+    builtins_module->giveAttr("__import__",
+                              new BoxedBuiltinFunctionOrMethod(import_func, "__import__",
+                                                               { None, None, None, boxInt(-1) }, NULL, import_doc));
 
     enumerate_cls = BoxedClass::create(type_cls, object_cls, &BoxedEnumerate::gcHandler, 0, 0, sizeof(BoxedEnumerate),
                                        false, "enumerate");

--- a/src/runtime/long.cpp
+++ b/src/runtime/long.cpp
@@ -778,7 +778,7 @@ Box* longInt(Box* v) {
         mpz_init_set(rtn->n, ((BoxedLong*)v)->n);
         return rtn;
     } else
-        return new BoxedInt(n);
+        return boxInt(n);
 }
 
 Box* longToLong(Box* self) {

--- a/src/runtime/objmodel.cpp
+++ b/src/runtime/objmodel.cpp
@@ -2728,7 +2728,7 @@ int64_t hashUnboxed(Box* obj) {
 
 extern "C" BoxedInt* hash(Box* obj) {
     int64_t r = hashUnboxed(obj);
-    return new BoxedInt(r);
+    return (BoxedInt*)boxInt(r);
 }
 
 template <ExceptionStyle S, Rewritable rewritable>

--- a/src/runtime/types.cpp
+++ b/src/runtime/types.cpp
@@ -549,7 +549,7 @@ Box* BoxedModule::getUnicodeConstant(llvm::StringRef ast_str) {
 BoxedInt* BoxedModule::getIntConstant(int64_t n) {
     BoxedInt*& r = int_constants[n];
     if (!r)
-        r = new BoxedInt(n);
+        r = (BoxedInt*)boxInt(n);
     return r;
 }
 

--- a/test/tests/int_ids2.py
+++ b/test/tests/int_ids2.py
@@ -1,0 +1,9 @@
+# while I think nothing requires that this works I actually found this in a library...
+import subprocess
+def f():
+    res = subprocess.Popen(["true"], stdout = subprocess.PIPE, stderr = subprocess.STDOUT)
+    stdout = res.communicate()[0]
+    res.wait()
+    if res.returncode is not 0:
+         raise ValueError
+f()


### PR DESCRIPTION
Before we did not use the interned ints for constants inside the source code
so every module had there on 0, 1 etc...