### PR TITLE
Temporarily disable the clang build on travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,7 +78,7 @@ before_script:
 
 script:
   - ccache -z
-  - ninja -j4 pyston check-deps && PYSTON_RUN_ARGS=G travis_wait 45 ctest --output-on-failure
+  - ninja -j4 pyston check-deps && PYSTON_RUN_ARGS=G travis_wait 60 ctest --output-on-failure
   - ccache -s
   - if [ -n "$(git status --porcelain --untracked=no)" ]; then echo "test suite left the source directory dirty"; git status; false; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: cpp
 
 compiler:
-  - clang
+  # - clang
   - gcc
 
 env:
@@ -13,8 +13,8 @@ env:
 
 matrix:
   exclude:
-    - compiler: gcc
-      env: TRAVIS_BUILD_TYPE=Debug CCACHE_DIR=$HOME/.ccache_debug
+    # - compiler: gcc
+    #   env: TRAVIS_BUILD_TYPE=Debug CCACHE_DIR=$HOME/.ccache_debug
 
 # use travis-ci docker based infrastructure
 sudo: false
@@ -28,12 +28,12 @@ addons:
   apt:
     sources:
     - kubuntu-backports
-    - llvm-toolchain-precise-3.5
+    # - llvm-toolchain-precise-3.5
     - ubuntu-toolchain-r-test
     packages:
     - autoconf
     - ccache
-    - clang-3.5
+    # - clang-3.5
     - cmake
     - g++-4.8
     - gdb

--- a/src/capi/typeobject.cpp
+++ b/src/capi/typeobject.cpp
@@ -3487,7 +3487,7 @@ static Box* tppProxyToTpCall(Box* self, CallRewriteArgs* rewrite_args, ArgPassSp
 }
 
 Box* proxyToTppCall(Box* self, Box* args, Box* kw) noexcept {
-    assert(self->cls->tpp_call.get<CAPI>() != NULL && self->cls->tpp_call.get<CAPI>() != tppProxyToTpCall<CAPI>);
+    assert(self->cls->tpp_call.get<CAPI>() != NULL && self->cls->tpp_call.get<CAPI>() != &tppProxyToTpCall<CAPI>);
     return self->cls->tpp_call.call<CAPI>(self, NULL, ArgPassSpec(0, 0, true, true), args, kw, NULL, NULL, NULL);
 }
 


### PR DESCRIPTION
since we were installing it from the LLVM APT repo, which they
took down since it was getting too expensive.  I guess we can
just run with the gcc build until that situation gets resolved.