### PR TITLE
Some misc performance optimizations

### DIFF
--- a/from_cpython/Objects/obmalloc.c
+++ b/from_cpython/Objects/obmalloc.c
@@ -9,15 +9,20 @@
  #endif
 #endif
 
+#define UNLIKELY(value) __builtin_expect((value), 0)
+#define LIKELY(value) __builtin_expect((value), 1)
+
 #ifdef WITH_VALGRIND
 #include <valgrind/valgrind.h>
 
+#if 0
 /* If we're using GCC, use __builtin_expect() to reduce overhead of
    the valgrind checks */
 #if defined(__GNUC__) && (__GNUC__ > 2) && defined(__OPTIMIZE__)
 #  define UNLIKELY(value) __builtin_expect((value), 0)
 #else
 #  define UNLIKELY(value) (value)
+#endif
 #endif
 
 /* -1 indicates that we haven't checked that we're running on valgrind yet. */
@@ -784,20 +789,20 @@ PyObject_Malloc(size_t nbytes)
      * things without checking for overflows or negatives.
      * As size_t is unsigned, checking for nbytes < 0 is not required.
      */
-    if (nbytes > PY_SSIZE_T_MAX)
+    if (UNLIKELY(nbytes > PY_SSIZE_T_MAX))
         return NULL;
 
     /*
      * This implicitly redirects malloc(0).
      */
-    if ((nbytes - 1) < SMALL_REQUEST_THRESHOLD) {
+    if (LIKELY((nbytes - 1) < SMALL_REQUEST_THRESHOLD)) {
         LOCK();
         /*
          * Most frequent paths first
          */
         size = (uint)(nbytes - 1) >> ALIGNMENT_SHIFT;
         pool = usedpools[size + size];
-        if (pool != pool->nextpool) {
+        if (LIKELY(pool != pool->nextpool)) {
             /*
              * There is a used pool for this size class.
              * Pick up the head block of its free list.


### PR DESCRIPTION
- switch back to CPython's PyUnicode_New (which uses the freelist)
- add some LIKELY/UNLIKELY annotations to PyUnicode_New and PyObject_Malloc

Results on top of refcounting are quite encouraging, but when on top of rearrange_and_call, it actually shows a small regression.  I feel like something weird is going on with pyxl_bench2_10x, and I feel like this change should help...