### PR TITLE
add prefix to Pyston defined True and False

### DIFF
--- a/from_cpython/Include/boolobject.h
+++ b/from_cpython/Include/boolobject.h
@@ -9,10 +9,7 @@ extern "C" {
 #endif
 
 
-// Pyston change: Try to avoid having to support mixing ints and bools
-// typedef PyIntObject PyBoolObject;
-struct _PyBoolObject;
-typedef struct _PyBoolObject PyBoolObject;
+typedef PyIntObject PyBoolObject;
 
 // Pyston change: this is no longer a static object
 PyAPI_DATA(PyTypeObject*) bool_cls;

--- a/from_cpython/Include/boolobject.h
+++ b/from_cpython/Include/boolobject.h
@@ -26,10 +26,10 @@ Don't forget to apply Py_INCREF() when returning either!!! */
 // Pyston change: these are currently stored as pointers, not as static globals
 /* Don't use these directly */
 //PyAPI_DATA(PyIntObject) _Py_ZeroStruct, _Py_TrueStruct;
-PyAPI_DATA(PyObject) *True, *False;
+PyAPI_DATA(PyObject) *pyston_True, *pyston_False;
 /* Use these macros */
-#define Py_False ((PyObject *) False)
-#define Py_True ((PyObject *) True)
+#define Py_False ((PyObject *) pyston_False)
+#define Py_True ((PyObject *) pyston_True)
 
 /* Macros for returning Py_True or Py_False, respectively */
 #define Py_RETURN_TRUE return Py_INCREF(Py_True), Py_True

--- a/from_cpython/Include/pyport.h
+++ b/from_cpython/Include/pyport.h
@@ -29,15 +29,272 @@ typedef ssize_t         Py_ssize_t;
 #define Py_FORMAT_PARSETUPLE(func,p1,p2)
 #define Py_GCC_ATTRIBUTE(x) __attribute__(x)
 
-
-
 // Pyston change: the rest of these have just been copied from CPython's pyport.h, in an arbitrary order:
 
-#if defined(__GNUC__) && __GNUC__ >= 3
-#define Py_ALIGNED(x) __attribute__((aligned(x)))
+
+/**************************************************************************
+Symbols and macros to supply platform-independent interfaces to basic
+C language & library operations whose spellings vary across platforms.
+
+Please try to make documentation here as clear as possible:  by definition,
+the stuff here is trying to illuminate C's darkest corners.
+
+Config #defines referenced here:
+
+SIGNED_RIGHT_SHIFT_ZERO_FILLS
+Meaning:  To be defined iff i>>j does not extend the sign bit when i is a
+          signed integral type and i < 0.
+Used in:  Py_ARITHMETIC_RIGHT_SHIFT
+
+Py_DEBUG
+Meaning:  Extra checks compiled in for debug mode.
+Used in:  Py_SAFE_DOWNCAST
+
+HAVE_UINTPTR_T
+Meaning:  The C9X type uintptr_t is supported by the compiler
+Used in:  Py_uintptr_t
+
+HAVE_LONG_LONG
+Meaning:  The compiler supports the C type "long long"
+Used in:  PY_LONG_LONG
+
+**************************************************************************/
+
+
+/* For backward compatibility only. Obsolete, do not use. */
+#ifdef HAVE_PROTOTYPES
+#define Py_PROTO(x) x
 #else
-#define Py_ALIGNED(x)
+#define Py_PROTO(x) ()
 #endif
+#ifndef Py_FPROTO
+#define Py_FPROTO(x) Py_PROTO(x)
+#endif
+
+/* typedefs for some C9X-defined synonyms for integral types.
+ *
+ * The names in Python are exactly the same as the C9X names, except with a
+ * Py_ prefix.  Until C9X is universally implemented, this is the only way
+ * to ensure that Python gets reliable names that don't conflict with names
+ * in non-Python code that are playing their own tricks to define the C9X
+ * names.
+ *
+ * NOTE: don't go nuts here!  Python has no use for *most* of the C9X
+ * integral synonyms.  Only define the ones we actually need.
+ */
+
+#ifdef HAVE_LONG_LONG
+#ifndef PY_LONG_LONG
+#define PY_LONG_LONG long long
+#if defined(LLONG_MAX)
+/* If LLONG_MAX is defined in limits.h, use that. */
+#define PY_LLONG_MIN LLONG_MIN
+#define PY_LLONG_MAX LLONG_MAX
+#define PY_ULLONG_MAX ULLONG_MAX
+#elif defined(__LONG_LONG_MAX__)
+/* Otherwise, if GCC has a builtin define, use that. */
+#define PY_LLONG_MAX __LONG_LONG_MAX__
+#define PY_LLONG_MIN (-PY_LLONG_MAX-1)
+#define PY_ULLONG_MAX (__LONG_LONG_MAX__*2ULL + 1ULL)
+#else
+/* Otherwise, rely on two's complement. */
+#define PY_ULLONG_MAX (~0ULL)
+#define PY_LLONG_MAX  ((long long)(PY_ULLONG_MAX>>1))
+#define PY_LLONG_MIN (-PY_LLONG_MAX-1)
+#endif /* LLONG_MAX */
+#endif
+#endif /* HAVE_LONG_LONG */
+
+/* a build with 30-bit digits for Python long integers needs an exact-width
+ * 32-bit unsigned integer type to store those digits.  (We could just use
+ * type 'unsigned long', but that would be wasteful on a system where longs
+ * are 64-bits.)  On Unix systems, the autoconf macro AC_TYPE_UINT32_T defines
+ * uint32_t to be such a type unless stdint.h or inttypes.h defines uint32_t.
+ * However, it doesn't set HAVE_UINT32_T, so we do that here.
+ */
+#ifdef uint32_t
+#define HAVE_UINT32_T 1
+#endif
+
+#ifdef HAVE_UINT32_T
+#ifndef PY_UINT32_T
+#define PY_UINT32_T uint32_t
+#endif
+#endif
+
+/* Macros for a 64-bit unsigned integer type; used for type 'twodigits' in the
+ * long integer implementation, when 30-bit digits are enabled.
+ */
+#ifdef uint64_t
+#define HAVE_UINT64_T 1
+#endif
+
+#ifdef HAVE_UINT64_T
+#ifndef PY_UINT64_T
+#define PY_UINT64_T uint64_t
+#endif
+#endif
+
+/* Signed variants of the above */
+#ifdef int32_t
+#define HAVE_INT32_T 1
+#endif
+
+#ifdef HAVE_INT32_T
+#ifndef PY_INT32_T
+#define PY_INT32_T int32_t
+#endif
+#endif
+
+#ifdef int64_t
+#define HAVE_INT64_T 1
+#endif
+
+#ifdef HAVE_INT64_T
+#ifndef PY_INT64_T
+#define PY_INT64_T int64_t
+#endif
+#endif
+
+/* If PYLONG_BITS_IN_DIGIT is not defined then we'll use 30-bit digits if all
+   the necessary integer types are available, and we're on a 64-bit platform
+   (as determined by SIZEOF_VOID_P); otherwise we use 15-bit digits. */
+
+#ifndef PYLONG_BITS_IN_DIGIT
+#if (defined HAVE_UINT64_T && defined HAVE_INT64_T && \
+     defined HAVE_UINT32_T && defined HAVE_INT32_T && SIZEOF_VOID_P >= 8)
+#define PYLONG_BITS_IN_DIGIT 30
+#else
+#define PYLONG_BITS_IN_DIGIT 15
+#endif
+#endif
+
+/* uintptr_t is the C9X name for an unsigned integral type such that a
+ * legitimate void* can be cast to uintptr_t and then back to void* again
+ * without loss of information.  Similarly for intptr_t, wrt a signed
+ * integral type.
+ */
+#ifdef HAVE_UINTPTR_T
+typedef uintptr_t       Py_uintptr_t;
+typedef intptr_t        Py_intptr_t;
+
+#elif SIZEOF_VOID_P <= SIZEOF_INT
+typedef unsigned int    Py_uintptr_t;
+typedef int             Py_intptr_t;
+
+#elif SIZEOF_VOID_P <= SIZEOF_LONG
+typedef unsigned long   Py_uintptr_t;
+typedef long            Py_intptr_t;
+
+#elif defined(HAVE_LONG_LONG) && (SIZEOF_VOID_P <= SIZEOF_LONG_LONG)
+typedef unsigned PY_LONG_LONG   Py_uintptr_t;
+typedef PY_LONG_LONG            Py_intptr_t;
+
+#else
+#   error "Python needs a typedef for Py_uintptr_t in pyport.h."
+#endif /* HAVE_UINTPTR_T */
+
+/* Py_ssize_t is a signed integral type such that sizeof(Py_ssize_t) ==
+ * sizeof(size_t).  C99 doesn't define such a thing directly (size_t is an
+ * unsigned integral type).  See PEP 353 for details.
+ */
+#ifdef HAVE_SSIZE_T
+typedef ssize_t         Py_ssize_t;
+#elif SIZEOF_VOID_P == SIZEOF_SIZE_T
+typedef Py_intptr_t     Py_ssize_t;
+#else
+#   error "Python needs a typedef for Py_ssize_t in pyport.h."
+#endif
+
+/* Largest possible value of size_t.
+   SIZE_MAX is part of C99, so it might be defined on some
+   platforms. If it is not defined, (size_t)-1 is a portable
+   definition for C89, due to the way signed->unsigned
+   conversion is defined. */
+#ifdef SIZE_MAX
+#define PY_SIZE_MAX SIZE_MAX
+#else
+#define PY_SIZE_MAX ((size_t)-1)
+#endif
+
+/* Largest positive value of type Py_ssize_t. */
+#define PY_SSIZE_T_MAX ((Py_ssize_t)(((size_t)-1)>>1))
+/* Smallest negative value of type Py_ssize_t. */
+#define PY_SSIZE_T_MIN (-PY_SSIZE_T_MAX-1)
+
+#if SIZEOF_PID_T > SIZEOF_LONG
+#   error "Python doesn't support sizeof(pid_t) > sizeof(long)"
+#endif
+
+/* PY_FORMAT_SIZE_T is a platform-specific modifier for use in a printf
+ * format to convert an argument with the width of a size_t or Py_ssize_t.
+ * C99 introduced "z" for this purpose, but not all platforms support that;
+ * e.g., MS compilers use "I" instead.
+ *
+ * These "high level" Python format functions interpret "z" correctly on
+ * all platforms (Python interprets the format string itself, and does whatever
+ * the platform C requires to convert a size_t/Py_ssize_t argument):
+ *
+ *     PyString_FromFormat
+ *     PyErr_Format
+ *     PyString_FromFormatV
+ *
+ * Lower-level uses require that you interpolate the correct format modifier
+ * yourself (e.g., calling printf, fprintf, sprintf, PyOS_snprintf); for
+ * example,
+ *
+ *     Py_ssize_t index;
+ *     fprintf(stderr, "index %" PY_FORMAT_SIZE_T "d sucks\n", index);
+ *
+ * That will expand to %ld, or %Id, or to something else correct for a
+ * Py_ssize_t on the platform.
+ */
+#ifndef PY_FORMAT_SIZE_T
+#   if SIZEOF_SIZE_T == SIZEOF_INT && !defined(__APPLE__)
+#       define PY_FORMAT_SIZE_T ""
+#   elif SIZEOF_SIZE_T == SIZEOF_LONG
+#       define PY_FORMAT_SIZE_T "l"
+#   elif defined(MS_WINDOWS)
+#       define PY_FORMAT_SIZE_T "I"
+#   else
+#       error "This platform's pyconfig.h needs to define PY_FORMAT_SIZE_T"
+#   endif
+#endif
+
+/* PY_FORMAT_LONG_LONG is analogous to PY_FORMAT_SIZE_T above, but for
+ * the long long type instead of the size_t type.  It's only available
+ * when HAVE_LONG_LONG is defined. The "high level" Python format
+ * functions listed above will interpret "lld" or "llu" correctly on
+ * all platforms.
+ */
+#ifdef HAVE_LONG_LONG
+#   ifndef PY_FORMAT_LONG_LONG
+#       if defined(MS_WIN64) || defined(MS_WINDOWS)
+#           define PY_FORMAT_LONG_LONG "I64"
+#       else
+#           error "This platform's pyconfig.h needs to define PY_FORMAT_LONG_LONG"
+#       endif
+#   endif
+#endif
+
+/* Py_LOCAL can be used instead of static to get the fastest possible calling
+ * convention for functions that are local to a given module.
+ *
+ * Py_LOCAL_INLINE does the same thing, and also explicitly requests inlining,
+ * for platforms that support that.
+ *
+ * If PY_LOCAL_AGGRESSIVE is defined before python.h is included, more
+ * "aggressive" inlining/optimizaion is enabled for the entire module.  This
+ * may lead to code bloat, and may slow things down for those reasons.  It may
+ * also lead to errors, if the code relies on pointer aliasing.  Use with
+ * care.
+ *
+ * NOTE: You can only use this for functions that are entirely local to a
+ * module; functions that are exported via method tables, callbacks, etc,
+ * should keep using static.
+ */
+
+#undef USE_INLINE /* XXX - set via configure? */
 
 #if defined(_MSC_VER)
 #if defined(PY_LOCAL_AGGRESSIVE)
