### PR TITLE
EH frame: use a single allocation for the EH frame + generated code

### DIFF
--- a/src/codegen/baseline_jit.cpp
+++ b/src/codegen/baseline_jit.cpp
@@ -53,17 +53,20 @@ const unsigned char eh_info[]
 static_assert(JitCodeBlock::num_stack_args == 2, "have to update EH table!");
 static_assert(JitCodeBlock::scratch_size == 256, "have to update EH table!");
 
+constexpr int code_size = JitCodeBlock::memory_size - sizeof(eh_info);
+
 JitCodeBlock::JitCodeBlock(llvm::StringRef name)
-    : code(new uint8_t[code_size]),
-      eh_frame(new uint8_t[sizeof(eh_info)]),
+    : memory(new uint8_t[memory_size]),
       entry_offset(0),
-      a(code.get(), code_size),
+      a(memory.get() + sizeof(eh_info), code_size),
       is_currently_writing(false),
       asm_failed(false) {
     static StatCounter num_jit_code_blocks("num_baselinejit_code_blocks");
     num_jit_code_blocks.log();
     static StatCounter num_jit_total_bytes("num_baselinejit_total_bytes");
-    num_jit_total_bytes.log(code_size);
+    num_jit_total_bytes.log(memory_size);
+
+    uint8_t* code = a.curInstPointer();
 
     // emit prolog
     a.push(assembler::R14);
@@ -78,20 +81,20 @@ JitCodeBlock::JitCodeBlock(llvm::StringRef name)
 
     // generate the eh frame...
     const int size = sizeof(eh_info);
-    void* eh_frame_addr = eh_frame.get();
+    void* eh_frame_addr = memory.get();
     memcpy(eh_frame_addr, eh_info, size);
 
     int32_t* offset_ptr = (int32_t*)((uint8_t*)eh_frame_addr + 0x20);
     int32_t* size_ptr = (int32_t*)((uint8_t*)eh_frame_addr + 0x24);
-    int64_t offset = (int8_t*)code.get() - (int8_t*)offset_ptr;
-    RELEASE_ASSERT(offset >= INT_MIN && offset <= INT_MAX, "");
+    int64_t offset = (int8_t*)code - (int8_t*)offset_ptr;
+    assert(offset >= INT_MIN && offset <= INT_MAX);
     *offset_ptr = offset;
     *size_ptr = code_size;
 
-    registerDynamicEhFrame((uint64_t)code.get(), code_size, (uint64_t)eh_frame_addr, size - 4);
+    registerDynamicEhFrame((uint64_t)code, code_size, (uint64_t)eh_frame_addr, size - 4);
     registerEHFrames((uint8_t*)eh_frame_addr, (uint64_t)eh_frame_addr, size);
 
-    g.func_addr_registry.registerFunction(("bjit_" + name).str(), code.get(), code_size, NULL);
+    g.func_addr_registry.registerFunction(("bjit_" + name).str(), code, code_size, NULL);
 }
 
 std::unique_ptr<JitFragmentWriter> JitCodeBlock::newFragment(CFGBlock* block, int patch_jump_offset) {
@@ -566,7 +569,7 @@ int JitFragmentWriter::finishCompilation() {
         int bytes_written = assembler->bytesWritten();
 
         // don't retry JITing very large blocks
-        const auto large_block_threshold = JitCodeBlock::code_size - 4096;
+        const auto large_block_threshold = code_size - 4096;
         if (bytes_written > large_block_threshold) {
             static StatCounter num_jit_large_blocks("num_baselinejit_skipped_large_blocks");
             num_jit_large_blocks.log();

--- a/src/codegen/baseline_jit.h
+++ b/src/codegen/baseline_jit.h
@@ -132,7 +132,7 @@ class JitFragmentWriter;
 class JitCodeBlock {
 public:
     static constexpr int scratch_size = 256;
-    static constexpr int code_size = 32768;
+    static constexpr int memory_size = 32768; // must fit the EH frame + generated code
     static constexpr int num_stack_args = 2;
 
     // scratch size + space for passing additional args on the stack without having to adjust the SP when calling
@@ -140,8 +140,8 @@ public:
     static constexpr int sp_adjustment = scratch_size + num_stack_args * 8 + 8 /* = alignment */;
 
 private:
-    std::unique_ptr<uint8_t[]> code;
-    std::unique_ptr<uint8_t[]> eh_frame;
+    // the memory block contains the EH frame directly followed by the generated machine code.
+    std::unique_ptr<uint8_t[]> memory;
     int entry_offset;
     assembler::Assembler a;
     bool is_currently_writing;

--- a/src/runtime/ics.h
+++ b/src/runtime/ics.h
@@ -22,24 +22,12 @@ namespace pyston {
 
 class ICInfo;
 
-class EHFrameManager {
-private:
-    void* eh_frame_addr;
-    bool omit_frame_pointer;
-
-public:
-    EHFrameManager(bool omit_frame_pointer) : eh_frame_addr(NULL), omit_frame_pointer(omit_frame_pointer) {}
-    ~EHFrameManager();
-    void writeAndRegister(void* func_addr, uint64_t func_size);
-};
-
 class RuntimeIC {
 private:
-    void* addr;
+    void* addr; // points to function start not the start of the allocated memory block.
 #ifndef NVALGRIND
     size_t total_size;
 #endif
-    EHFrameManager eh_frame;
 
     std::unique_ptr<ICInfo> icinfo;
 


### PR DESCRIPTION
This removes the 2GB process limitation I ran into.
(With the EH frame format we are using the code offset is specified as a 32bit signed offset)
I checked if aligning the code speeds it up but I did not notice any perf change.