### PR TITLE
cleanup abandon generators

### DIFF
--- a/from_cpython/Lib/test/test_abc.py
+++ b/from_cpython/Lib/test/test_abc.py
@@ -1,5 +1,3 @@
-# expected: reffail
-# - generator abandonment
 # Copyright 2007 Google, Inc. All Rights Reserved.
 # Licensed to PSF under a Contributor Agreement.
 

--- a/from_cpython/Lib/test/test_abstract_numbers.py
+++ b/from_cpython/Lib/test/test_abstract_numbers.py
@@ -1,5 +1,3 @@
-# expected: reffail
-# - generator abandonment
 """Unit tests for numbers.py."""
 
 import math

--- a/from_cpython/Lib/test/test_ast.py
+++ b/from_cpython/Lib/test/test_ast.py
@@ -1,5 +1,3 @@
-# expected: reffail
-# - generator abandonment
 import sys, itertools, unittest
 from test import test_support
 import ast

--- a/from_cpython/Lib/test/test_collections.py
+++ b/from_cpython/Lib/test/test_collections.py
@@ -1,5 +1,4 @@
 # expected: reffail
-# - generator abandonment
 import unittest, doctest, operator
 import inspect
 from test import test_support

--- a/from_cpython/Lib/test/test_contextlib.py
+++ b/from_cpython/Lib/test/test_contextlib.py
@@ -1,5 +1,3 @@
-# expected: reffail
-# - generator abandonment
 """Unit tests for contextlib.py, and other context managers."""
 
 import sys

--- a/from_cpython/Lib/test/test_cpickle.py
+++ b/from_cpython/Lib/test/test_cpickle.py
@@ -1,5 +1,3 @@
-# expected: reffail
-# - generator abandonment
 import cPickle
 import cStringIO
 import io

--- a/from_cpython/Lib/test/test_decimal.py
+++ b/from_cpython/Lib/test/test_decimal.py
@@ -1,5 +1,4 @@
 # expected: reffail
-# - generator abandonment
 # Copyright (c) 2004 Python Software Foundation.
 # All rights reserved.
 

--- a/from_cpython/Lib/test/test_file.py
+++ b/from_cpython/Lib/test/test_file.py
@@ -1,5 +1,3 @@
-# expected: reffail
-# - generator abandonment
 # NOTE: this file tests the new `io` library backported from Python 3.x.
 # Similar tests for the builtin file object can be found in test_file2k.py.
 

--- a/from_cpython/Lib/test/test_float.py
+++ b/from_cpython/Lib/test/test_float.py
@@ -1,5 +1,3 @@
-# expected: reffail
-# - generator abandonment
 import unittest, struct
 import os
 from test import test_support

--- a/from_cpython/Lib/test/test_fractions.py
+++ b/from_cpython/Lib/test/test_fractions.py
@@ -1,5 +1,3 @@
-# expected: reffail
-# - generator abandonment
 """Tests for Lib/fractions.py."""
 
 from decimal import Decimal

--- a/from_cpython/Lib/test/test_locale.py
+++ b/from_cpython/Lib/test/test_locale.py
@@ -1,5 +1,3 @@
-# expected: reffail
-# - generator abandonment
 from test.test_support import run_unittest, verbose
 import unittest
 import locale

--- a/from_cpython/Lib/test/test_mailbox.py
+++ b/from_cpython/Lib/test/test_mailbox.py
@@ -1,5 +1,3 @@
-# expected: reffail
-# - generator abandonment
 import os
 import sys
 import time

--- a/from_cpython/Lib/test/test_pickle.py
+++ b/from_cpython/Lib/test/test_pickle.py
@@ -1,5 +1,3 @@
-# expected: reffail
-# - generator abandonment
 import pickle
 from cStringIO import StringIO
 

--- a/from_cpython/Lib/test/test_pickletools.py
+++ b/from_cpython/Lib/test/test_pickletools.py
@@ -1,5 +1,3 @@
-# expected: reffail
-# - generator abandonment
 import pickle
 import pickletools
 from test import test_support

--- a/from_cpython/Lib/test/test_pkgutil.py
+++ b/from_cpython/Lib/test/test_pkgutil.py
@@ -1,5 +1,3 @@
-# expected: reffail
-# - generator abandonment
 from test.test_support import run_unittest
 import unittest
 import sys

--- a/from_cpython/Lib/test/test_quopri.py
+++ b/from_cpython/Lib/test/test_quopri.py
@@ -1,5 +1,3 @@
-# expected: reffail
-# - generator abandonment
 from test import test_support
 import unittest
 

--- a/from_cpython/Lib/test/test_robotparser.py
+++ b/from_cpython/Lib/test/test_robotparser.py
@@ -1,5 +1,3 @@
-# expected: reffail
-# - generator abandonment
 import unittest, StringIO, robotparser
 from test import test_support
 from urllib2 import urlopen, HTTPError