@@ -56,6 +313,63 @@ typedef ssize_t         Py_ssize_t;
 #define Py_LOCAL(type) static type
 #define Py_LOCAL_INLINE(type) static type
 #endif
+
+/* Py_MEMCPY can be used instead of memcpy in cases where the copied blocks
+ * are often very short.  While most platforms have highly optimized code for
+ * large transfers, the setup costs for memcpy are often quite high.  MEMCPY
+ * solves this by doing short copies "in line".
+ */
+
+#if defined(_MSC_VER)
+#define Py_MEMCPY(target, source, length) do {                          \
+        size_t i_, n_ = (length);                                       \
+        char *t_ = (void*) (target);                                    \
+        const char *s_ = (void*) (source);                              \
+        if (n_ >= 16)                                                   \
+            memcpy(t_, s_, n_);                                         \
+        else                                                            \
+            for (i_ = 0; i_ < n_; i_++)                                 \
+                t_[i_] = s_[i_];                                        \
+    } while (0)
+#else
+#define Py_MEMCPY memcpy
+#endif
+
+#include <stdlib.h>
+
+#ifdef HAVE_IEEEFP_H
+#include <ieeefp.h>  /* needed for 'finite' declaration on some platforms */
+#endif
+
+#include <math.h> /* Moved here from the math section, before extern "C" */
+
+/********************************************
+ * WRAPPER FOR <time.h> and/or <sys/time.h> *
+ ********************************************/
+
+#ifdef TIME_WITH_SYS_TIME
+#include <sys/time.h>
+#include <time.h>
+#else /* !TIME_WITH_SYS_TIME */
+#ifdef HAVE_SYS_TIME_H
+#include <sys/time.h>
+#else /* !HAVE_SYS_TIME_H */
+#include <time.h>
+#endif /* !HAVE_SYS_TIME_H */
+#endif /* !TIME_WITH_SYS_TIME */
+
+
+/******************************
+ * WRAPPER FOR <sys/select.h> *
+ ******************************/
+
+/* NB caller must include <sys/types.h> */
+
+#ifdef HAVE_SYS_SELECT_H
+
+#include <sys/select.h>
+
+#endif /* !HAVE_SYS_SELECT_H */
 
 /*******************************
  * stat() and fstat() fiddling *
@@ -97,6 +411,134 @@ typedef ssize_t         Py_ssize_t;
 #include <stat.h>
 #endif
 
+#if defined(PYCC_VACPP)
+/* VisualAge C/C++ Failed to Define MountType Field in sys/stat.h */
+#define S_IFMT (S_IFDIR|S_IFCHR|S_IFREG)
+#endif
+
+#ifndef S_ISREG
+#define S_ISREG(x) (((x) & S_IFMT) == S_IFREG)
+#endif
+
+#ifndef S_ISDIR
+#define S_ISDIR(x) (((x) & S_IFMT) == S_IFDIR)
+#endif
+
+
+#ifdef __cplusplus
+/* Move this down here since some C++ #include's don't like to be included
+   inside an extern "C" */
+extern "C" {
+#endif
+
+
+/* Py_ARITHMETIC_RIGHT_SHIFT
+ * C doesn't define whether a right-shift of a signed integer sign-extends
+ * or zero-fills.  Here a macro to force sign extension:
+ * Py_ARITHMETIC_RIGHT_SHIFT(TYPE, I, J)
+ *    Return I >> J, forcing sign extension.  Arithmetically, return the
+ *    floor of I/2**J.
+ * Requirements:
+ *    I should have signed integer type.  In the terminology of C99, this can
+ *    be either one of the five standard signed integer types (signed char,
+ *    short, int, long, long long) or an extended signed integer type.
+ *    J is an integer >= 0 and strictly less than the number of bits in the
+ *    type of I (because C doesn't define what happens for J outside that
+ *    range either).
+ *    TYPE used to specify the type of I, but is now ignored.  It's been left
+ *    in for backwards compatibility with versions <= 2.6 or 3.0.
+ * Caution:
+ *    I may be evaluated more than once.
+ */
+#ifdef SIGNED_RIGHT_SHIFT_ZERO_FILLS
+#define Py_ARITHMETIC_RIGHT_SHIFT(TYPE, I, J) \
+    ((I) < 0 ? -1-((-1-(I)) >> (J)) : (I) >> (J))
+#else
+#define Py_ARITHMETIC_RIGHT_SHIFT(TYPE, I, J) ((I) >> (J))
+#endif
+
+/* Py_FORCE_EXPANSION(X)
+ * "Simply" returns its argument.  However, macro expansions within the
+ * argument are evaluated.  This unfortunate trickery is needed to get
+ * token-pasting to work as desired in some cases.
+ */
+#define Py_FORCE_EXPANSION(X) X
+
+/* Py_SAFE_DOWNCAST(VALUE, WIDE, NARROW)
+ * Cast VALUE to type NARROW from type WIDE.  In Py_DEBUG mode, this
+ * assert-fails if any information is lost.
+ * Caution:
+ *    VALUE may be evaluated more than once.
+ */
+#ifdef Py_DEBUG
+#define Py_SAFE_DOWNCAST(VALUE, WIDE, NARROW) \
+    (assert((WIDE)(NARROW)(VALUE) == (VALUE)), (NARROW)(VALUE))
+#else
+#define Py_SAFE_DOWNCAST(VALUE, WIDE, NARROW) (NARROW)(VALUE)
+#endif
+
+/* Py_SET_ERRNO_ON_MATH_ERROR(x)
+ * If a libm function did not set errno, but it looks like the result
+ * overflowed or not-a-number, set errno to ERANGE or EDOM.  Set errno
+ * to 0 before calling a libm function, and invoke this macro after,
+ * passing the function result.
+ * Caution:
+ *    This isn't reliable.  See Py_OVERFLOWED comments.
+ *    X is evaluated more than once.
+ */
+#if defined(__FreeBSD__) || defined(__OpenBSD__) || (defined(__hpux) && defined(__ia64))
+#define _Py_SET_EDOM_FOR_NAN(X) if (isnan(X)) errno = EDOM;
+#else
+#define _Py_SET_EDOM_FOR_NAN(X) ;
+#endif
+#define Py_SET_ERRNO_ON_MATH_ERROR(X) \
+    do { \
+        if (errno == 0) { \
+            if ((X) == Py_HUGE_VAL || (X) == -Py_HUGE_VAL) \
+                errno = ERANGE; \
+            else _Py_SET_EDOM_FOR_NAN(X) \
+        } \
+    } while(0)
+
+/* Py_SET_ERANGE_ON_OVERFLOW(x)
+ * An alias of Py_SET_ERRNO_ON_MATH_ERROR for backward-compatibility.
+ */
+#define Py_SET_ERANGE_IF_OVERFLOW(X) Py_SET_ERRNO_ON_MATH_ERROR(X)
+
+/* Py_ADJUST_ERANGE1(x)
+ * Py_ADJUST_ERANGE2(x, y)
+ * Set errno to 0 before calling a libm function, and invoke one of these
+ * macros after, passing the function result(s) (Py_ADJUST_ERANGE2 is useful
+ * for functions returning complex results).  This makes two kinds of
+ * adjustments to errno:  (A) If it looks like the platform libm set
+ * errno=ERANGE due to underflow, clear errno. (B) If it looks like the
+ * platform libm overflowed but didn't set errno, force errno to ERANGE.  In
+ * effect, we're trying to force a useful implementation of C89 errno
+ * behavior.
+ * Caution:
+ *    This isn't reliable.  See Py_OVERFLOWED comments.
+ *    X and Y may be evaluated more than once.
+ */
+#define Py_ADJUST_ERANGE1(X)                                            \
+    do {                                                                \
+        if (errno == 0) {                                               \
+            if ((X) == Py_HUGE_VAL || (X) == -Py_HUGE_VAL)              \
+                errno = ERANGE;                                         \
+        }                                                               \
+        else if (errno == ERANGE && (X) == 0.0)                         \
+            errno = 0;                                                  \
+    } while(0)
+
+#define Py_ADJUST_ERANGE2(X, Y)                                         \
+    do {                                                                \
+        if ((X) == Py_HUGE_VAL || (X) == -Py_HUGE_VAL ||                \
+            (Y) == Py_HUGE_VAL || (Y) == -Py_HUGE_VAL) {                \
+                        if (errno == 0)                                 \
+                                errno = ERANGE;                         \
+        }                                                               \
+        else if (errno == ERANGE)                                       \
+            errno = 0;                                                  \
+    } while(0)
 
 /*  The functions _Py_dg_strtod and _Py_dg_dtoa in Python/dtoa.c (which are
  *  required to support the short float repr introduced in Python 3.1) require
@@ -170,6 +612,31 @@ typedef ssize_t         Py_ssize_t;
 #define _Py_SET_53BIT_PRECISION_END
 #endif
 
+/* If we can't guarantee 53-bit precision, don't use the code
+   in Python/dtoa.c, but fall back to standard code.  This
+   means that repr of a float will be long (17 sig digits).
+
+   Realistically, there are two things that could go wrong:
+
+   (1) doubles aren't IEEE 754 doubles, or
+   (2) we're on x86 with the rounding precision set to 64-bits
+       (extended precision), and we don't know how to change
+       the rounding precision.
+ */
+
+#if !defined(DOUBLE_IS_LITTLE_ENDIAN_IEEE754) && \
+    !defined(DOUBLE_IS_BIG_ENDIAN_IEEE754) && \
+    !defined(DOUBLE_IS_ARM_MIXED_ENDIAN_IEEE754)
+#define PY_NO_SHORT_FLOAT_REPR
+#endif
+
+/* double rounding is symptomatic of use of extended precision on x86.  If
+   we're seeing double rounding, and we don't have any mechanism available for
+   changing the FPU rounding precision, then don't use Python/dtoa.c. */
+#if defined(X87_DOUBLE_ROUNDING) && !defined(HAVE_PY_SET_53BIT_PRECISION)
+#define PY_NO_SHORT_FLOAT_REPR
+#endif
+
 /* Py_DEPRECATED(version)
  * Declare a variable, type, or function deprecated.
  * Usage:
@@ -183,6 +650,106 @@ typedef ssize_t         Py_ssize_t;
 #else
 #define Py_DEPRECATED(VERSION_UNUSED)
 #endif
+
+/**************************************************************************
+Prototypes that are missing from the standard include files on some systems
+(and possibly only some versions of such systems.)
+
+Please be conservative with adding new ones, document them and enclose them
+in platform-specific #ifdefs.
+**************************************************************************/
+
+#ifdef SOLARIS
+/* Unchecked */
+extern int gethostname(char *, int);
+#endif
+
+#ifdef __BEOS__
+/* Unchecked */
+/* It's in the libs, but not the headers... - [cjh] */
+int shutdown( int, int );
+#endif
+
+#ifdef HAVE__GETPTY
+#include <sys/types.h>          /* we need to import mode_t */
+extern char * _getpty(int *, int, mode_t, int);
+#endif
+
+/* On QNX 6, struct termio must be declared by including sys/termio.h
+   if TCGETA, TCSETA, TCSETAW, or TCSETAF are used.  sys/termio.h must
+   be included before termios.h or it will generate an error. */
+#if defined(HAVE_SYS_TERMIO_H) && !defined(__hpux)
+#include <sys/termio.h>
+#endif
+
+#if defined(HAVE_OPENPTY) || defined(HAVE_FORKPTY)
+#if !defined(HAVE_PTY_H) && !defined(HAVE_LIBUTIL_H) && !defined(HAVE_UTIL_H)
+/* BSDI does not supply a prototype for the 'openpty' and 'forkpty'
+   functions, even though they are included in libutil. */
+#include <termios.h>
+extern int openpty(int *, int *, char *, struct termios *, struct winsize *);
+extern pid_t forkpty(int *, char *, struct termios *, struct winsize *);
+#endif /* !defined(HAVE_PTY_H) && !defined(HAVE_LIBUTIL_H) */
+#endif /* defined(HAVE_OPENPTY) || defined(HAVE_FORKPTY) */
+
+
+/* These are pulled from various places. It isn't obvious on what platforms
+   they are necessary, nor what the exact prototype should look like (which
+   is likely to vary between platforms!) If you find you need one of these
+   declarations, please move them to a platform-specific block and include
+   proper prototypes. */
+#if 0
+
+/* From Modules/resource.c */
+extern int getrusage();
+extern int getpagesize();
+
+/* From Python/sysmodule.c and Modules/posixmodule.c */
+extern int fclose(FILE *);
+
+/* From Modules/posixmodule.c */
+extern int fdatasync(int);
+#endif /* 0 */
+
+
+/* On 4.4BSD-descendants, ctype functions serves the whole range of
+ * wchar_t character set rather than single byte code points only.
+ * This characteristic can break some operations of string object
+ * including str.upper() and str.split() on UTF-8 locales.  This
+ * workaround was provided by Tim Robbins of FreeBSD project.
+ */
+
+#ifdef __FreeBSD__
+#include <osreldate.h>
+#if __FreeBSD_version > 500039
+# define _PY_PORT_CTYPE_UTF8_ISSUE
+#endif
+#endif
+
+
+#if defined(__APPLE__)
+# define _PY_PORT_CTYPE_UTF8_ISSUE
+#endif
+
+#ifdef _PY_PORT_CTYPE_UTF8_ISSUE
+#include <ctype.h>
+#include <wctype.h>
+#undef isalnum
+#define isalnum(c) iswalnum(btowc(c))
+#undef isalpha
+#define isalpha(c) iswalpha(btowc(c))
+#undef islower
+#define islower(c) iswlower(btowc(c))
+#undef isspace
+#define isspace(c) iswspace(btowc(c))
+#undef isupper
+#define isupper(c) iswupper(btowc(c))
+#undef tolower
+#define tolower(c) towlower(btowc(c))
+#undef toupper
+#define toupper(c) towupper(btowc(c))
+#endif
+
 
 /* Declarations for symbol visibility.
 
@@ -271,14 +838,117 @@ typedef ssize_t         Py_ssize_t;
 #ifndef DL_IMPORT
 #       define DL_IMPORT(RTYPE) RTYPE
 #endif
+/* End of deprecated DL_* macros */
 
-#ifdef Py_DEBUG
-#define Py_SAFE_DOWNCAST(VALUE, WIDE, NARROW) \
-    (assert((WIDE)(NARROW)(VALUE) == (VALUE)), (NARROW)(VALUE))
-#else
-#define Py_SAFE_DOWNCAST(VALUE, WIDE, NARROW) (NARROW)(VALUE)
+/* If the fd manipulation macros aren't defined,
+   here is a set that should do the job */
+
+#if 0 /* disabled and probably obsolete */
+
+#ifndef FD_SETSIZE
+#define FD_SETSIZE      256
 #endif
 
+#ifndef FD_SET
+
+typedef long fd_mask;
+
+#define NFDBITS (sizeof(fd_mask) * NBBY)        /* bits per mask */
+#ifndef howmany
+#define howmany(x, y)   (((x)+((y)-1))/(y))
+#endif /* howmany */
+
+typedef struct fd_set {
+    fd_mask     fds_bits[howmany(FD_SETSIZE, NFDBITS)];
+} fd_set;
+
+#define FD_SET(n, p)    ((p)->fds_bits[(n)/NFDBITS] |= (1 << ((n) % NFDBITS)))
+#define FD_CLR(n, p)    ((p)->fds_bits[(n)/NFDBITS] &= ~(1 << ((n) % NFDBITS)))
+#define FD_ISSET(n, p)  ((p)->fds_bits[(n)/NFDBITS] & (1 << ((n) % NFDBITS)))
+#define FD_ZERO(p)      memset((char *)(p), '\0', sizeof(*(p)))
+
+#endif /* FD_SET */
+
+#endif /* fd manipulation macros */
+
+
+/* limits.h constants that may be missing */
+
+#ifndef INT_MAX
+#define INT_MAX 2147483647
+#endif
+
+#ifndef LONG_MAX
+#if SIZEOF_LONG == 4
+#define LONG_MAX 0X7FFFFFFFL
+#elif SIZEOF_LONG == 8
+#define LONG_MAX 0X7FFFFFFFFFFFFFFFL
+#else
+#error "could not set LONG_MAX in pyport.h"
+#endif
+#endif
+
+#ifndef LONG_MIN
+#define LONG_MIN (-LONG_MAX-1)
+#endif
+
+#ifndef LONG_BIT
+#define LONG_BIT (8 * SIZEOF_LONG)
+#endif
+
+#if LONG_BIT != 8 * SIZEOF_LONG
+/* 04-Oct-2000 LONG_BIT is apparently (mis)defined as 64 on some recent
+ * 32-bit platforms using gcc.  We try to catch that here at compile-time
+ * rather than waiting for integer multiplication to trigger bogus
+ * overflows.
+ */
+#error "LONG_BIT definition appears wrong for platform (bad gcc/glibc config?)."
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+/*
+ * Hide GCC attributes from compilers that don't support them.
+ */
+#if (!defined(__GNUC__) || __GNUC__ < 2 || \
+     (__GNUC__ == 2 && __GNUC_MINOR__ < 7) ) && \
+    !defined(RISCOS)
+#define Py_GCC_ATTRIBUTE(x)
+#else
+#define Py_GCC_ATTRIBUTE(x) __attribute__(x)
+#endif
+
+/*
+ * Add PyArg_ParseTuple format where available.
+ */
+#ifdef HAVE_ATTRIBUTE_FORMAT_PARSETUPLE
+#define Py_FORMAT_PARSETUPLE(func,p1,p2) __attribute__((format(func,p1,p2)))
+#else
+#define Py_FORMAT_PARSETUPLE(func,p1,p2)
+#endif
+
+/*
+ * Specify alignment on compilers that support it.
+ */
+#if defined(__GNUC__) && __GNUC__ >= 3
+#define Py_ALIGNED(x) __attribute__((aligned(x)))
+#else
+#define Py_ALIGNED(x)
+#endif
+
+/* Eliminate end-of-loop code not reached warnings from SunPro C
+ * when using do{...}while(0) macros
+ */
+#ifdef __SUNPRO_C
+#pragma error_messages (off,E_END_OF_LOOP_CODE_NOT_REACHED)
+#endif
+
+/*
+ * Older Microsoft compilers don't support the C99 long long literal suffixes,
+ * so these will be defined in PC/pyconfig.h for those compilers.
+ */
 #ifndef Py_LL
 #define Py_LL(x) x##LL
 #endif
