### PR TITLE
vregs: reuse block local vregs

### DIFF
--- a/src/codegen/baseline_jit.cpp
+++ b/src/codegen/baseline_jit.cpp
@@ -634,7 +634,9 @@ void JitFragmentWriter::emitSetBlockLocal(InternedString s, int vreg, STOLEN(Rew
     if (LOG_BJIT_ASSEMBLY)
         comment("BJIT: emitSetBlockLocal() start");
     RewriterVar* prev = local_syms[s];
-    if (!prev)
+    // if we never set this sym before in this BB and the symbol gets accessed in several blocks clear it because it
+    // could have been set in a previous block.
+    if (!prev && !block->cfg->getVRegInfo().isBlockLocalVReg(vreg))
         emitSetLocal(s, vreg, false, imm(nullptr)); // clear out the vreg
     local_syms[s] = v;
     if (LOG_BJIT_ASSEMBLY)
@@ -690,6 +692,7 @@ void JitFragmentWriter::emitSetLocal(InternedString s, int vreg, bool set_closur
         // but I suspect is not that big a deal as long as the llvm jit implements this kind of optimization.
         bool prev_nullable = true;
 
+        assert(!block->cfg->getVRegInfo().isBlockLocalVReg(vreg));
         vregs_array->replaceAttr(8 * vreg, v, prev_nullable);
     }
     if (LOG_BJIT_ASSEMBLY)

--- a/src/codegen/codegen.cpp
+++ b/src/codegen/codegen.cpp
@@ -73,34 +73,6 @@ BORROWED(BoxedCode*) FunctionMetadata::getCode() {
     return code_obj;
 }
 
-int FunctionMetadata::calculateNumVRegs() {
-    SourceInfo* source_info = source.get();
-
-    CFG* cfg = source_info->cfg;
-    assert(cfg && "We don't calculate the CFG inside this function because it can raise an exception and its "
-                  "therefore not safe to call at every point");
-
-    if (!cfg->hasVregsAssigned()) {
-        ScopeInfo* scope_info = source->getScopeInfo();
-        cfg->assignVRegs(param_names, scope_info);
-    }
-    return cfg->sym_vreg_map.size();
-}
-
-int FunctionMetadata::calculateNumUserVisibleVRegs() {
-    SourceInfo* source_info = source.get();
-
-    CFG* cfg = source_info->cfg;
-    assert(cfg && "We don't calculate the CFG inside this function because it can raise an exception and its "
-                  "therefore not safe to call at every point");
-
-    if (!cfg->hasVregsAssigned()) {
-        ScopeInfo* scope_info = source->getScopeInfo();
-        cfg->assignVRegs(param_names, scope_info);
-    }
-    return cfg->sym_vreg_map_user_visible.size();
-}
-
 void FunctionMetadata::addVersion(CompiledFunction* compiled) {
     assert(compiled);
     assert((compiled->spec != NULL) + (compiled->entry_descriptor != NULL) == 1);

--- a/src/codegen/irgen.cpp
+++ b/src/codegen/irgen.cpp
@@ -1009,8 +1009,6 @@ CompiledFunction* doCompile(FunctionMetadata* md, SourceInfo* source, ParamNames
 
     assert((entry_descriptor != NULL) + (spec != NULL) == 1);
 
-    md->calculateNumVRegs();
-
     if (VERBOSITY("irgen") >= 2)
         source->cfg->print();
 

--- a/src/codegen/irgen/hooks.cpp
+++ b/src/codegen/irgen/hooks.cpp
@@ -271,7 +271,7 @@ CompiledFunction* compileFunction(FunctionMetadata* f, FunctionSpecialization* s
 
     // Do the analysis now if we had deferred it earlier:
     if (source->cfg == NULL) {
-        source->cfg = computeCFG(source, source->body);
+        source->cfg = computeCFG(source, source->body, f->param_names);
     }
 
 

--- a/src/codegen/irgen/irgenerator.cpp
+++ b/src/codegen/irgen/irgenerator.cpp
@@ -244,7 +244,7 @@ void IRGenState::setupFrameInfoVar(llvm::Value* passed_closure, llvm::Value* pas
         assert(al->isStaticAlloca());
 
         assert(!vregs);
-        int num_user_visible_vregs = getMD()->calculateNumUserVisibleVRegs();
+        int num_user_visible_vregs = getSourceInfo()->cfg->getVRegInfo().getNumOfUserVisibleVRegs();
         if (num_user_visible_vregs > 0) {
             auto* vregs_alloca
                 = builder.CreateAlloca(g.llvm_value_type_ptr, getConstantInt(num_user_visible_vregs), "vregs");
@@ -1896,7 +1896,7 @@ private:
         auto cfg = irstate->getSourceInfo()->cfg;
         assert(vreg >= 0);
 
-        if (vreg < cfg->sym_vreg_map_user_visible.size()) {
+        if (cfg->getVRegInfo().isUserVisibleVReg(vreg)) {
             // looks like this store don't have to be volatile because llvm knows that the vregs are visible thru the
             // FrameInfo which escapes.
             auto* gep = emitter.getBuilder()->CreateConstInBoundsGEP1_64(irstate->getVRegsVar(), vreg);
@@ -2617,8 +2617,7 @@ private:
         auto vst = irstate->getScopeInfo()->getScopeTypeOfName(name);
         int vreg = -1;
         if (vst == ScopeInfo::VarScopeType::FAST || vst == ScopeInfo::VarScopeType::CLOSURE) {
-            assert(cfg->sym_vreg_map.count(name));
-            vreg = cfg->sym_vreg_map[name];
+            vreg = cfg->getVRegInfo().getVReg(name);
         }
         _doSet(vreg, name, vst, var, unw_info);
     }

--- a/src/codegen/unwinding.cpp
+++ b/src/codegen/unwinding.cpp
@@ -892,10 +892,9 @@ DeoptState getDeoptState() {
             // and assigning them to the new vregs array...
             // But deopts are so rare it's not really worth it.
             Box** vregs = frame_iter->getFrameInfo()->vregs;
-            for (const auto& p : cf->md->source->cfg->sym_vreg_map_user_visible) {
+            for (const auto& p : cf->md->source->cfg->getVRegInfo().getUserVisibleSymVRegMap()) {
                 if (is_undefined.count(p.first.s()))
                     continue;
-                assert(p.second >= 0 && p.second < cf->md->source->cfg->sym_vreg_map_user_visible.size());
 
                 Box* v = vregs[p.second];
                 if (!v)
@@ -950,8 +949,8 @@ BORROWED(Box*) fastLocalsToBoxedLocals() {
 
 static BoxedDict* localsForFrame(Box** vregs, CFG* cfg) {
     BoxedDict* rtn = new BoxedDict();
-    rtn->d.grow(cfg->sym_vreg_map_user_visible.size());
-    for (auto& l : cfg->sym_vreg_map_user_visible) {
+    rtn->d.grow(cfg->getVRegInfo().getNumOfUserVisibleVRegs());
+    for (auto& l : cfg->getVRegInfo().getUserVisibleSymVRegMap()) {
         Box* val = vregs[l.second];
         if (val) {
             assert(!rtn->d.count(l.first.getBox()));

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -508,9 +508,6 @@ public:
     void addVersion(void* f, ConcreteCompilerType* rtn_type, const std::vector<ConcreteCompilerType*>& arg_types,
                     ExceptionStyle exception_style = CXX);
 
-    int calculateNumVRegs();
-    int calculateNumUserVisibleVRegs();
-
     // Helper function, meant for the C++ runtime, which allocates a FunctionMetadata object and calls addVersion
     // once to it.
     static FunctionMetadata* create(void* f, ConcreteCompilerType* rtn_type, int nargs, bool takes_varargs,

--- a/test/unittests/analysis.cpp
+++ b/test/unittests/analysis.cpp
@@ -43,7 +43,8 @@ TEST_F(AnalysisTest, augassign) {
     SourceInfo* si = new SourceInfo(createModule(boxString("augassign"), fn.c_str()), scoping, future_flags, func,
             func->body, boxString(fn));
 
-    CFG* cfg = computeCFG(si, func->body);
+    ParamNames param_names(si->ast, si->getInternedStrings());
+    CFG* cfg = computeCFG(si, func->body, param_names);
     std::unique_ptr<LivenessAnalysis> liveness = computeLivenessInfo(cfg);
 
     //cfg->print();
@@ -74,7 +75,7 @@ void doOsrTest(bool is_osr, bool i_maybe_undefined) {
                     fn.c_str()), scoping, future_flags, func, func->body, boxString(fn)));
     FunctionMetadata* clfunc = new FunctionMetadata(0, false, false, std::move(si));
 
-    CFG* cfg = computeCFG(clfunc->source.get(), func->body);
+    CFG* cfg = computeCFG(clfunc->source.get(), func->body, clfunc->param_names);
     std::unique_ptr<LivenessAnalysis> liveness = computeLivenessInfo(cfg);
 
     // cfg->print();


### PR DESCRIPTION
this splits the vregs into three parts (from the two we had before user visible/not user visible):
```
user visible: used for all non compiler generated names, name could be used in a single block or multiple
              all frames contain atleast this vregs in order to do frame introspection
cross block : used for compiler generated names which get used in several blocks or which have closure scope
single block: used by compiler created names which are only used in a single block.
              get reused for different names

we assign the lowest numbers to the user visible ones, followed by the cross block ones and finally the single block
ones. we do this because not all tiers use all of the vregs and it still makes it fast to switch between tiers.
```
This reduces stack space because of the lower total number of vregs.
And additionally reduces the number of variables we have to clear in `deinitFrame` because we are now lazily keeping track of the maximum number of vregs which are currently used.

I don't like the names so I'm happy to get name suggestions.

```
perf change:
                                e71744864ade0ac57f:  origin/bjit_opt2_w:
           django_template3.py             2.6s (4)             2.4s (4)  -5.1%
                 pyxl_bench.py             2.4s (4)             2.2s (4)  -5.7%
     sqlalchemy_imperative2.py             2.6s (4)             2.5s (4)  -3.7%
                pyxl_bench2.py             1.2s (4)             1.2s (4)  -1.0%
       django_template3_10x.py            13.4s (4)            13.2s (4)  -1.6%
             pyxl_bench_10x.py            17.8s (4)            17.8s (4)  +0.2%
 sqlalchemy_imperative2_10x.py            19.3s (4)            18.9s (4)  -1.7%
            pyxl_bench2_10x.py            10.4s (4)            10.0s (4)  -3.7%
                       geomean                 5.6s                 5.4s  -2.8%

perf change with revision before the previous merged bjit improvements #1227
                                e71744864ade0ac57f:  origin/bjit_opt2_w:
           django_template3.py             2.8s (4)             2.4s (4)  -12.1%
                 pyxl_bench.py             2.8s (4)             2.2s (4)  -20.6%
     sqlalchemy_imperative2.py             2.7s (4)             2.5s (4)  -6.7%
                pyxl_bench2.py             1.2s (4)             1.2s (4)  -5.6%
       django_template3_10x.py            13.9s (4)            13.2s (4)  -4.9%
             pyxl_bench_10x.py            18.3s (4)            17.8s (4)  -2.6%
 sqlalchemy_imperative2_10x.py            19.4s (4)            18.9s (4)  -2.3%
            pyxl_bench2_10x.py            10.4s (4)            10.0s (4)  -3.8%
                       geomean                 5.8s                 5.4s  -7.5%


-SI minibenchmarks:
            before #1227     #1227    this PR
raytrace.py        21.29s -> 15.22s -> 11.18s
django_template.py  3.75s ->  3.24s ->  2.92s
richards.py         4.57s ->  3.20s ->  2.11s
```