### PR TITLE
Misc refcounting leaks encountered while fixing the generator abandonment tests

### DIFF
--- a/from_cpython/Modules/_io/bufferedio.c
+++ b/from_cpython/Modules/_io/bufferedio.c
@@ -732,6 +732,9 @@ _PyIO_trap_eintr(void)
     if (eintr_int == NULL) {
         eintr_int = PyLong_FromLong(EINTR);
         assert(eintr_int != NULL);
+
+        // Pyston change:
+        PyGC_RegisterStaticConstant(eintr_int);
     }
     if (!PyErr_ExceptionMatches(PyExc_EnvironmentError))
         return 0;

--- a/src/jit.cpp
+++ b/src/jit.cpp
@@ -476,7 +476,7 @@ static int main(int argc, char** argv) noexcept {
             }
         } else if (module != NULL) {
             // TODO: CPython uses the same main module for all code paths
-            main_module = createModule(boxString("__main__"), "<string>");
+            main_module = createModule(autoDecref(boxString("__main__")), "<string>");
             rtncode = (RunModule(module, 1) != 0);
         } else {
             main_module = createModule(autoDecref(boxString("__main__")), fn ? fn : "<stdin>");
@@ -526,6 +526,8 @@ static int main(int argc, char** argv) noexcept {
             PyObject* v = PyImport_ImportModule("readline");
             if (!v)
                 PyErr_Clear();
+            else
+                Py_CLEAR(v);
 
             printf("Pyston v%d.%d.%d (rev " STRINGIFY(GITREV) ")", PYSTON_VERSION_MAJOR, PYSTON_VERSION_MINOR,
                    PYSTON_VERSION_MICRO);

--- a/src/runtime/capi.cpp
+++ b/src/runtime/capi.cpp
@@ -987,8 +987,6 @@ extern "C" int PyRun_InteractiveOneFlags(FILE* fp, const char* filename, PyCompi
     // Pyston change:
     // d = PyModule_GetDict(m);
     // v = run_mod(mod, filename, d, d, flags, arena);
-    v = None;
-    Py_INCREF(v);
     assert(PyModule_Check(m));
     bool failed = false;
     try {
@@ -1005,7 +1003,9 @@ extern "C" int PyRun_InteractiveOneFlags(FILE* fp, const char* filename, PyCompi
         PyErr_Print();
         return -1;
     }
-    Py_DECREF(v);
+    // Pyston change: we dont't have v
+    // Py_DECREF(v);
+
     if (Py_FlushLine())
         PyErr_Clear();
     return 0;

--- a/src/runtime/objmodel.cpp
+++ b/src/runtime/objmodel.cpp
@@ -3120,6 +3120,7 @@ extern "C" void setattr(Box* obj, BoxedString* attr, STOLEN(Box*) attr_val) {
         STAT_TIMER(t1, "us_timer_slowpath_tpsetattr", 10);
 
         assert(attr->data()[attr->size()] == '\0');
+        AUTO_DECREF(attr_val);
         int rtn = obj->cls->tp_setattr(obj, const_cast<char*>(attr->data()), attr_val);
         if (rtn)
             throwCAPIException();

--- a/test/tests/dict.py
+++ b/test/tests/dict.py
@@ -1,4 +1,4 @@
-d = {2:2}
+d = {2:"should get overwritten", 2:2}
 d[1] = 1
 print d
 print d[1], d[1L], d[1.0], d[True]

--- a/test/tests/set.py
+++ b/test/tests/set.py
@@ -1,4 +1,4 @@
-s1 = {1}
+s1 = {1, 1}
 
 def sorted(s):
     l = list(s)


### PR DESCRIPTION
fixes leaks in
- interactive mode
- -m mode
- when calling ```tp_setattr``` from ```setattr()```
- creating duplicate set and dict entries from an AST node

I could not enable the tests yet because the need the generator abandonment fix but this fix is not ready yet but I want to land this fixes now so we don't do duplicate work.