### PR TITLE
Support attrwrapper as globals argument to execfile

### DIFF
--- a/src/codegen/irgen/hooks.cpp
+++ b/src/codegen/irgen/hooks.cpp
@@ -502,7 +502,8 @@ static void pickGlobalsAndLocals(Box*& globals, Box*& locals) {
     if (globals->cls == attrwrapper_cls)
         globals = unwrapAttrWrapper(globals);
 
-    assert(globals && (globals->cls == module_cls || globals->cls == dict_cls));
+    RELEASE_ASSERT(globals && (globals->cls == module_cls || globals->cls == dict_cls), "Unspported globals type: %s",
+                   globals ? globals->cls->tp_name : "NULL");
 
     if (globals) {
         // From CPython (they set it to be f->f_builtins):

--- a/test/tests/execfile_test.py
+++ b/test/tests/execfile_test.py
@@ -8,6 +8,11 @@ fn = os.path.join(os.path.dirname(__file__), 'execfile_target.py')
 execfile(fn)
 print "done with first execfile"
 execfile(fn)
+execfile(fn, globals())
+try:
+    execfile(fn, [])
+except Exception as e:
+    print type(e)
 
 print test_name
 print type(execfile_target)

--- a/test/tests/pyc_stress_test.py
+++ b/test/tests/pyc_stress_test.py
@@ -8,7 +8,7 @@ import multiprocessing
 def worker():
     global done
 
-    for i in xrange(1000):
+    for i in xrange(100):
         del sys.modules["pyc_import_target"]
         import pyc_import_target
 
@@ -30,10 +30,10 @@ idx = 0
 while l:
     p = l.pop()
     while p.is_alive():
-        for i in xrange(100):
+        for i in xrange(10):
             if os.path.exists(path):
                 os.remove(path)
-        for i in xrange(100):
+        for i in xrange(10):
             if os.path.exists(path):
                 with open(path, "rw+") as f:
                     f.write(chr(i) * 100)


### PR DESCRIPTION
Or rather, have execfile() be more permissive in what it accepts.
It may still abort when we get to pickGlobalsAndLocals() and we
discover that we can't actually execute in that particular attrwrapper.