### PR TITLE
use r12, r15 and rbx in bjit and inside bjit ICs, remove some nonzero checks

### DIFF
--- a/src/asm_writing/assembler.cpp
+++ b/src/asm_writing/assembler.cpp
@@ -57,7 +57,41 @@ const int dwarf_to_gp[] = {
 Register Register::fromDwarf(int dwarf_regnum) {
     assert(dwarf_regnum >= 0 && dwarf_regnum <= 16);
 
-    return Register(dwarf_to_gp[dwarf_regnum]);
+    Register reg(dwarf_to_gp[dwarf_regnum]);
+    assert(reg.getDwarfId() == dwarf_regnum);
+    return reg;
+}
+
+int Register::getDwarfId() const {
+    switch (regnum) {
+        case RAX.regnum:
+            return 0;
+        case RDX.regnum:
+            return 1;
+        case RCX.regnum:
+            return 2;
+        case RBX.regnum:
+            return 3;
+        case RSI.regnum:
+            return 4;
+        case RDI.regnum:
+            return 5;
+        case RBP.regnum:
+            return 6;
+        case RSP.regnum:
+            return 7;
+        case R8.regnum:
+        case R9.regnum:
+        case R10.regnum:
+        case R11.regnum:
+        case R12.regnum:
+        case R13.regnum:
+        case R14.regnum:
+        case R15.regnum:
+            return regnum;
+        default:
+            RELEASE_ASSERT(0, "not implemented");
+    };
 }
 
 GenericRegister GenericRegister::fromDwarf(int dwarf_regnum) {

--- a/src/asm_writing/assembler.cpp
+++ b/src/asm_writing/assembler.cpp
@@ -441,7 +441,7 @@ void Assembler::mov_generic(Indirect src, Register dest, MovType type) {
     bool needssib = (src_idx == 0b100);
 
     int mode;
-    if (src.offset == 0)
+    if (src.offset == 0 && src.base != RBP)
         mode = 0b00;
     else if (-0x80 <= src.offset && src.offset < 0x80)
         mode = 0b01;
@@ -544,7 +544,7 @@ void Assembler::movsd(Indirect src, XMMRegister dest) {
     bool needssib = (src_idx == 0b100);
 
     int mode;
-    if (src.offset == 0)
+    if (src.offset == 0 && src.base != RBP)
         mode = 0b00;
     else if (-0x80 <= src.offset && src.offset < 0x80)
         mode = 0b01;
@@ -588,7 +588,7 @@ void Assembler::movss(Indirect src, XMMRegister dest) {
     bool needssib = (src_idx == 0b100);
 
     int mode;
-    if (src.offset == 0)
+    if (src.offset == 0 && src.base != RBP)
         mode = 0b00;
     else if (-0x80 <= src.offset && src.offset < 0x80)
         mode = 0b01;
@@ -694,7 +694,7 @@ void Assembler::incl(Indirect mem) {
     emitByte(0xff);
 
     assert(-0x80 <= mem.offset && mem.offset < 0x80);
-    if (mem.offset == 0) {
+    if (mem.offset == 0 && mem.base != RBP) {
         emitModRM(0b00, 0, src_idx);
         if (needssib)
             emitSIB(0b00, 0b100, src_idx);
@@ -722,7 +722,7 @@ void Assembler::decl(Indirect mem) {
     emitByte(0xff);
 
     assert(-0x80 <= mem.offset && mem.offset < 0x80);
-    if (mem.offset == 0) {
+    if (mem.offset == 0 && mem.base != RBP) {
         emitModRM(0b00, 1, src_idx);
     } else {
         emitModRM(0b01, 1, src_idx);
@@ -761,7 +761,7 @@ void Assembler::incq(Indirect mem) {
     emitByte(0xff);
 
     assert(-0x80 <= mem.offset && mem.offset < 0x80);
-    if (mem.offset == 0) {
+    if (mem.offset == 0 && mem.base != RBP) {
         emitModRM(0b00, 0, src_idx);
         if (needssib)
             emitSIB(0b00, 0b100, src_idx);
@@ -789,7 +789,7 @@ void Assembler::decq(Indirect mem) {
     emitByte(0xff);
 
     assert(-0x80 <= mem.offset && mem.offset < 0x80);
-    if (mem.offset == 0) {
+    if (mem.offset == 0 && mem.base != RBP) {
         emitModRM(0b00, 1, src_idx);
     } else {
         emitModRM(0b01, 1, src_idx);
@@ -843,7 +843,7 @@ void Assembler::callq(Indirect mem) {
     emitByte(0xff);
 
     assert(-0x80 <= mem.offset && mem.offset < 0x80);
-    if (mem.offset == 0) {
+    if (mem.offset == 0 && mem.base != RBP) {
         emitModRM(0b00, 2, src_idx);
     } else {
         emitModRM(0b01, 2, src_idx);
@@ -902,7 +902,7 @@ void Assembler::cmp(Indirect mem, Immediate imm, MovType type) {
         emitRex(rex);
     emitByte(0x81);
 
-    if (mem.offset == 0) {
+    if (mem.offset == 0 && mem.base != RBP) {
         emitModRM(0b00, 7, src_idx);
         if (needssib)
             emitSIB(0b00, 0b100, src_idx);
@@ -944,7 +944,7 @@ void Assembler::cmp(Indirect mem, Register reg) {
     emitRex(rex);
     emitByte(0x3B);
 
-    if (mem.offset == 0) {
+    if (mem.offset == 0 && mem.base != RBP) {
         emitModRM(0b00, reg_idx, mem_idx);
         if (needssib)
             emitSIB(0b00, 0b100, mem_idx);
@@ -1066,7 +1066,7 @@ void Assembler::jmp(Indirect dest) {
 
     assert(reg_idx >= 0 && reg_idx < 8 && "not yet implemented");
     emitByte(0xFF);
-    if (dest.offset == 0) {
+    if (dest.offset == 0 && dest.base != RBP) {
         emitModRM(0b00, 0b100, reg_idx);
     } else if (-0x80 <= dest.offset && dest.offset < 0x80) {
         emitModRM(0b01, 0b100, reg_idx);

--- a/src/asm_writing/assembler.cpp
+++ b/src/asm_writing/assembler.cpp
@@ -940,17 +940,25 @@ void Assembler::cmp(Indirect mem, Register reg) {
     assert(mem_idx >= 0 && mem_idx < 8);
     assert(reg_idx >= 0 && reg_idx < 8);
 
+    bool needssib = (mem_idx == 0b100);
+
     emitRex(rex);
     emitByte(0x3B);
 
     if (mem.offset == 0) {
         emitModRM(0b00, reg_idx, mem_idx);
+        if (needssib)
+            emitSIB(0b00, 0b100, mem_idx);
     } else if (-0x80 <= mem.offset && mem.offset < 0x80) {
         emitModRM(0b01, reg_idx, mem_idx);
+        if (needssib)
+            emitSIB(0b00, 0b100, mem_idx);
         emitByte(mem.offset);
     } else {
         assert(fitsInto<int32_t>(mem.offset));
         emitModRM(0b10, reg_idx, mem_idx);
+        if (needssib)
+            emitSIB(0b00, 0b100, mem_idx);
         emitInt(mem.offset, 4);
     }
 }

--- a/src/asm_writing/assembler.cpp
+++ b/src/asm_writing/assembler.cpp
@@ -526,13 +526,12 @@ void Assembler::movsd(Indirect src, XMMRegister dest) {
     int dest_idx = dest.regnum;
 
     if (src_idx >= 8) {
-        trap();
-        rex |= REX_R;
+        rex |= REX_B;
         src_idx -= 8;
     }
     if (dest_idx >= 8) {
         trap();
-        rex |= REX_B;
+        rex |= REX_R;
         dest_idx -= 8;
     }
 

--- a/src/asm_writing/icinfo.h
+++ b/src/asm_writing/icinfo.h
@@ -94,6 +94,7 @@ private:
     TypeRecorder* const type_recorder;
     int retry_in, retry_backoff;
     int times_rewritten;
+    assembler::RegisterSet allocatable_registers;
 
     DecrefInfo slowpath_decref_info;
     // This is a vector of locations which always need to get decrefed inside this IC.
@@ -107,7 +108,8 @@ private:
 public:
     ICInfo(void* start_addr, void* slowpath_rtn_addr, void* continue_addr, StackInfo stack_info, int size,
            llvm::CallingConv::ID calling_conv, LiveOutSet live_outs, assembler::GenericRegister return_register,
-           TypeRecorder* type_recorder, std::vector<Location> ic_global_decref_locations);
+           TypeRecorder* type_recorder, std::vector<Location> ic_global_decref_locations,
+           assembler::RegisterSet allocatable_registers = assembler::RegisterSet::stdAllocatable());
     ~ICInfo();
     void* const start_addr, *const slowpath_rtn_addr, *const continue_addr;
 
@@ -132,6 +134,8 @@ public:
     int percentMegamorphic() const { return times_rewritten * 100 / IC_MEGAMORPHIC_THRESHOLD; }
     int percentBackedoff() const { return retry_backoff; }
     int timesRewritten() const { return times_rewritten; }
+
+    assembler::RegisterSet getAllocatableRegs() const { return allocatable_registers; }
 
     friend class ICSlotRewrite;
 

--- a/src/asm_writing/rewriter.h
+++ b/src/asm_writing/rewriter.h
@@ -516,8 +516,7 @@ protected:
     // Allocates a register.  dest must be of type Register or AnyReg
     // If otherThan is a register, guaranteed to not use that register.
     assembler::Register allocReg(Location dest, Location otherThan = Location::any());
-    assembler::Register allocReg(Location dest, Location otherThan,
-                                 llvm::ArrayRef<assembler::Register> valid_registers);
+    assembler::Register allocReg(Location dest, Location otherThan, assembler::RegisterSet valid_registers);
     assembler::XMMRegister allocXMMReg(Location dest, Location otherThan = Location::any());
     // Allocates an 8-byte region in the scratch space
     Location allocScratch();
@@ -609,7 +608,7 @@ protected:
 #endif
     }
 
-    llvm::ArrayRef<assembler::Register> allocatable_regs;
+    assembler::RegisterSet allocatable_regs;
 
 public:
     // This should be called exactly once for each argument

--- a/src/asm_writing/types.h
+++ b/src/asm_writing/types.h
@@ -48,6 +48,7 @@ struct Register {
 
     void dump() const;
 
+    int getDwarfId() const;
     static Register fromDwarf(int dwarf_regnum);
 
     static constexpr int numRegs() { return 16; }

--- a/src/codegen/baseline_jit.cpp
+++ b/src/codegen/baseline_jit.cpp
@@ -43,6 +43,8 @@ static llvm::DenseMap<CFGBlock*, std::vector<void*>> block_patch_locations;
 //   asm volatile ("" ::: "r14");
 //   asm volatile ("" ::: "r13");
 //   asm volatile ("" ::: "r12");
+//   asm volatile ("" ::: "rbx");
+//   asm volatile ("" ::: "rbp");
 //   char scratch[256+16];
 //   foo(scratch);
 // }
@@ -50,15 +52,16 @@ static llvm::DenseMap<CFGBlock*, std::vector<void*>> block_patch_locations;
 // It omits the frame pointer but saves r12, r13, r14 and r15
 // use 'objdump -s -j .eh_frame <obj.file>' to dump it
 const unsigned char eh_info[]
-    = { 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0x7a, 0x52, 0x00, 0x01, 0x78, 0x10, 0x01,
-        0x1b, 0x0c, 0x07, 0x08, 0x90, 0x01, 0x00, 0x00, 0x2c, 0x00, 0x00, 0x00, 0x1c, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x00, 0x28, 0x00, 0x00, 0x00, 0x00, 0x42, 0x0e, 0x10, 0x42, 0x0e, 0x18, 0x42,
-        0x0e, 0x20, 0x42, 0x0e, 0x28, 0x47, 0x0e, 0xc0, 0x02, 0x8c, 0x05, 0x8d, 0x04, 0x8e, 0x03, 0x8f,
-        0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+    = { 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0x7a, 0x52, 0x00, 0x01, 0x78, 0x10, 0x01, 0x1b,
+        0x0c, 0x07, 0x08, 0x90, 0x01, 0x00, 0x00, 0x34, 0x00, 0x00, 0x00, 0x1c, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x2c, 0x00, 0x00, 0x00, 0x00, 0x41, 0x0e, 0x10, 0x42, 0x0e, 0x18, 0x42, 0x0e, 0x20, 0x42,
+        0x0e, 0x28, 0x42, 0x0e, 0x30, 0x41, 0x0e, 0x38, 0x47, 0x0e, 0xd0, 0x02, 0x83, 0x07, 0x8c, 0x06, 0x8d,
+        0x05, 0x8e, 0x04, 0x8f, 0x03, 0x86, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
 static_assert(JitCodeBlock::num_stack_args == 2, "have to update EH table!");
 static_assert(JitCodeBlock::scratch_size == 256, "have to update EH table!");
 
 constexpr int code_size = JitCodeBlock::memory_size - sizeof(eh_info);
+constexpr assembler::RegisterSet JitCodeBlock::additional_regs;
 
 JitCodeBlock::MemoryManager::MemoryManager() {
     int protection = PROT_READ | PROT_WRITE | PROT_EXEC;
@@ -86,10 +89,12 @@ JitCodeBlock::JitCodeBlock(llvm::StringRef name)
     uint8_t* code = a.curInstPointer();
 
     // emit prolog
+    a.push(assembler::RBP);
     a.push(assembler::R15);
     a.push(assembler::R14);
     a.push(assembler::R13);
     a.push(assembler::R12);
+    a.push(assembler::RBX);
     static_assert(sp_adjustment % 16 == 8, "stack isn't aligned");
     a.sub(assembler::Immediate(sp_adjustment), assembler::RSP);
     a.mov(assembler::RDI, assembler::R13);                                // interpreter pointer
@@ -131,9 +136,10 @@ std::unique_ptr<JitFragmentWriter> JitCodeBlock::newFragment(CFGBlock* block, in
     void* fragment_start = a.curInstPointer() - patch_jump_offset;
     long fragment_offset = a.bytesWritten() - patch_jump_offset;
     long bytes_left = a.bytesLeft() + patch_jump_offset;
+    constexpr assembler::RegisterSet bjit_allocatable_regs = assembler::RegisterSet::stdAllocatable() | additional_regs;
     std::unique_ptr<ICInfo> ic_info(new ICInfo(fragment_start, nullptr, nullptr, stack_info, bytes_left,
                                                llvm::CallingConv::C, live_outs, assembler::RAX, 0,
-                                               std::vector<Location>()));
+                                               std::vector<Location>(), bjit_allocatable_regs));
     std::unique_ptr<ICSlotRewrite> rewrite = ic_info->startRewrite("");
 
     return std::unique_ptr<JitFragmentWriter>(new JitFragmentWriter(
@@ -156,13 +162,6 @@ void JitCodeBlock::fragmentFinished(int bytes_written, int num_bytes_overlapping
     ic_info.appendDecrefInfosTo(decref_infos);
 }
 
-static const assembler::Register bjit_allocatable_regs[]
-    = { assembler::RAX, assembler::RCX, assembler::RDX,
-        // no RSP
-        // no RBP
-        assembler::RDI, assembler::RSI, assembler::R8,  assembler::R9,
-        assembler::R10, assembler::R11, assembler::R12, assembler::R15 };
-
 JitFragmentWriter::JitFragmentWriter(CFGBlock* block, std::unique_ptr<ICInfo> ic_info,
                                      std::unique_ptr<ICSlotRewrite> rewrite, int code_offset, int num_bytes_overlapping,
                                      void* entry_code, JitCodeBlock& code_block)
@@ -175,7 +174,6 @@ JitFragmentWriter::JitFragmentWriter(CFGBlock* block, std::unique_ptr<ICInfo> ic
       code_block(code_block),
       interp(0),
       ic_info(std::move(ic_info)) {
-    allocatable_regs = bjit_allocatable_regs;
 
     added_changing_action = true;
 
@@ -1062,10 +1060,12 @@ void JitFragmentWriter::_emitJump(CFGBlock* b, RewriterVar* block_next, ExitInfo
         exit_info.exit_start = assembler->curInstPointer();
         block_next->getInReg(assembler::RAX, true);
         assembler->add(assembler::Immediate(JitCodeBlock::sp_adjustment), assembler::RSP);
+        assembler->pop(assembler::RBX);
         assembler->pop(assembler::R12);
         assembler->pop(assembler::R13);
         assembler->pop(assembler::R14);
         assembler->pop(assembler::R15);
+        assembler->pop(assembler::RBP);
         assembler->retq();
 
         // make sure we have at least 'min_patch_size' of bytes available.
@@ -1097,10 +1097,12 @@ void JitFragmentWriter::_emitOSRPoint() {
         assembler->clear_reg(assembler::RAX); // = next block to execute
         assembler->mov(assembler::Immediate(ASTInterpreterJitInterface::osr_dummy_value), assembler::RDX);
         assembler->add(assembler::Immediate(JitCodeBlock::sp_adjustment), assembler::RSP);
+        assembler->pop(assembler::RBX);
         assembler->pop(assembler::R12);
         assembler->pop(assembler::R13);
         assembler->pop(assembler::R14);
         assembler->pop(assembler::R15);
+        assembler->pop(assembler::RBP);
         assembler->retq();
     }
     interp->bumpUse();
@@ -1134,7 +1136,14 @@ void JitFragmentWriter::_emitPPCall(RewriterVar* result, void* func_addr, llvm::
     uint8_t* pp_end = rewrite->getSlotStart() + assembler->bytesWritten();
     assert(assembler->hasFailed() || (pp_start + pp_size + call_size == pp_end));
 
-    std::unique_ptr<ICSetupInfo> setup_info(ICSetupInfo::initialize(true, pp_size, ICSetupInfo::Generic, NULL));
+    assembler::RegisterSet regs = assembler::RegisterSet::stdAllocatable();
+    for (assembler::Register reg : JitCodeBlock::additional_regs) {
+        if (vars_by_location.count(reg) == 0)
+            regs |= assembler::RegisterSet(reg);
+    }
+
+    std::unique_ptr<ICSetupInfo> setup_info(ICSetupInfo::initialize(true, pp_size, ICSetupInfo::Generic, NULL, regs));
+
 
     // calculate available scratch space
     int pp_scratch_size = 0;
@@ -1190,10 +1199,12 @@ void JitFragmentWriter::_emitReturn(RewriterVar* return_val) {
     return_val->getInReg(assembler::RDX, true);
     assembler->clear_reg(assembler::RAX);
     assembler->add(assembler::Immediate(JitCodeBlock::sp_adjustment), assembler::RSP);
+    assembler->pop(assembler::RBX);
     assembler->pop(assembler::R12);
     assembler->pop(assembler::R13);
     assembler->pop(assembler::R14);
     assembler->pop(assembler::R15);
+    assembler->pop(assembler::RBP);
     assembler->retq();
     return_val->bumpUse();
 }

--- a/src/codegen/baseline_jit.h
+++ b/src/codegen/baseline_jit.h
@@ -211,6 +211,7 @@ private:
     // TODO: in the future we could reuse this information between different basic blocks
     llvm::DenseSet<int> known_non_null_vregs;
     std::unique_ptr<ICInfo> ic_info;
+    llvm::SmallPtrSet<RewriterVar*, 4> var_is_a_python_bool;
 
     // Optional points to a CFGBlock and a patch location which should get patched to a direct jump if
     // the specified block gets JITed. The patch location is guaranteed to be at least 'min_patch_size' bytes long.
@@ -333,7 +334,7 @@ private:
     static Box* createSetHelper(uint64_t num, Box** data);
     static Box* createTupleHelper(uint64_t num, Box** data);
     static Box* exceptionMatchesHelper(Box* obj, Box* cls);
-    static Box* hasnextHelper(Box* b);
+    static BORROWED(Box*) hasnextHelper(Box* b);
     static BORROWED(Box*) nonzeroHelper(Box* b);
     static BORROWED(Box*) notHelper(Box* b);
     static Box* runtimeCallHelper(Box* obj, ArgPassSpec argspec, TypeRecorder* type_recorder, Box** args,

--- a/src/codegen/patchpoints.cpp
+++ b/src/codegen/patchpoints.cpp
@@ -44,8 +44,10 @@ int ICSetupInfo::totalSize() const {
 
 static std::vector<std::pair<PatchpointInfo*, void* /* addr of func to call */>> new_patchpoints;
 
-ICSetupInfo* ICSetupInfo::initialize(bool has_return_value, int size, ICType type, TypeRecorder* type_recorder) {
-    ICSetupInfo* rtn = new ICSetupInfo(type, size, has_return_value, type_recorder);
+ICSetupInfo* ICSetupInfo::initialize(bool has_return_value, int size, ICType type, TypeRecorder* type_recorder,
+                                     assembler::RegisterSet allocatable_regs) {
+    ICSetupInfo* rtn = new ICSetupInfo(type, size, has_return_value, type_recorder, allocatable_regs);
+
 
     // We use size == CALL_ONLY_SIZE to imply that the call isn't patchable
     assert(rtn->totalSize() > CALL_ONLY_SIZE);

--- a/src/codegen/patchpoints.h
+++ b/src/codegen/patchpoints.h
@@ -20,6 +20,7 @@
 
 #include "llvm/IR/CallingConv.h"
 
+#include "asm_writing/types.h"
 #include "codegen/stackmaps.h"
 #include "core/common.h"
 
@@ -64,14 +65,20 @@ public:
     };
 
 private:
-    ICSetupInfo(ICType type, int size, bool has_return_value, TypeRecorder* type_recorder)
-        : type(type), size(size), has_return_value(has_return_value), type_recorder(type_recorder) {}
+    ICSetupInfo(ICType type, int size, bool has_return_value, TypeRecorder* type_recorder,
+                assembler::RegisterSet allocatable_regs)
+        : type(type),
+          size(size),
+          has_return_value(has_return_value),
+          type_recorder(type_recorder),
+          allocatable_regs(allocatable_regs) {}
 
 public:
     const ICType type;
     const int size;
     const bool has_return_value;
     TypeRecorder* const type_recorder;
+    assembler::RegisterSet allocatable_regs;
 
     int totalSize() const;
     bool hasReturnValue() const { return has_return_value; }
@@ -90,7 +97,8 @@ public:
         return llvm::CallingConv::C;
     }
 
-    static ICSetupInfo* initialize(bool has_return_value, int size, ICType type, TypeRecorder* type_recorder);
+    static ICSetupInfo* initialize(bool has_return_value, int size, ICType type, TypeRecorder* type_recorder,
+                                   assembler::RegisterSet allocatable_regs = assembler::RegisterSet::stdAllocatable());
 };
 
 struct PatchpointInfo {

--- a/src/codegen/unwinding.cpp
+++ b/src/codegen/unwinding.cpp
@@ -574,7 +574,7 @@ public:
                             assert(l.stack_second_offset % 8 == 0);
                             b = b_ptr[l.stack_second_offset / 8];
                         } else if (l.type == Location::Register) {
-                            b = (Box*)get_cursor_reg(cursor, l.regnum);
+                            b = (Box*)get_cursor_reg(cursor, l.asRegister().getDwarfId());
                         } else {
                             RELEASE_ASSERT(0, "not implemented");
                         }


### PR DESCRIPTION
Small bjit and rewriter improvements
- use r12, r15 and rbx in bjit and inside bjit ICs
- remove some nonzero calls when we already know that the object is a python bool
- don't check if the arguments of a function are nonzero in the entry block

Also changes the way we keep track of which registers are available inside the rewriter:
Keeping the available registers in a bitset makes it more memory efficient and
also easier and faster to calculate a subset of the registers.
I will soon implement the 'otherThan' functionality using it which would fix the current problem of only allowing to exclude one register.
