### PR TITLE
Quick fix for issue #1083

### DIFF
--- a/src/analysis/scoping_analysis.cpp
+++ b/src/analysis/scoping_analysis.cpp
@@ -423,16 +423,14 @@ public:
             }
 
             // Sort in order of `num_parents_from_passed_closure`
-            std::sort(allDerefVarsAndInfo.begin(), allDerefVarsAndInfo.end(), derefComparator);
+            std::sort(
+                allDerefVarsAndInfo.begin(), allDerefVarsAndInfo.end(),
+                [](const std::pair<InternedString, DerefInfo>& p1, const std::pair<InternedString, DerefInfo>& p2) {
+                    return p1.second.num_parents_from_passed_closure < p2.second.num_parents_from_passed_closure;
+                });
         }
         return allDerefVarsAndInfo;
     }
-
-private:
-    static bool derefComparator(const std::pair<InternedString, DerefInfo>& p1,
-                                const std::pair<InternedString, DerefInfo>& p2) {
-        return p1.second.num_parents_from_passed_closure < p2.second.num_parents_from_passed_closure;
-    };
 };
 
 static void raiseGlobalAndLocalException(InternedString name, AST* node) {

--- a/src/capi/object.cpp
+++ b/src/capi/object.cpp
@@ -569,23 +569,28 @@ extern "C" PyObject** _PyObject_GetDictPtr(PyObject* obj) noexcept {
     Py_ssize_t dictoffset;
     PyTypeObject* tp = Py_TYPE(obj);
 
-    dictoffset = tp->tp_dictoffset;
-    if (dictoffset == 0)
-        return NULL;
-    if (dictoffset < 0) {
-        Py_ssize_t tsize;
-        size_t size;
+    if (!tp->instancesHaveHCAttrs()) {
+        dictoffset = tp->tp_dictoffset;
+        if (dictoffset == 0)
+            return NULL;
+        if (dictoffset < 0) {
+            Py_ssize_t tsize;
+            size_t size;
 
-        tsize = ((PyVarObject*)obj)->ob_size;
-        if (tsize < 0)
-            tsize = -tsize;
-        size = _PyObject_VAR_SIZE(tp, tsize);
+            tsize = ((PyVarObject*)obj)->ob_size;
+            if (tsize < 0)
+                tsize = -tsize;
+            size = _PyObject_VAR_SIZE(tp, tsize);
 
-        dictoffset += (long)size;
-        assert(dictoffset > 0);
-        assert(dictoffset % SIZEOF_VOID_P == 0);
+            dictoffset += (long)size;
+            assert(dictoffset > 0);
+            assert(dictoffset % SIZEOF_VOID_P == 0);
+        }
+        return (PyObject**)((char*)obj + dictoffset);
+    } else {
+        fatalOrError(PyExc_NotImplementedError, "unimplemented for hcattrs");
+        return nullptr;
     }
-    return (PyObject**)((char*)obj + dictoffset);
 }
 
 /* These methods are used to control infinite recursion in repr, str, print,

--- a/src/capi/object.cpp
+++ b/src/capi/object.cpp
@@ -566,8 +566,26 @@ extern "C" int PyObject_HasAttrString(PyObject* v, const char* name) noexcept {
 
 // I'm not sure how we can support this one:
 extern "C" PyObject** _PyObject_GetDictPtr(PyObject* obj) noexcept {
-    fatalOrError(PyExc_NotImplementedError, "unimplemented");
-    return nullptr;
+    Py_ssize_t dictoffset;
+    PyTypeObject* tp = Py_TYPE(obj);
+
+    dictoffset = tp->tp_dictoffset;
+    if (dictoffset == 0)
+        return NULL;
+    if (dictoffset < 0) {
+        Py_ssize_t tsize;
+        size_t size;
+
+        tsize = ((PyVarObject*)obj)->ob_size;
+        if (tsize < 0)
+            tsize = -tsize;
+        size = _PyObject_VAR_SIZE(tp, tsize);
+
+        dictoffset += (long)size;
+        assert(dictoffset > 0);
+        assert(dictoffset % SIZEOF_VOID_P == 0);
+    }
+    return (PyObject**)((char*)obj + dictoffset);
 }
 
 /* These methods are used to control infinite recursion in repr, str, print,

--- a/src/runtime/float.cpp
+++ b/src/runtime/float.cpp
@@ -1631,7 +1631,7 @@ void setupFloat() {
     _addFunc("__rdiv__", BOXED_FLOAT, (void*)floatRDivFloat, (void*)floatRDivInt, (void*)floatRDiv);
     _addFunc("__floordiv__", BOXED_FLOAT, (void*)floatFloorDivFloat, (void*)floatFloorDivInt, (void*)floatFloorDiv);
     float_cls->giveAttr("__rfloordiv__",
-                        new BoxedFunction(FunctionMetadata::create((void*)floatRFloorDiv, BOXED_FLOAT, 2)));
+                        new BoxedFunction(FunctionMetadata::create((void*)floatRFloorDiv, UNKNOWN, 2)));
     _addFunc("__truediv__", BOXED_FLOAT, (void*)floatDivFloat, (void*)floatDivInt, (void*)floatTruediv);
     float_cls->giveAttr("__rtruediv__", new BoxedFunction(FunctionMetadata::create((void*)floatRTruediv, UNKNOWN, 2)));
 

--- a/test/tests/datetime_test.py
+++ b/test/tests/datetime_test.py
@@ -2,6 +2,16 @@
 # Doesn't test much of the functionality, but even importing the module is tough:
 
 import datetime
+
+def typeErrorTest(val):
+    try:
+        x = datetime.timedelta(43)
+        x // val
+    except TypeError as e:
+        return True
+    return False
+
+
 print repr(datetime.time())
 print datetime.datetime.__base__
 print repr(datetime.datetime(1, 2, 3))
@@ -11,3 +21,8 @@ print str(datetime.timedelta(0))
 datetime.datetime.now().now()
 
 print datetime.datetime(1924, 2, 3).strftime("%B %d, %Y - %X")
+
+a = 3
+b = 3.4
+assert not typeErrorTest(a)
+assert typeErrorTest(b)


### PR DESCRIPTION
* Quick fix for issue #1083
* use _PyObject_GetDictPtr of cpython implementation
* `std::sort(allDerefVarsAndInfo.begin(), allDerefVarsAndInfo.end(), derefComparator);` to remove functor and use lambda expression

now pyston can fully execute `test/cpython/test_datetime.py`