### PR TITLE
Fix a llvm-tier getiter() bug

### DIFF
--- a/src/codegen/compvars.cpp
+++ b/src/codegen/compvars.cpp
@@ -1993,8 +1993,16 @@ public:
                                const std::vector<BoxedString*>* keyword_names) override {
         ExceptionStyle exception_style = info.preferredExceptionStyle();
 
+        bool no_attribute = false;
+        bool* no_attribute_ptr = NULL;
+        if (flags.null_on_nonexistent)
+            no_attribute_ptr = &no_attribute;
+
         CompilerVariable* called_constant = tryCallattrConstant(emitter, info, var, attr, flags.cls_only, flags.argspec,
-                                                                args, keyword_names, NULL, exception_style);
+                                                                args, keyword_names, no_attribute_ptr, exception_style);
+
+        if (no_attribute)
+            return new ConcreteCompilerVariable(UNKNOWN, getNullPtr(g.llvm_value_type_ptr), 1);
 
         if (called_constant)
             return called_constant;

--- a/test/tests/unicode_iteration.py
+++ b/test/tests/unicode_iteration.py
@@ -1,0 +1,5 @@
+def f():
+    u = u'aoeu'
+    for c in u:
+        print repr(c)
+f()


### PR DESCRIPTION
If we find a type that
- we think we can reason about statically
- does not have an `__iter__` but can be iterated via `__getitem__`

we previously just bailed saying that we know it doesn't have an `__iter__` method
(instead of calling getiterHelper like we should).  I think we've always had this,
we've just never run into it until testing the refcounting in llvm-only mode.