### PR TITLE
rewriter+bjit: remove duplicate getattrs, misc codegen improvements

### DIFF
--- a/src/asm_writing/rewriter.cpp
+++ b/src/asm_writing/rewriter.cpp
@@ -1036,7 +1036,7 @@ void Rewriter::_setupCall(bool has_side_effects, llvm::ArrayRef<RewriterVar*> ar
             uintptr_t counter_addr = (uintptr_t)(&picked_slot->num_inside);
             if (isLargeConstant(counter_addr)) {
                 assembler::Register reg = allocReg(Location::any(), preserve);
-                assembler->mov(assembler::Immediate(counter_addr), reg);
+                const_loader.loadConstIntoReg(counter_addr, reg);
                 assembler->incl(assembler::Indirect(reg, 0));
             } else {
                 assembler->incl(assembler::Immediate(counter_addr));
@@ -1540,7 +1540,7 @@ void Rewriter::commit() {
         uintptr_t counter_addr = (uintptr_t)(&picked_slot->num_inside);
         if (isLargeConstant(counter_addr)) {
             assembler::Register reg = allocReg(Location::any(), getReturnDestination());
-            assembler->mov(assembler::Immediate(counter_addr), reg);
+            const_loader.loadConstIntoReg(counter_addr, reg);
             assembler->decl(assembler::Indirect(reg, 0));
         } else {
             assembler->decl(assembler::Immediate(counter_addr));

--- a/src/asm_writing/rewriter.h
+++ b/src/asm_writing/rewriter.h
@@ -570,6 +570,11 @@ protected:
     void _decref(RewriterVar* var, llvm::ArrayRef<RewriterVar*> vars_to_bump = {});
     void _xdecref(RewriterVar* var, llvm::ArrayRef<RewriterVar*> vars_to_bump = {});
 
+    // emits a call instruction using the smallest encoding.
+    // either doing a relative call if or otherwise loading the address into the supplied register and calling it.
+    // the caller of this function must make sure that the supplied register can be safely overwriten.
+    void _callOptimalEncoding(assembler::Register tmp_reg, void* func_addr);
+
     void assertConsistent() {
 #ifndef NDEBUG
         for (RewriterVar& var : vars) {

--- a/src/asm_writing/rewriter.h
+++ b/src/asm_writing/rewriter.h
@@ -565,8 +565,8 @@ protected:
 
     // These do not call bumpUse on their arguments:
     void _incref(RewriterVar* var, int num_refs = 1);
-    void _decref(RewriterVar* var);
-    void _xdecref(RewriterVar* var);
+    void _decref(RewriterVar* var, llvm::ArrayRef<RewriterVar*> vars_to_bump = {});
+    void _xdecref(RewriterVar* var, llvm::ArrayRef<RewriterVar*> vars_to_bump = {});
 
     void assertConsistent() {
 #ifndef NDEBUG

--- a/src/asm_writing/rewriter.h
+++ b/src/asm_writing/rewriter.h
@@ -263,7 +263,8 @@ private:
     Location arg_loc;
     std::pair<int /*offset*/, int /*size*/> scratch_allocation;
 
-    llvm::SmallSet<std::tuple<int, uint64_t, bool>, 4> attr_guards; // used to detect duplicate guards
+    llvm::SmallSet<std::tuple<int, uint64_t, bool>, 4> attr_guards;  // used to detect duplicate guards
+    llvm::SmallDenseMap<std::pair<int, int>, RewriterVar*> getattrs; // used to detect duplicate getAttrs
 
     // Gets a copy of this variable in a register, spilling/reloading if necessary.
     // TODO have to be careful with the result since the interface doesn't guarantee

--- a/src/asm_writing/rewriter.h
+++ b/src/asm_writing/rewriter.h
@@ -237,11 +237,11 @@ private:
     // /* some code */
     // bumpUseLateIfNecessary();
     void bumpUseEarlyIfPossible() {
-        if (reftype != RefType::OWNED && !hasScratchAllocation())
+        if (reftype != RefType::OWNED && !isScratchAllocation())
             bumpUse();
     }
     void bumpUseLateIfNecessary() {
-        if (reftype == RefType::OWNED || hasScratchAllocation())
+        if (reftype == RefType::OWNED || isScratchAllocation())
             bumpUse();
     }
 
@@ -252,8 +252,9 @@ private:
     // Don't call it directly: call bumpUse and releaseIfNoUses instead.
     void _release();
     bool isDoneUsing() { return next_use == uses.size(); }
-    bool hasScratchAllocation() const { return scratch_allocation.second > 0; }
-    void resetHasScratchAllocation() { scratch_allocation = std::make_pair(0, 0); }
+    bool isScratchAllocation() const { return scratch_allocation.second > 0; }
+    void resetIsScratchAllocation() { scratch_allocation = std::make_pair(0, 0); }
+    Location getScratchLocation(int additional_offset_in_bytes = 0);
     bool needsDecref(int current_action_index);
 
     // Indicates if this variable is an arg, and if so, what location the arg is from.

--- a/src/asm_writing/rewriter.h
+++ b/src/asm_writing/rewriter.h
@@ -202,7 +202,8 @@ public:
 
     template <typename Src, typename Dst> inline RewriterVar* getAttrCast(int offset, Location loc = Location::any());
 
-    bool isConstant() { return is_constant; }
+    bool isConstant() const { return is_constant; }
+    bool isContantNull() const { return isConstant() && constant_value == 0; }
 
 protected:
     void incref();

--- a/src/codegen/baseline_jit.cpp
+++ b/src/codegen/baseline_jit.cpp
@@ -177,6 +177,8 @@ JitFragmentWriter::JitFragmentWriter(CFGBlock* block, std::unique_ptr<ICInfo> ic
       ic_info(std::move(ic_info)) {
     allocatable_regs = bjit_allocatable_regs;
 
+    added_changing_action = true;
+
     if (LOG_BJIT_ASSEMBLY)
         comment("BJIT: JitFragmentWriter() start");
     interp = createNewVar();

--- a/src/codegen/baseline_jit.cpp
+++ b/src/codegen/baseline_jit.cpp
@@ -1012,8 +1012,8 @@ void JitFragmentWriter::_emitGetLocal(RewriterVar* val_var, const char* name) {
     {
         assembler::ForwardJump jnz(*assembler, assembler::COND_NOT_ZERO);
         assembler->mov(assembler::Immediate((uint64_t)name), assembler::RDI);
-        assembler->mov(assembler::Immediate((void*)assertNameDefinedHelper), assembler::R11);
-        assembler->callq(assembler::R11);
+
+        _callOptimalEncoding(assembler::R11, (void*)assertNameDefinedHelper);
 
         registerDecrefInfoHere();
     }

--- a/src/codegen/baseline_jit.cpp
+++ b/src/codegen/baseline_jit.cpp
@@ -1011,8 +1011,7 @@ void JitFragmentWriter::_emitGetLocal(RewriterVar* val_var, const char* name) {
     _setupCall(false, {});
     {
         assembler::ForwardJump jnz(*assembler, assembler::COND_NOT_ZERO);
-        assembler->mov(assembler::Immediate((uint64_t)name), assembler::RDI);
-
+        const_loader.loadConstIntoReg((uint64_t)name, assembler::RDI);
         _callOptimalEncoding(assembler::R11, (void*)assertNameDefinedHelper);
 
         registerDecrefInfoHere();

--- a/src/codegen/baseline_jit.h
+++ b/src/codegen/baseline_jit.h
@@ -207,6 +207,9 @@ private:
     RewriterVar* interp;
     RewriterVar* vregs_array;
     llvm::DenseMap<InternedString, RewriterVar*> local_syms;
+    // keeps track which non block local vregs are known to have a non NULL value
+    // TODO: in the future we could reuse this information between different basic blocks
+    llvm::DenseSet<int> known_non_null_vregs;
     std::unique_ptr<ICInfo> ic_info;
 
     // Optional points to a CFGBlock and a patch location which should get patched to a direct jump if


### PR DESCRIPTION
Misc improvements, please take a look at the individual commits to find out what changed
```
                                   upstream/master:    origin/bjit_opt7:
           django_template3.py             2.6s (4)             2.4s (4)  -6.7%
                 pyxl_bench.py             2.3s (4)             2.2s (4)  -1.9%
     sqlalchemy_imperative2.py             2.8s (4)             2.6s (4)  -7.9%
                pyxl_bench2.py             1.2s (4)             1.2s (4)  -2.0%
       django_template3_10x.py            13.9s (4)            13.1s (4)  -5.7%
             pyxl_bench_10x.py            17.6s (4)            17.5s (4)  -0.9%
 sqlalchemy_imperative2_10x.py            20.4s (4)            18.9s (4)  -7.5%
            pyxl_bench2_10x.py            10.2s (4)            10.0s (4)  -1.9%
                       geomean                 5.6s                 5.4s  -4.4%

```