### PR TITLE
Make rearrangeArgs take a callback instead passing back values

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -776,7 +776,7 @@ check$1 test$1: $(PYTHON_EXE_DEPS) pyston$1
 	@# we pass -I to cpython tests and skip failing ones because they are sloooow otherwise
 	$(PYTHON) $(TOOLS_DIR)/tester.py -R pyston$1 -j$(TEST_THREADS) -a=-S -k --exit-code-only --skip-failing -t50 $(TEST_DIR)/cpython $(ARGS)
 	$(PYTHON) $(TOOLS_DIR)/tester.py -R pyston$1 -j$(TEST_THREADS) -k -a=-S --exit-code-only --skip-failing -t600 $(TEST_DIR)/integration $(ARGS)
-	$(PYTHON) $(TOOLS_DIR)/tester.py -a=-X -R pyston$1 -j$(TEST_THREADS) -a=-n -a=-S -k $(TESTS_DIR) $(ARGS)
+	$(PYTHON) $(TOOLS_DIR)/tester.py -a=-X -R pyston$1 -j$(TEST_THREADS) -a=-n -a=-S -t50 -k $(TESTS_DIR) $(ARGS)
 	$(PYTHON) $(TOOLS_DIR)/tester.py -R pyston$1 -j$(TEST_THREADS) -a=-O -a=-S -k $(TESTS_DIR) $(ARGS)
 
 .PHONY: run$1 dbg$1

--- a/src/capi/typeobject.cpp
+++ b/src/capi/typeobject.cpp
@@ -3411,11 +3411,39 @@ static Box* tppProxyToTpCall(Box* self, CallRewriteArgs* rewrite_args, ArgPassSp
         paramspec.takes_kwargs = false;
     }
 
-    bool rewrite_success = false;
-    Box** oargs = NULL;
+    auto continuation = [=](CallRewriteArgs* rewrite_args, Box* arg1, Box* arg2, Box* arg3, Box** args) {
+        if (!paramspec.takes_kwargs)
+            arg2 = NULL;
+
+        if (rewrite_args) {
+            if (!paramspec.takes_kwargs)
+                rewrite_args->arg2 = rewrite_args->rewriter->loadConst(0, Location::forArg(2));
+
+            // Currently, guard that the value of tp_call didn't change, and then
+            // emit a call to the current function address.
+            // It might be better to just load the current value of tp_call and call it
+            // (after guarding it's not null), or maybe not.  But the rewriter doesn't currently
+            // support calling a RewriterVar (can only call fixed function addresses).
+            RewriterVar* r_cls = rewrite_args->obj->getAttr(offsetof(Box, cls));
+            r_cls->addAttrGuard(offsetof(BoxedClass, tp_call), (intptr_t)self->cls->tp_call);
+
+            rewrite_args->out_rtn = rewrite_args->rewriter->call(true, (void*)self->cls->tp_call, rewrite_args->obj,
+                                                                 rewrite_args->arg1, rewrite_args->arg2);
+            rewrite_args->out_rtn->setType(RefType::OWNED);
+            if (S == CXX)
+                rewrite_args->rewriter->checkAndThrowCAPIException(rewrite_args->out_rtn);
+            rewrite_args->out_success = true;
+        }
+
+        Box* r = self->cls->tp_call(self, arg1, arg2);
+        if (!r)
+            throwCAPIException();
+        return r;
+    };
+
     try {
-        rearrangeArguments(paramspec, NULL, "", NULL, rewrite_args, rewrite_success, argspec, arg1, arg2, arg3, args,
-                           oargs, keyword_names, NULL);
+        return rearrangeArgumentsAndCall(paramspec, NULL, "", NULL, rewrite_args, argspec, arg1, arg2, arg3, args,
+                                         keyword_names, continuation);
     } catch (ExcInfo e) {
         if (S == CAPI) {
             setCAPIException(e);
@@ -3423,39 +3451,6 @@ static Box* tppProxyToTpCall(Box* self, CallRewriteArgs* rewrite_args, ArgPassSp
         } else
             throw e;
     }
-
-    AUTO_DECREF(arg1);
-    if (!paramspec.takes_kwargs)
-        arg2 = NULL;
-    AUTO_XDECREF(arg2);
-
-    if (!rewrite_success)
-        rewrite_args = NULL;
-
-    if (rewrite_args) {
-        if (!paramspec.takes_kwargs)
-            rewrite_args->arg2 = rewrite_args->rewriter->loadConst(0, Location::forArg(2));
-
-        // Currently, guard that the value of tp_call didn't change, and then
-        // emit a call to the current function address.
-        // It might be better to just load the current value of tp_call and call it
-        // (after guarding it's not null), or maybe not.  But the rewriter doesn't currently
-        // support calling a RewriterVar (can only call fixed function addresses).
-        RewriterVar* r_cls = rewrite_args->obj->getAttr(offsetof(Box, cls));
-        r_cls->addAttrGuard(offsetof(BoxedClass, tp_call), (intptr_t)self->cls->tp_call);
-
-        rewrite_args->out_rtn = rewrite_args->rewriter->call(true, (void*)self->cls->tp_call, rewrite_args->obj,
-                                                             rewrite_args->arg1, rewrite_args->arg2);
-        rewrite_args->out_rtn->setType(RefType::OWNED);
-        if (S == CXX)
-            rewrite_args->rewriter->checkAndThrowCAPIException(rewrite_args->out_rtn);
-        rewrite_args->out_success = true;
-    }
-
-    Box* r = self->cls->tp_call(self, arg1, arg2);
-    if (!r && S == CXX)
-        throwCAPIException();
-    return r;
 }
 
 extern "C" void PyType_RequestHcAttrs(PyTypeObject* cls, int offset) noexcept {

--- a/src/capi/typeobject.cpp
+++ b/src/capi/typeobject.cpp
@@ -3436,21 +3436,15 @@ static Box* tppProxyToTpCall(Box* self, CallRewriteArgs* rewrite_args, ArgPassSp
         }
 
         Box* r = self->cls->tp_call(self, arg1, arg2);
-        if (!r)
+        if (S == CXX && !r)
             throwCAPIException();
         return r;
     };
 
