### PR TITLE
ICs: variable size IC slots

### DIFF
--- a/src/asm_writing/assembler.h
+++ b/src/asm_writing/assembler.h
@@ -206,6 +206,7 @@ public:
     uint8_t* startAddr() const { return start_addr; }
     int bytesLeft() const { return end_addr - addr; }
     int bytesWritten() const { return addr - start_addr; }
+    int size() const { return end_addr - start_addr; }
     uint8_t* curInstPointer() { return addr; }
     void setCurInstPointer(uint8_t* ptr) { addr = ptr; }
     bool isExactlyFull() const { return addr == end_addr; }

--- a/src/asm_writing/rewriter.h
+++ b/src/asm_writing/rewriter.h
@@ -502,8 +502,11 @@ protected:
     }
 
     int last_guard_action;
-    int offset_eq_jmp_slowpath;
-    int offset_ne_jmp_slowpath;
+    int offset_eq_jmp_next_slot;
+    int offset_ne_jmp_next_slot;
+
+    // keeps track of all jumps to the next slot so we can patch them if the size of the current slot changes
+    std::vector<NextSlotJumpInfo> next_slot_jmps;
 
     // Move the original IC args back into their original registers:
     void restoreArgs();
@@ -535,9 +538,9 @@ protected:
     // Do the bookkeeping to say that var is no longer in location l
     void removeLocationFromVar(RewriterVar* var, Location l);
 
-    bool finishAssembly(int continue_offset) override;
+    bool finishAssembly(int continue_offset, bool& should_fill_with_nops, bool& variable_size_slots) override;
 
-    void _slowpathJump(bool condition_eq);
+    void _nextSlotJump(bool condition_eq);
     void _trap();
     void _loadConst(RewriterVar* result, int64_t val);
     void _setupCall(bool has_side_effects, llvm::ArrayRef<RewriterVar*> args = {},

--- a/src/codegen/baseline_jit.h
+++ b/src/codegen/baseline_jit.h
@@ -302,7 +302,7 @@ public:
     void abortCompilation();
     int finishCompilation();
 
-    bool finishAssembly(int continue_offset) override;
+    bool finishAssembly(int continue_offset, bool& should_fill_with_nops, bool& variable_size_slots) override;
 
 private:
     RewriterVar* allocArgs(const llvm::ArrayRef<RewriterVar*> args, RewriterVar::SetattrType);
@@ -319,8 +319,8 @@ private:
     RewriterVar* emitCallWithAllocatedArgs(void* func_addr, const llvm::ArrayRef<RewriterVar*> args,
                                            const llvm::ArrayRef<RewriterVar*> additional_uses);
     std::pair<RewriterVar*, RewriterAction*> emitPPCall(void* func_addr, llvm::ArrayRef<RewriterVar*> args,
-                                                        unsigned char num_slots, unsigned short slot_size,
-                                                        AST* ast_node = NULL, TypeRecorder* type_recorder = NULL,
+                                                        unsigned short pp_size, AST* ast_node = NULL,
+                                                        TypeRecorder* type_recorder = NULL,
                                                         llvm::ArrayRef<RewriterVar*> additional_uses = {});
 
     static void assertNameDefinedHelper(const char* id);
@@ -340,8 +340,8 @@ private:
     void _emitGetLocal(RewriterVar* val_var, const char* name);
     void _emitJump(CFGBlock* b, RewriterVar* block_next, ExitInfo& exit_info);
     void _emitOSRPoint();
-    void _emitPPCall(RewriterVar* result, void* func_addr, llvm::ArrayRef<RewriterVar*> args, int num_slots,
-                     int slot_size, AST* ast_node, llvm::ArrayRef<RewriterVar*> vars_to_bump);
+    void _emitPPCall(RewriterVar* result, void* func_addr, llvm::ArrayRef<RewriterVar*> args, unsigned short pp_size,
+                     AST* ast_node, llvm::ArrayRef<RewriterVar*> vars_to_bump);
     void _emitRecordType(RewriterVar* type_recorder_var, RewriterVar* obj_cls_var);
     void _emitReturn(RewriterVar* v);
     void _emitSideExit(STOLEN(RewriterVar*) var, RewriterVar* val_constant, CFGBlock* next_block,

--- a/src/codegen/patchpoints.h
+++ b/src/codegen/patchpoints.h
@@ -64,17 +64,12 @@ public:
     };
 
 private:
-    ICSetupInfo(ICType type, int num_slots, int slot_size, bool has_return_value, TypeRecorder* type_recorder)
-        : type(type),
-          num_slots(num_slots),
-          slot_size(slot_size),
-          has_return_value(has_return_value),
-          type_recorder(type_recorder) {}
+    ICSetupInfo(ICType type, int size, bool has_return_value, TypeRecorder* type_recorder)
+        : type(type), size(size), has_return_value(has_return_value), type_recorder(type_recorder) {}
 
 public:
     const ICType type;
-
-    const int num_slots, slot_size;
+    const int size;
     const bool has_return_value;
     TypeRecorder* const type_recorder;
 
@@ -95,8 +90,7 @@ public:
         return llvm::CallingConv::C;
     }
 
