### PR TITLE
exec, input: if globals has no __builtins__ add it as a dictwrapper

### DIFF
--- a/src/codegen/irgen/hooks.cpp
+++ b/src/codegen/irgen/hooks.cpp
@@ -513,7 +513,7 @@ static void pickGlobalsAndLocals(Box*& globals, Box*& locals) {
 
         auto requested_builtins = PyDict_GetItemString(globals_dict, "__builtins__");
         if (requested_builtins == NULL)
-            PyDict_SetItemString(globals_dict, "__builtins__", builtins_module);
+            PyDict_SetItemString(globals_dict, "__builtins__", PyEval_GetBuiltins());
         else
             RELEASE_ASSERT(requested_builtins == builtins_module
                                || requested_builtins == builtins_module->getAttrWrapper(),
@@ -577,7 +577,7 @@ void exec(Box* boxedCode, Box* globals, Box* locals, FutureFlags caller_future_f
     if (PyDict_GetItemString(globals, "__builtins__") == NULL)
         // Pyston change:
         // PyDict_SetItemString(globals, "__builtins__", f->f_builtins);
-        PyDict_SetItemString(globals, "__builtins__", builtins_module);
+        PyDict_SetItemString(globals, "__builtins__", PyEval_GetBuiltins());
 
     if (PyCode_Check(prog)) {
         /* Pyston change:

--- a/src/runtime/builtin_modules/builtins.cpp
+++ b/src/runtime/builtin_modules/builtins.cpp
@@ -1671,7 +1671,7 @@ Box* input(Box* prompt) {
     // in the current global scope.
     // e.g. eval('input()', {})
     if (PyDict_GetItemString(gbls, "__builtins__") == NULL) {
-        if (PyDict_SetItemString(gbls, "__builtins__", builtins_module) != 0)
+        if (PyDict_SetItemString(gbls, "__builtins__", PyEval_GetBuiltins()) != 0)
             throwCAPIException();
     }
 

--- a/test/extra/lxml_test.py
+++ b/test/extra/lxml_test.py
@@ -33,7 +33,7 @@ def install_and_test_lxml():
 
     subprocess.check_call([PYTHON_EXE, "setup.py", "build_ext", "-i", "--with-cython"], cwd=LXML_DIR)
  
-    expected = [{'ran': 1381, 'failures': 3}]
+    expected = [{'ran': 1381, 'failures': 1}]
     run_test([PYTHON_EXE, "test.py"], cwd=LXML_DIR, expected=expected)
     
 create_virtenv(ENV_NAME, None, force_create = True)

--- a/test/tests/exec_in_test.py
+++ b/test/tests/exec_in_test.py
@@ -224,3 +224,5 @@ exec """
 def g():
     print sorted(globals().items())
 """ in d
+
+exec "hasattr(__builtins__, 'get')" in {} # check if __builtins__ becomes dict like instead of a module

--- a/test/tests/input.py
+++ b/test/tests/input.py
@@ -3,9 +3,12 @@ import sys
 
 success_tests = ["1234",            # just a number
                  "    123",         # whitespaces get trimmed
-                 "str(5) + \"6\""   # test for builtin function
+                 "str(5) + \"6\"",  # test for builtin function
+                 "hasattr(__builtins__, 'get')"
                 ]
-special_tests = ["str(10)"]
+special_tests = ["str(10)",
+                 "hasattr(__builtins__, 'get')"
+                 ]
 failure_tests = ["abcd"]
 
 orig_stdin = sys.stdin
@@ -15,9 +18,10 @@ sys.stdin = sio
 for _ in success_tests:
     print repr(input())
 
-# Special test: if the globals is empty, __builtin__ should be added to it
-# in the call to input().
-print repr(eval("input()", {}))
+for _ in special_tests:
+    # Special test: if the globals is empty, __builtin__ should be added to it
+    # in the call to input().
+    print repr(eval("input()", {}))
 
 try:
     print repr(input())


### PR DESCRIPTION
before we added a it as a module which made code fail
which does something like `__builtins__["unicode"]`