### PR TITLE
wip: cache refcounting pass results, add tuple free list and don't update boxed frame on exit when it's not used

### DIFF
--- a/src/codegen/entry.cpp
+++ b/src/codegen/entry.cpp
@@ -344,6 +344,7 @@ void PystonObjectCache::calculateModuleHash(const llvm::Module* M, EffortLevel e
     llvm::WriteBitcodeToFile(M, hash_stream);
     hash_stream << (int)effort;
     hash_stream << USE_REGALLOC_BASIC;
+    hash_stream << 1;
     hash_before_codegen = hash_stream.getHash();
 }
 

--- a/src/codegen/irgen.cpp
+++ b/src/codegen/irgen.cpp
@@ -1126,7 +1126,17 @@ CompiledFunction* doCompile(FunctionMetadata* md, SourceInfo* source, ParamNames
 
     emitBBs(&irstate, types, entry_descriptor, blocks);
 
-    RefcountTracker::addRefcounts(&irstate);
+    // Calculate the module hash before adding the refcount instruction and before doing any optimizations.
+    // This has the advantage that we can skip running the opt passes when we have cached object file
+    // but the disadvantage that optimizations are not allowed to add new symbolic constants and that we have to make
+    // sure that changes to the refcounting pass change the hash we generate...
+    bool have_cached_filed = false;
+    if (ENABLE_JIT_OBJECT_CACHE) {
+        g.object_cache->calculateModuleHash(g.cur_module, effort);
+        have_cached_filed = g.object_cache->haveCacheFileForHash();
+    }
+    if (!have_cached_filed)
+        RefcountTracker::addRefcounts(&irstate);
 
     int num_instructions = std::distance(llvm::inst_begin(f), llvm::inst_end(f));
     static StatCounter num_llvm_insts("num_llvm_insts");
@@ -1154,18 +1164,8 @@ CompiledFunction* doCompile(FunctionMetadata* md, SourceInfo* source, ParamNames
     static StatCounter us_irgen("us_compiling_irgen");
     us_irgen.log(irgen_us);
 
-
-    // Calculate the module hash before doing any optimizations.
-    // This has the advantage that we can skip running the opt passes when we have cached object file
-    // but the disadvantage that optimizations are not allowed to add new symbolic constants...
-    if (ENABLE_JIT_OBJECT_CACHE) {
-        g.object_cache->calculateModuleHash(g.cur_module, effort);
-        if (ENABLE_LLVMOPTS && !g.object_cache->haveCacheFileForHash())
-            optimizeIR(f, effort);
-    } else {
-        if (ENABLE_LLVMOPTS)
-            optimizeIR(f, effort);
-    }
+    if (ENABLE_LLVMOPTS && !have_cached_filed)
+        optimizeIR(f, effort);
 
     g.cur_module = NULL;
 

--- a/src/runtime/frame.cpp
+++ b/src/runtime/frame.cpp
@@ -185,7 +185,6 @@ public:
     }
     static int clear(Box* self) noexcept {
         BoxedFrame* o = static_cast<BoxedFrame*>(self);
-        assert(o->hasExited());
         Py_CLEAR(o->_back);
         Py_CLEAR(o->_code);
         Py_CLEAR(o->_globals);
@@ -264,7 +263,9 @@ extern "C" void deinitFrame(FrameInfo* frame_info) {
     cur_thread_state.frame_info = frame_info->back;
     BoxedFrame* frame = frame_info->frame_obj;
     if (frame) {
-        frame->handleFrameExit();
+        // we don't have to call handleFrameExit() if are the only owner because we will clear it in the next line..
+        if (frame->ob_refcnt > 1)
+            frame->handleFrameExit();
         Py_CLEAR(frame_info->frame_obj);
     }
 

--- a/src/runtime/types.cpp
+++ b/src/runtime/types.cpp
@@ -3778,7 +3778,7 @@ void HiddenClass::dump() noexcept {
     }
 }
 
-static void tupledealloc(PyTupleObject* op) noexcept {
+void BoxedTuple::dealloc(PyTupleObject* op) noexcept {
     Py_ssize_t i;
     Py_ssize_t len = Py_SIZE(op);
     PyObject_GC_UnTrack(op);
@@ -3787,10 +3787,11 @@ static void tupledealloc(PyTupleObject* op) noexcept {
         while (--i >= 0)
             Py_XDECREF(op->ob_item[i]);
 #if PyTuple_MAXSAVESIZE > 0
-        if (len < PyTuple_MAXSAVESIZE && numfree[len] < PyTuple_MAXFREELIST && Py_TYPE(op) == &PyTuple_Type) {
+        if (likely(len < PyTuple_MAXSAVESIZE && BoxedTuple::numfree[len] < PyTuple_MAXFREELIST
+                   && ((BoxedTuple*)op)->cls == tuple_cls)) {
             op->ob_item[0] = (PyObject*)free_list[len];
             numfree[len]++;
-            free_list[len] = op;
+            free_list[len] = (BoxedTuple*)op;
             goto done; /* return */
         }
 #endif
@@ -4245,7 +4246,7 @@ void setupRuntime() {
     // Not sure why CPython defines sizeof(PyTupleObject) to include one element,
     // but we copy that, which means we have to subtract that extra pointer to get the tp_basicsize:
     tuple_cls = new (0) BoxedClass(object_cls, 0, 0, sizeof(BoxedTuple) - sizeof(Box*), false, "tuple", true,
-                                   (destructor)tupledealloc, NULL, true, (traverseproc)tupletraverse, NOCLEAR);
+                                   (destructor)BoxedTuple::dealloc, NULL, true, (traverseproc)tupletraverse, NOCLEAR);
 
     tuple_cls->tp_flags |= Py_TPFLAGS_TUPLE_SUBCLASS;
     tuple_cls->tp_itemsize = sizeof(Box*);


### PR DESCRIPTION
```
                                upstream/refcounti:  origin/cache_refco:
           django_template3.py             2.9s (4)             2.7s (4)  -4.4%
                 pyxl_bench.py             2.9s (4)             2.8s (4)  -3.6%
     sqlalchemy_imperative2.py             2.8s (4)             2.7s (4)  -2.4%
                pyxl_bench2.py             1.3s (4)             1.3s (4)  -0.3%
       django_template3_10x.py            14.4s (4)            13.7s (4)  -4.8%
             pyxl_bench_10x.py            18.8s (4)            18.4s (4)  -2.1%
 sqlalchemy_imperative2_10x.py            20.1s (4)            19.8s (4)  -1.5%
            pyxl_bench2_10x.py            11.0s (4)            10.5s (4)  -5.1%
                       geomean                 6.0s                 5.9s  -3.0%
```

The object cache change is a little bit risky because we have to manually make sure that if we change something inside the refcounting pass that we generate a new hash. (aka add some new seed value to ```PystonObjectCache::calculateModuleHash``` in the future we should probably take the pyston executable as seed...)
 