--- a/from_cpython/Lib/test/test_typechecks.py
+++ b/from_cpython/Lib/test/test_typechecks.py
@@ -1,5 +1,3 @@
-# expected: reffail
-# - generator abandonment
 """Unit tests for __instancecheck__ and __subclasscheck__."""
 
 import unittest

--- a/from_cpython/Lib/test/test_urllib.py
+++ b/from_cpython/Lib/test/test_urllib.py
@@ -1,5 +1,3 @@
-# expected: reffail
-# - generator abandonment
 """Regresssion tests for urllib"""
 
 import urllib

--- a/from_cpython/Lib/test/test_urllib2.py
+++ b/from_cpython/Lib/test/test_urllib2.py
@@ -1,5 +1,3 @@
-# expected: reffail
-# - generator abandonment
 import unittest
 from test import test_support
 

--- a/from_cpython/Lib/test/test_urllib2net.py
+++ b/from_cpython/Lib/test/test_urllib2net.py
@@ -1,5 +1,3 @@
-# expected: reffail
-# - generator abandonment
 import unittest
 from test import test_support
 from test.test_urllib2 import sanepathname2url

--- a/from_cpython/Lib/test/test_urlparse.py
+++ b/from_cpython/Lib/test/test_urlparse.py
@@ -1,5 +1,3 @@
-# expected: reffail
-# - generator abandonment
 from test import test_support
 import unittest
 import urlparse

--- a/from_cpython/Lib/test/test_with.py
+++ b/from_cpython/Lib/test/test_with.py
@@ -1,5 +1,3 @@
-# expected: reffail
-# - generator abandonment
 """Unit tests for the with statement specified in PEP 343."""
 
 

--- a/from_cpython/Lib/test/test_xrange.py
+++ b/from_cpython/Lib/test/test_xrange.py
@@ -1,5 +1,3 @@
-# expected: reffail
-# - generator abandonment
 # Python test set -- built-in functions
 
 import test.test_support, unittest

--- a/src/codegen/ast_interpreter.cpp
+++ b/src/codegen/ast_interpreter.cpp
@@ -785,8 +785,10 @@ Box* ASTInterpreter::doOSR(AST_Jump* node) {
         return nullptr;
     }
 
-    if (generator)
-        sorted_symbol_table[source_info->getInternedStrings().get(PASSED_GENERATOR_NAME)] = incref(generator);
+    if (generator) {
+        // generated is only borrowed in order to not introduce cycles
+        sorted_symbol_table[source_info->getInternedStrings().get(PASSED_GENERATOR_NAME)] = generator;
+    }
 
     if (frame_info.passed_closure)
         sorted_symbol_table[source_info->getInternedStrings().get(PASSED_CLOSURE_NAME)]