-    static ICSetupInfo* initialize(bool has_return_value, int num_slots, int slot_size, ICType type,
-                                   TypeRecorder* type_recorder);
+    static ICSetupInfo* initialize(bool has_return_value, int size, ICType type, TypeRecorder* type_recorder);
 };
 
 struct PatchpointInfo {

--- a/src/runtime/ics.cpp
+++ b/src/runtime/ics.cpp
@@ -188,7 +188,7 @@ static void writeTrivialEhFrame(void* eh_frame_addr, void* func_addr, uint64_t f
 #define SCRATCH_BYTES 0x30
 #endif
 
-RuntimeIC::RuntimeIC(void* func_addr, int num_slots, int slot_size) {
+RuntimeIC::RuntimeIC(void* func_addr, int patchable_size) {
     static StatCounter sc("runtime_ics_num");
     sc.log();
 
@@ -228,8 +228,6 @@ RuntimeIC::RuntimeIC(void* func_addr, int num_slots, int slot_size) {
 #endif
         static const int CALL_SIZE = 13;
 
-        int patchable_size = num_slots * slot_size;
-
         int total_code_size = PROLOGUE_SIZE + patchable_size + CALL_SIZE + EPILOGUE_SIZE;
 
 #ifdef NVALGRIND
@@ -248,7 +246,7 @@ RuntimeIC::RuntimeIC(void* func_addr, int num_slots, int slot_size) {
         // printf("Allocated runtime IC at %p\n", addr);
 
         std::unique_ptr<ICSetupInfo> setup_info(
-            ICSetupInfo::initialize(true, num_slots, slot_size, ICSetupInfo::Generic, NULL));
+            ICSetupInfo::initialize(true, patchable_size, ICSetupInfo::Generic, NULL));
         uint8_t* pp_start = (uint8_t*)addr + PROLOGUE_SIZE;
         uint8_t* pp_end = pp_start + patchable_size + CALL_SIZE;
 

--- a/src/runtime/ics.h
+++ b/src/runtime/ics.h
@@ -35,7 +35,7 @@ private:
     void operator=(const RuntimeIC&) = delete;
 
 protected:
-    RuntimeIC(void* addr, int num_slots, int slot_size);
+    RuntimeIC(void* addr, int patchable_size);
     ~RuntimeIC();
 
     template <class... Args> uint64_t call_int(Args... args) {
@@ -57,7 +57,7 @@ protected:
 
 class CallattrIC : public RuntimeIC {
 public:
-    CallattrIC() : RuntimeIC((void*)callattr, 1, 320) {}
+    CallattrIC() : RuntimeIC((void*)callattr, 320) {}
 
     Box* call(Box* obj, BoxedString* attr, CallattrFlags flags, Box* arg0, Box* arg1, Box* arg2, Box** args,
               const std::vector<BoxedString*>* keyword_names) {
@@ -67,7 +67,7 @@ public:
 
 class CallattrCapiIC : public RuntimeIC {
 public:
-    CallattrCapiIC() : RuntimeIC((void*)callattrCapi, 1, 320) {}
+    CallattrCapiIC() : RuntimeIC((void*)callattrCapi, 320) {}
 
     Box* call(Box* obj, BoxedString* attr, CallattrFlags flags, Box* arg0, Box* arg1, Box* arg2, Box** args,
               const std::vector<BoxedString*>* keyword_names) {
@@ -78,14 +78,14 @@ public:
 
 class BinopIC : public RuntimeIC {
 public:
-    BinopIC() : RuntimeIC((void*)binop, 2, 240) {}
+    BinopIC() : RuntimeIC((void*)binop, 2 * 240) {}
 
     Box* call(Box* lhs, Box* rhs, int op_type) { return (Box*)call_ptr(lhs, rhs, op_type); }
 };
 
 class NonzeroIC : public RuntimeIC {
 public:
-    NonzeroIC() : RuntimeIC((void*)nonzero, 1, 512) {}
+    NonzeroIC() : RuntimeIC((void*)nonzero, 512) {}
 
     bool call(Box* obj) { return call_bool(obj); }
 };


### PR DESCRIPTION
ICs: variable size IC slots
before this change we had a fixed number of equal size slots inside an IC.
Because of the large difference in rewrite sizes a fixed slot size is not ideal.
We often ended up with too large slots which prevented us from emitting more slots.
(or very large ICs in general which are bad for memory usage and the instruction cache)

With this commit we will start with a single slot with the size of the whole IC and then decreasing its size to the actual bytes emitted
and creating a new slot which starts directly at the end of the previous slot.
We will repeat to to this until the space left is smaller than the number of bytes the last slot required.
This makes it a little bit less likely that we will be successful in overwritting an existing slot
but our benchmarks show that it is still a large win on all our benchmarks.

Some notable changes are:
- we pick the slot to rewrite much earlier now and prevent it from getting rewritten while we rewrite using num_inside = 1
  the reason is that we would otherwise not know how big the slot is
- when we resize a slot we have to patch the failing guard jumps to the address of the next slot

```
           django_template3.py             2.4s (4)             2.3s (4)  -4.3%
                 pyxl_bench.py             2.3s (4)             2.2s (4)  -3.0%
     sqlalchemy_imperative2.py             2.6s (4)             2.5s (4)  -0.8%
                pyxl_bench2.py             1.1s (4)             1.0s (4)  -9.7%
       django_template3_10x.py            13.1s (4)            12.5s (4)  -4.2%
             pyxl_bench_10x.py            17.7s (4)            16.9s (4)  -4.7%
 sqlalchemy_imperative2_10x.py            19.0s (4)            18.9s (4)  -0.9%
            pyxl_bench2_10x.py             9.7s (4)             8.4s (4)  -13.4%
                       geomean                 5.3s                 5.1s  -5.2%
```