### PR TITLE
Improve REPL support

### DIFF
--- a/src/core/ast.cpp
+++ b/src/core/ast.cpp
@@ -2236,17 +2236,4 @@ void flatten(AST_expr* root, std::vector<AST*>& output, bool expand_scopes) {
 
     root->accept(&visitor);
 }
-
-void makeModuleInteractive(AST_Module* m) {
-    for (int i = 0; i < m->body.size(); ++i) {
-        AST_stmt* s = m->body[i];
-        if (s->type != AST_TYPE::Expr)
-            continue;
-
-        AST_Expr* expr = (AST_Expr*)s;
-        AST_LangPrimitive* print_expr = new AST_LangPrimitive(AST_LangPrimitive::PRINT_EXPR);
-        print_expr->args.push_back(expr->value);
-        expr->value = print_expr;
-    }
-}
 }

--- a/src/core/ast.h
+++ b/src/core/ast.h
@@ -1444,10 +1444,6 @@ template <class T, class R> void findNodes(const R& roots, std::vector<T*>& outp
     }
 }
 
-// Take a normally-parsed module, and convert it (inplace) to a form that will print out any bare expressions.
-// This is used for "single" mode or the repl.
-void makeModuleInteractive(AST_Module* m);
-
 llvm::StringRef getOpSymbol(int op_type);
 BORROWED(BoxedString*) getOpName(int op_type);
 int getReverseCmpOp(int op_type, bool& success);


### PR DESCRIPTION
This fixes a bug with expressions inside loops in interactive mode
that resulted in expressions not being printed:

    >> for i in range(3):
    ...    i
    ...
    >>

Python prints the value every iteration:

    >> for i in range(3):
    ...    i
    ...
    0
    1
    2
    >>>

The same also applies to while loops.