### PR TITLE
str: use tp_as_sequence instead of tp_as_number

### DIFF
--- a/test/extra/numpy_fulltest.py
+++ b/test/extra/numpy_fulltest.py
@@ -89,7 +89,7 @@ except:
 
 try:
     test_helper.run_test(['sh', '-c', '. %s/bin/activate && python %s/numpy/tools/test-installed-numpy.py' % (ENV_DIR, ENV_DIR)],
-            ENV_NAME, [dict(ran=5781, errors=2, failures=1)])
+            ENV_NAME, [dict(ran=5781, errors=1, failures=1)])
 finally:
     if USE_CUSTOM_PATCHES:
         print_progress_header("Unpatching NumPy...")


### PR DESCRIPTION
string is special in that it is a c++ type which has tp_as_number and tp_as_sequence.
This causes problems because when we fixup the slot dispatcher we will set the tp_as_number fields but not the
tp_as_sequence because setting both can cause problems.
Some extensions (e.g. numpy) require that we use the sq_* functions instead of nb_*.
Therefore clear the tp_as_number fields (except nb_remainder which cpython has set too because it is not part of
tp_as_sequence).