### PR TITLE
bjit: microptimization use r13 instead of r12 for the interpreter pointer

### DIFF
--- a/src/codegen/baseline_jit.h
+++ b/src/codegen/baseline_jit.h
@@ -70,7 +70,7 @@ class JitFragmentWriter;
 // register or stack slot but we aren't if it outlives the block - we have to store it in the interpreter instance.
 //
 // We use the following callee-save regs to speed up the generated code:
-//      r12: pointer to ASTInterpreter instance
+//      r13: pointer to ASTInterpreter instance
 //      r14: pointer to the vregs array
 //
 // To execute a specific CFGBlock one has to call:
@@ -91,10 +91,10 @@ class JitFragmentWriter;
 // Basic layout of generated code block is:
 // entry_code:
 //      push   %r14                 ; save r14
-//      push   %r12                 ; save r12
+//      push   %r13                 ; save r13
 //      sub    $0x118,%rsp          ; setup scratch, 0x118 = scratch_size + 16 = space for two func args passed on the
 //                                                                               stack + 8 byte for stack alignment
-//      mov    %rdi,%r12            ; copy the pointer to ASTInterpreter instance into r12
+//      mov    %rdi,%r13            ; copy the pointer to ASTInterpreter instance into r13
 //      mov    %rdx,%r14            ; copy the pointer to the vregs array into r14
 //      jmpq   *0x8(%rsi)           ; jump to block->code
 //                                      possible values: first_JitFragment, second_JitFragment,...
@@ -107,7 +107,7 @@ class JitFragmentWriter;
 //      jne    end_side_exit
 //      movabs $0x215bb60,%rax      ; rax = CFGBlock* to interpret next (rax is the 1. return reg)
 //      add    $0x118,%rsp          ; restore stack pointer
-//      pop    %r12                 ; restore r12
+//      pop    %r13                 ; restore r13
 //      pop    %r14                 ; restore r14
 //      ret                         ; exit to the interpreter which will interpret the specified CFGBLock*
 //    end_side_exit:
@@ -120,7 +120,7 @@ class JitFragmentWriter;
 //                                    in this case 0 which means we are finished
 //      movabs $0x1270014108,%rdx   ; rdx must contain the Box* value to return
 //      add    $0x118,%rsp          ; restore stack pointer
-//      pop    %r12                 ; restore r12
+//      pop    %r13                 ; restore r13
 //      pop    %r14                 ; restore r14
 //      ret
 //


### PR DESCRIPTION
saves a few bytes because r12 requires the SIB byte
django_template bjit bytes emitted shrinks from 3016247 to 3006353