### PR TITLE
only lookup __[set/get/del]slice__ for slice AST nodes

### DIFF
--- a/src/asm_writing/rewriter.h
+++ b/src/asm_writing/rewriter.h
@@ -147,6 +147,7 @@ public:
 
     void addGuard(uint64_t val);
     void addGuardNotEq(uint64_t val);
+    void addGuardNotLt0();
     void addAttrGuard(int offset, uint64_t val, bool negate = false);
     RewriterVar* getAttr(int offset, Location loc = Location::any(), assembler::MovType type = assembler::MovType::Q);
     // getAttrFloat casts to double (maybe I should make that separate?)
@@ -502,8 +503,6 @@ protected:
     }
 
     int last_guard_action;
-    int offset_eq_jmp_next_slot;
-    int offset_ne_jmp_next_slot;
 
     // keeps track of all jumps to the next slot so we can patch them if the size of the current slot changes
     std::vector<NextSlotJumpInfo> next_slot_jmps;
@@ -540,7 +539,7 @@ protected:
 
     bool finishAssembly(int continue_offset, bool& should_fill_with_nops, bool& variable_size_slots) override;
 
-    void _nextSlotJump(bool condition_eq);
+    void _nextSlotJump(assembler::ConditionCode condition);
     void _trap();
     void _loadConst(RewriterVar* result, int64_t val);
     void _setupCall(bool has_side_effects, llvm::ArrayRef<RewriterVar*> args = {},
@@ -557,8 +556,7 @@ protected:
     void _checkAndThrowCAPIException(RewriterVar* r, int64_t exc_val, assembler::MovType size);
 
     // The public versions of these are in RewriterVar
-    void _addGuard(RewriterVar* var, RewriterVar* val_constant);
-    void _addGuardNotEq(RewriterVar* var, RewriterVar* val_constant);
+    void _addGuard(RewriterVar* var, RewriterVar* val_constant, bool negate = false);
     void _addAttrGuard(RewriterVar* var, int offset, RewriterVar* val_constant, bool negate = false);
     void _getAttr(RewriterVar* result, RewriterVar* var, int offset, Location loc = Location::any(),
                   assembler::MovType type = assembler::MovType::Q);

--- a/src/capi/typeobject.cpp
+++ b/src/capi/typeobject.cpp
@@ -1242,7 +1242,7 @@ static int slot_tp_descr_set(PyObject* self, PyObject* target, PyObject* value) 
 
 PyObject* slot_sq_item(PyObject* self, Py_ssize_t i) noexcept {
     STAT_TIMER(t0, "us_timer_slot_sqitem", SLOT_AVOIDABILITY(self));
-    return getitemInternal<CAPI>(self, autoDecref(boxInt(i)));
+    return PyObject_GetItem(self, autoDecref(boxInt(i)));
 }
 
 /* Pyston change: static */ Py_ssize_t slot_sq_length(PyObject* self) noexcept {

--- a/src/codegen/ast_interpreter.cpp
+++ b/src/codegen/ast_interpreter.cpp
@@ -554,12 +554,27 @@ void ASTInterpreter::doStore(AST_expr* node, STOLEN(Value) value) {
         Value target = visit_expr(subscript->value);
         AUTO_DECREF(target.o);
 
-        Value slice = visit_slice(subscript->slice);
-        AUTO_DECREF(slice.o);
+        bool is_slice = (subscript->slice->type == AST_TYPE::Slice) && (((AST_Slice*)subscript->slice)->step == NULL);
+        if (is_slice) {
+            AST_Slice* slice = (AST_Slice*)subscript->slice;
+            Value lower = slice->lower ? visit_expr(slice->lower) : Value();
+            AUTO_XDECREF(lower.o);
+            Value upper = slice->upper ? visit_expr(slice->upper) : Value();
+            AUTO_XDECREF(upper.o);
+            assert(slice->step == NULL);
 
-        if (jit)
-            jit->emitSetItem(target, slice, value);
-        setitem(target.o, slice.o, value.o);
+            if (jit)
+                jit->emitAssignSlice(target, lower, upper, value);
+            assignSlice(target.o, lower.o, upper.o, value.o);
+        } else {
+            Value slice = visit_slice(subscript->slice);
+
+            AUTO_DECREF(slice.o);
+
+            if (jit)
+                jit->emitSetItem(target, slice, value);
+            setitem(target.o, slice.o, value.o);
+        }
     } else {
         RELEASE_ASSERT(0, "not implemented");
     }
@@ -1321,11 +1336,26 @@ Value ASTInterpreter::visit_delete(AST_Delete* node) {
                 AST_Subscript* sub = (AST_Subscript*)target_;
                 Value value = visit_expr(sub->value);
                 AUTO_DECREF(value.o);
-                Value slice = visit_slice(sub->slice);
-                AUTO_DECREF(slice.o);
-                if (jit)
-                    jit->emitDelItem(value, slice);
-                delitem(value.o, slice.o);
+
+                bool is_slice = (sub->slice->type == AST_TYPE::Slice) && (((AST_Slice*)sub->slice)->step == NULL);
+                if (is_slice) {
+                    AST_Slice* slice = (AST_Slice*)sub->slice;
+                    Value lower = slice->lower ? visit_expr(slice->lower) : Value();
+                    AUTO_XDECREF(lower.o);
+                    Value upper = slice->upper ? visit_expr(slice->upper) : Value();
+                    AUTO_XDECREF(upper.o);
+                    assert(slice->step == NULL);
+
+                    if (jit)
+                        jit->emitAssignSlice(value, lower, upper, jit->imm(0ul));
+                    assignSlice(value.o, lower.o, upper.o, NULL);
+                } else {
+                    Value slice = visit_slice(sub->slice);
+                    AUTO_DECREF(slice.o);
+                    if (jit)
+                        jit->emitDelItem(value, slice);
+                    delitem(value.o, slice.o);
+                }
                 break;
             }
             case AST_TYPE::Attribute: {
@@ -1735,10 +1765,31 @@ Value ASTInterpreter::visit_name(AST_Name* node) {
 Value ASTInterpreter::visit_subscript(AST_Subscript* node) {
     Value value = visit_expr(node->value);
     AUTO_DECREF(value.o);
-    Value slice = visit_slice(node->slice);
-    AUTO_DECREF(slice.o);
 
-    return Value(getitem(value.o, slice.o), jit ? jit->emitGetItem(node, value, slice) : NULL);
+    bool is_slice = (node->slice->type == AST_TYPE::Slice) && (((AST_Slice*)node->slice)->step == NULL);
+    if (is_slice) {
+        AST_Slice* slice = (AST_Slice*)node->slice;
+        Value lower = slice->lower ? visit_expr(slice->lower) : Value();
+        AUTO_XDECREF(lower.o);
+        Value upper = slice->upper ? visit_expr(slice->upper) : Value();
+        AUTO_XDECREF(upper.o);
+        assert(slice->step == NULL);
+
+        Value v;
+        if (jit)
+            v.var = jit->emitApplySlice(value, lower, upper);
+        v.o = applySlice(value.o, lower.o, upper.o);
+        return v;
+    } else {
+        Value slice = visit_slice(node->slice);
+        AUTO_DECREF(slice.o);
+
+        Value v;
+        if (jit)
+            v.var = jit->emitGetItem(node, value, slice);
+        v.o = getitem(value.o, slice.o);
+        return v;
+    }
 }
 
 Value ASTInterpreter::visit_list(AST_List* node) {

--- a/src/codegen/baseline_jit.cpp
+++ b/src/codegen/baseline_jit.cpp
@@ -208,6 +208,14 @@ RewriterVar* JitFragmentWriter::emitAugbinop(AST_expr* node, RewriterVar* lhs, R
     return emitPPCall((void*)augbinop, { lhs, rhs, imm(op_type) }, 2 * 320, node).first->setType(RefType::OWNED);
 }
 
+RewriterVar* JitFragmentWriter::emitApplySlice(RewriterVar* target, RewriterVar* lower, RewriterVar* upper) {
+    if (!lower)
+        lower = imm(0ul);
+    if (!upper)
+        upper = imm(0ul);
+    return emitPPCall((void*)applySlice, { target, lower, upper }, 256).first->setType(RefType::OWNED);
+}
+
 RewriterVar* JitFragmentWriter::emitBinop(AST_expr* node, RewriterVar* lhs, RewriterVar* rhs, int op_type) {
     return emitPPCall((void*)binop, { lhs, rhs, imm(op_type) }, 2 * 240, node).first->setType(RefType::OWNED);
 }
@@ -551,6 +559,15 @@ RewriterVar* JitFragmentWriter::emitYield(RewriterVar* v) {
                    ->setType(RefType::OWNED);
     v->refConsumed();
     return rtn;
+}
+
+void JitFragmentWriter::emitAssignSlice(RewriterVar* target, RewriterVar* lower, RewriterVar* upper,
+                                        RewriterVar* value) {
+    if (!lower)
+        lower = imm(0ul);
+    if (!upper)
+        upper = imm(0ul);
+    emitPPCall((void*)assignSlice, { target, lower, upper, value }, 256).first;
 }
 
 void JitFragmentWriter::emitDelAttr(RewriterVar* target, BoxedString* attr) {

--- a/src/codegen/baseline_jit.h
+++ b/src/codegen/baseline_jit.h
@@ -239,6 +239,7 @@ public:
     RewriterVar* imm(void* val);
 
     RewriterVar* emitAugbinop(AST_expr* node, RewriterVar* lhs, RewriterVar* rhs, int op_type);
+    RewriterVar* emitApplySlice(RewriterVar* target, RewriterVar* lower, RewriterVar* upper);
     RewriterVar* emitBinop(AST_expr* node, RewriterVar* lhs, RewriterVar* rhs, int op_type);
     RewriterVar* emitCallattr(AST_expr* node, RewriterVar* obj, BoxedString* attr, CallattrFlags flags,
                               const llvm::ArrayRef<RewriterVar*> args, std::vector<BoxedString*>* keyword_names);
@@ -275,6 +276,7 @@ public:
     std::vector<RewriterVar*> emitUnpackIntoArray(RewriterVar* v, uint64_t num);
     RewriterVar* emitYield(RewriterVar* v);
 
+    void emitAssignSlice(RewriterVar* target, RewriterVar* lower, RewriterVar* upper, RewriterVar* value);
     void emitDelAttr(RewriterVar* target, BoxedString* attr);
     void emitDelGlobal(BoxedString* name);
     void emitDelItem(RewriterVar* target, RewriterVar* slice);

--- a/src/codegen/irgen/irgenerator.cpp
+++ b/src/codegen/irgen/irgenerator.cpp
@@ -1508,7 +1508,6 @@ private:
     CompilerVariable* evalSubscript(AST_Subscript* node, const UnwindInfo& unw_info) {
         CompilerVariable* value = evalExpr(node->value, unw_info);
         CompilerVariable* slice = evalSlice(node->slice, unw_info);
-
         CompilerVariable* rtn = value->getitem(emitter, getOpInfoForNode(node, unw_info), slice);
         return rtn;
     }
@@ -1992,31 +1991,59 @@ private:
         t->setattr(emitter, getEmptyOpInfo(unw_info), target->attr.getBox(), val);
     }
 
-    void _doSetitem(AST_Subscript* target, CompilerVariable* val, const UnwindInfo& unw_info) {
-        CompilerVariable* tget = evalExpr(target->value, unw_info);
-        CompilerVariable* slice = evalSlice(target->slice, unw_info);
+    void _assignSlice(llvm::Value* target, llvm::Value* value, const UnboxedSlice& slice_val,
+                      const UnwindInfo& unw_info) {
+        llvm::Value* cstart, *cstop;
+        cstart = slice_val.start ? slice_val.start->makeConverted(emitter, UNKNOWN)->getValue()
+                                 : emitter.setType(getNullPtr(g.llvm_value_type_ptr), RefType::BORROWED);
+        cstop = slice_val.stop ? slice_val.stop->makeConverted(emitter, UNKNOWN)->getValue()
+                               : emitter.setType(getNullPtr(g.llvm_value_type_ptr), RefType::BORROWED);
 
-        ConcreteCompilerVariable* converted_target = tget->makeConverted(emitter, tget->getBoxType());
-        ConcreteCompilerVariable* converted_slice = slice->makeConverted(emitter, slice->getBoxType());
-
-        ConcreteCompilerVariable* converted_val = val->makeConverted(emitter, val->getBoxType());
-
-        // TODO add a CompilerVariable::setattr, which can (similar to getitem)
-        // statically-resolve the function if possible, and only fall back to
-        // patchpoints if it couldn't.
         bool do_patchpoint = ENABLE_ICSETITEMS;
         if (do_patchpoint) {
             ICSetupInfo* pp = createSetitemIC(getEmptyOpInfo(unw_info).getTypeRecorder());
 
             std::vector<llvm::Value*> llvm_args;
-            llvm_args.push_back(converted_target->getValue());
-            llvm_args.push_back(converted_slice->getValue());
-            llvm_args.push_back(converted_val->getValue());
+            llvm_args.push_back(target);
+            llvm_args.push_back(cstart);
+            llvm_args.push_back(cstop);
+            llvm_args.push_back(value);
 
-            emitter.createIC(pp, (void*)pyston::setitem, llvm_args, unw_info);
+            emitter.createIC(pp, (void*)pyston::assignSlice, llvm_args, unw_info);
         } else {
-            emitter.createCall3(unw_info, g.funcs.setitem, converted_target->getValue(), converted_slice->getValue(),
-                                converted_val->getValue());
+            emitter.createCall(unw_info, g.funcs.assignSlice, { target, cstart, cstop, value });
+        }
+    }
+
+    void _doSetitem(AST_Subscript* target, CompilerVariable* val, const UnwindInfo& unw_info) {
+        CompilerVariable* tget = evalExpr(target->value, unw_info);
+
+        CompilerVariable* slice = evalSlice(target->slice, unw_info);
+        ConcreteCompilerVariable* converted_target = tget->makeConverted(emitter, tget->getBoxType());
+        ConcreteCompilerVariable* converted_val = val->makeConverted(emitter, val->getBoxType());
+
+        if (slice->getType() == UNBOXED_SLICE && !extractSlice(slice).step) {
+            _assignSlice(converted_target->getValue(), converted_val->getValue(), extractSlice(slice), unw_info);
+        } else {
+            ConcreteCompilerVariable* converted_slice = slice->makeConverted(emitter, slice->getBoxType());
+
+            // TODO add a CompilerVariable::setattr, which can (similar to getitem)
+            // statically-resolve the function if possible, and only fall back to
+            // patchpoints if it couldn't.
+            bool do_patchpoint = ENABLE_ICSETITEMS;
+            if (do_patchpoint) {
+                ICSetupInfo* pp = createSetitemIC(getEmptyOpInfo(unw_info).getTypeRecorder());
+
+                std::vector<llvm::Value*> llvm_args;
+                llvm_args.push_back(converted_target->getValue());
+                llvm_args.push_back(converted_slice->getValue());
+                llvm_args.push_back(converted_val->getValue());
+
+                emitter.createIC(pp, (void*)pyston::setitem, llvm_args, unw_info);
+            } else {
+                emitter.createCall3(unw_info, g.funcs.setitem, converted_target->getValue(),
+                                    converted_slice->getValue(), converted_val->getValue());
+            }
         }
     }
 
@@ -2125,19 +2152,27 @@ private:
         CompilerVariable* slice = evalSlice(target->slice, unw_info);
 
         ConcreteCompilerVariable* converted_target = tget->makeConverted(emitter, tget->getBoxType());
-        ConcreteCompilerVariable* converted_slice = slice->makeConverted(emitter, slice->getBoxType());
 
-        bool do_patchpoint = ENABLE_ICDELITEMS;
-        if (do_patchpoint) {
-            ICSetupInfo* pp = createDelitemIC(getEmptyOpInfo(unw_info).getTypeRecorder());
-
-            std::vector<llvm::Value*> llvm_args;
-            llvm_args.push_back(converted_target->getValue());
-            llvm_args.push_back(converted_slice->getValue());
-
-            emitter.createIC(pp, (void*)pyston::delitem, llvm_args, unw_info);
+        if (slice->getType() == UNBOXED_SLICE && !extractSlice(slice).step) {
+            _assignSlice(converted_target->getValue(),
+                         emitter.setType(getNullPtr(g.llvm_value_type_ptr), RefType::BORROWED), extractSlice(slice),
+                         unw_info);
         } else {
-            emitter.createCall2(unw_info, g.funcs.delitem, converted_target->getValue(), converted_slice->getValue());
+            ConcreteCompilerVariable* converted_slice = slice->makeConverted(emitter, slice->getBoxType());
+
+            bool do_patchpoint = ENABLE_ICDELITEMS;
+            if (do_patchpoint) {
+                ICSetupInfo* pp = createDelitemIC(getEmptyOpInfo(unw_info).getTypeRecorder());
+
+                std::vector<llvm::Value*> llvm_args;
+                llvm_args.push_back(converted_target->getValue());
+                llvm_args.push_back(converted_slice->getValue());
+
+                emitter.createIC(pp, (void*)pyston::delitem, llvm_args, unw_info);
+            } else {
+                emitter.createCall2(unw_info, g.funcs.delitem, converted_target->getValue(),
+                                    converted_slice->getValue());
+            }
         }
     }
 

--- a/src/codegen/runtime_hooks.cpp
+++ b/src/codegen/runtime_hooks.cpp
@@ -229,6 +229,8 @@ void initGlobalFuncs(GlobalState& g) {
     GET(getiterHelper);
     GET(hasnext);
     GET(apply_slice);
+    GET(applySlice);
+    GET(assignSlice);
 
     GET(unpackIntoArray);
     GET(raiseAttributeError);

--- a/src/codegen/runtime_hooks.h
+++ b/src/codegen/runtime_hooks.h
@@ -39,7 +39,7 @@ struct GlobalFuncs {
     llvm::Value* getattr, *getattr_capi, *setattr, *delattr, *delitem, *delGlobal, *nonzero, *binop, *compare,
         *augbinop, *unboxedLen, *getitem, *getitem_capi, *getclsattr, *getGlobal, *setitem, *unaryop, *import,
         *importFrom, *importStar, *repr, *exceptionMatches, *yield_capi, *getiterHelper, *hasnext, *setGlobal,
-        *apply_slice;
+        *apply_slice, *applySlice, *assignSlice;
 
     llvm::Value* unpackIntoArray, *raiseAttributeError, *raiseAttributeErrorStr, *raiseAttributeErrorCapi,
         *raiseAttributeErrorStrCapi, *raiseNotIterableError, *raiseIndexErrorStr, *raiseIndexErrorStrCapi,

--- a/src/runtime/classobj.cpp
+++ b/src/runtime/classobj.cpp
@@ -777,6 +777,15 @@ Box* instanceGetslice(Box* _inst, Box* i, Box* j) {
     return runtimeCall(getslice_func, ArgPassSpec(2), i, j, NULL, NULL, NULL);
 }
 
+Box* instance_slice(PyObject* self, Py_ssize_t i, Py_ssize_t j) noexcept {
+    try {
+        return instanceGetslice(self, autoDecref(boxInt(i)), autoDecref((boxInt(j))));
+    } catch (ExcInfo e) {
+        setCAPIException(e);
+        return 0;
+    }
+}
+
 Box* instanceSetslice(Box* _inst, Box* i, Box* j, Box** sequence) {
     RELEASE_ASSERT(_inst->cls == instance_cls, "");
     BoxedInstance* inst = static_cast<BoxedInstance*>(_inst);
@@ -2005,5 +2014,6 @@ void setupClassobj() {
     instance_cls->tp_as_number->nb_index = instance_index;
     instance_cls->tp_as_number->nb_power = instance_pow;
     instance_cls->tp_as_number->nb_inplace_power = instance_ipow;
+    instance_cls->tp_as_sequence->sq_slice = instance_slice;
 }
 }

--- a/src/runtime/dict.cpp
+++ b/src/runtime/dict.cpp
@@ -377,13 +377,13 @@ extern "C" BORROWED(PyObject*) PyDict_GetItem(PyObject* dict, PyObject* key) noe
         /* preserve the existing exception */
         PyObject* err_type, *err_value, *err_tb;
         PyErr_Fetch(&err_type, &err_value, &err_tb);
-        Box* b = getitemInternal<CAPI>(dict, key);
+        Box* b = PyObject_GetItem(dict, key);
         /* ignore errors */
         PyErr_Restore(err_type, err_value, err_tb);
         Py_XDECREF(b);
         return b;
     } else {
-        Box* b = getitemInternal<CAPI>(dict, key);
+        Box* b = PyObject_GetItem(dict, key);
         if (b == NULL)
             PyErr_Clear();
         else
@@ -514,13 +514,7 @@ extern "C" int PyDict_DelItem(PyObject* op, PyObject* key) noexcept {
     }
 
     ASSERT(op->cls == attrwrapper_cls, "%s", getTypeName(op));
-    try {
-        delitem(op, key);
-        return 0;
-    } catch (ExcInfo e) {
-        setCAPIException(e);
-        return -1;
-    }
+    return PyObject_DelItem(op, key);
 }
 
 extern "C" int PyDict_DelItemString(PyObject* v, const char* key) noexcept {

--- a/src/runtime/inline/link_forcer.cpp
+++ b/src/runtime/inline/link_forcer.cpp
@@ -105,6 +105,8 @@ void force() {
     FORCE(getiterHelper);
     FORCE(hasnext);
     FORCE(apply_slice);
+    FORCE(applySlice);
+    FORCE(assignSlice);
 
     FORCE(unpackIntoArray);
     FORCE(raiseAttributeError);

--- a/src/runtime/objmodel.cpp
+++ b/src/runtime/objmodel.cpp
@@ -6073,13 +6073,8 @@ static Box* callItemAttr(Box* target, BoxedString* item_str, Box* item, Box* val
 
     if (rewrite_args) {
         CallattrRewriteArgs crewrite_args(rewrite_args);
-        Box* r;
-        if (value)
-            r = callattrInternal2<S, REWRITABLE>(target, item_str, CLASS_ONLY, &crewrite_args, ArgPassSpec(2), item,
-                                                 value);
-        else
-            r = callattrInternal1<S, REWRITABLE>(target, item_str, CLASS_ONLY, &crewrite_args, ArgPassSpec(1), item);
-
+        Box* r = callattrInternal2<S, REWRITABLE>(target, item_str, CLASS_ONLY, &crewrite_args,
+                                                  ArgPassSpec(value ? 2 : 1), item, value);
         if (crewrite_args.isSuccessful()) {
             rewrite_args->out_success = true;
             if (r || PyErr_Occurred())
@@ -6090,171 +6085,286 @@ static Box* callItemAttr(Box* target, BoxedString* item_str, Box* item, Box* val
         }
         return r;
     } else {
-        if (value)
-            return callattrInternal2<S, NOT_REWRITABLE>(target, item_str, CLASS_ONLY, NULL, ArgPassSpec(2), item,
-                                                        value);
-        else
-            return callattrInternal1<S, NOT_REWRITABLE>(target, item_str, CLASS_ONLY, NULL, ArgPassSpec(1), item);
+        return callattrInternal2<S, NOT_REWRITABLE>(target, item_str, CLASS_ONLY, NULL, ArgPassSpec(value ? 2 : 1),
+                                                    item, value);
     }
 }
 
 #define ISINDEX(x) ((x) == NULL || PyInt_Check(x) || PyLong_Check(x) || PyIndex_Check(x))
 
-extern "C" PyObject* apply_slice(PyObject* u, PyObject* v, PyObject* w) noexcept /* return u[v:w] */
-{
-    // TODO: add rewriting here
+static int64_t isSliceIndexHelper(Box* a, Box* b) {
+    return ISINDEX(a) && ISINDEX(b);
+}
 
-    PyTypeObject* tp = u->cls;
-    PySequenceMethods* sq = tp->tp_as_sequence;
+template <ExceptionStyle S> static Box* applySliceHelper(Box* u, Box* a, Box* b) noexcept(S == CAPI) {
+    Py_ssize_t ilow = 0, ihigh = PY_SSIZE_T_MAX;
+    if (!_PyEval_SliceIndex(a, &ilow)) {
+        if (S == CXX)
+            throwCAPIException();
+        return NULL;
+    }
+    if (!_PyEval_SliceIndex(b, &ihigh)) {
+        if (S == CXX)
+            throwCAPIException();
+        return NULL;
+    }
 
-    if (sq && sq->sq_slice && ISINDEX(v) && ISINDEX(w)) {
-        Py_ssize_t ilow = 0, ihigh = PY_SSIZE_T_MAX;
-        if (!_PyEval_SliceIndex(v, &ilow))
-            return NULL;
-        if (!_PyEval_SliceIndex(w, &ihigh))
-            return NULL;
-        return PySequence_GetSlice(u, ilow, ihigh);
+    PySequenceMethods* sq = u->cls->tp_as_sequence;
+    if (ilow < 0 || ihigh < 0) {
+        if (sq->sq_length) {
+            Py_ssize_t l = (*sq->sq_length)(u);
+            if (l < 0) {
+                if (S == CXX)
+                    throwCAPIException();
+                return NULL;
+            }
+            if (ilow < 0)
+                ilow += l;
+            if (ihigh < 0)
+                ihigh += l;
+        }
+    }
+    Box* rtn = sq->sq_slice(u, ilow, ihigh);
+    if (S == CXX && !rtn)
+        throwCAPIException();
+    return rtn;
+}
+
+template <ExceptionStyle S> static int assignSliceHelper(Box* u, Box* a, Box* b, Box* x) noexcept(S == CAPI) {
+    Py_ssize_t ilow = 0, ihigh = PY_SSIZE_T_MAX;
+    if (!_PyEval_SliceIndex(a, &ilow)) {
+        if (S == CXX)
+            throwCAPIException();
+        return -1;
+    }
+    if (!_PyEval_SliceIndex(b, &ihigh)) {
+        if (S == CXX)
+            throwCAPIException();
+        return -1;
+    }
+
+    PySequenceMethods* sq = u->cls->tp_as_sequence;
+    if (ilow < 0 || ihigh < 0) {
+        if (sq->sq_length) {
+            Py_ssize_t l = (*sq->sq_length)(u);
+            if (l < 0) {
+                if (S == CXX)
+                    throwCAPIException();
+                return -1;
+            }
+            if (ilow < 0)
+                ilow += l;
+            if (ihigh < 0)
+                ihigh += l;
+        }
+    }
+
+    int rtn = sq->sq_ass_slice(u, ilow, ihigh, x);
+    if (S == CXX && rtn == -1)
+        throwCAPIException();
+    return rtn;
+}
+
+static std::pair<RewriterVar*, RewriterVar*> extractIntSliceStartStop(std::unique_ptr<Rewriter>& rewriter,
+                                                                      PyObject* start, PyObject* stop,
+                                                                      RewriterVar* r_start, RewriterVar* r_stop) {
+    RewriterVar* r_start_int = NULL;
+    RewriterVar* r_stop_int = NULL;
+    if (start) {
+        r_start->addGuardNotEq(0);
+        r_start->addAttrGuard(offsetof(Box, cls), (uint64_t)int_cls);
+        r_start_int = r_start->getAttr(offsetof(BoxedInt, n));
+        r_start_int->addGuardNotLt0();
+    } else {
+        r_start->addGuard(0);
+        r_start_int = rewriter->loadConst(0);
+    }
+    if (stop) {
+        r_stop->addGuardNotEq(0);
+        r_stop->addAttrGuard(offsetof(Box, cls), (uint64_t)int_cls);
+        r_stop_int = r_stop->getAttr(offsetof(BoxedInt, n));
+        r_stop_int->addGuardNotLt0();
+    } else {
+        r_stop->addGuard(0);
+        r_stop_int = rewriter->loadConst(PY_SSIZE_T_MAX);
+    }
+    return std::make_pair(r_start_int, r_stop_int);
+}
+
+/* return u[v:w] */
+template <ExceptionStyle S>
+PyObject* applySliceIntern(PyObject* u, PyObject* v, PyObject* w,
+                           std::unique_ptr<Rewriter>& rewriter) noexcept(S == CAPI) {
+    RewriterVar* r_obj = NULL, * r_start = NULL, * r_stop = NULL, * r_cls = NULL, * r_sq = NULL;
+    if (rewriter) {
+        r_obj = rewriter->getArg(0);
+        r_start = rewriter->getArg(1);
+        r_stop = rewriter->getArg(2);
+
+        r_cls = r_obj->getAttr(offsetof(Box, cls));
+        r_sq = r_cls->getAttr(offsetof(BoxedClass, tp_as_sequence));
+    }
+
+    PySequenceMethods* sq = u->cls->tp_as_sequence;
+    if (sq && sq->sq_slice && isSliceIndexHelper(v, w)) {
+        // call __getslice__
+        if (rewriter) {
+            r_sq->addGuardNotEq(0);
+            r_sq->addAttrGuard(offsetof(PySequenceMethods, sq_slice), (intptr_t)sq->sq_slice);
+
+            // handle int >= 0 and null because it is so frequent
+            if ((!v || (v->cls == int_cls && (PyInt_AS_LONG(v) >= 0)))
+                && (!w || (w->cls == int_cls && (PyInt_AS_LONG(w) >= 0)))) {
+                RewriterVar* r_start_int = NULL;
+                RewriterVar* r_stop_int = NULL;
+                std::tie(r_start_int, r_stop_int) = extractIntSliceStartStop(rewriter, v, w, r_start, r_stop);
+                RewriterVar* r_rtn = rewriter->call(true, (void*)sq->sq_slice, r_obj, r_start_int, r_stop_int)
+                                         ->setType(RefType::OWNED);
+                if (S == CXX)
+                    rewriter->checkAndThrowCAPIException(r_rtn);
+                rewriter->commitReturning(r_rtn);
+            } else {
+                RewriterVar* r_guard = rewriter->call(false, (void*)isSliceIndexHelper, r_start, r_stop);
+                r_guard->addGuardNotEq(0);
+
+                RewriterVar* r_rtn = rewriter->call(true, (void*)&applySliceHelper<S>, r_obj, r_start, r_stop)
+                                         ->setType(RefType::OWNED);
+                rewriter->commitReturning(r_rtn);
+            }
+        }
+        return applySliceHelper<S>(u, v, w);
+    }
+
+    // call __getitem__
+    if (rewriter && (!sq || !sq->sq_slice)) {
+        // rewrite getitem
+        if (sq) {
+            r_sq->addGuardNotEq(0);
+            r_sq->addAttrGuard(offsetof(PySequenceMethods, sq_slice), 0);
+        } else
+            r_sq->addGuard(0);
+
+        RewriterVar* r_slice = rewriter->call(false, (void*)PySlice_New, r_start, r_stop, rewriter->loadConst(0ul))
+                                   ->setType(RefType::OWNED);
+        Box* slice = PySlice_New(v, w, NULL);
+        AUTO_DECREF(slice);
+
+        GetitemRewriteArgs rewrite_args(rewriter.get(), r_obj, r_slice, rewriter->getReturnDestination());
+        Box* rtn = getitemInternal<S>(u, slice, &rewrite_args);
+
+        if (!rewrite_args.out_success) {
+            rewriter.reset(NULL);
+        } else if (rtn) {
+            rewriter->commitReturning(rewrite_args.out_rtn);
+        }
+        return rtn;
     } else {
         PyObject* slice = PySlice_New(v, w, NULL);
         if (slice != NULL) {
             PyObject* res = PyObject_GetItem(u, slice);
             Py_DECREF(slice);
+            if (S == CXX && !res)
+                throwCAPIException();
             return res;
-        } else
+        } else {
+            if (S == CXX)
+                throwCAPIException();
             return NULL;
+        }
     }
 }
 
-// This function decides whether to call the slice operator (e.g. __getslice__)
-// or the item operator (__getitem__).
-template <ExceptionStyle S, Rewritable rewritable>
-static Box* callItemOrSliceAttr(Box* target, BoxedString* item_str, BoxedString* slice_str, Box* slice, Box* value,
-                                CallRewriteArgs* rewrite_args) noexcept(S == CAPI) {
-    if (rewritable == NOT_REWRITABLE) {
-        assert(!rewrite_args);
-        rewrite_args = NULL;
-    }
+extern "C" PyObject* apply_slice(PyObject* u, PyObject* v, PyObject* w) noexcept {
+    std::unique_ptr<Rewriter> rewriter(
+        Rewriter::createRewriter(__builtin_extract_return_addr(__builtin_return_address(0)), 3, "apply_slice"));
 
-    // This function contains a lot of logic for deciding between whether to call
-    // the slice operator or the item operator, so we can match CPython's behavior
-    // on custom classes that define those operators. However, for builtin types,
-    // we know we can call either and the behavior will be the same. Adding all those
-    // guards are unnecessary and bad for performance.
-    //
-    // Also, for special slicing logic (e.g. open slice ranges [:]), the builtin types
-    // have C-implemented functions that already handle all the edge cases, so we don't
-    // need to have a slowpath for them here.
-    if (target->cls == list_cls || target->cls == str_cls || target->cls == unicode_cls) {
-        if (rewrite_args) {
-            rewrite_args->obj->addAttrGuard(offsetof(Box, cls), (uint64_t)target->cls);
-        }
-        return callItemAttr<S, rewritable>(target, item_str, slice, value, rewrite_args);
-    }
+    return applySliceIntern<CAPI>(u, v, w, rewriter);
+}
 
-    // Guard on the type of the object (need to have the slice operator attribute to call it).
-    bool has_slice_attr = false;
-    if (rewrite_args) {
-        RewriterVar* target_cls = rewrite_args->obj->getAttr(offsetof(Box, cls));
-        GetattrRewriteArgs grewrite_args(rewrite_args->rewriter, target_cls, Location::any());
-        has_slice_attr = (bool)typeLookup(target->cls, slice_str, &grewrite_args);
-        if (!grewrite_args.isSuccessful()) {
-            rewrite_args = NULL;
-        } else {
-            RewriterVar* rtn;
-            ReturnConvention return_convention;
-            std::tie(rtn, return_convention) = grewrite_args.getReturn();
-            if (return_convention != ReturnConvention::HAS_RETURN && return_convention != ReturnConvention::NO_RETURN)
-                rewrite_args = NULL;
+extern "C" PyObject* applySlice(PyObject* u, PyObject* v, PyObject* w) {
+    std::unique_ptr<Rewriter> rewriter(
+        Rewriter::createRewriter(__builtin_extract_return_addr(__builtin_return_address(0)), 3, "apply_slice"));
 
-            if (rewrite_args)
-                assert(has_slice_attr == (return_convention == ReturnConvention::HAS_RETURN));
-        }
-    } else {
-        has_slice_attr = (bool)typeLookup(target->cls, slice_str);
-    }
+    return applySliceIntern<CXX>(u, v, w, rewriter);
+}
 
-    if (!has_slice_attr) {
-        return callItemAttr<S, rewritable>(target, item_str, slice, value, rewrite_args);
-    }
+/* u[v:w] = x */
+template <ExceptionStyle S>
+int assignSliceInternal(PyObject* u, PyObject* v, PyObject* w, PyObject* x,
+                        std::unique_ptr<Rewriter>& rewriter) noexcept(S == CAPI) {
+    PySequenceMethods* sq = u->cls->tp_as_sequence;
+    if (sq && sq->sq_ass_slice && isSliceIndexHelper(v, w)) {
+        // call __setslice__ / __delslice__
+        if (rewriter) {
+            RewriterVar* r_obj = rewriter->getArg(0);
+            RewriterVar* r_start = rewriter->getArg(1);
+            RewriterVar* r_stop = rewriter->getArg(2);
+            RewriterVar* r_value = rewriter->getArg(3);
 
-    // Need a slice object to use the slice operators.
-    if (rewrite_args) {
-        rewrite_args->arg1->addAttrGuard(offsetof(Box, cls), (uint64_t)slice->cls);
-    }
-    if (slice->cls != slice_cls) {
-        return callItemAttr<S, rewritable>(target, item_str, slice, value, rewrite_args);
-    }
+            RewriterVar* r_cls = r_obj->getAttr(offsetof(Box, cls));
+            RewriterVar* r_sq = r_cls->getAttr(offsetof(BoxedClass, tp_as_sequence));
+            r_sq->addGuardNotEq(0);
+            r_sq->addAttrGuard(offsetof(PySequenceMethods, sq_ass_slice), (intptr_t)sq->sq_ass_slice);
 
-    BoxedSlice* bslice = (BoxedSlice*)slice;
+            // handle int >= 0 and null because it is so frequent
+            if ((!v || (v->cls == int_cls && (PyInt_AS_LONG(v) >= 0)))
+                && (!w || (w->cls == int_cls && (PyInt_AS_LONG(w) >= 0)))) {
+                RewriterVar* r_start_int = NULL;
+                RewriterVar* r_stop_int = NULL;
+                std::tie(r_start_int, r_stop_int) = extractIntSliceStartStop(rewriter, v, w, r_start, r_stop);
+                RewriterVar* r_rtn
+                    = rewriter->call(true, (void*)sq->sq_ass_slice, r_obj, r_start_int, r_stop_int, r_value);
+                if (S == CXX) {
+                    rewriter->checkAndThrowCAPIException(r_rtn, -1, assembler::MovType::L);
+                    rewriter->commit();
+                } else
+                    rewriter->commitReturningNonPython(r_rtn);
+            } else {
+                RewriterVar* r_guard = rewriter->call(false, (void*)isSliceIndexHelper, r_start, r_stop);
+                r_guard->addGuardNotEq(0);
 
-    // If we use slice notation with a step parameter (e.g. o[1:10:2]), the slice operator
-    // functions don't support that, so fallback to the item operator functions.
-    if (bslice->step->cls != none_cls) {
-        if (rewrite_args) {
-            rewrite_args->arg1->getAttr(offsetof(BoxedSlice, step))
-                ->addAttrGuard(offsetof(Box, cls), (uint64_t)none_cls, /*negate=*/true);
-        }
-
-        return callItemAttr<S, rewritable>(target, item_str, slice, value, rewrite_args);
-    } else {
-        rewrite_args = NULL;
-        REWRITE_ABORTED("");
-
-        // If the slice cannot be used as integer slices, also fall back to the get operator.
-        // We could optimize further here by having a version of isSliceIndex that
-        // creates guards, but it would only affect some rare edge cases.
-        if (!isSliceIndex(bslice->start) || !isSliceIndex(bslice->stop)) {
-            return callItemAttr<S, NOT_REWRITABLE>(target, item_str, slice, value, rewrite_args);
-        }
-
-        // If we don't specify the start/stop (e.g. o[:]), the slice operator functions
-        // CPython seems to use 0 and sys.maxint as the default values.
-        int64_t start = 0, stop = PyInt_GetMax();
-        if (S == CAPI) {
-            if (bslice->start != None)
-                if (!_PyEval_SliceIndex(bslice->start, &start))
-                    return NULL;
-            if (bslice->stop != None)
-                if (!_PyEval_SliceIndex(bslice->stop, &stop))
-                    return NULL;
-        } else {
-            sliceIndex(bslice->start, &start);
-            sliceIndex(bslice->stop, &stop);
-        }
-
-        adjustNegativeIndicesOnObject(target, &start, &stop);
-        if (PyErr_Occurred())
-            throwCAPIException();
-
-        Box* boxedStart = boxInt(start);
-        Box* boxedStop = boxInt(stop);
-        AUTO_DECREF(boxedStart);
-        AUTO_DECREF(boxedStop);
-
-        if (rewrite_args) {
-            CallattrRewriteArgs crewrite_args(rewrite_args);
-            Box* r;
-            if (value)
-                r = callattrInternal3<S, REWRITABLE>(target, slice_str, CLASS_ONLY, &crewrite_args, ArgPassSpec(3),
-                                                     boxedStart, boxedStop, value);
-            else
-                r = callattrInternal2<S, REWRITABLE>(target, slice_str, CLASS_ONLY, &crewrite_args, ArgPassSpec(2),
-                                                     boxedStart, boxedStop);
-
-            if (crewrite_args.isSuccessful()) {
-                rewrite_args->out_success = true;
-                rewrite_args->out_rtn = crewrite_args.getReturn(ReturnConvention::HAS_RETURN);
+                RewriterVar* r_rtn
+                    = rewriter->call(true, (void*)&assignSliceHelper<S>, r_obj, r_start, r_stop, r_value);
+                if (S == CAPI)
+                    rewriter->commitReturningNonPython(r_rtn);
+                else
+                    rewriter->commit();
             }
-            return r;
-        } else {
-            if (value)
-                return callattrInternal3<S, NOT_REWRITABLE>(target, slice_str, CLASS_ONLY, NULL, ArgPassSpec(3),
-                                                            boxedStart, boxedStop, value);
-            else
-                return callattrInternal2<S, NOT_REWRITABLE>(target, slice_str, CLASS_ONLY, NULL, ArgPassSpec(2),
-                                                            boxedStart, boxedStop);
         }
+        return assignSliceHelper<S>(u, v, w, x);
     }
+
+    // call __setitem__ / __delitem__
+    PyObject* slice = PySlice_New(v, w, NULL);
+    if (slice != NULL) {
+        int res;
+        if (x != NULL)
+            res = PyObject_SetItem(u, slice, x);
+        else
+            res = PyObject_DelItem(u, slice);
+        Py_DECREF(slice);
+        if (S == CXX && res == -1)
+            throwCAPIException();
+        return res;
+    } else {
+        if (S == CXX)
+            throwCAPIException();
+        return -1;
+    }
+}
+
+extern "C" int assign_slice(PyObject* u, PyObject* v, PyObject* w, PyObject* x) noexcept {
+    std::unique_ptr<Rewriter> rewriter(
+        Rewriter::createRewriter(__builtin_extract_return_addr(__builtin_return_address(0)), 4, "assign_slice"));
+
+    return assignSliceInternal<CAPI>(u, v, w, x, rewriter);
+}
+
+extern "C" void assignSlice(PyObject* u, PyObject* v, PyObject* w, PyObject* x) {
+    std::unique_ptr<Rewriter> rewriter(
+        Rewriter::createRewriter(__builtin_extract_return_addr(__builtin_return_address(0)), 4, "assign_slice"));
+
+    assignSliceInternal<CXX>(u, v, w, x, rewriter);
 }
 
 template <ExceptionStyle S, Rewritable rewritable>
@@ -6301,7 +6411,6 @@ Box* getitemInternal(Box* target, Box* slice, GetitemRewriteArgs* rewrite_args) 
     }
 
     static BoxedString* getitem_str = getStaticString("__getitem__");
-    static BoxedString* getslice_str = getStaticString("__getslice__");
 
     Box* rtn;
     try {
@@ -6309,7 +6418,7 @@ Box* getitemInternal(Box* target, Box* slice, GetitemRewriteArgs* rewrite_args) 
             CallRewriteArgs crewrite_args(rewrite_args->rewriter, rewrite_args->target, rewrite_args->destination);
             crewrite_args.arg1 = rewrite_args->slice;
 
-            rtn = callItemOrSliceAttr<S, REWRITABLE>(target, getitem_str, getslice_str, slice, NULL, &crewrite_args);
+            rtn = callItemAttr<S, REWRITABLE>(target, getitem_str, slice, NULL, &crewrite_args);
 
             if (!crewrite_args.out_success) {
                 rewrite_args = NULL;
@@ -6317,7 +6426,7 @@ Box* getitemInternal(Box* target, Box* slice, GetitemRewriteArgs* rewrite_args) 
                 rewrite_args->out_rtn = crewrite_args.out_rtn;
             }
         } else {
-            rtn = callItemOrSliceAttr<S, NOT_REWRITABLE>(target, getitem_str, getslice_str, slice, NULL, NULL);
+            rtn = callItemAttr<S, NOT_REWRITABLE>(target, getitem_str, slice, NULL, NULL);
         }
     } catch (ExcInfo e) {
         if (S == CAPI) {
@@ -6356,13 +6465,13 @@ Box* getitemInternal(Box* target, Box* slice, GetitemRewriteArgs* rewrite_args) 
     return rtn;
 }
 // Force instantiation of the template
-template Box* getitemInternal<CAPI, REWRITABLE>(Box*, Box*, GetitemRewriteArgs*);
+template Box* getitemInternal<CAPI, REWRITABLE>(Box*, Box*, GetitemRewriteArgs*) noexcept;
 template Box* getitemInternal<CXX, REWRITABLE>(Box*, Box*, GetitemRewriteArgs*);
-template Box* getitemInternal<CAPI, NOT_REWRITABLE>(Box*, Box*, GetitemRewriteArgs*);
+template Box* getitemInternal<CAPI, NOT_REWRITABLE>(Box*, Box*, GetitemRewriteArgs*) noexcept;
 template Box* getitemInternal<CXX, NOT_REWRITABLE>(Box*, Box*, GetitemRewriteArgs*);
 
 // target[slice]
-extern "C" Box* getitem(Box* target, Box* slice) {
+template <ExceptionStyle S> static Box* getitemEntry(Box* target, Box* slice, void* return_addr) noexcept(S == CAPI) {
     STAT_TIMER(t0, "us_timer_slowpath_getitem", 10);
 
     // This possibly could just be represented as a single callattr; the only tricky part
@@ -6372,49 +6481,14 @@ extern "C" Box* getitem(Box* target, Box* slice) {
     static StatCounter slowpath_getitem("slowpath_getitem");
     slowpath_getitem.log();
 
-    std::unique_ptr<Rewriter> rewriter(
-        Rewriter::createRewriter(__builtin_extract_return_addr(__builtin_return_address(0)), 2, "getitem"));
+    std::unique_ptr<Rewriter> rewriter(Rewriter::createRewriter(return_addr, 2, "getitem"));
 
     Box* rtn;
     if (rewriter.get()) {
         GetitemRewriteArgs rewrite_args(rewriter.get(), rewriter->getArg(0), rewriter->getArg(1),
                                         rewriter->getReturnDestination());
 
-        rtn = getitemInternal<CXX>(target, slice, &rewrite_args);
-
-        if (!rewrite_args.out_success) {
-            rewriter.reset(NULL);
-        } else {
-            rewriter->commitReturning(rewrite_args.out_rtn);
-        }
-    } else {
-        rtn = getitemInternal<CXX>(target, slice);
-    }
-    assert(rtn);
-
-    return rtn;
-}
-
-// target[slice]
-extern "C" Box* getitem_capi(Box* target, Box* slice) noexcept {
-    STAT_TIMER(t0, "us_timer_slowpath_getitem", 10);
-
-    // This possibly could just be represented as a single callattr; the only tricky part
-    // are the error messages.
-    // Ex "(1)[1]" and "(1).__getitem__(1)" give different error messages.
-
-    static StatCounter slowpath_getitem("slowpath_getitem");
-    slowpath_getitem.log();
-
-    std::unique_ptr<Rewriter> rewriter(
-        Rewriter::createRewriter(__builtin_extract_return_addr(__builtin_return_address(0)), 2, "getitem"));
-
-    Box* rtn;
-    if (rewriter.get()) {
-        GetitemRewriteArgs rewrite_args(rewriter.get(), rewriter->getArg(0), rewriter->getArg(1),
-                                        rewriter->getReturnDestination());
-
-        rtn = getitemInternal<CAPI>(target, slice, &rewrite_args);
+        rtn = getitemInternal<S, REWRITABLE>(target, slice, &rewrite_args);
 
         if (!rewrite_args.out_success) {
             rewriter.reset(NULL);
@@ -6422,10 +6496,18 @@ extern "C" Box* getitem_capi(Box* target, Box* slice) noexcept {
             rewriter->commitReturning(rewrite_args.out_rtn);
         }
     } else {
-        rtn = getitemInternal<CAPI>(target, slice);
+        rtn = getitemInternal<S>(target, slice);
     }
 
     return rtn;
+}
+
+extern "C" Box* getitem(Box* target, Box* slice) {
+    return getitemEntry<CXX>(target, slice, __builtin_extract_return_addr(__builtin_return_address(0)));
+}
+
+extern "C" Box* getitem_capi(Box* target, Box* slice) noexcept {
+    return getitemEntry<CAPI>(target, slice, __builtin_extract_return_addr(__builtin_return_address(0)));
 }
 
 // target[slice] = value
@@ -6439,7 +6521,6 @@ extern "C" void setitem(Box* target, Box* slice, Box* value) {
         Rewriter::createRewriter(__builtin_extract_return_addr(__builtin_return_address(0)), 3, "setitem"));
 
     static BoxedString* setitem_str = getStaticString("__setitem__");
-    static BoxedString* setslice_str = getStaticString("__setslice__");
 
     auto&& m = target->cls->tp_as_mapping;
     if (m && m->mp_ass_subscript && m->mp_ass_subscript != slot_mp_ass_subscript) {
@@ -6468,13 +6549,13 @@ extern "C" void setitem(Box* target, Box* slice, Box* value) {
         rewrite_args.arg1 = rewriter->getArg(1);
         rewrite_args.arg2 = rewriter->getArg(2);
 
-        rtn = callItemOrSliceAttr<CXX, REWRITABLE>(target, setitem_str, setslice_str, slice, value, &rewrite_args);
+        rtn = callItemAttr<CXX, REWRITABLE>(target, setitem_str, slice, value, &rewrite_args);
 
         if (!rewrite_args.out_success) {
             rewriter.reset(NULL);
         }
     } else {
-        rtn = callItemOrSliceAttr<CXX, NOT_REWRITABLE>(target, setitem_str, setslice_str, slice, value, NULL);
+        rtn = callItemAttr<CXX, NOT_REWRITABLE>(target, setitem_str, slice, value, NULL);
     }
 
     if (rtn == NULL) {
@@ -6497,20 +6578,18 @@ extern "C" void delitem(Box* target, Box* slice) {
         Rewriter::createRewriter(__builtin_extract_return_addr(__builtin_return_address(0)), 2, "delitem"));
 
     static BoxedString* delitem_str = getStaticString("__delitem__");
-    static BoxedString* delslice_str = getStaticString("__delslice__");
-
     Box* rtn;
     if (rewriter.get()) {
         CallRewriteArgs rewrite_args(rewriter.get(), rewriter->getArg(0), rewriter->getReturnDestination());
         rewrite_args.arg1 = rewriter->getArg(1);
 
-        rtn = callItemOrSliceAttr<CXX, REWRITABLE>(target, delitem_str, delslice_str, slice, NULL, &rewrite_args);
+        rtn = callItemAttr<CXX, REWRITABLE>(target, delitem_str, slice, NULL, &rewrite_args);
 
         if (!rewrite_args.out_success) {
             rewriter.reset(NULL);
         }
     } else {
-        rtn = callItemOrSliceAttr<CXX, NOT_REWRITABLE>(target, delitem_str, delslice_str, slice, NULL, NULL);
+        rtn = callItemAttr<CXX, NOT_REWRITABLE>(target, delitem_str, slice, NULL, NULL);
     }
 
     if (rtn == NULL) {

--- a/src/runtime/objmodel.h
+++ b/src/runtime/objmodel.h
@@ -88,6 +88,9 @@ extern "C" Box* getitem_capi(Box* value, Box* slice) noexcept __attribute__((noi
 extern "C" void setitem(Box* target, Box* slice, Box* value) __attribute__((noinline));
 extern "C" void delitem(Box* target, Box* slice) __attribute__((noinline));
 extern "C" PyObject* apply_slice(PyObject* u, PyObject* v, PyObject* w) noexcept;
+extern "C" PyObject* applySlice(PyObject* u, PyObject* v, PyObject* w);
+extern "C" int assign_slice(PyObject* u, PyObject* v, PyObject* w, PyObject* x) noexcept;
+extern "C" void assignSlice(PyObject* u, PyObject* v, PyObject* w, PyObject* x);
 extern "C" Box* getclsattr(Box* obj, BoxedString* attr) __attribute__((noinline));
 extern "C" Box* getclsattrMaybeNonstring(Box* obj, Box* attr) __attribute__((noinline));
 extern "C" Box* unaryop(Box* operand, int op_type) __attribute__((noinline));

--- a/test/test_extension/slots_test.c
+++ b/test/test_extension/slots_test.c
@@ -326,7 +326,7 @@ static PyTypeObject slots_tester_map= {
     0,                                  /* tp_getattro */
     0,                                  /* tp_setattro */
     0,                                  /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT,                 /* tp_flags */
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,                 /* tp_flags */
     0,                   /* tp_doc */
     0,                                  /* tp_traverse */
     0,                                  /* tp_clear */

--- a/test/tests/capi_slots.py
+++ b/test/tests/capi_slots.py
@@ -242,3 +242,12 @@ class C(object):
 c = C()
 proxy = weakref.proxy(c)
 print isinstance(proxy, C)
+
+# test if __setslice__ is prioritised over mp_ass_subscript
+class D(slots_test.SlotsTesterMap):
+    def __setslice__(self, *args):
+        print "setslice", args
+d = D(1)
+for i in xrange(10):
+    print i
+    d[1:2] = 1

--- a/test/tests/slice.py
+++ b/test/tests/slice.py
@@ -101,11 +101,13 @@ sliceable[3:8]
 both[0]
 both[:]
 both[3:8]
+both[slice(3, 8)]
 both[::2] # this should call __getitem__ since __getslice__ doesn't support steps
 
 both[0] = xrange(2)
 both[:] = xrange(2)
 both[3:8] = xrange(2)
+both[slice(3, 8)] = xrange(2)
 both[::2] = xrange(2)
 
 # Should all call getitem as a fallback
@@ -118,6 +120,7 @@ both[1:2:'c']
 del both[0]
 del both[:]
 del both[3:8]
+del both[slice(3, 8)]
 del both [::2]
 
 try:


### PR DESCRIPTION
only lookup `__[set/get/del]slice__` for slice AST nodes
before this change
`C()[slice(1,2)] = "a"`
would call into `__setslice__` because it got handled as
`C()[1,2] = "a"`
the problems only appeared after the guarding change in `setitem` because before we called `mp_ass_subscript` even when it was `slot_mp_ass_subscript` when we encountered before a type which had a `!=  slot_mp_ass_subscript` (we missed the guard)


I'm not sure if there is not a much nicer way to resolve this which I missed.. 