### PR TITLE
[WIP]Some miscs numpy fixing

### DIFF
--- a/src/runtime/str.cpp
+++ b/src/runtime/str.cpp
@@ -1184,7 +1184,7 @@ extern "C" Box* strMul(BoxedString* lhs, Box* rhs) {
             PyErr_Clear();
             raiseExcHelper(OverflowError, "cannot fit 'long' into index-sized integer");
         }
-    } else if (PyIndex_Check(rhs)) {
+    } else if (PyIndex_Check(rhs) && !PySequence_Check(rhs)) {
         n = PyNumber_AsSsize_t(rhs, PyExc_OverflowError);
         if (n == -1 && PyErr_Occurred())
             throwCAPIException();


### PR DESCRIPTION
NumPy array defined `__index__` attribute, and it is a `PySequence`. I think in Python, we should avoid to let string object to handle `str` multiply with an object who defined them both.