### PR TITLE
Trying to reduce allocations in refcounting branch

### DIFF
--- a/src/codegen/ast_interpreter.cpp
+++ b/src/codegen/ast_interpreter.cpp
@@ -821,6 +821,7 @@ Box* ASTInterpreter::doOSR(AST_Jump* node) {
     OSRExit exit(found_entry);
 
     std::vector<Box*> arg_array;
+    arg_array.reserve(sorted_symbol_table.size());
     for (auto& it : sorted_symbol_table) {
         arg_array.push_back(it.second);
     }
@@ -1089,10 +1090,14 @@ Value ASTInterpreter::createFunction(AST* node, AST_arguments* args, const std::
 
     std::vector<Box*> defaults;
     llvm::SmallVector<RewriterVar*, 4> defaults_vars;
+    defaults.reserve(args->defaults.size());
 
     RewriterVar* defaults_var = NULL;
-    if (jit)
+    if (jit) {
         defaults_var = args->defaults.size() ? jit->allocate(args->defaults.size()) : jit->imm(0ul);
+        defaults_vars.reserve(args->defaults.size());
+    }
+
     int i = 0;
     for (AST_expr* d : args->defaults) {
         Value v = visit_expr(d);
@@ -1180,6 +1185,7 @@ Value ASTInterpreter::visit_makeFunction(AST_MakeFunction* mkfn) {
     AST_arguments* args = node->args;
 
     std::vector<Value> decorators;
+    decorators.reserve(node->decorator_list.size());
     for (AST_expr* d : node->decorator_list)
         decorators.push_back(visit_expr(d));
 
@@ -1210,6 +1216,7 @@ Value ASTInterpreter::visit_makeClass(AST_MakeClass* mkclass) {
     }
 
     std::vector<Box*> decorators;
+    decorators.reserve(node->decorator_list.size());
     for (AST_expr* d : node->decorator_list)
         decorators.push_back(visit_expr(d).o);
 
@@ -1485,6 +1492,9 @@ Value ASTInterpreter::visit_call(AST_Call* node) {
 
     std::vector<Box*> args;
     llvm::SmallVector<RewriterVar*, 8> args_vars;
+    args.reserve(node->args.size());
+    args_vars.reserve(node->args.size());
+
     for (AST_expr* e : node->args) {
         Value v = visit_expr(e);
         args.push_back(v.o);

--- a/src/runtime/builtin_modules/builtins.cpp
+++ b/src/runtime/builtin_modules/builtins.cpp
@@ -803,9 +803,13 @@ Box* map(Box* f, BoxedTuple* args) {
     if (num_iterable == 1)
         return map2(f, args->elts[0]);
 
-    std::deque<BoxIteratorRange> ranges;
+    std::vector<BoxIteratorRange> ranges;
     std::vector<BoxIterator> args_it;
     std::vector<BoxIterator> args_end;
+
+    ranges.reserve(args->size());
+    args_it.reserve(args->size());
+    args_end.reserve(args->size());
 
     for (auto e : *args) {
         auto range = e->pyElements();

--- a/src/runtime/builtin_modules/builtins.cpp
+++ b/src/runtime/builtin_modules/builtins.cpp
@@ -803,15 +803,15 @@ Box* map(Box* f, BoxedTuple* args) {
     if (num_iterable == 1)
         return map2(f, args->elts[0]);
 
-    std::vector<BoxIteratorRange> ranges;
+    std::deque<BoxIteratorRange> ranges;
     std::vector<BoxIterator> args_it;
     std::vector<BoxIterator> args_end;
 
     for (auto e : *args) {
         auto range = e->pyElements();
-        args_it.emplace_back(range.begin());
-        args_end.emplace_back(range.end());
         ranges.push_back(std::move(range));
+        args_it.emplace_back(ranges.back().begin());
+        args_end.emplace_back(ranges.back().end());
     }
     assert(args_it.size() == num_iterable);
     assert(args_end.size() == num_iterable);
@@ -1221,11 +1221,13 @@ Box* zip(BoxedTuple* containers) {
         return incref(rtn);
 
     std::vector<BoxIteratorRange> ranges;
+    ranges.reserve(containers->size());
     for (auto container : *containers) {
-        ranges.push_back(std::move(container->pyElements()));
+        ranges.push_back(container->pyElements());
     }
 
     std::vector<BoxIterator> iterators;
+    iterators.reserve(containers->size());
     for (auto&& range : ranges) {
         iterators.push_back(std::move(range.begin()));
     }

--- a/src/runtime/generator.cpp
+++ b/src/runtime/generator.cpp
@@ -45,7 +45,7 @@ static std::deque<uint64_t> available_addrs;
 #define STACK_REDZONE_SIZE PAGE_SIZE
 #define MAX_STACK_SIZE (4 * 1024 * 1024)
 
-static std::unordered_map<void*, BoxedGenerator*> s_generator_map;
+static llvm::DenseMap<void*, BoxedGenerator*> s_generator_map;
 static_assert(THREADING_USE_GIL, "have to make the generator map thread safe!");
 
 class RegisterHelper {

--- a/src/runtime/iterators.cpp
+++ b/src/runtime/iterators.cpp
@@ -165,23 +165,19 @@ public:
 BoxIteratorRange Box::pyElements() {
     if (this->cls == list_cls) {
         using BoxIteratorList = BoxIteratorIndex<BoxedList>;
-        std::unique_ptr<BoxIteratorImpl> begin(new BoxIteratorList((BoxedList*)this));
         BoxIteratorImpl* end = BoxIteratorList::end();
-        return BoxIteratorRange(std::move(begin), end);
+        return BoxIteratorRange(end, (BoxedList*)this, (BoxIteratorList*)nullptr);
     } else if (this->cls == tuple_cls) {
         using BoxIteratorTuple = BoxIteratorIndex<BoxedTuple>;
-        std::unique_ptr<BoxIteratorImpl> begin(new BoxIteratorTuple((BoxedTuple*)this));
         BoxIteratorImpl* end = BoxIteratorTuple::end();
-        return BoxIteratorRange(std::move(begin), end);
+        return BoxIteratorRange(end, (BoxedTuple*)this, (BoxIteratorTuple*)nullptr);
     } else if (this->cls == str_cls) {
         using BoxIteratorString = BoxIteratorIndex<BoxedString>;
-        std::unique_ptr<BoxIteratorImpl> begin(new BoxIteratorString((BoxedString*)this));
         BoxIteratorImpl* end = BoxIteratorString::end();
-        return BoxIteratorRange(std::move(begin), end);
+        return BoxIteratorRange(end, (BoxedString*)this, (BoxIteratorString*)nullptr);
     } else {
-        std::unique_ptr<BoxIteratorImpl> begin(new BoxIteratorGeneric(this));
         BoxIteratorImpl* end = BoxIteratorGeneric::end();
-        return BoxIteratorRange(std::move(begin), end);
+        return BoxIteratorRange(end, this, (BoxIteratorGeneric*)nullptr);
     }
 }
 }

--- a/src/runtime/types.h
+++ b/src/runtime/types.h
@@ -657,13 +657,13 @@ public:
 
     void* operator new(size_t size, int capacity) {
         assert(size == sizeof(GCdArray));
-        return PyMem_MALLOC(capacity * sizeof(Box*) + size);
+        return PyObject_Malloc(capacity * sizeof(Box*) + size);
     }
 
-    void operator delete(void* p) { PyMem_FREE(p); }
+    void operator delete(void* p) { PyObject_Free(p); }
 
     static GCdArray* grow(GCdArray* array, int capacity) {
-        return (GCdArray*)PyMem_REALLOC(array, capacity * sizeof(Box*) + sizeof(GCdArray));
+        return (GCdArray*)PyObject_Realloc(array, capacity * sizeof(Box*) + sizeof(GCdArray));
     }
 };
 


### PR DESCRIPTION
We seem to be calling malloc() a lot more than we used to.  Some manual sampling turned up a couple places that could be fixed:
- Anything that used to use a STLCompatAllocator got switched back to malloc, which is quite a bit slower for allocation/reallocation.  I tried to reserve() the space to reduce this a little bit.
- pyElements had gained an allocation, which this commit gets rid of
- some things got switched from our gc functions to PyMem_Malloc which is malloc

The net result is pretty small :/  about 1% on django_template3 and less on sqlalchemy_imperative2