### PR TITLE
interpreter: mark created_closure as live variable inside yields

### DIFF
--- a/src/codegen/ast_interpreter.h
+++ b/src/codegen/ast_interpreter.h
@@ -53,6 +53,7 @@ struct ASTInterpreterJitInterface {
     static void setLocalClosureHelper(void* interp, long vreg, InternedString id, Box* v);
     static void uncacheExcInfoHelper(void* interp);
     static void raise0Helper(void* interp) __attribute__((noreturn));
+    static Box* yieldHelper(void* interp, STOLEN(Box*) value);
 };
 
 class RewriterVar;

--- a/src/codegen/baseline_jit.cpp
+++ b/src/codegen/baseline_jit.cpp
@@ -536,10 +536,7 @@ std::vector<RewriterVar*> JitFragmentWriter::emitUnpackIntoArray(RewriterVar* v,
 }
 
 RewriterVar* JitFragmentWriter::emitYield(RewriterVar* v) {
-    RewriterVar* generator = getInterp()->getAttr(ASTInterpreterJitInterface::getGeneratorOffset());
-    static_assert(sizeof(llvm::ArrayRef<Box*>) == sizeof(void*) * 2,
-                  "we pass two 0ul args to initalize the llvm::ArrayRef");
-    auto rtn = call(false, (void*)yield, generator, v, imm(0ul), imm(0ul))->setType(RefType::OWNED);
+    auto rtn = call(false, (void*)ASTInterpreterJitInterface::yieldHelper, getInterp(), v)->setType(RefType::OWNED);
     v->refConsumed();
     return rtn;
 }

--- a/src/runtime/types.cpp
+++ b/src/runtime/types.cpp
@@ -2354,18 +2354,20 @@ public:
         RELEASE_ASSERT(_self->cls == attrwrapper_cls, "");
         AttrWrapper* self = static_cast<AttrWrapper*>(_self);
 
-        if (_key->cls != str_cls)
-            self->convertToDictBacked();
-
         if (self->isDictBacked()) {
             static BoxedString* get_str = getStaticString("get");
             return callattrInternal<CXX, NOT_REWRITABLE>(self->getDictBacking(), get_str, LookupScope::CLASS_ONLY, NULL,
                                                          ArgPassSpec(2), _key, def, NULL, NULL, NULL);
         }
 
-        RELEASE_ASSERT(_key->cls == str_cls, "");
+        _key = coerceUnicodeToStr<CXX>(_key);
+        if (_key->cls != str_cls) {
+            Py_DECREF(_key);
+            return incref(def);
+        }
+
+        assert(_key->cls == str_cls);
         BoxedString* key = static_cast<BoxedString*>(_key);
-        Py_INCREF(key);
         internStringMortalInplace(key);
         AUTO_DECREF(key);
 

--- a/src/runtime/types.cpp
+++ b/src/runtime/types.cpp
@@ -4049,6 +4049,8 @@ void AttrWrapperIter::dealloc(Box* _o) noexcept {
 void BoxedClosure::dealloc(Box* _o) noexcept {
     BoxedClosure* o = (BoxedClosure*)_o;
 
+    PyObject_GC_UnTrack(o);
+
     for (int i = 0; i < o->nelts; i++) {
         Py_XDECREF(o->elts[i]);
     }
@@ -4065,6 +4067,8 @@ int BoxedClosure::traverse(Box* _o, visitproc visit, void* arg) noexcept {
         Py_VISIT(o->elts[i]);
     }
 
+    Py_VISIT(o->parent);
+
     return 0;
 }
 
@@ -4074,6 +4078,8 @@ int BoxedClosure::clear(Box* _o) noexcept {
     for (int i = 0; i < o->nelts; i++) {
         Py_CLEAR(o->elts[i]);
     }
+
+    Py_CLEAR(o->parent);
 
     return 0;
 }

--- a/test/tests/generator_cycle2.py
+++ b/test/tests/generator_cycle2.py
@@ -1,0 +1,16 @@
+# Test a generator cycle involving an unfinished generator.
+# this used to leak in the interpreter
+import gc
+def f(z):
+    l = ((lambda x, l: x**y)(z, l) for y in xrange(10))
+    return l
+
+def test():
+    g = f(4)
+    print g.next()
+    return g
+
+g = test()
+print g.next()
+gc.collect()
+print gc.garbage


### PR DESCRIPTION
without this we would never traverse the variable and the GC would therefore be unable to destroy the generator