--- a/src/codegen/ast_interpreter.cpp
+++ b/src/codegen/ast_interpreter.cpp
@@ -993,7 +993,6 @@ Value ASTInterpreter::visit_langPrimitive(AST_LangPrimitive* node) {
 
 Value ASTInterpreter::visit_yield(AST_Yield* node) {
     Value value = node->value ? visit_expr(node->value) : getNone();
-    AUTO_DECREF(value.o);
     assert(generator && generator->cls == generator_cls);
 
     return Value(yield(generator, value.o), jit ? jit->emitYield(value) : NULL);

--- a/src/codegen/ast_interpreter.h
+++ b/src/codegen/ast_interpreter.h
@@ -79,7 +79,7 @@ Box* astInterpretFunction(FunctionMetadata* f, Box* closure, Box* generator, Box
 Box* astInterpretFunctionEval(FunctionMetadata* cf, Box* globals, Box* boxedLocals);
 // this function is implemented in the src/codegen/ast_interpreter_exec.S assembler file
 extern "C" Box* astInterpretDeopt(FunctionMetadata* cf, AST_expr* after_expr, AST_stmt* enclosing_stmt, Box* expr_val,
-                                  FrameStackState frame_state);
+                                  STOLEN(FrameStackState) frame_state);
 
 struct FrameInfo;
 FrameInfo* getFrameInfoForInterpretedFrame(void* frame_ptr);

--- a/src/codegen/baseline_jit.cpp
+++ b/src/codegen/baseline_jit.cpp
@@ -537,7 +537,9 @@ std::vector<RewriterVar*> JitFragmentWriter::emitUnpackIntoArray(RewriterVar* v,
 
 RewriterVar* JitFragmentWriter::emitYield(RewriterVar* v) {
     RewriterVar* generator = getInterp()->getAttr(ASTInterpreterJitInterface::getGeneratorOffset());
-    return call(false, (void*)yield, generator, v)->setType(RefType::OWNED);
+    auto rtn = call(false, (void*)yield, generator, v)->setType(RefType::OWNED);
+    v->refConsumed();
+    return rtn;
 }
 
 void JitFragmentWriter::emitDelAttr(RewriterVar* target, BoxedString* attr) {

--- a/src/codegen/baseline_jit.cpp
+++ b/src/codegen/baseline_jit.cpp
@@ -537,7 +537,9 @@ std::vector<RewriterVar*> JitFragmentWriter::emitUnpackIntoArray(RewriterVar* v,
 
 RewriterVar* JitFragmentWriter::emitYield(RewriterVar* v) {
     RewriterVar* generator = getInterp()->getAttr(ASTInterpreterJitInterface::getGeneratorOffset());
-    auto rtn = call(false, (void*)yield, generator, v)->setType(RefType::OWNED);
+    static_assert(sizeof(llvm::ArrayRef<Box*>) == sizeof(void*) * 2,
+                  "we pass two 0ul args to initalize the llvm::ArrayRef");
+    auto rtn = call(false, (void*)yield, generator, v, imm(0ul), imm(0ul))->setType(RefType::OWNED);
     v->refConsumed();
     return rtn;
 }

--- a/src/codegen/irgen.cpp
+++ b/src/codegen/irgen.cpp
@@ -655,8 +655,10 @@ static void emitBBs(IRGenState* irstate, TypeAnalysis* types, const OSREntryDesc
             if (source->getScopeInfo()->takesClosure())
                 names.insert(source->getInternedStrings().get(PASSED_CLOSURE_NAME));
 
-            if (source->is_generator)
+            if (source->is_generator) {
+                assert(0 && "not sure if this is correct");
                 names.insert(source->getInternedStrings().get(PASSED_GENERATOR_NAME));
+            }
 
             for (const InternedString& s : names) {
                 // printf("adding guessed phi for %s\n", s.c_str());

--- a/src/codegen/irgen.cpp
+++ b/src/codegen/irgen.cpp
@@ -299,6 +299,13 @@ static ConcreteCompilerType* getTypeAtBlockStart(TypeAnalysis* types, InternedSt
         return types->getTypeAtBlockStart(name, block);
 }
 
+static bool shouldPhisOwnThisSym(llvm::StringRef name) {
+    // generating unnecessary increfs to the passed generator would introduce cycles inside the generator
+    if (name == PASSED_GENERATOR_NAME)
+        return false;
+    return true;
+}
+
 llvm::Value* handlePotentiallyUndefined(ConcreteCompilerVariable* is_defined_var, llvm::Type* rtn_type,
                                         llvm::BasicBlock*& cur_block, IREmitter& emitter, bool speculate_undefined,
                                         std::function<llvm::Value*(IREmitter&)> when_defined,
@@ -624,7 +631,8 @@ static void emitBBs(IRGenState* irstate, TypeAnalysis* types, const OSREntryDesc
                 llvm::PHINode* phi = emitter->getBuilder()->CreatePHI(analyzed_type->llvmType(),
                                                                       block->predecessors.size() + 1, p.first.s());
                 if (analyzed_type->getBoxType() == analyzed_type) {
-                    irstate->getRefcounts()->setType(phi, RefType::OWNED);
+                    RefType type = shouldPhisOwnThisSym(p.first.s()) ? RefType::OWNED : RefType::BORROWED;
+                    irstate->getRefcounts()->setType(phi, type);
                 }
                 ConcreteCompilerVariable* var = new ConcreteCompilerVariable(analyzed_type, phi);
                 generator->giveLocalSymbol(p.first, var);
@@ -665,8 +673,10 @@ static void emitBBs(IRGenState* irstate, TypeAnalysis* types, const OSREntryDesc
                 ConcreteCompilerType* type = getTypeAtBlockStart(types, s, block);
                 llvm::PHINode* phi
                     = emitter->getBuilder()->CreatePHI(type->llvmType(), block->predecessors.size(), s.s());
-                if (type->getBoxType() == type)
-                    irstate->getRefcounts()->setType(phi, RefType::OWNED);
+                if (type->getBoxType() == type) {
+                    RefType type = shouldPhisOwnThisSym(s.s()) ? RefType::OWNED : RefType::BORROWED;
+                    irstate->getRefcounts()->setType(phi, type);
+                }
                 ConcreteCompilerVariable* var = new ConcreteCompilerVariable(type, phi);
                 generator->giveLocalSymbol(s, var);
 
@@ -766,8 +776,10 @@ static void emitBBs(IRGenState* irstate, TypeAnalysis* types, const OSREntryDesc
                     // printf("block %d: adding phi for %s from pred %d\n", block->idx, name.c_str(), pred->idx);
                     llvm::PHINode* phi = emitter->getBuilder()->CreatePHI(cv->getType()->llvmType(),
                                                                           block->predecessors.size(), name.s());
-                    if (cv->getType()->getBoxType() == cv->getType())
-                        irstate->getRefcounts()->setType(phi, RefType::OWNED);
+                    if (cv->getType()->getBoxType() == cv->getType()) {
+                        RefType type = shouldPhisOwnThisSym(name.s()) ? RefType::OWNED : RefType::BORROWED;
+                        irstate->getRefcounts()->setType(phi, type);
+                    }
                     // emitter->getBuilder()->CreateCall(g.funcs.dump, phi);
                     ConcreteCompilerVariable* var = new ConcreteCompilerVariable(cv->getType(), phi);
                     generator->giveLocalSymbol(name, var);
@@ -875,7 +887,7 @@ static void emitBBs(IRGenState* irstate, TypeAnalysis* types, const OSREntryDesc
                 llvm::Value* val = v->getValue();
                 llvm_phi->addIncoming(v->getValue(), llvm_exit_blocks[b->predecessors[j]]);
 
-                if (v->getType()->getBoxType() == v->getType()) {
+                if (v->getType()->getBoxType() == v->getType() && shouldPhisOwnThisSym(it->first.s())) {
                     // llvm::outs() << *v->getValue() << " is getting consumed by phi " << *llvm_phi << '\n';
                     assert(llvm::isa<llvm::BranchInst>(terminator));
                     irstate->getRefcounts()->refConsumed(v->getValue(), terminator);

--- a/src/codegen/irgen/irgenerator.cpp
+++ b/src/codegen/irgen/irgenerator.cpp
@@ -1544,8 +1544,9 @@ private:
         CompilerVariable* value = node->value ? evalExpr(node->value, unw_info) : emitter.getNone();
         ConcreteCompilerVariable* convertedValue = value->makeConverted(emitter, value->getBoxType());
 
-        llvm::Value* rtn
+        llvm::Instruction* rtn
             = emitter.createCall2(unw_info, g.funcs.yield, convertedGenerator->getValue(), convertedValue->getValue());
+        emitter.refConsumed(convertedValue->getValue(), rtn);
         emitter.setType(rtn, RefType::OWNED);
 
         return new ConcreteCompilerVariable(UNKNOWN, rtn);

--- a/src/codegen/irgen/irgenerator.cpp
+++ b/src/codegen/irgen/irgenerator.cpp
@@ -1540,14 +1540,26 @@ private:
         assert(generator);
         ConcreteCompilerVariable* convertedGenerator = generator->makeConverted(emitter, generator->getBoxType());
 
-
         CompilerVariable* value = node->value ? evalExpr(node->value, unw_info) : emitter.getNone();
         ConcreteCompilerVariable* convertedValue = value->makeConverted(emitter, value->getBoxType());
 
+        std::vector<llvm::Value*> args;
+        args.push_back(convertedGenerator->getValue());
+        args.push_back(convertedValue->getValue());
+        args.push_back(getConstantInt(0, g.i32)); // the refcounting inserter handles yields specially and adds all
+                                                  // owned objects as additional arguments to it
+
+        // put the yield call at the beginning of a new basic block to make it easier for the refcounting inserter.
+        llvm::BasicBlock* yield_block = emitter.createBasicBlock("yield_block");
+        emitter.getBuilder()->CreateBr(yield_block);
+        emitter.setCurrentBasicBlock(yield_block);
+
+        // we do a capi call because it makes it easier for the refcounter to replace the instruction
         llvm::Instruction* rtn
-            = emitter.createCall2(unw_info, g.funcs.yield, convertedGenerator->getValue(), convertedValue->getValue());
+            = emitter.createCall(unw_info, g.funcs.yield_capi, args, CAPI, getNullPtr(g.llvm_value_type_ptr));
         emitter.refConsumed(convertedValue->getValue(), rtn);
         emitter.setType(rtn, RefType::OWNED);
+        emitter.setNullable(rtn, true);
 
         return new ConcreteCompilerVariable(UNKNOWN, rtn);
     }

--- a/src/codegen/runtime_hooks.cpp
+++ b/src/codegen/runtime_hooks.cpp
@@ -225,7 +225,7 @@ void initGlobalFuncs(GlobalState& g) {
     GET(importStar);
     GET(repr);
     GET(exceptionMatches);
-    GET(yield);
+    GET(yield_capi);
     GET(getiterHelper);
     GET(hasnext);
     GET(apply_slice);

--- a/src/codegen/runtime_hooks.h
+++ b/src/codegen/runtime_hooks.h
@@ -38,7 +38,8 @@ struct GlobalFuncs {
         *makePendingCalls, *setFrameExcInfo;
     llvm::Value* getattr, *getattr_capi, *setattr, *delattr, *delitem, *delGlobal, *nonzero, *binop, *compare,
         *augbinop, *unboxedLen, *getitem, *getitem_capi, *getclsattr, *getGlobal, *setitem, *unaryop, *import,
-        *importFrom, *importStar, *repr, *exceptionMatches, *yield, *getiterHelper, *hasnext, *setGlobal, *apply_slice;
+        *importFrom, *importStar, *repr, *exceptionMatches, *yield_capi, *getiterHelper, *hasnext, *setGlobal,
+        *apply_slice;
 
     llvm::Value* unpackIntoArray, *raiseAttributeError, *raiseAttributeErrorStr, *raiseAttributeErrorCapi,
         *raiseAttributeErrorStrCapi, *raiseNotIterableError, *raiseIndexErrorStr, *raiseIndexErrorStrCapi,

--- a/src/codegen/unwinding.cpp
+++ b/src/codegen/unwinding.cpp
@@ -462,6 +462,9 @@ bool frameIsPythonFrame(unw_word_t ip, unw_word_t bp, unw_cursor_t* cursor, Pyth
         }
     }
 
+    if (info->getFrameInfo()->isDisabledFrame())
+        return false;
+
     return true;
 }
 

--- a/src/codegen/unwinding.h
+++ b/src/codegen/unwinding.h
@@ -33,6 +33,7 @@ struct FrameInfo;
 void registerDynamicEhFrame(uint64_t code_addr, size_t code_size, uint64_t eh_frame_addr, size_t eh_frame_size);
 uint64_t getCXXUnwindSymbolAddress(llvm::StringRef sym);
 bool isUnwinding(); // use this instead of std::uncaught_exception
+void setUnwinding(bool);
 
 void setupUnwinding();
 BORROWED(BoxedModule*) getCurrentModule();

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -23,6 +23,7 @@
 #include <stddef.h>
 #include <vector>
 
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/iterator_range.h"
 #include "Python.h"
 

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -1056,6 +1056,7 @@ struct FrameInfo {
     // Calling disableDeinit makes future deinitFrameMaybe() frames not call deinitFrame().
     // For use by deopt(), which takes over deinit responsibility for its caller.
     void disableDeinit(FrameInfo* replacement_frame);
+    bool isDisabledFrame() const { return back == NO_DEINIT; }
 
     FrameInfo(ExcInfo exc)
         : exc(exc),

--- a/src/runtime/cxx_unwind.cpp
+++ b/src/runtime/cxx_unwind.cpp
@@ -95,6 +95,11 @@ bool isUnwinding() {
     return is_unwinding;
 }
 
+void setUnwinding(bool b) {
+    assert(!in_cleanup_code);
+    is_unwinding = b;
+}
+
 extern "C" {
 
 static NORETURN void panic(void) {

--- a/src/runtime/frame.cpp
+++ b/src/runtime/frame.cpp
@@ -247,17 +247,18 @@ void FrameInfo::disableDeinit(FrameInfo* replacement_frame) {
 
     // Kinda hacky but maybe worth it to not store any extra bits:
     back = NO_DEINIT;
+    assert(isDisabledFrame());
 }
 
 extern "C" void deinitFrameMaybe(FrameInfo* frame_info) {
     // Note: this has to match FrameInfo::disableDeinit
-    if (frame_info->back != FrameInfo::NO_DEINIT)
+    if (!frame_info->isDisabledFrame())
         deinitFrame(frame_info);
 }
 
 extern "C" void deinitFrame(FrameInfo* frame_info) {
     // This can fire if we have a call to deinitFrame() that should be to deinitFrameMaybe() instead
-    assert(frame_info->back != FrameInfo::NO_DEINIT);
+    assert(!frame_info->isDisabledFrame());
 
     assert(cur_thread_state.frame_info == frame_info);
     cur_thread_state.frame_info = frame_info->back;

--- a/src/runtime/generator.cpp
+++ b/src/runtime/generator.cpp
@@ -332,13 +332,13 @@ Box* generatorHasnext(Box* s) {
 }
 
 
-extern "C" Box* yield(BoxedGenerator* obj, Box* value) {
+extern "C" Box* yield(BoxedGenerator* obj, STOLEN(Box*) value) {
     STAT_TIMER(t0, "us_timer_generator_switching", 0);
 
     assert(obj->cls == generator_cls);
     BoxedGenerator* self = static_cast<BoxedGenerator*>(obj);
     assert(!self->returnValue);
-    self->returnValue = incref(value);
+    self->returnValue = value;
 
     threading::popGenerator();
 
@@ -371,6 +371,7 @@ extern "C" Box* yield(BoxedGenerator* obj, Box* value) {
     if (self->exception.type) {
         ExcInfo e = self->exception;
         self->exception = ExcInfo(NULL, NULL, NULL);
+        Py_CLEAR(self->returnValue);
         throw e;
     }
 

--- a/src/runtime/generator.cpp
+++ b/src/runtime/generator.cpp
@@ -107,7 +107,6 @@ void generatorEntry(BoxedGenerator* g) {
             auto r = callCLFunc<ExceptionStyle::CXX, NOT_REWRITABLE>(func->md, nullptr, func->md->numReceivedArgs(),
                                                                      func->closure, g, func->globals, g->arg1, g->arg2,
                                                                      g->arg3, args);
-            assert(r == None);
             Py_DECREF(r);
         } catch (ExcInfo e) {
             // unhandled exception: propagate the exception to the caller

--- a/src/runtime/generator.cpp
+++ b/src/runtime/generator.cpp
@@ -100,7 +100,8 @@ void generatorEntry(BoxedGenerator* g) {
 
             // call body of the generator
             BoxedFunctionBase* func = g->function;
-            KEEP_ALIVE(func);
+            // unnecessary because the generator owns g->function
+            // KEEP_ALIVE(func);
 
             Box** args = g->args ? &g->args->elts[0] : nullptr;
             auto r = callCLFunc<ExceptionStyle::CXX, NOT_REWRITABLE>(func->md, nullptr, func->md->numReceivedArgs(),
@@ -331,8 +332,25 @@ Box* generatorHasnext(Box* s) {
     return boxBool(generatorHasnextUnboxed(s));
 }
 
+extern "C" Box* yield_capi(BoxedGenerator* obj, STOLEN(Box*) value, int num_live_values, ...) noexcept {
+    try {
+        llvm::SmallVector<Box*, 8> live_values;
+        live_values.reserve(num_live_values);
+        va_list ap;
+        va_start(ap, num_live_values);
+        for (int i = 0; i < num_live_values; ++i) {
+            live_values.push_back(va_arg(ap, Box*));
+        }
+        va_end(ap);
 
-extern "C" Box* yield(BoxedGenerator* obj, STOLEN(Box*) value) {
+        return yield(obj, value, live_values);
+    } catch (ExcInfo e) {
+        setCAPIException(e);
+        return NULL;
+    }
+}
+
+extern "C" Box* yield(BoxedGenerator* obj, STOLEN(Box*) value, llvm::ArrayRef<Box*> live_values) {
     STAT_TIMER(t0, "us_timer_generator_switching", 0);
 
     assert(obj->cls == generator_cls);
@@ -350,9 +368,11 @@ extern "C" Box* yield(BoxedGenerator* obj, STOLEN(Box*) value) {
     // reset current frame to the caller tops frame --> removes the frame the generator added
     cur_thread_state.frame_info = self->top_caller_frame_info;
     obj->paused_frame_info = generator_frame_info;
+    obj->live_values = live_values;
     swapContext(&self->context, self->returnContext, 0);
     FrameInfo* top_new_caller_frame_info = (FrameInfo*)cur_thread_state.frame_info;
     obj->paused_frame_info = NULL;
+    obj->live_values = llvm::ArrayRef<Box*>();
 
     // the caller of the generator can change between yield statements that means we can't just restore the top of the
     // frame to the point before the yield instead we have to update it.
@@ -379,7 +399,6 @@ extern "C" Box* yield(BoxedGenerator* obj, STOLEN(Box*) value) {
     self->returnValue = NULL;
     return r;
 }
-
 
 extern "C" BoxedGenerator* createGenerator(BoxedFunctionBase* function, Box* arg1, Box* arg2, Box* arg3, Box** args) {
     assert(function);
@@ -492,8 +511,12 @@ extern "C" int PyGen_NeedsFinalizing(PyGenObject* gen) noexcept {
     // CPython has some optimizations for not needing to finalize generators that haven't exited, but
     // which are guaranteed to not need any special cleanups.
     // For now just say anything still in-progress needs finalizing.
-    return (bool)self->paused_frame_info;
+    if (!(bool)self->paused_frame_info)
+        return false;
 
+    return true;
+// TODO: is this safe? probably not...
+// return self->paused_frame_info->stmt->type == AST_TYPE::Invoke;
 #if 0
     int i;
     PyFrameObject* f = gen->gi_frame;
@@ -513,17 +536,97 @@ extern "C" int PyGen_NeedsFinalizing(PyGenObject* gen) noexcept {
 #endif
 }
 
+static PyObject* generator_close(PyGenObject* gen, PyObject* args) noexcept {
+    try {
+        return generatorClose((Box*)gen);
+    } catch (ExcInfo e) {
+        setCAPIException(e);
+        return NULL;
+    }
+}
+
+static void generator_del(PyObject* self) noexcept {
+    PyObject* res;
+    PyObject* error_type, *error_value, *error_traceback;
+    BoxedGenerator* gen = (BoxedGenerator*)self;
+
+    // Pyston change:
+    // if (gen->gi_frame == NULL || gen->gi_frame->f_stacktop == NULL)
+    if (!gen->paused_frame_info)
+        /* Generator isn't paused, so no need to close */
+        return;
+
+    /* Temporarily resurrect the object. */
+    assert(self->ob_refcnt == 0);
+    self->ob_refcnt = 1;
+
+    /* Save the current exception, if any. */
+    PyErr_Fetch(&error_type, &error_value, &error_traceback);
+
+    // Pyston change:
+    // res = gen_close(gen, NULL);
+    res = generator_close((PyGenObject*)gen, NULL);
+
+    if (res == NULL)
+        PyErr_WriteUnraisable(self);
+    else
+        Py_DECREF(res);
+
+    /* Restore the saved exception. */
+    PyErr_Restore(error_type, error_value, error_traceback);
+
+    /* Undo the temporary resurrection; can't use DECREF here, it would
+     * cause a recursive call.
+     */
+    assert(self->ob_refcnt > 0);
+    if (--self->ob_refcnt == 0)
+        return; /* this is the normal path out */
+
+    /* close() resurrected it!  Make it look like the original Py_DECREF
+     * never happened.
+     */
+    {
+        Py_ssize_t refcnt = self->ob_refcnt;
+        _Py_NewReference(self);
+        self->ob_refcnt = refcnt;
+    }
+    assert(PyType_IS_GC(self->cls) && _Py_AS_GC(self)->gc.gc_refs != _PyGC_REFS_UNTRACKED);
+
+    /* If Py_REF_DEBUG, _Py_NewReference bumped _Py_RefTotal, so
+     * we need to undo that. */
+    _Py_DEC_REFTOTAL;
+/* If Py_TRACE_REFS, _Py_NewReference re-added self to the object
+ * chain, so no more to do there.
+ * If COUNT_ALLOCS, the original decref bumped tp_frees, and
+ * _Py_NewReference bumped tp_allocs:  both of those need to be
+ * undone.
+ */
+#ifdef COUNT_ALLOCS
+    --self->ob_type->tp_frees;
+    --self->ob_type->tp_allocs;
+#endif
+}
+
 static void generator_dealloc(BoxedGenerator* self) noexcept {
     assert(isSubclass(self->cls, generator_cls));
 
     // Hopefully this never happens:
     assert(!self->running);
 
-    // I don't think this should get hit currently because we don't properly collect the cycle that this would
-    // represent:
-    ASSERT(!self->paused_frame_info, "Can't clean up a generator that is currently paused");
+    _PyObject_GC_UNTRACK(self);
 
-    PyObject_GC_UnTrack(self);
+    if (self->weakreflist != NULL)
+        PyObject_ClearWeakRefs(self);
+
+    _PyObject_GC_TRACK(self);
+
+    if (self->paused_frame_info) {
+        Py_TYPE(self)->tp_del(self);
+        if (self->ob_refcnt > 0)
+            return; /* resurrected.  :( */
+    }
+
+    _PyObject_GC_UNTRACK(self);
 
     freeGeneratorStack(self);
 
@@ -547,8 +650,6 @@ static void generator_dealloc(BoxedGenerator* self) noexcept {
     Py_CLEAR(self->exception.value);
     Py_CLEAR(self->exception.traceback);
 
-    PyObject_ClearWeakRefs(self);
-
     self->cls->tp_free(self);
 }
 
@@ -559,6 +660,10 @@ static int generator_traverse(BoxedGenerator* self, visitproc visit, void* arg) 
         int r = frameinfo_traverse(self->paused_frame_info, visit, arg);
         if (r)
             return r;
+    }
+
+    for (auto v : self->live_values) {
+        Py_VISIT(v);
     }
 
     int numArgs = self->function->md->numReceivedArgs();
@@ -610,5 +715,6 @@ void setupGenerator() {
 
     generator_cls->freeze();
     generator_cls->tp_iter = PyObject_SelfIter;
+    generator_cls->tp_del = generator_del; // don't do giveAttr("__del__") because it should not be visible from python
 }
 }

--- a/src/runtime/generator.h
+++ b/src/runtime/generator.h
@@ -29,7 +29,7 @@ void setupGenerator();
 void generatorEntry(BoxedGenerator* g);
 Context* getReturnContextForGeneratorFrame(void* frame_addr);
 
-extern "C" Box* yield(BoxedGenerator* obj, Box* value);
+extern "C" Box* yield(BoxedGenerator* obj, STOLEN(Box*) value);
 extern "C" BoxedGenerator* createGenerator(BoxedFunctionBase* function, Box* arg1, Box* arg2, Box* arg3, Box** args);
 }
 

--- a/src/runtime/generator.h
+++ b/src/runtime/generator.h
@@ -29,7 +29,8 @@ void setupGenerator();
 void generatorEntry(BoxedGenerator* g);
 Context* getReturnContextForGeneratorFrame(void* frame_addr);
 
-extern "C" Box* yield(BoxedGenerator* obj, STOLEN(Box*) value);
+extern "C" Box* yield(BoxedGenerator* obj, STOLEN(Box*) value, llvm::ArrayRef<Box*> live_values = {});
+extern "C" Box* yield_capi(BoxedGenerator* obj, STOLEN(Box*) value, int num_live_values = 0, ...) noexcept;
 extern "C" BoxedGenerator* createGenerator(BoxedFunctionBase* function, Box* arg1, Box* arg2, Box* arg3, Box** args);
 }
 

--- a/src/runtime/inline/link_forcer.cpp
+++ b/src/runtime/inline/link_forcer.cpp
@@ -101,7 +101,7 @@ void force() {
     FORCE(repr);
     FORCE(str);
     FORCE(exceptionMatches);
-    FORCE(yield);
+    FORCE(yield_capi);
     FORCE(getiterHelper);
     FORCE(hasnext);
     FORCE(apply_slice);

--- a/src/runtime/objmodel.cpp
+++ b/src/runtime/objmodel.cpp
@@ -148,7 +148,6 @@ extern "C" Box* deopt(AST_expr* expr, Box* value) {
         deopt_state.frame_state.frame_info->exc.value = NULL;
     }
 
-    AUTO_DECREF(deopt_state.frame_state.locals);
     return astInterpretDeopt(deopt_state.cf->md, expr, deopt_state.current_stmt, value, deopt_state.frame_state);
 }
 

--- a/src/runtime/types.h
+++ b/src/runtime/types.h
@@ -1257,6 +1257,8 @@ public:
     FrameInfo* paused_frame_info; // The FrameInfo the generator was on when it called yield (or NULL if the generator
                                   // hasn't started or has exited).
 
+    llvm::ArrayRef<Box*> live_values;
+
 #if STAT_TIMERS
     StatTimer* prev_stack;
     StatTimer my_timer;

--- a/test/tests/dash_m.py
+++ b/test/tests/dash_m.py
@@ -1,5 +1,3 @@
-# expected: reffail
-# - generator abandonment
 import os
 import sys
 import subprocess

--- a/test/tests/decorated_func_line.py
+++ b/test/tests/decorated_func_line.py
@@ -1,5 +1,3 @@
-# expected: reffail
-# - generator abandonment
 def wrapper(f):
     return f
 

--- a/test/tests/deopt_generator_tests.py
+++ b/test/tests/deopt_generator_tests.py
@@ -1,4 +1,3 @@
-# expected: reffail
 # skip-if: '-O' in EXTRA_JIT_ARGS or '-n'  in EXTRA_JIT_ARGS
 # statcheck: 4 <= noninit_count('num_deopt') < 50
 # statcheck: 1 <= stats["num_osr_exits"] <= 2

--- a/test/tests/exec_directory.py
+++ b/test/tests/exec_directory.py
@@ -1,5 +1,3 @@
-# expected: reffail
-# - generator abandonment
 import sys
 import os
 import subprocess

--- a/test/tests/generator_abandonment.py
+++ b/test/tests/generator_abandonment.py
@@ -1,5 +1,3 @@
-# expected: reffail
-
 print any(i == 5 for i in xrange(10))
 
 

--- a/test/tests/generator_collection_finally.py
+++ b/test/tests/generator_collection_finally.py
@@ -1,4 +1,3 @@
-# expected: fail
 # We currently don't call finalizers when destroying a generator.
 def G():
     try:

--- a/test/tests/generator_collection_running.py
+++ b/test/tests/generator_collection_running.py
@@ -1,4 +1,3 @@
-# expected: reffail
 # This test checks if generators which get started but haven't yet stopped (=not raisen a StopIteration exc, etc)
 # get freed when there aren't any references to the generators left.
 

--- a/test/tests/generator_cycle.py
+++ b/test/tests/generator_cycle.py
@@ -1,7 +1,24 @@
-# expected: reffail
 # Test a generator cycle involving an unfinished generator.
+import gc
 
 def f():
     g = (i in (None, g) for i in xrange(2))
     print g.next()
 print f()
+gc.collect()
+# print gc.garbage # XX pyston will put this into garbage currently
+
+def f():
+   g = None
+   def G():
+       c = g
+       g
+       yield 1
+       yield 2
+       yield 3
+   g = G()
+   g.next()
+
+print f()
+gc.collect()
+# print gc.garbage # XX pyston will put this into garbage currently

--- a/test/tests/generator_nonrunning_collection.py
+++ b/test/tests/generator_nonrunning_collection.py
@@ -1,4 +1,3 @@
-# expected: reffail
 def g():
     l1 = [1]
     l2 = [2]

--- a/test/tests/generator_threads.py
+++ b/test/tests/generator_threads.py
@@ -1,4 +1,3 @@
-# expected: reffail
 # Pass a started generator to two different threads, and make them both
 # try to run it at the same time.
 

--- a/test/tests/generators.py
+++ b/test/tests/generators.py
@@ -1,4 +1,3 @@
-# expected: reffail
 def G1(i=0):
     while True:
         yield i

--- a/test/tests/generators.py
+++ b/test/tests/generators.py
@@ -8,7 +8,7 @@ g1 = G1()
 for i in range(5):
     print g1.next()
 print g1.__name__
-
+print hasattr(g1, "__del__")
 
 
 def G2():

--- a/test/tests/nonzero_exceptions.py
+++ b/test/tests/nonzero_exceptions.py
@@ -42,13 +42,10 @@ try:
 except MyException, e:
     print e
 
-# TODO: reenable this once generator abandonment is working again
-"""
 try:
     print list(1 for i in range(5) if C(7))
 except MyException, e:
     print e
-"""
 
 try:
     print 1 if C(8) else 0


### PR DESCRIPTION
in order to break cycles we need to traverse all generator owned object at yields.
The interpreter is fine because it stores all objects inside the vregs so they will already get visited.
For the llvm jit pass all owned object to the yield call as vararg argument.

We will currently leak (move objects to ```gc.garbage```) when a generator is involved in a cycle because our ```PyGen_NeedsFinalizing``` is much more conservative.

This also has the advantage that we are now much better in reusing generator stacks 
e.g. ```django_template3_10x.py``` ```generator_stack_created``` improves from 15528 to 4

