### PR TITLE
some minor NumPy fixing

### DIFF
--- a/src/runtime/builtin_modules/builtins.cpp
+++ b/src/runtime/builtin_modules/builtins.cpp
@@ -1462,7 +1462,7 @@ extern "C" BORROWED(PyObject*) PyEval_GetGlobals(void) noexcept {
 }
 
 extern "C" BORROWED(PyObject*) PyEval_GetBuiltins(void) noexcept {
-    return builtins_module;
+    return builtins_module->getAttrWrapper();
 }
 
 Box* ellipsisRepr(Box* self) {

--- a/src/runtime/str.cpp
+++ b/src/runtime/str.cpp
@@ -1164,6 +1164,13 @@ extern "C" Box* strMod(BoxedString* lhs, Box* rhs) {
     return rtn;
 }
 
+Box* strRMod(BoxedString* lhs, Box* rhs) {
+    Box* rtn = PyString_Format(rhs, lhs);
+    if (!rtn)
+        throwCAPIException();
+    return rtn;
+}
+
 extern "C" Box* strMul(BoxedString* lhs, Box* rhs) {
     assert(PyString_Check(lhs));
 
@@ -2926,6 +2933,7 @@ void setupStr() {
 
     str_cls->giveAttr("__add__", new BoxedFunction(FunctionMetadata::create((void*)strAdd, UNKNOWN, 2)));
     str_cls->giveAttr("__mod__", new BoxedFunction(FunctionMetadata::create((void*)strMod, UNKNOWN, 2)));
+    str_cls->giveAttr("__rmod__", new BoxedFunction(FunctionMetadata::create((void*)strRMod, UNKNOWN, 2)));
     str_cls->giveAttr("__mul__", new BoxedFunction(FunctionMetadata::create((void*)strMul, UNKNOWN, 2)));
     // TODO not sure if this is right in all cases:
     str_cls->giveAttr("__rmul__", new BoxedFunction(FunctionMetadata::create((void*)strMul, UNKNOWN, 2)));

--- a/src/runtime/types.cpp
+++ b/src/runtime/types.cpp
@@ -1595,6 +1595,12 @@ static Box* builtinFunctionOrMethodName(Box* b, void*) {
     return incref(func->name);
 }
 
+static Box* wrapperobjectName(Box* w, void*) {
+    assert(w->cls == wrapperobject_cls);
+    BoxedWrapperObject* wrapper_obj = static_cast<BoxedWrapperObject*>(w);
+    return boxString(wrapper_obj->descr->wrapper->name);
+}
+
 static Box* functionCode(Box* self, void*) {
     assert(self->cls == function_cls);
     BoxedFunction* func = static_cast<BoxedFunction*>(self);
@@ -4530,6 +4536,8 @@ void setupRuntime() {
 
     instancemethod_cls->giveAttr("im_class", new BoxedMemberDescriptor(BoxedMemberDescriptor::OBJECT,
                                                                        offsetof(BoxedInstanceMethod, im_class), true));
+
+    wrapperobject_cls->giveAttrDescriptor("__name__", wrapperobjectName, NULL);
 
     slice_cls->giveAttr(
         "__new__",

--- a/src/runtime/types.cpp
+++ b/src/runtime/types.cpp
@@ -2990,9 +2990,7 @@ static PyObject* object_new(PyTypeObject* type, PyObject* args, PyObject* kwds) 
         builtins = PyEval_GetBuiltins();
         if (builtins == NULL)
             goto error;
-        // Pyston change: builtins is a module not a dict
-        // sorted = PyDict_GetItemString(builtins, "sorted");
-        sorted = builtins->getattr(autoDecref(internStringMortal("sorted")));
+        sorted = PyDict_GetItemString(builtins, "sorted");
         if (sorted == NULL)
             goto error;
         sorted_methods = PyObject_CallFunctionObjArgs(sorted, abstract_methods, NULL);

--- a/test/tests/str_functions.py
+++ b/test/tests/str_functions.py
@@ -215,3 +215,9 @@ for i in xrange(-8, 8):
         print i,j, repr(s[i:j])
         for k in (-2, 1, 1, 2):
             print i,j,k, repr(s[i:j:k]), repr(s[slice(i, j, k)])
+
+
+class D(str):
+    pass
+
+print(D('abc').__rmod__('%s'))

--- a/test/tests/wrapperdesc.py
+++ b/test/tests/wrapperdesc.py
@@ -5,4 +5,5 @@ print type(C).__str__ is object.__str__
 print type(None).__str__ is object.__str__
 print type(None).__str__ is None.__str__
 print type(None.__str__)
+print(None.__str__.__name__)
 print type(type(None).__str__.__get__(None, type(None)))


### PR DESCRIPTION
Without `str.__rmod__`, `"%s" % numpy.string_` will force NumPy call `numpy.reminder`. This is horrible. 