### PR TITLE
microptimization: mark _PyGC_generation0 as having a const address

### DIFF
--- a/from_cpython/Include/objimpl.h
+++ b/from_cpython/Include/objimpl.h
@@ -260,7 +260,7 @@ typedef union _gc_head {
     long double dummy;  /* force worst-case alignment */
 } PyGC_Head;
 
-extern PyGC_Head *_PyGC_generation0;
+extern PyGC_Head * const _PyGC_generation0;
 
 #define _Py_AS_GC(o) ((PyGC_Head *)(o)-1)
 

--- a/from_cpython/Modules/gcmodule.c
+++ b/from_cpython/Modules/gcmodule.c
@@ -47,7 +47,7 @@ static struct gc_generation generations[NUM_GENERATIONS] = {
     {{{GEN_HEAD(2), GEN_HEAD(2), 0}},           10,             0},
 };
 
-PyGC_Head *_PyGC_generation0 = GEN_HEAD(0);
+PyGC_Head * const _PyGC_generation0 = GEN_HEAD(0);
 
 static int enabled = 1; /* automatic collection enabled? */
 


### PR DESCRIPTION
this is an advantage for _PyObject_GC_TRACK
which before compiled to something like this:
```
        cmpq    $-2, -16(%rdi)
        jne     .LBB0_2
        movq    $-3, -16(%rdi)
        movq    _PyGC_generation0(%rip), %rax
        movq    %rax, -32(%rdi)
        movq    _PyGC_generation0(%rip), %rax
        movq    8(%rax), %rax
        movq    %rax, -24(%rdi)
        leaq    -32(%rdi), %rcx
        movq    %rcx, (%rax)
        movq    _PyGC_generation0(%rip), %rax
        movq    %rcx, 8(%rax)
```
and now compiles to
```
        cmpq    $-2, -16(%rdi)
        jne     .LBB0_2
        movq    $-3, -16(%rdi)
        movq    _PyGC_generation0(%rip), %rax
        movq    %rax, -32(%rdi)
        movq    8(%rax), %rcx
        movq    %rcx, -24(%rdi)
        leaq    -32(%rdi), %rdx
        movq    %rdx, (%rcx)
        movq    %rdx, 8(%rax)
```
notice that it had to load `_PyGC_generation0` three times because the compiler had to assume that because of aliasing it got modified.
(and this loads actually showed up in profiling as somewhat expensive)

previous PR pointing to the refcounting branch: https://github.com/dropbox/pyston/pull/1199