### PR TITLE
socket fixes

### DIFF
--- a/from_cpython/Lib/ssl.py
+++ b/from_cpython/Lib/ssl.py
@@ -156,6 +156,9 @@ class SSLSocket(socket):
         self.suppress_ragged_eofs = suppress_ragged_eofs
         self._makefile_refs = 0
 
+        # Pyston change: socket close: we have to decrease the socket refcount by calling close (pypy does the same)
+        sock.close()
+
     def read(self, len=1024):
 
         """Read up to LEN bytes and return them.
@@ -371,11 +374,21 @@ class SSLSocket(socket):
         works with the SSL connection.  Just use the code
         from the socket module."""
 
-        self._makefile_refs += 1
+        # Pyston change: socket close: we increase the refcount inside _fileobject.__init__
+        # self._makefile_refs += 1
+
         # close=True so as to decrement the reference count when done with
         # the file-like object.
         return _fileobject(self, mode, bufsize, close=True)
 
+    # Pyston change: socket close: add refcounting similar to pypys approach
+    def _reuse(self):
+        self._makefile_refs += 1
+    def _drop(self):
+        if self._makefile_refs < 1:
+            self.close()
+        else:
+            self._makefile_refs -= 1
 
 
 def wrap_socket(sock, keyfile=None, certfile=None,

--- a/from_cpython/Lib/test/test_asynchat.py
+++ b/from_cpython/Lib/test/test_asynchat.py
@@ -1,4 +1,3 @@
-# expected: fail
 # test asynchat
 
 import asyncore, asynchat, socket, time

--- a/from_cpython/Lib/test/test_asyncore.py
+++ b/from_cpython/Lib/test/test_asyncore.py
@@ -1,4 +1,3 @@
-# expected: fail
 import asyncore
 import unittest
 import select

--- a/from_cpython/Lib/test/test_ftplib.py
+++ b/from_cpython/Lib/test/test_ftplib.py
@@ -1,4 +1,3 @@
-# expected: fail
 """Test script for ftplib module."""
 
 # Modified by Giampaolo Rodola' to test FTP class, IPv6 and TLS

--- a/from_cpython/Lib/test/test_httplib.py
+++ b/from_cpython/Lib/test/test_httplib.py
@@ -1,4 +1,3 @@
-# expected: fail
 import httplib
 import array
 import httplib

--- a/from_cpython/Lib/test/test_poplib.py
+++ b/from_cpython/Lib/test/test_poplib.py
@@ -1,4 +1,3 @@
-# expected: fail
 """Test script for poplib module."""
 
 # Modified by Giampaolo Rodola' to give poplib.POP3 and poplib.POP3_SSL

--- a/from_cpython/Lib/test/test_ssl.py
+++ b/from_cpython/Lib/test/test_ssl.py
@@ -1,4 +1,3 @@
-# expected: fail
 # Test the support for SSL and sockets
 
 import sys

--- a/from_cpython/Lib/test/test_telnetlib.py
+++ b/from_cpython/Lib/test/test_telnetlib.py
@@ -1,4 +1,3 @@
-# expected: fail
 import socket
 import telnetlib
 import time

--- a/from_cpython/Lib/test/test_urllib2net.py
+++ b/from_cpython/Lib/test/test_urllib2net.py
@@ -1,4 +1,3 @@
-# expected: fail
 import unittest
 from test import test_support
 from test.test_urllib2 import sanepathname2url

--- a/from_cpython/Lib/test/test_urllibnet.py
+++ b/from_cpython/Lib/test/test_urllibnet.py
@@ -1,4 +1,3 @@
-# expected: fail
 import unittest
 from test import test_support
 

--- a/from_cpython/Lib/urllib2.py
+++ b/from_cpython/Lib/urllib2.py
@@ -1200,6 +1200,11 @@ class AbstractHTTPHandler(BaseHandler):
         # out of socket._fileobject() and into a base class.
 
         r.recv = r.read
+
+        # Pyston change: socket close: add refcounting similar to pypys approach
+        r._reuse = lambda: None
+        r._drop = lambda: None
+
         fp = socket._fileobject(r, close=True)
 
         resp = addinfourl(fp, r.msg, req.get_full_url())

--- a/from_cpython/Modules/socketmodule.h
+++ b/from_cpython/Modules/socketmodule.h
@@ -132,6 +132,9 @@ typedef struct {
                                         sets a Python exception */
     double sock_timeout;                 /* Operation timeout in seconds;
                                         0.0 means non-blocking */
+
+    // Pyston change: socket close: add refcounting similar to pypys approach
+    int close_ref_count;
 } PySocketSockObject;
 
 /* --- C API ----------------------------------------------------*/

--- a/src/jit.cpp
+++ b/src/jit.cpp
@@ -379,6 +379,16 @@ static int main(int argc, char** argv) {
             setvbuf(stderr, (char*)NULL, _IONBF, BUFSIZ);
         }
 
+#ifdef SIGPIPE
+        PyOS_setsig(SIGPIPE, SIG_IGN);
+#endif
+#ifdef SIGXFZ
+        PyOS_setsig(SIGXFZ, SIG_IGN);
+#endif
+#ifdef SIGXFSZ
+        PyOS_setsig(SIGXFSZ, SIG_IGN);
+#endif
+
         if (ASSEMBLY_LOGGING) {
             assembler::disassemblyInitialize();
         }

--- a/test/CPYTHON_TEST_NOTES.md
+++ b/test/CPYTHON_TEST_NOTES.md
@@ -24,8 +24,6 @@ test_al                 No module named al
 test_applesingle        Not really a failure, but it tries to skip itself and we don't support that
 test_argparse           [unknown]
 test_ascii_formatd      segfault in ctypes (but only on CI)
-test_asynchat           [unknown]
-test_asyncore           [unknown]
 test_atexit             [unknown]
 test_audioop            [unknown]
 test_bigmem             [unknown]
@@ -96,7 +94,6 @@ test_file_eintr         not sure
 test_fileio             [unknown]
 test_fork1              [unknown]
 test_frozen             [unknown]
-test_ftplib             [unknown]
 test_funcattrs          we don't allow changing numing of function defaults
 test_functools          unknown errors
 test_future5            [unknown]
@@ -112,7 +109,6 @@ test_gl                 [unknown]
 test_grammar            bug in our tokenizer
 test_heapq              [unknown]
 test_hotshot            [unknown]
-test_httplib            [unknown]
 test_httpservers        [unknown]
 test_idle               [unknown]
 test_imageop            [unknown]
@@ -155,7 +151,6 @@ test_pep352             various unique bugs
 test_pickletools        [unknown]
 test_pickle             unknown
 test_pkg                unknown bug
-test_poplib             SSLError (but only on CI)
 test_pprint             [unknown]
 test_profile            [unknown]
 test_py3kwarn           [unknown]
@@ -173,11 +168,10 @@ test_scope              eval of code object from existing function (not currentl
 test_scriptpackages     [unknown]
 test_shelve             [unknown]
 test_site               [unknown]
-test_socketserver       [unknown]
+test_socketserver       missing imp.lock_held, otherwise works
 test_socket             [unknown]
 test_sort               argument specification issue in listSort?
 test_sqlite             [unknown]
-test_ssl                [unknown]
 test_startfile          [unknown]
 test_str                memory leak?
 test_structmembers      [unknown]
@@ -194,7 +188,6 @@ test_sys_settrace       [unknown]
 test_sys                [unknown]
 test_tarfile            [unknown]
 test_tcl                [unknown]
-test_telnetlib          [unknown]
 test_tempfile           [unknown]
 test_threaded_import    [unknown]
 test_threading_local    [unknown]
@@ -217,8 +210,6 @@ test_unicode_file       exit code 139, no error message
 test_unittest           serialize_ast assert
 test_univnewlines2k     [unknown]
 test_univnewlines       [unknown]
-test_urllib2net         [unknown]
-test_urllibnet          [unknown]
 test_userdict           segfault: repr of recursive dict?
 test_userlist           slice(1L, 1L)
 test_userstring         float(1L); hangs in test_replace

--- a/test/cpython/badcert.pem
+++ b/test/cpython/badcert.pem
@@ -1,0 +1,1 @@
+../../from_cpython/Lib/test/badcert.pem

--- a/test/cpython/badkey.pem
+++ b/test/cpython/badkey.pem
@@ -1,0 +1,1 @@
+../../from_cpython/Lib/test/badkey.pem

--- a/test/cpython/https_svn_python_org_root.pem
+++ b/test/cpython/https_svn_python_org_root.pem
@@ -1,0 +1,1 @@
+../../from_cpython/Lib/test/https_svn_python_org_root.pem

--- a/test/cpython/keycert.pem
+++ b/test/cpython/keycert.pem
@@ -1,0 +1,1 @@
+../../from_cpython/Lib/test/keycert.pem

--- a/test/cpython/nokia.pem
+++ b/test/cpython/nokia.pem
@@ -1,0 +1,1 @@
+../../from_cpython/Lib/test/nokia.pem

--- a/test/cpython/nullbytecert.pem
+++ b/test/cpython/nullbytecert.pem
@@ -1,0 +1,1 @@
+../../from_cpython/Lib/test/nullbytecert.pem

--- a/test/cpython/nullcert.pem
+++ b/test/cpython/nullcert.pem
@@ -1,0 +1,1 @@
+../../from_cpython/Lib/test/nullcert.pem

--- a/test/cpython/sha256.pem
+++ b/test/cpython/sha256.pem
@@ -1,0 +1,1 @@
+../../from_cpython/Lib/test/sha256.pem

--- a/test/cpython/wrongcert.pem
+++ b/test/cpython/wrongcert.pem
@@ -1,0 +1,1 @@
+../../from_cpython/Lib/test/wrongcert.pem

--- a/test/extra/M2Crypto_patch.patch
+++ b/test/extra/M2Crypto_patch.patch
@@ -20,4 +20,18 @@ diff -ur M2Crypto-0.21.1.orig/SWIG/_lib.i ./SWIG/_lib.i
              new_style_callback = 1;
          }    
      } else {
-
+diff -ur M2Crypto-0.21.1/M2Crypto/m2urllib2.py ./M2Crypto/m2urllib2.py
+--- M2Crypto-0.21.1/M2Crypto/m2urllib2.py	2011-01-15 19:10:05.000000000 +0000
++++ ./M2Crypto/m2urllib2.py	2016-02-10 14:36:12.091812337 +0000
+@@ -97,6 +97,11 @@
+         # out of socket._fileobject() and into a base class.
+ 
+         r.recv = r.read
++
++        # Pyston change: our socket implementation needs this functions
++        r._reuse = lambda: None
++        r._drop = lambda: None
++
+         fp = _closing_fileobject(r)
+ 
+         resp = addinfourl(fp, r.msg, req.get_full_url())


### PR DESCRIPTION
The socket implementation used to only call close on a socket when all references where gone.
This works fine for cpython which uses reference counting but for pyston (and pypy) this is a problem.
This works around the problem in a similar way as pypy does.
It also uses the same method names so that 3th party libs which already support pypy will automatically work with pyston too.
(e.g. urllib3)

I would prefer if we get ref counting but meanwhile this improves the situation a lot. (While I'm not sure if this does not break other stuff but I would prefer to not spend to much time on this now if it may get replaced soon)