@@ -287,198 +957,4 @@ typedef ssize_t         Py_ssize_t;
 #define Py_ULL(x) Py_LL(x##U)
 #endif
 
-/* Largest positive value of type Py_ssize_t. */
-#define PY_SSIZE_T_MAX ((Py_ssize_t)(((size_t)-1)>>1))
-/* Smallest negative value of type Py_ssize_t. */
-#define PY_SSIZE_T_MIN (-PY_SSIZE_T_MAX-1)
-
-#ifdef uint32_t
-#define HAVE_UINT32_T 1
-#endif
-
-#ifdef HAVE_UINT32_T
-#ifndef PY_UINT32_T
-#define PY_UINT32_T uint32_t
-#endif
-#endif
-
-/* Macros for a 64-bit unsigned integer type; used for type 'twodigits' in the
- * long integer implementation, when 30-bit digits are enabled.
- */
-#ifdef uint64_t
-#define HAVE_UINT64_T 1
-#endif
-
-#ifdef HAVE_UINT64_T
-#ifndef PY_UINT64_T
-#define PY_UINT64_T uint64_t
-#endif
-#endif
-
-/* Signed variants of the above */
-#ifdef int32_t
-#define HAVE_INT32_T 1
-#endif
-
-#ifdef HAVE_INT32_T
-#ifndef PY_INT32_T
-#define PY_INT32_T int32_t
-#endif
-#endif
-
-#ifdef int64_t
-#define HAVE_INT64_T 1
-#endif
-
-#ifdef HAVE_INT64_T
-#ifndef PY_INT64_T
-#define PY_INT64_T int64_t
-#endif
-#endif
-
-/* uintptr_t is the C9X name for an unsigned integral type such that a
- * legitimate void* can be cast to uintptr_t and then back to void* again
- * without loss of information.  Similarly for intptr_t, wrt a signed
- * integral type.
- */
-#ifdef HAVE_UINTPTR_T
-typedef uintptr_t       Py_uintptr_t;
-typedef intptr_t        Py_intptr_t;
-
-#elif SIZEOF_VOID_P <= SIZEOF_INT
-typedef unsigned int    Py_uintptr_t;
-typedef int             Py_intptr_t;
-
-#elif SIZEOF_VOID_P <= SIZEOF_LONG
-typedef unsigned long   Py_uintptr_t;
-typedef long            Py_intptr_t;
-
-#elif defined(HAVE_LONG_LONG) && (SIZEOF_VOID_P <= SIZEOF_LONG_LONG)
-typedef unsigned PY_LONG_LONG   Py_uintptr_t;
-typedef PY_LONG_LONG            Py_intptr_t;
-
-#else
-#   error "Python needs a typedef for Py_uintptr_t in pyport.h."
-#endif /* HAVE_UINTPTR_T */
-
-#if defined(_MSC_VER)
-#define Py_MEMCPY(target, source, length) do {                          \
-        size_t i_, n_ = (length);                                       \
-        char *t_ = (void*) (target);                                    \
-        const char *s_ = (void*) (source);                              \
-        if (n_ >= 16)                                                   \
-            memcpy(t_, s_, n_);                                         \
-        else                                                            \
-            for (i_ = 0; i_ < n_; i_++)                                 \
-                t_[i_] = s_[i_];                                        \
-    } while (0)
-#else
-#define Py_MEMCPY memcpy
-#endif
-
-/********************************************
- * WRAPPER FOR <time.h> and/or <sys/time.h> *
- ********************************************/
-#ifdef TIME_WITH_SYS_TIME
-#include <sys/time.h>
-#include <time.h>
-#else /* !TIME_WITH_SYS_TIME */
-#ifdef HAVE_SYS_TIME_H
-#include <sys/time.h>
-#else /* !HAVE_SYS_TIME_H */
-#include <time.h>
-#endif /* !HAVE_SYS_TIME_H */
-#endif /* !TIME_WITH_SYS_TIME */
-
-#ifdef SIZE_MAX
-#define PY_SIZE_MAX SIZE_MAX
-#else
-#define PY_SIZE_MAX ((size_t)-1)
-#endif
-
-/* Py_ARITHMETIC_RIGHT_SHIFT
- * C doesn't define whether a right-shift of a signed integer sign-extends
- * or zero-fills.  Here a macro to force sign extension:
- * Py_ARITHMETIC_RIGHT_SHIFT(TYPE, I, J)
- *    Return I >> J, forcing sign extension.  Arithmetically, return the
- *    floor of I/2**J.
- * Requirements:
- *    I should have signed integer type.  In the terminology of C99, this can
- *    be either one of the five standard signed integer types (signed char,
- *    short, int, long, long long) or an extended signed integer type.
- *    J is an integer >= 0 and strictly less than the number of bits in the
- *    type of I (because C doesn't define what happens for J outside that
- *    range either).
- *    TYPE used to specify the type of I, but is now ignored.  It's been left
- *    in for backwards compatibility with versions <= 2.6 or 3.0.
- * Caution:
- *    I may be evaluated more than once.
- */
-#ifdef SIGNED_RIGHT_SHIFT_ZERO_FILLS
-#define Py_ARITHMETIC_RIGHT_SHIFT(TYPE, I, J) \
-    ((I) < 0 ? -1-((-1-(I)) >> (J)) : (I) >> (J))
-#else
-#define Py_ARITHMETIC_RIGHT_SHIFT(TYPE, I, J) ((I) >> (J))
-#endif
-
 #endif /* Py_PYPORT_H */
