### PR TITLE
Add a ReturnConvention for getattrs that can C++ throw

### DIFF
--- a/src/capi/typeobject.cpp
+++ b/src/capi/typeobject.cpp
@@ -1013,6 +1013,8 @@ Box* slotTpGetattrHookInternal(Box* self, BoxedString* name, GetattrRewriteArgs*
                     return res;
                 } else if (return_convention == ReturnConvention::NO_RETURN) {
                     assert(!res);
+                } else if (return_convention == ReturnConvention::MAYBE_EXC) {
+                    rewrite_args = NULL;
                 } else if (return_convention == ReturnConvention::CAPI_RETURN
                            || return_convention == ReturnConvention::NOEXC_POSSIBLE) {
                     // If we get a CAPI return, we probably did a function call, and these guards

--- a/src/runtime/builtin_modules/builtins.cpp
+++ b/src/runtime/builtin_modules/builtins.cpp
@@ -576,8 +576,17 @@ Box* getattrFuncInternal(BoxedFunctionBase* func, CallRewriteArgs* rewrite_args,
             std::tie(r_rtn, return_convention) = grewrite_args.getReturn();
 
             // Convert to NOEXC_POSSIBLE:
-            if (return_convention == ReturnConvention::NO_RETURN)
+            if (return_convention == ReturnConvention::NO_RETURN) {
+                return_convention = ReturnConvention::NOEXC_POSSIBLE;
                 r_rtn = rewrite_args->rewriter->loadConst(0);
+            } else if (return_convention == ReturnConvention::MAYBE_EXC) {
+                if (default_value)
+                    rewrite_args = NULL;
+            }
+            assert(!rewrite_args || return_convention == ReturnConvention::NOEXC_POSSIBLE
+                   || return_convention == ReturnConvention::HAS_RETURN
+                   || return_convention == ReturnConvention::CAPI_RETURN
+                   || (default_value == NULL && return_convention == ReturnConvention::MAYBE_EXC));
         }
     } else {
         rtn = getattrInternal<CAPI>(obj, str);
@@ -687,8 +696,15 @@ Box* hasattrFuncInternal(BoxedFunctionBase* func, CallRewriteArgs* rewrite_args,
             std::tie(r_rtn, return_convention) = grewrite_args.getReturn();
 
             // Convert to NOEXC_POSSIBLE:
-            if (return_convention == ReturnConvention::NO_RETURN)
+            if (return_convention == ReturnConvention::NO_RETURN) {
+                return_convention = ReturnConvention::NOEXC_POSSIBLE;
                 r_rtn = rewrite_args->rewriter->loadConst(0);
+            } else if (return_convention == ReturnConvention::MAYBE_EXC) {
+                rewrite_args = NULL;
+            }
+            assert(!rewrite_args || return_convention == ReturnConvention::NOEXC_POSSIBLE
+                   || return_convention == ReturnConvention::HAS_RETURN
+                   || return_convention == ReturnConvention::CAPI_RETURN);
         }
     } else {
         rtn = getattrInternal<CAPI>(obj, str);

--- a/src/runtime/rewrite_args.h
+++ b/src/runtime/rewrite_args.h
@@ -49,6 +49,7 @@ enum class ReturnConvention {
     NO_RETURN,
     CAPI_RETURN,
     NOEXC_POSSIBLE,
+    MAYBE_EXC,
 };
 
 class _ReturnConventionBase {
@@ -99,6 +100,8 @@ public:
                     assert(!PyErr_Occurred());
                 } else if (r == ReturnConvention::CAPI_RETURN) {
                     assert((bool)b ^ (bool)PyErr_Occurred());
+                } else if (r == ReturnConvention::MAYBE_EXC) {
+                    assert(b);
                 } else {
                     assert(r == ReturnConvention::NOEXC_POSSIBLE);
                 }

--- a/test/tests/getattr_start_failing_test.py
+++ b/test/tests/getattr_start_failing_test.py
@@ -1,0 +1,16 @@
+g = 0
+class C(object):
+    @property
+    def f(self):
+        print "f"
+        if g:
+            raise AttributeError()
+
+c = C()
+
+for i in xrange(100):
+    print i, getattr(c, 'f', 0)
+
+    if i == 50:
+        g = 1
+


### PR DESCRIPTION
Otherwise callers have no way of knowing if an exception might
occur in the rewritten code, and they'd have to conservatively
not rewrite those cases (such as 3-arg getattr).

Well, previously getattr() wasn't doing that, so it would rewrite
itself correctly for a descriptor that is not throwing now, but would
start throwing later (those exceptions would get propagated instead
of being caught by getattr).