### PR TITLE
Fix some leaks related to signals

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,7 +78,7 @@ before_script:
 
 script:
   - ccache -z
-  - ninja -j4 pyston check-deps && PYSTON_RUN_ARGS=G travis_wait 60 ctest --output-on-failure
+  - time ninja -j4 pyston check-deps && PYSTON_RUN_ARGS=G travis_wait 60 ctest --output-on-failure
   - ccache -s
   - if [ -n "$(git status --porcelain --untracked=no)" ]; then echo "test suite left the source directory dirty"; git status; false; fi
 

--- a/from_cpython/Include/Python.h
+++ b/from_cpython/Include/Python.h
@@ -145,6 +145,16 @@ PyAPI_FUNC(PyObject*) _PyGC_GetGarbage(void) PYSTON_NOEXCEPT;
 PyAPI_FUNC(void) PyGC_Enable(void) PYSTON_NOEXCEPT;
 PyAPI_FUNC(void) PyGC_Disable(void) PYSTON_NOEXCEPT;
 
+#ifdef Py_TRACE_REFS
+// This function is a semi-smart leak finder.  Using the cycle-collector
+// infrastructure, it will find all non-heap references remaining.  This is
+// an improvement over calling _Py_PrintReferenceAddresses, since this will
+// automatically filter out any objects that are only indirectly leaked.
+//
+// This will destroy the heap, so it has to be the last thing called.
+PyAPI_FUNC(void) _PyGC_FindLeaks(void) PYSTON_NOEXCEPT;
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/capi/object.cpp
+++ b/src/capi/object.cpp
@@ -1195,7 +1195,7 @@ extern "C" void _PyTrash_thread_destroy_chain() noexcept {
  */
 extern "C" {
 // static PyObject refchain = { &refchain, &refchain };
-static PyObject refchain(Box::createRefchain());
+PyObject refchain(Box::createRefchain());
 }
 
 /* Insert op at the front of the list of all objects.  If force is true,

--- a/src/codegen/compvars.cpp
+++ b/src/codegen/compvars.cpp
@@ -373,10 +373,10 @@ public:
             llvm_args.push_back(var->getValue());
             llvm_args.push_back(converted_slice->getValue());
 
-            llvm::Value* uncasted
+            llvm::Instruction* uncasted
                 = emitter.createIC(pp, (void*)(target_exception_style == CAPI ? pyston::getitem_capi : pyston::getitem),
                                    llvm_args, info.unw_info, target_exception_style, getNullPtr(g.llvm_value_type_ptr));
-            rtn = emitter.getBuilder()->CreateIntToPtr(uncasted, g.llvm_value_type_ptr);
+            rtn = createAfter<llvm::IntToPtrInst>(uncasted, uncasted, g.llvm_value_type_ptr, "");
             emitter.setType(rtn, RefType::OWNED);
         } else {
             rtn = emitter.createCall2(
@@ -419,9 +419,9 @@ public:
         // var has __iter__()
         emitter.setCurrentBasicBlock(bb_has_iter);
         ICSetupInfo* pp = createGenericIC(info.getTypeRecorder(), true, 128);
-        llvm::Value* uncasted = emitter.createIC(pp, (void*)pyston::createBoxedIterWrapperIfNeeded,
-                                                 { converted_iter_call->getValue() }, info.unw_info);
-        llvm::Value* value_has_iter = emitter.getBuilder()->CreateIntToPtr(uncasted, g.llvm_value_type_ptr);
+        llvm::Instruction* uncasted = emitter.createIC(pp, (void*)pyston::createBoxedIterWrapperIfNeeded,
+                                                       { converted_iter_call->getValue() }, info.unw_info);
+        llvm::Value* value_has_iter = createAfter<llvm::IntToPtrInst>(uncasted, uncasted, g.llvm_value_type_ptr, "");
         emitter.setType(value_has_iter, RefType::OWNED);
         llvm::BasicBlock* value_has_iter_bb = emitter.currentBasicBlock();
         auto has_iter_terminator = emitter.getBuilder()->CreateBr(bb_join);
@@ -475,8 +475,8 @@ public:
             llvm_args.push_back(converted_rhs->getValue());
             llvm_args.push_back(getConstantInt(op_type, g.i32));
 
-            llvm::Value* uncasted = emitter.createIC(pp, rt_func_addr, llvm_args, info.unw_info);
-            rtn = emitter.getBuilder()->CreateIntToPtr(uncasted, g.llvm_value_type_ptr);
+            llvm::Instruction* uncasted = emitter.createIC(pp, rt_func_addr, llvm_args, info.unw_info);
+            rtn = createAfter<llvm::IntToPtrInst>(uncasted, uncasted, g.llvm_value_type_ptr, "");
         } else {
             rtn = emitter.createCall3(info.unw_info, rt_func, var->getValue(), converted_rhs->getValue(),
                                       getConstantInt(op_type, g.i32));
@@ -562,9 +562,9 @@ CompilerVariable* UnknownType::getattr(IREmitter& emitter, const OpInfo& info, C
         llvm_args.push_back(var->getValue());
         llvm_args.push_back(ptr);
 
-        llvm::Value* uncasted = emitter.createIC(pp, raw_func, llvm_args, info.unw_info, target_exception_style,
-                                                 getNullPtr(g.llvm_value_type_ptr));
-        rtn_val = emitter.getBuilder()->CreateIntToPtr(uncasted, g.llvm_value_type_ptr);
+        llvm::Instruction* uncasted = emitter.createIC(pp, raw_func, llvm_args, info.unw_info, target_exception_style,
+                                                       getNullPtr(g.llvm_value_type_ptr));
+        rtn_val = createAfter<llvm::IntToPtrInst>(uncasted, uncasted, g.llvm_value_type_ptr, "");
     } else {
         rtn_val = emitter.createCall2(info.unw_info, llvm_func, var->getValue(), ptr, target_exception_style,
                                       getNullPtr(g.llvm_value_type_ptr));
@@ -666,7 +666,7 @@ _call(IREmitter& emitter, const OpInfo& info, llvm::Value* func, ExceptionStyle 
 
         assert(llvm::cast<llvm::FunctionType>(llvm::cast<llvm::PointerType>(func->getType())->getElementType())
                    ->getReturnType() == g.llvm_value_type_ptr);
-        rtn = emitter.getBuilder()->CreateIntToPtr(uncasted, g.llvm_value_type_ptr);
+        rtn = createAfter<llvm::IntToPtrInst>(uncasted, uncasted, g.llvm_value_type_ptr, "");
     } else {
         // printf("\n");
         // func->dump();
@@ -792,8 +792,8 @@ ConcreteCompilerVariable* UnknownType::unaryop(IREmitter& emitter, const OpInfo&
         llvm_args.push_back(converted->getValue());
         llvm_args.push_back(getConstantInt(op_type, g.i32));
 
-        llvm::Value* uncasted = emitter.createIC(pp, (void*)pyston::unaryop, llvm_args, info.unw_info);
-        rtn = emitter.getBuilder()->CreateIntToPtr(uncasted, g.llvm_value_type_ptr);
+        llvm::Instruction* uncasted = emitter.createIC(pp, (void*)pyston::unaryop, llvm_args, info.unw_info);
+        rtn = createAfter<llvm::IntToPtrInst>(uncasted, uncasted, g.llvm_value_type_ptr, "");
     } else {
         rtn = emitter.createCall2(info.unw_info, g.funcs.unaryop, converted->getValue(),
                                   getConstantInt(op_type, g.i32));

--- a/src/runtime/types.cpp
+++ b/src/runtime/types.cpp
@@ -4741,7 +4741,7 @@ extern "C" void Py_Finalize() noexcept {
     if (assert_refs) {
 #ifdef Py_TRACE_REFS
         if (_Py_RefTotal != 0)
-            _Py_PrintReferenceAddressesCapped(stderr, 10);
+            _PyGC_FindLeaks();
 #endif
 
         RELEASE_ASSERT(_Py_RefTotal == 0, "%ld refs remaining!", _Py_RefTotal);

--- a/test/tests/signal_ref_test.py
+++ b/test/tests/signal_ref_test.py
@@ -1,0 +1,19 @@
+import os
+import signal
+import threading
+import time
+
+def f():
+    time.sleep(0.1)
+    os.kill(os.getpid(), signal.SIGINT)
+t = threading.Thread(target=f)
+t.start()
+
+def g():
+    while True:
+        -(0.2 ** 5)
+try:
+    g()
+    assert 0
+except KeyboardInterrupt:
+    pass


### PR DESCRIPTION
I think this is why test_telnetlib fails sporadically (it's hard to reproduce so I'm not 100% sure).  We currently leak references in most cases if we throw an exception via a signal.

Also, this PR changes the leak-checking behavior to only report "direct" leaks, and hides objects that were only leaked due to being referenced by other leaked objects.  Hopefully this makes debugging future leaks easier.