-
-/* Py_ADJUST_ERANGE1(x)
- * Py_ADJUST_ERANGE2(x, y)
- * Set errno to 0 before calling a libm function, and invoke one of these
- * macros after, passing the function result(s) (Py_ADJUST_ERANGE2 is useful
- * for functions returning complex results).  This makes two kinds of
- * adjustments to errno:  (A) If it looks like the platform libm set
- * errno=ERANGE due to underflow, clear errno. (B) If it looks like the
- * platform libm overflowed but didn't set errno, force errno to ERANGE.  In
- * effect, we're trying to force a useful implementation of C89 errno
- * behavior.
- * Caution:
- *    This isn't reliable.  See Py_OVERFLOWED comments.
- *    X and Y may be evaluated more than once.
- */
-#define Py_ADJUST_ERANGE1(X)                                            \
-    do {                                                                \
-        if (errno == 0) {                                               \
-            if ((X) == Py_HUGE_VAL || (X) == -Py_HUGE_VAL)              \
-                errno = ERANGE;                                         \
-        }                                                               \
-        else if (errno == ERANGE && (X) == 0.0)                         \
-            errno = 0;                                                  \
-    } while(0)
-
-#define Py_ADJUST_ERANGE2(X, Y)                                         \
-    do {                                                                \
-        if ((X) == Py_HUGE_VAL || (X) == -Py_HUGE_VAL ||                \
-            (Y) == Py_HUGE_VAL || (Y) == -Py_HUGE_VAL) {                \
-                        if (errno == 0)                                 \
-                                errno = ERANGE;                         \
-        }                                                               \
-        else if (errno == ERANGE)                                       \
-            errno = 0;                                                  \
-    } while(0)
-
-/* If we can't guarantee 53-bit precision, don't use the code
-   in Python/dtoa.c, but fall back to standard code.  This
-   means that repr of a float will be long (17 sig digits).
-
-   Realistically, there are two things that could go wrong:
-
-   (1) doubles aren't IEEE 754 doubles, or
-   (2) we're on x86 with the rounding precision set to 64-bits
-       (extended precision), and we don't know how to change
-       the rounding precision.
- */
-
-#if !defined(DOUBLE_IS_LITTLE_ENDIAN_IEEE754) && \
-    !defined(DOUBLE_IS_BIG_ENDIAN_IEEE754) && \
-    !defined(DOUBLE_IS_ARM_MIXED_ENDIAN_IEEE754)
-#define PY_NO_SHORT_FLOAT_REPR
-#endif
-
-/* double rounding is symptomatic of use of extended precision on x86.  If
-   we're seeing double rounding, and we don't have any mechanism available for
-   changing the FPU rounding precision, then don't use Python/dtoa.c. */
-#if defined(X87_DOUBLE_ROUNDING) && !defined(HAVE_PY_SET_53BIT_PRECISION)
-#define PY_NO_SHORT_FLOAT_REPR
-#endif

