### PR TITLE
Extract the logic from DEFAULT_CLASS_SIMPLE

### DIFF
--- a/src/runtime/inline/dict.cpp
+++ b/src/runtime/inline/dict.cpp
@@ -26,7 +26,7 @@ BoxedDictIterator::BoxedDictIterator(BoxedDict* d) : d(d), it(d->d.begin()), itE
 Box* dict_iter(Box* s) noexcept {
     assert(PyDict_Check(s));
     BoxedDict* self = static_cast<BoxedDict*>(s);
-    return new (&PyDictIterKey_Type) BoxedDictIterator(self);
+    return new (&PyDictIterKey_Type, FAST_GC) BoxedDictIterator(self);
 }
 
 Box* dictIterKeys(Box* s) {
@@ -36,13 +36,13 @@ Box* dictIterKeys(Box* s) {
 Box* dictIterValues(Box* s) {
     assert(PyDict_Check(s));
     BoxedDict* self = static_cast<BoxedDict*>(s);
-    return new (&PyDictIterValue_Type) BoxedDictIterator(self);
+    return new (&PyDictIterValue_Type, FAST_GC) BoxedDictIterator(self);
 }
 
 Box* dictIterItems(Box* s) {
     assert(PyDict_Check(s));
     BoxedDict* self = static_cast<BoxedDict*>(s);
-    return new (&PyDictIterItem_Type) BoxedDictIterator(self);
+    return new (&PyDictIterItem_Type, FAST_GC) BoxedDictIterator(self);
 }
 
 Box* dictIterIter(Box* s) {

--- a/src/runtime/inline/list.cpp
+++ b/src/runtime/inline/list.cpp
@@ -33,7 +33,7 @@ Box* listIterIter(Box* s) {
 Box* listIter(Box* s) noexcept {
     assert(PyList_Check(s));
     BoxedList* self = static_cast<BoxedList*>(s);
-    return new BoxedListIterator(self, 0);
+    return new (list_iterator_cls, FAST_GC) BoxedListIterator(self, 0);
 }
 
 Box* listiterHasnext(Box* s) {
@@ -89,7 +89,7 @@ Box* listiter_next(Box* s) noexcept {
 Box* listReversed(Box* s) {
     assert(PyList_Check(s));
     BoxedList* self = static_cast<BoxedList*>(s);
-    return new (list_reverse_iterator_cls) BoxedListIterator(self, self->size - 1);
+    return new (list_reverse_iterator_cls, FAST_GC) BoxedListIterator(self, self->size - 1);
 }
 
 Box* listreviterHasnext(Box* s) {

--- a/src/runtime/list.h
+++ b/src/runtime/list.h
@@ -28,8 +28,6 @@ public:
     int pos;
     BoxedListIterator(BoxedList* l, int start);
 
-    DEFAULT_CLASS(list_iterator_cls);
-
     static void dealloc(BoxedListIterator* o) noexcept {
         PyObject_GC_UnTrack(o);
         Py_XDECREF(o->l);

--- a/src/runtime/long.h
+++ b/src/runtime/long.h
@@ -33,7 +33,7 @@ public:
 
     BoxedLong() __attribute__((visibility("default"))) {}
 
-    DEFAULT_CLASS(long_cls);
+    DEFAULT_CLASS_SIMPLE(long_cls, false);
 };
 
 extern "C" Box* createLong(llvm::StringRef s);

--- a/src/runtime/types.cpp
+++ b/src/runtime/types.cpp
@@ -2214,7 +2214,7 @@ public:
         b = NULL;
     }
 
-    DEFAULT_CLASS(attrwrapper_cls);
+    DEFAULT_CLASS_SIMPLE(attrwrapper_cls, true);
 
 
     BORROWED(Box*) getUnderlying() {


### PR DESCRIPTION
so that it can be used in more places.  Looking at pyxl_bench2_10x,
most of the calls to PyType_GenericAlloc are from the dict and list
iterator classes, which don't use DEFAULT_CLASS_SIMPLE (or DEFAULT_CLASS)
since they use the same C++ class with multiple Python classes.  So
by extracting out the core of that function, it's now usable by those
other classes.

Also convert some things to DEFAULT_CLASS_SIMPLE while we're at it.