### PR TITLE
Misc refcounting leaks encountered while fixing the generator abandonment tests part 2

### DIFF
--- a/from_cpython/Lib/test/test_parser.py
+++ b/from_cpython/Lib/test/test_parser.py
@@ -1,5 +1,3 @@
-# expected: reffail
-# - leaked refs
 import parser
 import unittest
 import sys

--- a/from_cpython/Lib/test/test_structseq.py
+++ b/from_cpython/Lib/test/test_structseq.py
@@ -1,5 +1,3 @@
-# expected: reffail
-# - unknown segfault
 import unittest
 from test import test_support
 

--- a/from_cpython/Modules/parsermodule.c
+++ b/from_cpython/Modules/parsermodule.c
@@ -3477,7 +3477,7 @@ initparser(void)
         PyObject *func, *pickler;
 
         func = PyObject_GetAttrString(copyreg, "pickle");
-        pickle_constructor = PyObject_GetAttrString(module, "sequence2st");
+        pickle_constructor = PyGC_RegisterStaticConstant(PyObject_GetAttrString(module, "sequence2st"));
         pickler = PyObject_GetAttrString(module, "_pickler");
         Py_XINCREF(pickle_constructor);
         if ((func != NULL) && (pickle_constructor != NULL)

--- a/src/runtime/float.cpp
+++ b/src/runtime/float.cpp
@@ -1122,7 +1122,7 @@ static Box* floatConjugate(Box* b, void*) {
         raiseExcHelper(TypeError, "descriptor 'conjugate' requires a 'float' object but received a '%s'",
                        getTypeName(b));
     if (b->cls == float_cls) {
-        return b;
+        return incref(b);
     } else {
         assert(PyFloat_Check(b));
         return boxFloat(static_cast<BoxedFloat*>(b)->d);

--- a/src/runtime/iterobject.cpp
+++ b/src/runtime/iterobject.cpp
@@ -116,7 +116,7 @@ Box* seqiter_next(Box* s) noexcept {
             hasnext = seqreviterHasnext_capi(s);
         else
             RELEASE_ASSERT(0, "");
-        AUTO_DECREF(hasnext);
+        AUTO_XDECREF(hasnext);
         if (hasnext != True)
             return NULL;
     }

--- a/src/runtime/set.h
+++ b/src/runtime/set.h
@@ -42,7 +42,7 @@ public:
     static int clear(Box* self) noexcept;
 };
 
-void _setAddStolen(BoxedSet* self, STOLEN(BoxAndHash) val);
+void _setAddStolen(BoxedSet* self, STOLEN(Box*) val);
 }
 
 #endif

--- a/src/runtime/types.cpp
+++ b/src/runtime/types.cpp
@@ -2425,8 +2425,9 @@ public:
 
         Box* r = self->b->getattr(key);
         if (r) {
+            Py_INCREF(r);
             self->b->delattr(key, NULL);
-            return incref(r);
+            return r;
         } else {
             if (default_)
                 return incref(default_);

--- a/test/tests/float.py
+++ b/test/tests/float.py
@@ -69,6 +69,7 @@ print (0.5).as_integer_ratio()
 print (0.5).is_integer()
 print (1.0).is_integer()
 print 1.0.__hash__(), 1.1.__hash__(), -1.1.__hash__()
+print (0.5).conjugate(), (0.6).imag
 
 print 1.0 ** (10 ** 100)
 print (-1.0) ** (10 ** 100)

--- a/test/tests/tuples.py
+++ b/test/tests/tuples.py
@@ -260,3 +260,6 @@ try:
     print((1, 2) * d)
 except TypeError as e:
     print(e.message)
+
+# this triggers a tuple resize because generators have a unknown len:
+print len(tuple(v*10 for v in range(100)))


### PR DESCRIPTION
this issues all got triggered by cpython test we currently have disabled.

Generally I'm not really sure what pattern to use (and I'm very inconsistent with it) when a value needs to get decrefed incase a exception get's throwen but else returned. 
- create a ```AUTO_DECREF(x)``` and do a ```return incref(x)```
- use a try catch block and only decref in the catch (probably fastest way to do it in case the exception is very unlikely but also verbose)
- use something like ```ExceptionCleanup``` which decrefs it in the destructor when an exception gets thrown...