--- a/src/codegen/ast_interpreter.cpp
+++ b/src/codegen/ast_interpreter.cpp
@@ -635,7 +635,7 @@ Value ASTInterpreter::visit_extslice(AST_ExtSlice* node) {
 
 Value ASTInterpreter::visit_branch(AST_Branch* node) {
     Value v = visit_expr(node->test);
-    ASSERT(v.o == True || v.o == False, "Should have called NONZERO before this branch");
+    ASSERT(v.o == Py_True || v.o == Py_False, "Should have called NONZERO before this branch");
 
     // TODO could potentially avoid doing this if we skip the incref in NONZERO
     AUTO_DECREF(v.o);
@@ -644,10 +644,10 @@ Value ASTInterpreter::visit_branch(AST_Branch* node) {
         // Special note: emitSideExit decrefs v for us.
         // TODO: since the value is always True or False, maybe could optimize by putting the decref
         // before the conditional instead of after.
-        jit->emitSideExit(v, v.o, v.o == True ? node->iffalse : node->iftrue);
+        jit->emitSideExit(v, v.o, v.o == Py_True ? node->iffalse : node->iftrue);
     }
 
-    if (v.o == True)
+    if (v.o == Py_True)
         next_block = node->iftrue;
     else
         next_block = node->iffalse;

--- a/src/codegen/baseline_jit.cpp
+++ b/src/codegen/baseline_jit.cpp
@@ -973,11 +973,11 @@ Box* JitFragmentWriter::hasnextHelper(Box* b) {
 }
 
 BORROWED(Box*) JitFragmentWriter::nonzeroHelper(Box* b) {
-    return b->nonzeroIC() ? True : False;
+    return b->nonzeroIC() ? Py_True : Py_False;
 }
 
 BORROWED(Box*) JitFragmentWriter::notHelper(Box* b) {
-    return b->nonzeroIC() ? False : True;
+    return b->nonzeroIC() ? Py_False : Py_True;
 }
 
 Box* JitFragmentWriter::runtimeCallHelper(Box* obj, ArgPassSpec argspec, TypeRecorder* type_recorder, Box** args,
@@ -1167,7 +1167,7 @@ void JitFragmentWriter::_emitSideExit(STOLEN(RewriterVar*) var, RewriterVar* val
     assert(next_block_var->is_constant);
     uint64_t val = val_constant->constant_value;
 
-    assert(val == (uint64_t)True || val == (uint64_t)False);
+    assert(val == (uint64_t)Py_True || val == (uint64_t)Py_False);
 
     // HAXX ahead:
     // Override the automatic refcounting system, to force a decref to happen before the jump.

--- a/src/codegen/compvars.cpp
+++ b/src/codegen/compvars.cpp
@@ -2384,8 +2384,8 @@ public:
         ASSERT(other_type == UNKNOWN || other_type == BOXED_BOOL, "%s", other_type->debugName().c_str());
         llvm::Value* boxed = emitter.getBuilder()->CreateSelect(
             i1FromBool(emitter, var),
-            emitter.setType(embedRelocatablePtr(True, g.llvm_value_type_ptr), RefType::BORROWED),
-            emitter.setType(embedRelocatablePtr(False, g.llvm_value_type_ptr), RefType::BORROWED));
+            emitter.setType(embedRelocatablePtr(Py_True, g.llvm_value_type_ptr), RefType::BORROWED),
+            emitter.setType(embedRelocatablePtr(Py_False, g.llvm_value_type_ptr), RefType::BORROWED));
         emitter.setType(boxed, RefType::BORROWED);
         return new ConcreteCompilerVariable(other_type, boxed);
     }

--- a/src/codegen/opt/const_classes.cpp
+++ b/src/codegen/opt/const_classes.cpp
@@ -62,9 +62,9 @@ private:
             llvm::errs() << "Constant-folding this load: " << *li << '\n';
         }
         if (gv->getName() == "True")
-            li->replaceAllUsesWith(embedConstantPtr(True, g.llvm_bool_type_ptr));
+            li->replaceAllUsesWith(embedConstantPtr(Py_True, g.llvm_bool_type_ptr));
         else
-            li->replaceAllUsesWith(embedConstantPtr(False, g.llvm_bool_type_ptr));
+            li->replaceAllUsesWith(embedConstantPtr(Py_False, g.llvm_bool_type_ptr));
         return true;
     }
 

