### PR TITLE
Fix usage of undef variables

### DIFF
--- a/src/codegen/compvars.cpp
+++ b/src/codegen/compvars.cpp
@@ -2782,10 +2782,6 @@ public:
         return rtn;
     }
     ConcreteCompilerVariable* makeConverted(IREmitter& emitter, VAR* var, ConcreteCompilerType* other_type) override {
-        if (other_type == other_type->getBoxType()) {
-            assert(other_type == UNKNOWN);
-            return emitter.getNone()->makeConverted(emitter, other_type);
-        }
         llvm::Value* v = llvm::UndefValue::get(other_type->llvmType());
         return new ConcreteCompilerVariable(other_type, v);
     }

--- a/src/codegen/irgen/irgenerator.cpp
+++ b/src/codegen/irgen/irgenerator.cpp
@@ -922,7 +922,7 @@ private:
                     // trigger an exception, but the irgenerator will know that definitely-defined
                     // local symbols will not throw.
                     emitter.getBuilder()->CreateUnreachable();
-                    exc_type = exc_value = exc_tb = emitter.getNone();
+                    exc_type = exc_value = exc_tb = undefVariable();
                     // endBlock(DEAD);
                 }
 

--- a/src/codegen/irgen/refcounts.cpp
+++ b/src/codegen/irgen/refcounts.cpp
@@ -76,6 +76,9 @@ bool RefcountTracker::isNullable(llvm::Value* v) {
 }
 
 void RefcountTracker::refConsumed(llvm::Value* v, llvm::Instruction* inst) {
+    if (llvm::isa<UndefValue>(v))
+        return;
+
     assert(this->vars[v].reftype != RefType::UNKNOWN);
 
     this->refs_consumed[inst].push_back(v);
@@ -630,6 +633,9 @@ void RefcountTracker::addRefcounts(IRGenState* irstate) {
     int num_untracked = 0;
     auto check_val_missed = [&](llvm::Value* v) {
         if (rt->vars.count(v))
+            return;
+
+        if (llvm::isa<UndefValue>(v))
             return;
 
         auto t = v->getType();

--- a/test/tests/undef_join.py
+++ b/test/tests/undef_join.py
@@ -1,0 +1,9 @@
+# Regression test: promoting an UNDEF to a known type
+
+def f():
+    match = None # This could be a function that usually returns None but sometimes returns a string
+    if 0:
+        s = match.foo() or ""
+        print s
+for i in xrange(10000):
+    f()


### PR DESCRIPTION
I think I had gotten confused and mixed up "undefined variables" (Python
variables which hadn't gotten set) and "undefined values" (results of
expressions that the JIT knows will throw, or otherwise can't evaluate).

For undefined *variables*, we represent them using None, since they can
still have refcount operations done on them.

For undefined *values* (or results), we can use llvm's undefValues, since
they should never be touched.