### PR TITLE
Fix cpython parser bool operation conversion

### DIFF
--- a/src/codegen/cpython_ast.cpp
+++ b/src/codegen/cpython_ast.cpp
@@ -139,7 +139,7 @@ public:
 
     AST_TYPE::AST_TYPE convert(boolop_ty op) {
         switch (op) {
-            CASE(Add);
+            CASE(And);
             CASE(Or);
         }
         // GCC wants this:

--- a/src/codegen/parser.cpp
+++ b/src/codegen/parser.cpp
@@ -1106,11 +1106,11 @@ AST_Module* parse_file(const char* fn, FutureFlags inherited_flags) {
 
 const char* getMagic() {
     if (ENABLE_CPYTHON_PARSER)
-        return "a\nCO";
+        return "a\nCP";
     else if (ENABLE_PYPA_PARSER)
-        return "a\ncO";
+        return "a\ncP";
     else
-        return "a\nco";
+        return "a\ncp";
 }
 
 #define MAGIC_STRING_LENGTH 4

--- a/src/core/ast.cpp
+++ b/src/core/ast.cpp
@@ -1560,6 +1560,9 @@ bool PrintVisitor::visit_langprimitive(AST_LangPrimitive* node) {
         case AST_LangPrimitive::HASNEXT:
             stream << "HASNEXT";
             break;
+        case AST_LangPrimitive::PRINT_EXPR:
+            stream << "PRINT_EXPR";
+            break;
         default:
             RELEASE_ASSERT(0, "%d", node->opcode);
     }

--- a/src/core/cfg.cpp
+++ b/src/core/cfg.cpp
@@ -746,9 +746,11 @@ private:
             if (node->op_type == AST_TYPE::Or) {
                 br->iftrue = crit_break_block;
                 br->iffalse = next_block;
-            } else {
+            } else if (node->op_type == AST_TYPE::And) {
                 br->iffalse = crit_break_block;
                 br->iftrue = next_block;
+            } else {
+                RELEASE_ASSERT(0, "");
             }
 
             curblock = crit_break_block;


### PR DESCRIPTION
Because we only checked for Or's instead of checking for Ands this did not cause any issues except when printing the CFG