--- a/src/runtime/bool.cpp
+++ b/src/runtime/bool.cpp
@@ -20,7 +20,7 @@
 
 namespace pyston {
 
-Box* True, *False;
+Box* pyston_True, *pyston_False;
 
 extern "C" PyObject* PyBool_FromLong(long n) noexcept {
     return boxBool(n != 0);
@@ -34,13 +34,13 @@ extern "C" Box* boolRepr(BoxedBool* v) {
     static BoxedString* true_str = getStaticString("True");
     static BoxedString* false_str = getStaticString("False");
 
-    if (v == True)
+    if (v == Py_True)
         return incref(true_str);
     return incref(false_str);
 }
 
 size_t bool_hash(BoxedBool* v) {
-    return v == True;
+    return v == Py_True;
 }
 
 Box* boolHash(BoxedBool* v) {

--- a/src/runtime/builtin_modules/builtins.cpp
+++ b/src/runtime/builtin_modules/builtins.cpp
@@ -2354,7 +2354,7 @@ void setupBuiltins() {
     builtins_module->giveAttrBorrowed("Ellipsis", Ellipsis);
     builtins_module->giveAttrBorrowed("None", None);
 
-    builtins_module->giveAttrBorrowed("__debug__", False);
+    builtins_module->giveAttrBorrowed("__debug__", Py_False);
 
     notimplemented_cls = BoxedClass::create(type_cls, object_cls, 0, 0, sizeof(Box), false, "NotImplementedType", false,
                                             NULL, NULL, false);
@@ -2486,10 +2486,10 @@ void setupBuiltins() {
         = new FunctionMetadata(4, false, false, ParamNames({ "", "cmp", "key", "reverse" }, "", ""));
     sorted_func->addVersion((void*)sorted, LIST, { UNKNOWN, UNKNOWN, UNKNOWN, UNKNOWN });
     builtins_module->giveAttr(
-        "sorted", new BoxedBuiltinFunctionOrMethod(sorted_func, "sorted", { None, None, False }, NULL, sorted_doc));
+        "sorted", new BoxedBuiltinFunctionOrMethod(sorted_func, "sorted", { None, None, Py_False }, NULL, sorted_doc));
 
-    builtins_module->giveAttrBorrowed("True", True);
-    builtins_module->giveAttrBorrowed("False", False);
+    builtins_module->giveAttrBorrowed("True", Py_True);
+    builtins_module->giveAttrBorrowed("False", Py_False);
 
     range_obj = new BoxedBuiltinFunctionOrMethod(FunctionMetadata::create((void*)range, LIST, 3, false, false), "range",
                                                  { NULL, NULL }, NULL, range_doc);

--- a/src/runtime/builtin_modules/pyston.cpp
+++ b/src/runtime/builtin_modules/pyston.cpp
@@ -74,6 +74,6 @@ void setupPyston() {
                                               FunctionMetadata::create((void*)clearStats, NONE, 0), "clearStats"));
     pyston_module->giveAttr(
         "dumpStats", new BoxedBuiltinFunctionOrMethod(FunctionMetadata::create((void*)dumpStats, NONE, 1, false, false),
-                                                      "dumpStats", { False }));
+                                                      "dumpStats", { Py_False }));
 }
 }

