### PR TITLE
Switch to /usr/bin/env sh for portability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SHELL := /bin/bash
+SHELL := /usr/bin/env sh
 
 # prints variables for debugging
 print-%: ; @echo $($*)


### PR DESCRIPTION
See also: #1069 

There are other scripts (``configure_travis.sh`` and ``src/run-tests.sh`` in libpypa upstream). Need to get a Ubuntu system up to double check they wouldn't break (they would if there we bash-specific code in it)