-    try {
+    return callCXXFromStyle<S>([&]() {
         return rearrangeArgumentsAndCall(paramspec, NULL, "", NULL, rewrite_args, argspec, arg1, arg2, arg3, args,
                                          keyword_names, continuation);
-    } catch (ExcInfo e) {
-        if (S == CAPI) {
-            setCAPIException(e);
-            return NULL;
-        } else
-            throw e;
-    }
+    });
 }
 
 extern "C" void PyType_RequestHcAttrs(PyTypeObject* cls, int offset) noexcept {

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -262,15 +262,15 @@ struct ParamReceiveSpec {
         assert(num_defaults <= MAX_DEFAULTS);
     }
 
-    bool operator==(ParamReceiveSpec rhs) {
+    bool operator==(ParamReceiveSpec rhs) const {
         return takes_varargs == rhs.takes_varargs && takes_kwargs == rhs.takes_kwargs
                && num_defaults == rhs.num_defaults && num_args == rhs.num_args;
     }
 
-    bool operator!=(ParamReceiveSpec rhs) { return !(*this == rhs); }
+    bool operator!=(ParamReceiveSpec rhs) const { return !(*this == rhs); }
 
-    int totalReceived() { return num_args + (takes_varargs ? 1 : 0) + (takes_kwargs ? 1 : 0); }
-    int kwargsIndex() { return num_args + (takes_varargs ? 1 : 0); }
+    int totalReceived() const { return num_args + (takes_varargs ? 1 : 0) + (takes_kwargs ? 1 : 0); }
+    int kwargsIndex() const { return num_args + (takes_varargs ? 1 : 0); }
 };
 
 // Inline-caches contain fastpath code, and need to know that their fastpath is valid for a particular set

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -270,6 +270,7 @@ struct ParamReceiveSpec {
     bool operator!=(ParamReceiveSpec rhs) const { return !(*this == rhs); }
 
     int totalReceived() const { return num_args + (takes_varargs ? 1 : 0) + (takes_kwargs ? 1 : 0); }
+    int varargsIndex() const { return num_args; }
     int kwargsIndex() const { return num_args + (takes_varargs ? 1 : 0); }
 };
 

--- a/src/runtime/builtin_modules/builtins.cpp
+++ b/src/runtime/builtin_modules/builtins.cpp
@@ -553,104 +553,102 @@ template <ExceptionStyle S>
 Box* getattrFuncInternal(BoxedFunctionBase* func, CallRewriteArgs* rewrite_args, ArgPassSpec argspec, Box* arg1,
                          Box* arg2, Box* arg3, Box** args, const std::vector<BoxedString*>* keyword_names) {
     static Box* defaults[] = { NULL };
-    bool rewrite_success = false;
-    rearrangeArguments(ParamReceiveSpec(3, 1, false, false), NULL, "getattr", defaults, rewrite_args, rewrite_success,
-                       argspec, arg1, arg2, arg3, args, NULL, keyword_names, NULL);
-    if (!rewrite_success)
-        rewrite_args = NULL;
 
-    Box* obj = arg1;
-    Box* _str = arg2;
-    Box* default_value = arg3;
+    auto continuation = [=](CallRewriteArgs* rewrite_args, Box* arg1, Box* arg2, Box* arg3, Box** args) {
+        Box* obj = arg1;
+        Box* _str = arg2;
+        Box* default_value = arg3;
 
-    AUTO_DECREF(obj);
-    AUTO_DECREF(_str);
-    AUTO_XDECREF(default_value);
+        if (rewrite_args) {
+            // We need to make sure that the attribute string will be the same.
+            // Even though the passed string might not be the exact attribute name
+            // that we end up looking up (because we need to encode it or intern it),
+            // guarding on that object means (for strings and unicode) that the string
+            // value is fixed.
+            if (!PyString_CheckExact(_str) && !PyUnicode_CheckExact(_str))
+                rewrite_args = NULL;
+            else {
+                if (PyString_CheckExact(_str) && PyString_CHECK_INTERNED(_str) == SSTATE_INTERNED_IMMORTAL) {
+                    // can avoid keeping the extra gc reference
+                } else {
+                    rewrite_args->rewriter->addGCReference(_str);
+                }
 
-    if (rewrite_args) {
-        // We need to make sure that the attribute string will be the same.
-        // Even though the passed string might not be the exact attribute name
-        // that we end up looking up (because we need to encode it or intern it),
-        // guarding on that object means (for strings and unicode) that the string
-        // value is fixed.
-        if (!PyString_CheckExact(_str) && !PyUnicode_CheckExact(_str))
-            rewrite_args = NULL;
-        else {
-            if (PyString_CheckExact(_str) && PyString_CHECK_INTERNED(_str) == SSTATE_INTERNED_IMMORTAL) {
-                // can avoid keeping the extra gc reference
-            } else {
-                rewrite_args->rewriter->addGCReference(_str);
+                rewrite_args->arg2->addGuard((intptr_t)arg2);
             }
-
-            rewrite_args->arg2->addGuard((intptr_t)arg2);
         }
-    }
 
-    _str = coerceUnicodeToStr<S>(_str);
-    if (S == CAPI && !_str)
-        return NULL;
+        _str = coerceUnicodeToStr<CXX>(_str);
 
-    if (!PyString_Check(_str)) {
-        Py_DECREF(_str);
-        if (S == CAPI) {
-            PyErr_SetString(TypeError, "getattr(): attribute name must be string");
-            return NULL;
-        } else
+        if (!PyString_Check(_str)) {
+            Py_DECREF(_str);
             raiseExcHelper(TypeError, "getattr(): attribute name must be string");
-    }
-
-    BoxedString* str = static_cast<BoxedString*>(_str);
-    if (!PyString_CHECK_INTERNED(str))
-        internStringMortalInplace(str);
-    AUTO_DECREF(str);
-
-    Box* rtn;
-    RewriterVar* r_rtn;
-    if (rewrite_args) {
-        GetattrRewriteArgs grewrite_args(rewrite_args->rewriter, rewrite_args->arg1, rewrite_args->destination);
-        rtn = getattrInternal<CAPI>(obj, str, &grewrite_args);
-        // TODO could make the return valid in the NOEXC_POSSIBLE case via a helper
-        if (!grewrite_args.isSuccessful())
-            rewrite_args = NULL;
-        else {
-            ReturnConvention return_convention;
-            std::tie(r_rtn, return_convention) = grewrite_args.getReturn();
-
-            // Convert to NOEXC_POSSIBLE:
-            if (return_convention == ReturnConvention::NO_RETURN) {
-                return_convention = ReturnConvention::NOEXC_POSSIBLE;
-                r_rtn = rewrite_args->rewriter->loadConst(0);
-            } else if (return_convention == ReturnConvention::MAYBE_EXC) {
-                if (default_value)
-                    rewrite_args = NULL;
-            }
-            assert(!rewrite_args || return_convention == ReturnConvention::NOEXC_POSSIBLE
-                   || return_convention == ReturnConvention::HAS_RETURN
-                   || return_convention == ReturnConvention::CAPI_RETURN
-                   || (default_value == NULL && return_convention == ReturnConvention::MAYBE_EXC));
         }
-    } else {
-        rtn = getattrInternal<CAPI>(obj, str);
+
+        BoxedString* str = static_cast<BoxedString*>(_str);
+        if (!PyString_CHECK_INTERNED(str))
+            internStringMortalInplace(str);
+        AUTO_DECREF(str);
+
+        Box* rtn;
+        RewriterVar* r_rtn;
+        if (rewrite_args) {
+            GetattrRewriteArgs grewrite_args(rewrite_args->rewriter, rewrite_args->arg1, rewrite_args->destination);
+            rtn = getattrInternal<CAPI>(obj, str, &grewrite_args);
+            // TODO could make the return valid in the NOEXC_POSSIBLE case via a helper
+            if (!grewrite_args.isSuccessful())
+                rewrite_args = NULL;
+            else {
+                ReturnConvention return_convention;
+                std::tie(r_rtn, return_convention) = grewrite_args.getReturn();
+
+                // Convert to NOEXC_POSSIBLE:
+                if (return_convention == ReturnConvention::NO_RETURN) {
+                    return_convention = ReturnConvention::NOEXC_POSSIBLE;
+                    r_rtn = rewrite_args->rewriter->loadConst(0);
+                } else if (return_convention == ReturnConvention::MAYBE_EXC) {
+                    if (default_value)
+                        rewrite_args = NULL;
+                }
+                assert(!rewrite_args || return_convention == ReturnConvention::NOEXC_POSSIBLE
+                       || return_convention == ReturnConvention::HAS_RETURN
+                       || return_convention == ReturnConvention::CAPI_RETURN
+                       || (default_value == NULL && return_convention == ReturnConvention::MAYBE_EXC));
+            }
+        } else {
+            rtn = getattrInternal<CAPI>(obj, str);
+        }
+
+        if (rewrite_args) {
+            assert(PyString_CHECK_INTERNED(str) == SSTATE_INTERNED_IMMORTAL);
+            RewriterVar* r_str = rewrite_args->rewriter->loadConst((intptr_t)str, Location::forArg(2));
+            RewriterVar* final_rtn
+                = rewrite_args->rewriter->call(false, (void*)getattrFuncHelper, r_rtn, rewrite_args->arg1, r_str,
+                                               rewrite_args->arg3)->setType(RefType::OWNED);
+            r_rtn->refConsumed();
+
+            if (S == CXX)
+                rewrite_args->rewriter->checkAndThrowCAPIException(final_rtn);
+            rewrite_args->out_success = true;
+            rewrite_args->out_rtn = final_rtn;
+        }
+
+        Box* r = getattrFuncHelper(rtn, obj, str, default_value);
+        if (!r)
+            throwCAPIException();
+        return r;
+    };
+
+    try {
+        return rearrangeArgumentsAndCall(ParamReceiveSpec(3, 1, false, false), NULL, "getattr", defaults, rewrite_args,
+                                         argspec, arg1, arg2, arg3, args, keyword_names, continuation);
+    } catch (ExcInfo e) {
+        if (S == CAPI) {
+            setCAPIException(e);
+            return NULL;
+        }
+        throw e;
     }
-
-    if (rewrite_args) {
-        assert(PyString_CHECK_INTERNED(str) == SSTATE_INTERNED_IMMORTAL);
-        RewriterVar* r_str = rewrite_args->rewriter->loadConst((intptr_t)str, Location::forArg(2));
-        RewriterVar* final_rtn
-            = rewrite_args->rewriter->call(false, (void*)getattrFuncHelper, r_rtn, rewrite_args->arg1, r_str,
-                                           rewrite_args->arg3)->setType(RefType::OWNED);
-        r_rtn->refConsumed();
-
-        if (S == CXX)
-            rewrite_args->rewriter->checkAndThrowCAPIException(final_rtn);
-        rewrite_args->out_success = true;
-        rewrite_args->out_rtn = final_rtn;
-    }
-
-    Box* r = getattrFuncHelper(rtn, obj, str, default_value);
-    if (S == CXX && !r)
-        throwCAPIException();
-    return r;
 }
 
 Box* setattrFunc(Box* obj, Box* _str, Box* value) {
@@ -688,97 +686,95 @@ static Box* hasattrFuncHelper(STOLEN(Box*) return_val) noexcept {
 template <ExceptionStyle S>
 Box* hasattrFuncInternal(BoxedFunctionBase* func, CallRewriteArgs* rewrite_args, ArgPassSpec argspec, Box* arg1,
                          Box* arg2, Box* arg3, Box** args, const std::vector<BoxedString*>* keyword_names) {
-    bool rewrite_success = false;
-    rearrangeArguments(ParamReceiveSpec(2, 0, false, false), NULL, "hasattr", NULL, rewrite_args, rewrite_success,
-                       argspec, arg1, arg2, arg3, args, NULL, keyword_names, NULL);
-    if (!rewrite_success)
-        rewrite_args = NULL;
+    auto continuation = [=](CallRewriteArgs* rewrite_args, Box* arg1, Box* arg2, Box* arg3, Box** args) {
+        Box* obj = arg1;
+        Box* _str = arg2;
 
-    AUTO_DECREF(arg1);
-    AUTO_DECREF(arg2);
-
-    Box* obj = arg1;
-    Box* _str = arg2;
-
-    if (rewrite_args) {
-        // We need to make sure that the attribute string will be the same.
-        // Even though the passed string might not be the exact attribute name
-        // that we end up looking up (because we need to encode it or intern it),
-        // guarding on that object means (for strings and unicode) that the string
-        // value is fixed.
-        if (!PyString_CheckExact(_str) && !PyUnicode_CheckExact(_str))
-            rewrite_args = NULL;
-        else {
-            if (PyString_CheckExact(_str) && PyString_CHECK_INTERNED(_str) == SSTATE_INTERNED_IMMORTAL) {
-                // can avoid keeping the extra gc reference
-            } else {
-                rewrite_args->rewriter->addGCReference(_str);
-            }
-
-            rewrite_args->arg2->addGuard((intptr_t)arg2);
-        }
-    }
-
-    _str = coerceUnicodeToStr<S>(_str);
-    if (S == CAPI && !_str)
-        return NULL;
-
-    if (!PyString_Check(_str)) {
-        Py_DECREF(_str);
-        if (S == CAPI) {
-            PyErr_SetString(TypeError, "hasattr(): attribute name must be string");
-            return NULL;
-        } else
-            raiseExcHelper(TypeError, "hasattr(): attribute name must be string");
-    }
-
-    BoxedString* str = static_cast<BoxedString*>(_str);
-
-    if (!PyString_CHECK_INTERNED(str))
-        internStringMortalInplace(str);
-    AUTO_DECREF(str);
-
-    Box* rtn;
-    RewriterVar* r_rtn;
-    if (rewrite_args) {
-        GetattrRewriteArgs grewrite_args(rewrite_args->rewriter, rewrite_args->arg1, rewrite_args->destination);
-        rtn = getattrInternal<CAPI>(obj, str, &grewrite_args);
-        if (!grewrite_args.isSuccessful())
-            rewrite_args = NULL;
-        else {
-            ReturnConvention return_convention;
-            std::tie(r_rtn, return_convention) = grewrite_args.getReturn();
-
-            // Convert to NOEXC_POSSIBLE:
-            if (return_convention == ReturnConvention::NO_RETURN) {
-                return_convention = ReturnConvention::NOEXC_POSSIBLE;
-                r_rtn = rewrite_args->rewriter->loadConst(0);
-            } else if (return_convention == ReturnConvention::MAYBE_EXC) {
+        if (rewrite_args) {
+            // We need to make sure that the attribute string will be the same.
+            // Even though the passed string might not be the exact attribute name
+            // that we end up looking up (because we need to encode it or intern it),
+            // guarding on that object means (for strings and unicode) that the string
+            // value is fixed.
+            if (!PyString_CheckExact(_str) && !PyUnicode_CheckExact(_str))
                 rewrite_args = NULL;
+            else {
+                if (PyString_CheckExact(_str) && PyString_CHECK_INTERNED(_str) == SSTATE_INTERNED_IMMORTAL) {
+                    // can avoid keeping the extra gc reference
+                } else {
+                    rewrite_args->rewriter->addGCReference(_str);
+                }
+
+                rewrite_args->arg2->addGuard((intptr_t)arg2);
             }
-            assert(!rewrite_args || return_convention == ReturnConvention::NOEXC_POSSIBLE
-                   || return_convention == ReturnConvention::HAS_RETURN
-                   || return_convention == ReturnConvention::CAPI_RETURN);
         }
-    } else {
-        rtn = getattrInternal<CAPI>(obj, str);
+
+        _str = coerceUnicodeToStr<CXX>(_str);
+
+        if (!PyString_Check(_str)) {
+            Py_DECREF(_str);
+            raiseExcHelper(TypeError, "hasattr(): attribute name must be string");
+        }
+
+        BoxedString* str = static_cast<BoxedString*>(_str);
+
+        if (!PyString_CHECK_INTERNED(str))
+            internStringMortalInplace(str);
+        AUTO_DECREF(str);
+
+        Box* rtn;
+        RewriterVar* r_rtn;
+        if (rewrite_args) {
+            GetattrRewriteArgs grewrite_args(rewrite_args->rewriter, rewrite_args->arg1, rewrite_args->destination);
+            rtn = getattrInternal<CAPI>(obj, str, &grewrite_args);
+            if (!grewrite_args.isSuccessful())
+                rewrite_args = NULL;
+            else {
+                ReturnConvention return_convention;
+                std::tie(r_rtn, return_convention) = grewrite_args.getReturn();
+
+                // Convert to NOEXC_POSSIBLE:
+                if (return_convention == ReturnConvention::NO_RETURN) {
+                    return_convention = ReturnConvention::NOEXC_POSSIBLE;
+                    r_rtn = rewrite_args->rewriter->loadConst(0);
+                } else if (return_convention == ReturnConvention::MAYBE_EXC) {
+                    rewrite_args = NULL;
+                }
+                assert(!rewrite_args || return_convention == ReturnConvention::NOEXC_POSSIBLE
+                       || return_convention == ReturnConvention::HAS_RETURN
+                       || return_convention == ReturnConvention::CAPI_RETURN);
+            }
+        } else {
+            rtn = getattrInternal<CAPI>(obj, str);
+        }
+
+        if (rewrite_args) {
+            RewriterVar* final_rtn
+                = rewrite_args->rewriter->call(false, (void*)hasattrFuncHelper, r_rtn)->setType(RefType::OWNED);
+            r_rtn->refConsumed();
+
+            if (S == CXX)
+                rewrite_args->rewriter->checkAndThrowCAPIException(final_rtn);
+            rewrite_args->out_success = true;
+            rewrite_args->out_rtn = final_rtn;
+        }
+
+        Box* r = hasattrFuncHelper(rtn);
+        if (!r)
+            throwCAPIException();
+        return r;
+    };
+
+    try {
+        return rearrangeArgumentsAndCall(ParamReceiveSpec(2, 0, false, false), NULL, "hasattr", NULL, rewrite_args,
+                                         argspec, arg1, arg2, arg3, args, keyword_names, continuation);
+    } catch (ExcInfo e) {
+        if (S == CAPI) {
+            setCAPIException(e);
+            return NULL;
+        }
+        throw e;
     }
-
-    if (rewrite_args) {
-        RewriterVar* final_rtn
-            = rewrite_args->rewriter->call(false, (void*)hasattrFuncHelper, r_rtn)->setType(RefType::OWNED);
-        r_rtn->refConsumed();
-
-        if (S == CXX)
-            rewrite_args->rewriter->checkAndThrowCAPIException(final_rtn);
-        rewrite_args->out_success = true;
-        rewrite_args->out_rtn = final_rtn;
-    }
-
-    Box* r = hasattrFuncHelper(rtn);
-    if (S == CXX && !r)
-        throwCAPIException();
-    return r;
 }
 
 Box* map2(Box* f, Box* container) {

--- a/src/runtime/descr.cpp
+++ b/src/runtime/descr.cpp
@@ -695,13 +695,15 @@ Box* BoxedWrapperDescriptor::tppCall(Box* _self, CallRewriteArgs* rewrite_args, 
             RELEASE_ASSERT(0, "%d", flags);
         }
 
-        if (!rtn)
+        if (S == CXX && !rtn)
             throwCAPIException();
         return rtn;
     };
 
-    return rearrangeArgumentsAndCall(paramspec, NULL, self->wrapper->name.data(), NULL, rewrite_args, argspec, arg1,
-                                     arg2, arg3, args, keyword_names, continuation);
+    return callCXXFromStyle<S>([&]() {
+        return rearrangeArgumentsAndCall(paramspec, NULL, self->wrapper->name.data(), NULL, rewrite_args, argspec, arg1,
+                                         arg2, arg3, args, keyword_names, continuation);
+    });
 }
 
 static Box* wrapperdescrGetDoc(Box* b, void*) {

--- a/src/runtime/generator.cpp
+++ b/src/runtime/generator.cpp
@@ -429,11 +429,14 @@ extern "C" BoxedGenerator::BoxedGenerator(BoxedFunctionBase* function, Box* arg1
 #endif
 {
     Py_INCREF(function);
-    Py_XINCREF(arg1);
-    Py_XINCREF(arg2);
-    Py_XINCREF(arg3);
 
     int numArgs = function->md->numReceivedArgs();
+    if (numArgs > 0)
+        Py_XINCREF(arg1);
+    if (numArgs > 1)
+        Py_XINCREF(arg2);
+    if (numArgs > 2)
+        Py_XINCREF(arg3);
     if (numArgs > 3) {
         numArgs -= 3;
         this->args = new (numArgs) GCdArray();
@@ -631,15 +634,16 @@ static void generator_dealloc(BoxedGenerator* self) noexcept {
 
     int numArgs = self->function->md->numReceivedArgs();
     if (numArgs > 3) {
-        numArgs -= 3;
-        for (int i = 0; i < numArgs; i++) {
+        for (int i = 0; i < numArgs - 3; i++) {
             Py_CLEAR(self->args->elts[i]);
         }
     }
-
-    Py_CLEAR(self->arg1);
-    Py_CLEAR(self->arg2);
-    Py_CLEAR(self->arg3);
+    if (numArgs > 2)
+        Py_CLEAR(self->arg3);
+    if (numArgs > 1)
+        Py_CLEAR(self->arg2);
+    if (numArgs > 0)
+        Py_CLEAR(self->arg1);
 
     Py_CLEAR(self->function);
 
@@ -667,15 +671,16 @@ static int generator_traverse(BoxedGenerator* self, visitproc visit, void* arg) 
 
     int numArgs = self->function->md->numReceivedArgs();
     if (numArgs > 3) {
-        numArgs -= 3;
-        for (int i = 0; i < numArgs; i++) {
+        for (int i = 0; i < numArgs - 3; i++) {
             Py_VISIT(self->args->elts[i]);
         }
     }
-
-    Py_VISIT(self->arg1);
-    Py_VISIT(self->arg2);
-    Py_VISIT(self->arg3);
+    if (numArgs > 2)
+        Py_VISIT(self->arg3);
+    if (numArgs > 1)
+        Py_VISIT(self->arg2);
+    if (numArgs > 0)
+        Py_VISIT(self->arg1);
 
     Py_VISIT(self->function);
 

--- a/src/runtime/rewrite_args.h
+++ b/src/runtime/rewrite_args.h
@@ -333,7 +333,6 @@ public:
 // rearrangeArgumentsAndCall supports both CAPI- and CXX- exception styles for continuation, and will propagate them
 // back to the caller.  For now, it can also throw its own exceptions such as "not enough arguments", and will throw
 // them in the CXX style.
-template <Rewritable rewritable = REWRITABLE>
 Box* rearrangeArgumentsAndCall(ParamReceiveSpec paramspec, const ParamNames* param_names, const char* func_name,
                                Box** defaults, CallRewriteArgs* rewrite_args, ArgPassSpec argspec, Box* arg1, Box* arg2,
                                Box* arg3, Box** args, const std::vector<BoxedString*>* keyword_names,

--- a/src/runtime/rewrite_args.h
+++ b/src/runtime/rewrite_args.h
@@ -292,26 +292,58 @@ struct CompareRewriteArgs {
         : rewriter(rewriter), lhs(lhs), rhs(rhs), destination(destination), out_success(false), out_rtn(NULL) {}
 };
 
-// Passes the output arguments back through oarg.  Passes the rewrite success by setting rewrite_success.
-// Directly modifies rewrite_args args in place, but only if rewrite_success got set.
-// oargs needs to be pre-allocated by the caller, since it's assumed that they will want to use alloca.
-// The caller is responsible for guarding for paramspec, argspec, param_names, and defaults.
-// TODO Fix this function's signature.  should we pass back out through args?  the common case is that they
-// match anyway.  Or maybe it should call a callback function, which could save on the common case.
+typedef Box* (*rearrange_target_t)(void*, CallRewriteArgs*, Box*, Box*, Box*, Box**);
+
+// This is a magical helper class that converts a functor (in particular, lambdas) into a [function pointer, void* data]
+// pair.  This lets us pass the functor efficiently: we can avoid doing an allocation (by storing the functor on the
+// stack),
+// and also avoid making the receiving function have to be a template.
 //
-// Reference semantics: takes borrowed references, and everything written out is an owned reference.
+// In effect, it does what you would have to do to create a function pointer + void* pair, like one would pass to
+// C-style functions.
+class FunctorPointer {
+private:
+    template <typename Functor> class ConversionHelper {
+    public:
+        static Box* call(void* f, CallRewriteArgs* rewrite_args, Box* arg1, Box* arg2, Box* arg3, Box** args) {
+            // static_assert(decltypeD
+            return (*(Functor*)f)(rewrite_args, arg1, arg2, arg3, args);
+        }
+    };
+
+    rearrange_target_t function_pointer;
+    void* functor;
+
+public:
+    template <typename Functor>
+    FunctorPointer(Functor& f)
+        : function_pointer(ConversionHelper<Functor>::call), functor(&f) {}
+
+    Box* operator()(CallRewriteArgs* rewrite_args, Box* arg1, Box* arg2, Box* arg3, Box** args) {
+        return function_pointer(functor, rewrite_args, arg1, arg2, arg3, args);
+    }
+};
+
+// rearrangeArgumentsAndCall maps from a given set of arguments (the structure specified by an ArgPassSpec) to the
+// parameter form than the receiving function expects (given by the ParamReceiveSpec).  After it does this, it will
+// call `continuation` and return the result.
+//
+// The caller is responsible for guarding for paramspec, argspec, param_names, and defaults.
+//
+// rearrangeArgumentsAndCall supports both CAPI- and CXX- exception styles for continuation, and will propagate them
+// back to the caller.  For now, it can also throw its own exceptions such as "not enough arguments", and will throw
+// them in the CXX style.
 template <Rewritable rewritable = REWRITABLE>
-void rearrangeArguments(ParamReceiveSpec paramspec, const ParamNames* param_names, const char* func_name,
-                        Box** defaults, _CallRewriteArgsBase* rewrite_args, bool& rewrite_success, ArgPassSpec argspec,
-                        Box*& arg1, Box*& arg2, Box*& arg3, Box** args, Box** oargs,
-                        const std::vector<BoxedString*>* keyword_names, bool* oargs_owned);
+Box* rearrangeArgumentsAndCall(ParamReceiveSpec paramspec, const ParamNames* param_names, const char* func_name,
+                               Box** defaults, CallRewriteArgs* rewrite_args, ArgPassSpec argspec, Box* arg1, Box* arg2,
+                               Box* arg3, Box** args, const std::vector<BoxedString*>* keyword_names,
+                               FunctorPointer continuation);
 
 // new_args should be allocated by the caller if at least three args get passed in.
 // rewrite_args will get modified in place.
 ArgPassSpec bindObjIntoArgs(Box* bind_obj, RewriterVar* r_bind_obj, _CallRewriteArgsBase* rewrite_args,
                             ArgPassSpec argspec, Box*& arg1, Box*& arg2, Box*& arg3, Box** args, Box** new_args);
 
-void decrefOargs(RewriterVar* oargs, bool* oargs_owned, int oargs_size);
 } // namespace pyston
 
 #endif

--- a/src/runtime/types.h
+++ b/src/runtime/types.h
@@ -413,41 +413,6 @@ public:
 #define AUTO_DECREF_ARRAY(x, size) AutoDecrefArray<false> CAT(_autodecref_, __LINE__)((x), (size))
 #define AUTO_XDECREF_ARRAY(x, size) AutoDecrefArray<true> CAT(_autodecref_, __LINE__)((x), (size))
 
-class AutoDecrefArgs {
-private:
-    int num_args;
-    Box* arg1, *arg2, *arg3;
-    Box** args;
-
-public:
-    AutoDecrefArgs(int num_args, Box* arg1, Box* arg2, Box* arg3, Box** args)
-        : num_args(num_args), arg1(arg1), arg2(arg2), arg3(arg3), args(args) {}
-    AutoDecrefArgs(ParamReceiveSpec paramspec, Box* arg1, Box* arg2, Box* arg3, Box** args)
-        : num_args(paramspec.totalReceived()), arg1(arg1), arg2(arg2), arg3(arg3), args(args) {}
-
-    ~AutoDecrefArgs() {
-        // TODO Minor optimization: only the last arg (kwargs) is allowed to be NULL.
-        switch (num_args) {
-            default:
-                for (int i = 0; i < num_args - 3; i++) {
-                    Py_XDECREF(args[i]);
-                }
-            case 3:
-                Py_XDECREF(arg3);
-            case 2:
-                Py_XDECREF(arg2);
-            case 1:
-                Py_XDECREF(arg1);
-            case 0:
-                break;
-        }
-    }
-};
-// Note: this captures the first three args by value (like AUTO_DECREF) but the array by reference.
-// You can also pass a ParamReceiveSpec instead of an int for num_args
-#define AUTO_DECREF_ARGS(num_args, arg1, arg2, arg3, args)                                                             \
-    AutoDecrefArgs CAT(_autodecref_, __LINE__)((num_args), (arg1), (arg2), (arg3), (args))
-
 template <typename B> B* incref(B* b) {
     Py_INCREF(b);
     return b;

--- a/src/runtime/types.h
+++ b/src/runtime/types.h
@@ -422,6 +422,32 @@ template <typename B> B* xincref(B* b) {
     return b;
 }
 
+// Helper function: calls a CXX-style function from a templated function.  This is more efficient than the
+// easier-to-type version:
+//
+// try {
+//     return f();
+// } catch (ExcInfo e) {
+//     if (S == CAPI) {
+//         setCAPIException(e);
+//         return NULL;
+//     } else
+//         throw e;
+// }
+//
+// since this version does not need the try-catch block when called from a CXX-style function
+template <ExceptionStyle S, typename Functor> Box* callCXXFromStyle(Functor f) {
+    if (S == CAPI) {
+        try {
+            return f();
+        } catch (ExcInfo e) {
+            setCAPIException(e);
+            return NULL;
+        }
+    } else
+        return f();
+}
+
 //#define DISABLE_INT_FREELIST
 
 extern "C" int PyInt_ClearFreeList() noexcept;

--- a/test/tests/arg_refs.py
+++ b/test/tests/arg_refs.py
@@ -1,0 +1,10 @@
+# Tests to see if we add any extra refs to function arguments.
+
+import sys
+print sys.getrefcount(object())
+
+def f(o):
+    print sys.getrefcount(o)
+
+# This gives 3 for CPython and our interpreter, but 2 for the llvm tier:
+# f(object())


### PR DESCRIPTION
This lets it more-efficiently keep track of the different situations in which it might return, because it doesn't have to pass back data signalling which path it took and what cleanups need to be done afterwards.

This is a perf win and also lets us not incref the args in as many cases -- before it was kind of expensive to pass back an extra flag saying whether or not the args should be decreffed.

```
                                origin/refcounting:  personal/rearrange:
       django_template3_10x.py            13.8s (2)            13.6s (2)  -1.4%
 sqlalchemy_imperative2_10x.py            19.2s (2)            18.9s (2)  -1.5%
            pyxl_bench2_10x.py            11.3s (2)            10.4s (2)  -8.6%
                       geomean                14.4s                13.9s  -3.9%
```