### PR TITLE
check return value instead of calling checkAndThrowCAPIException()

### DIFF
--- a/src/codegen/pypa-parser.cpp
+++ b/src/codegen/pypa-parser.cpp
@@ -981,7 +981,8 @@ pypa::String pypaEscapeDecoder(const pypa::String& s, const pypa::String& encodi
             BoxedString* str_utf8 = (BoxedString*)PyUnicode_AsUTF8String(str);
             AUTO_DECREF(str_utf8);
             assert(str_utf8->cls == str_cls);
-            checkAndThrowCAPIException();
+            if (!str_utf8)
+                throwCAPIException();
             return str_utf8->s().str();
         }
 

--- a/src/runtime/builtin_modules/builtins.cpp
+++ b/src/runtime/builtin_modules/builtins.cpp
@@ -350,7 +350,7 @@ extern "C" Box* unichr(Box* arg) {
 
     Box* rtn = PyUnicode_FromOrdinal(n);
     if (!rtn)
-        checkAndThrowCAPIException();
+        throwCAPIException();
     return rtn;
 }
 
@@ -409,21 +409,27 @@ Box* range(Box* start, Box* stop, Box* step) {
     if (stop == NULL) {
         istart = 0;
         istop = PyLong_AsLong(start);
-        checkAndThrowCAPIException();
+        if ((istop == -1) && PyErr_Occurred())
+            throwCAPIException();
         istep = 1;
     } else if (step == NULL) {
         istart = PyLong_AsLong(start);
-        checkAndThrowCAPIException();
+        if ((istart == -1) && PyErr_Occurred())
+            throwCAPIException();
         istop = PyLong_AsLong(stop);
-        checkAndThrowCAPIException();
+        if ((istop == -1) && PyErr_Occurred())
+            throwCAPIException();
         istep = 1;
     } else {
         istart = PyLong_AsLong(start);
-        checkAndThrowCAPIException();
+        if ((istart == -1) && PyErr_Occurred())
+            throwCAPIException();
         istop = PyLong_AsLong(stop);
-        checkAndThrowCAPIException();
+        if ((istop == -1) && PyErr_Occurred())
+            throwCAPIException();
         istep = PyLong_AsLong(step);
-        checkAndThrowCAPIException();
+        if ((istep == -1) && PyErr_Occurred())
+            throwCAPIException();
     }
 
     BoxedList* rtn = new BoxedList();
@@ -470,7 +476,7 @@ Box* isinstance_func(Box* obj, Box* cls) {
 Box* issubclass_func(Box* child, Box* parent) {
     int rtn = PyObject_IsSubclass(child, parent);
     if (rtn < 0)
-        checkAndThrowCAPIException();
+        throwCAPIException();
     return boxBool(rtn);
 }
 
@@ -479,7 +485,6 @@ Box* intern_func(Box* str) {
         raiseExcHelper(TypeError, "can't intern subclass of string");
     Py_INCREF(str);
     PyString_InternInPlace(&str);
-    checkAndThrowCAPIException();
     return str;
 }
 
@@ -1797,7 +1802,8 @@ Box* builtinApply(Box* func, Box* _args, Box* keywords) {
         if (!PySequence_Check(_args))
             raiseExcHelper(TypeError, "apply() arg 2 expected sequence, found %s", getTypeName(_args));
         args = PySequence_Tuple(_args);
-        checkAndThrowCAPIException();
+        if (!args)
+            throwCAPIException();
     } else {
         args = incref(_args);
     }

--- a/src/runtime/inline/xrange.cpp
+++ b/src/runtime/inline/xrange.cpp
@@ -154,13 +154,16 @@ Box* xrange(Box* cls, Box* start, Box* stop, Box** args) {
 
     if (stop == NULL) {
         i64 istop = PyLong_AsLong(start);
-        checkAndThrowCAPIException();
+        if ((istop == -1) && PyErr_Occurred())
+            throwCAPIException();
         return new BoxedXrange(0, istop, 1);
     } else if (step == NULL) {
         i64 istart = PyLong_AsLong(start);
-        checkAndThrowCAPIException();
+        if ((istart == -1) && PyErr_Occurred())
+            throwCAPIException();
         i64 istop = PyLong_AsLong(stop);
-        checkAndThrowCAPIException();
+        if ((istop == -1) && PyErr_Occurred())
+            throwCAPIException();
         i64 n = BoxedXrange::get_len_of_range(istart, istop, 1);
         if (n > (unsigned long)LONG_MAX || (long)n > PY_SSIZE_T_MAX) {
             raiseExcHelper(OverflowError, "xrange() result has too many items");
@@ -168,11 +171,14 @@ Box* xrange(Box* cls, Box* start, Box* stop, Box** args) {
         return new BoxedXrange(istart, istop, 1);
     } else {
         i64 istart = PyLong_AsLong(start);
-        checkAndThrowCAPIException();
+        if ((istart == -1) && PyErr_Occurred())
+            throwCAPIException();
         i64 istop = PyLong_AsLong(stop);
-        checkAndThrowCAPIException();
+        if ((istop == -1) && PyErr_Occurred())
+            throwCAPIException();
         i64 istep = PyLong_AsLong(step);
-        checkAndThrowCAPIException();
+        if ((istep == -1) && PyErr_Occurred())
+            throwCAPIException();
         if (istep == 0)
             raiseExcHelper(ValueError, "xrange() arg 3 must not be zero");
         unsigned long n = BoxedXrange::get_len_of_range(istart, istop, istep);

--- a/src/runtime/iterators.cpp
+++ b/src/runtime/iterators.cpp
@@ -57,7 +57,8 @@ public:
         if (next) {
             value = next;
         } else {
-            checkAndThrowCAPIException();
+            if (PyErr_Occurred())
+                throwCAPIException();
             Py_CLEAR(iterator);
             *this = *end();
         }

--- a/src/runtime/str.cpp
+++ b/src/runtime/str.cpp
@@ -2306,7 +2306,8 @@ Box* strDecode(BoxedString* self, Box* encoding, Box* error) {
 
     Box* result = PyString_AsDecodedObject(self, encoding_str ? encoding_str->data() : NULL,
                                            error_str ? error_str->data() : NULL);
-    checkAndThrowCAPIException();
+    if (!result)
+        throwCAPIException();
     return result;
 }
 
@@ -2331,7 +2332,8 @@ Box* strEncode(BoxedString* self, Box* encoding, Box* error) {
 
     Box* result = PyString_AsEncodedObject(self, encoding_str ? encoding_str->data() : PyUnicode_GetDefaultEncoding(),
                                            error_str ? error_str->data() : NULL);
-    checkAndThrowCAPIException();
+    if (!result)
+        throwCAPIException();
     return result;
 }
 

--- a/src/runtime/types.cpp
+++ b/src/runtime/types.cpp
@@ -268,7 +268,8 @@ BoxedString* Box::reprICAsString() {
 
     if (isSubclass(r->cls, unicode_cls)) {
         r = PyUnicode_AsASCIIString(autoDecref(r));
-        checkAndThrowCAPIException();
+        if (!r)
+            throwCAPIException();
     }
     if (r->cls != str_cls) {
         Py_DECREF(r);
@@ -2115,7 +2116,8 @@ static PyObject* type_subclasses(PyTypeObject* type, PyObject* args_ignored) noe
 Box* typeSubclasses(BoxedClass* self) {
     assert(PyType_Check(self));
     Box* rtn = type_subclasses(self, 0);
-    checkAndThrowCAPIException();
+    if (!rtn)
+        throwCAPIException();
     return rtn;
 }
 


### PR DESCRIPTION
this should make pyston more robust to cases where the error is set by a previous operation

no functional change intended