### PR TITLE
binop: use PyNumber_* for user defined classes

### DIFF
--- a/src/runtime/builtin_modules/builtins.cpp
+++ b/src/runtime/builtin_modules/builtins.cpp
@@ -1404,7 +1404,7 @@ Box* ellipsisRepr(Box* self) {
     return boxString("Ellipsis");
 }
 Box* divmod(Box* lhs, Box* rhs) {
-    return binopInternal<NOT_REWRITABLE>(lhs, rhs, AST_TYPE::DivMod, false, NULL);
+    return binopInternal<NOT_REWRITABLE, false>(lhs, rhs, AST_TYPE::DivMod, NULL);
 }
 
 Box* powFunc(Box* x, Box* y, Box* z) {

--- a/src/runtime/objmodel.h
+++ b/src/runtime/objmodel.h
@@ -113,8 +113,8 @@ template <Rewritable rewritable>
 void setattrGeneric(Box* obj, BoxedString* attr, STOLEN(Box*) val, SetattrRewriteArgs* rewrite_args);
 
 struct BinopRewriteArgs;
-template <Rewritable rewritable>
-Box* binopInternal(Box* lhs, Box* rhs, int op_type, bool inplace, BinopRewriteArgs* rewrite_args);
+template <Rewritable rewritable, bool inplace>
+Box* binopInternal(Box* lhs, Box* rhs, int op_type, BinopRewriteArgs* rewrite_args);
 
 struct CallRewriteArgs;
 template <ExceptionStyle S, Rewritable rewritable>

--- a/test/extra/lxml_test.py
+++ b/test/extra/lxml_test.py
@@ -33,7 +33,7 @@ def install_and_test_lxml():
 
     subprocess.check_call([PYTHON_EXE, "setup.py", "build_ext", "-i", "--with-cython"], cwd=LXML_DIR)
  
-    expected = [{'ran': 1381, 'failures': 3, 'errors': 1}]
+    expected = [{'ran': 1381, 'failures': 3}]
     run_test([PYTHON_EXE, "test.py"], cwd=LXML_DIR, expected=expected)
     
 create_virtenv(ENV_NAME, None, force_create = True)


### PR DESCRIPTION
this speeds up a simple numpy benchmark by about 10x.

```
           django_template3.py             2.8s (4)             2.8s (4)  +0.0%
                 pyxl_bench.py             2.8s (4)             2.9s (4)  +1.8%
     sqlalchemy_imperative2.py             2.8s (4)             2.8s (4)  +0.4%
                pyxl_bench2.py             1.2s (4)             1.3s (4)  +2.9%
       django_template3_10x.py            13.8s (4)            14.0s (4)  +0.8%
             pyxl_bench_10x.py            18.5s (4)            18.4s (4)  -0.6%
 sqlalchemy_imperative2_10x.py            19.7s (4)            19.6s (4)  -0.3%
            pyxl_bench2_10x.py            10.5s (4)            10.5s (4)  +0.1%
                       geomean                 5.9s                 5.9s  +0.6%
```