--- a/src/runtime/builtin_modules/sys.cpp
+++ b/src/runtime/builtin_modules/sys.cpp
@@ -767,7 +767,7 @@ void setupSys() {
                                                  "exit", { None }, NULL, exit_doc));
 
     sys_module->giveAttr("warnoptions", new BoxedList());
-    sys_module->giveAttrBorrowed("py3kwarning", False);
+    sys_module->giveAttrBorrowed("py3kwarning", Py_False);
     sys_module->giveAttr("byteorder", boxString(isLittleEndian() ? "little" : "big"));
 
     sys_module->giveAttr("platform", boxString(Py_GetPlatform()));
@@ -792,7 +792,7 @@ void setupSys() {
                                                   "getrecursionlimit", getrecursionlimit_doc));
 
     // As we don't support compile() etc yet force 'dont_write_bytecode' to true.
-    sys_module->giveAttrBorrowed("dont_write_bytecode", True);
+    sys_module->giveAttrBorrowed("dont_write_bytecode", Py_True);
 
     sys_module->giveAttr("prefix", boxString(Py_GetPrefix()));
     sys_module->giveAttr("exec_prefix", boxString(Py_GetExecPrefix()));

--- a/src/runtime/capi.cpp
+++ b/src/runtime/capi.cpp
@@ -572,7 +572,7 @@ extern "C" long _Py_HashPointer(void* p) noexcept {
 
 extern "C" int PyObject_IsTrue(PyObject* o) noexcept {
     if (o->cls == bool_cls)
-        return o == True;
+        return o == Py_True;
 
     try {
         return o->nonzeroIC();

--- a/src/runtime/dict.cpp
+++ b/src/runtime/dict.cpp
@@ -624,7 +624,7 @@ extern "C" int PyDict_Contains(PyObject* op, PyObject* key) noexcept {
             Box* rtn = PyObject_CallMethod(op, "__contains__", "O", key);
             if (!rtn)
                 return -1;
-            return autoDecref(rtn) == True;
+            return autoDecref(rtn) == Py_True;
         }
 
         BoxedDict* mp = (BoxedDict*)op;
@@ -695,7 +695,7 @@ Box* dictNe(BoxedDict* self, Box* _rhs) {
     if (eq == NotImplemented)
         return eq;
     AUTO_DECREF(eq);
-    if (eq == True)
+    if (eq == Py_True)
         Py_RETURN_FALSE;
     Py_RETURN_TRUE;
 }

--- a/src/runtime/float.cpp
+++ b/src/runtime/float.cpp
@@ -748,8 +748,9 @@ template <ExceptionStyle S> Box* floatNew(BoxedClass* _cls, Box* a) noexcept(S =
 // Roughly analogous to CPython's float_new.
 // The arguments need to be unpacked from args and kwds.
 static Box* floatNewPacked(BoxedClass* type, Box* args, Box* kwds) noexcept {
-    PyObject* x = False; // False is like initalizing it to 0.0 but faster because we don't need to box it in case the
-                         // optional arg exists
+    PyObject* x
+        = Py_False; // False is like initalizing it to 0.0 but faster because we don't need to box it in case the
+                    // optional arg exists
     static char* kwlist[2] = { NULL, NULL };
     kwlist[0] = const_cast<char*>("x");
 

--- a/src/runtime/inline/boxing.h
+++ b/src/runtime/inline/boxing.h
@@ -40,7 +40,7 @@ extern "C" inline bool unboxBool(Box* b) {
     // - the jit knows True is constant once the program starts
     // - this function will get inlined as well as boxBool
     // So in the presence of optimizations, I think this should do better:
-    return b == True;
+    return b == Py_True;
     // return static_cast<BoxedBool*>(b)->b;
 }
 }

--- a/src/runtime/iterobject.cpp
+++ b/src/runtime/iterobject.cpp
@@ -117,7 +117,7 @@ Box* seqiter_next(Box* s) noexcept {
         else
             RELEASE_ASSERT(0, "");
         AUTO_XDECREF(hasnext);
-        if (hasnext != True)
+        if (hasnext != Py_True)
             return NULL;
     }
 

--- a/src/runtime/list.cpp
+++ b/src/runtime/list.cpp
@@ -1009,7 +1009,7 @@ extern "C" int PyList_Sort(PyObject* v) noexcept {
     }
 
     try {
-        listSort((BoxedList*)v, None, None, False);
+        listSort((BoxedList*)v, None, None, Py_False);
     } catch (ExcInfo e) {
         setCAPIException(e);
         return -1;
@@ -1492,7 +1492,7 @@ void setupList() {
     list_cls->giveAttr("sort",
                        new BoxedFunction(FunctionMetadata::create((void*)listSortFunc, NONE, 4, false, false,
                                                                   ParamNames({ "", "cmp", "key", "reverse" }, "", "")),
-                                         { None, None, False }));
+                                         { None, None, Py_False }));
     list_cls->giveAttr("__contains__", new BoxedFunction(FunctionMetadata::create((void*)listContains, BOXED_BOOL, 2)));
 
     list_cls->giveAttr(

--- a/src/runtime/objmodel.cpp
+++ b/src/runtime/objmodel.cpp
@@ -5709,7 +5709,7 @@ static bool convert3wayCompareResultToBool(Box* v, int op_type) {
 template <bool negate> Box* nonzeroAndBox(Box* b) {
     if (likely(b->cls == bool_cls)) {
         if (negate)
-            return boxBool(b != True);
+            return boxBool(b != Py_True);
         return incref(b);
     }
 
@@ -5836,7 +5836,7 @@ Box* compareInternal(Box* lhs, Box* rhs, int op_type, CompareRewriteArgs* rewrit
         if (contained->cls == bool_cls) {
             if (op_type == AST_TYPE::NotIn) {
                 Py_DECREF(contained);
-                return boxBool(contained == False);
+                return boxBool(contained == Py_False);
             } else {
                 return contained;
             }

--- a/src/runtime/set.cpp
+++ b/src/runtime/set.cpp
@@ -690,7 +690,7 @@ Box* setNe(BoxedSet* self, BoxedSet* rhs) {
     Box* r = setEq(self, rhs);
     AUTO_DECREF(r);
     assert(r->cls == bool_cls);
-    return boxBool(r == False);
+    return boxBool(r == Py_False);
 }
 
 Box* setLe(BoxedSet* self, BoxedSet* rhs) {

--- a/src/runtime/str.cpp
+++ b/src/runtime/str.cpp
@@ -2194,7 +2194,7 @@ Box* strStartswith(BoxedString* self, Box* elt, Box* start, Box** _args) {
         for (auto e : *static_cast<BoxedTuple*>(elt)) {
             auto b = strStartswith(self, e, start, _args);
             assert(b->cls == bool_cls);
-            if (b == True)
+            if (b == Py_True)
                 return b;
             Py_DECREF(b);
         }
@@ -2266,7 +2266,7 @@ Box* strEndswith(BoxedString* self, Box* elt, Box* start, Box** _args) {
         for (auto e : *static_cast<BoxedTuple*>(elt)) {
             auto b = strEndswith(self, e, start, _args);
             assert(b->cls == bool_cls);
-            if (b == True)
+            if (b == Py_True)
                 return b;
             Py_DECREF(b);
         }

--- a/src/runtime/types.cpp
+++ b/src/runtime/types.cpp
@@ -2494,7 +2494,7 @@ public:
         AUTO_DECREF(key);
 
         Box* r = self->b->getattr(key);
-        return incref(r ? True : False);
+        return incref(r ? Py_True : Py_False);
     }
 
     static Box* hasKey(Box* _self, Box* _key) {
@@ -2508,7 +2508,7 @@ public:
         if (!rtn)
             return -1;
         AUTO_DECREF(rtn);
-        return rtn == True;
+        return rtn == Py_True;
     }
 
     static Box* keys(Box* _self) {
@@ -2739,7 +2739,7 @@ public:
                                                      _other, NULL, NULL, NULL, NULL);
     }
 
-    static Box* ne(Box* _self, Box* _other) { return incref(eq(_self, _other) == True ? False : True); }
+    static Box* ne(Box* _self, Box* _other) { return incref(eq(_self, _other) == Py_True ? Py_False : Py_True); }
 
     friend class AttrWrapperIter;
 };
@@ -4170,10 +4170,10 @@ void setupRuntime() {
     LONG = typeFromClass(long_cls);
     BOXED_COMPLEX = typeFromClass(complex_cls);
 
-    True = new BoxedBool(true);
-    False = new BoxedBool(false);
-    constants.push_back(True);
-    constants.push_back(False);
+    pyston_True = new BoxedBool(true);
+    pyston_False = new BoxedBool(false);
+    constants.push_back(pyston_True);
+    constants.push_back(pyston_False);
 
     // Need to initialize interned_ints early:
     setupInt();

--- a/src/runtime/types.h
+++ b/src/runtime/types.h
@@ -114,7 +114,7 @@ extern BoxedClass* object_cls, *type_cls, *bool_cls, *int_cls, *long_cls, *float
 extern std::vector<BoxedClass*> exception_types;
 
 extern "C" {
-extern Box* None, *NotImplemented, *True, *False, *Ellipsis;
+extern Box* None, *NotImplemented, *pyston_True, *pyston_False, *Ellipsis;
 }
 extern "C" {
 extern Box* repr_obj, *len_obj, *hash_obj, *range_obj, *abs_obj, *min_obj, *max_obj, *open_obj, *id_obj, *chr_obj,

--- a/src/runtime/util.cpp
+++ b/src/runtime/util.cpp
@@ -168,7 +168,7 @@ extern "C" void dumpEx(void* p, int levels) {
         printf("Refcount: %ld\n", b->ob_refcnt);
 
         if (b->cls == bool_cls) {
-            printf("The %s object\n", b == True ? "True" : "False");
+            printf("The %s object\n", b == Py_True ? "True" : "False");
         }
 
         if (PyType_Check(b)) {


### PR DESCRIPTION
Some extensions will use `True` and `False` from other package. For example, X11 defines `True` and `False` in `/usr/include/X11/Xlib.h`. Which will cause name conflict when try to build extensions which use x11.

I think this is not good solution. V8 encountered it too:
https://bugs.chromium.org/p/v8/issues/detail?id=448
But we can't control how extension handle it. So just add a prefix to it.

closes #1242