### PR TITLE
Some scipy fixes

### DIFF
--- a/src/codegen/irgen/refcounts.cpp
+++ b/src/codegen/irgen/refcounts.cpp
@@ -77,6 +77,10 @@ llvm::Value* RefcountTracker::setType(llvm::Value* v, RefType reftype) {
 
     assert(var.reftype == reftype || var.reftype == RefType::UNKNOWN);
     var.reftype = reftype;
+
+    if (llvm::isa<ConstantPointerNull>(v))
+        var.nullable = true;
+
     return v;
 }
 

--- a/src/core/cfg.cpp
+++ b/src/core/cfg.cpp
@@ -1700,8 +1700,10 @@ public:
                         l = r + 1;
                         continue;
                     }
-                    pushAssign(tmpname, new AST_Attribute(makeLoad(tmpname, node, true), AST_TYPE::Load,
-                                                          internString(a->name.s().substr(l, r - l))));
+                    auto attr = new AST_Attribute(makeLoad(tmpname, node, true), AST_TYPE::Load,
+                                                  internString(a->name.s().substr(l, r - l)));
+                    attr->lineno = import->lineno;
+                    pushAssign(tmpname, attr);
                     l = r + 1;
                 } while (l < a->name.s().size());
                 pushAssign(a->asname, makeLoad(tmpname, node, true));

--- a/test/extra/pyopenssl_test.py
+++ b/test/extra/pyopenssl_test.py
@@ -20,8 +20,9 @@ subprocess.check_call(["sed", "-i", 's/\\(def test_digest.*\\)/\\1\\n        ret
 
 # This particular test is bad; it fails if run close to a second-boundary
 # https://github.com/pyca/pyopenssl/issues/266
-subprocess.check_call(["sed", "-i", 's/\\(def test_export_test.*\\)/\\1\\n        return/',
+subprocess.check_call(["sed", "-i", 's/\\(def test_export_text.*\\)/\\1\\n        return/',
     os.path.join(PYOPENSSL_DIR, "test", "test_crypto.py")])
+print os.path.join(PYOPENSSL_DIR, "test", "test_crypto.py")
 
 expected = [{'ran': 438}]
 run_test([NOSETESTS_EXE], cwd=PYOPENSSL_DIR, expected=expected)

--- a/test/tests/test_package/import_target.py
+++ b/test/tests/test_package/import_target.py
@@ -1,1 +1,27 @@
 print "running test_package.import_target"
+
+# Since we are currently importing test_package.import_target, this
+# import will succeed (return directly from sys.modules), even though
+# test_package will not have the 'import_target' attribute yet
+
+import test_package.import_target
+
+try:
+    print test_package.import_target
+    assert 0
+except AttributeError:
+    pass
+
+try:
+    print getattr(test_package, 'import_target')
+    assert 0
+except AttributeError:
+    pass
+
+# You can do 'import test_package.import_target', but adding an asname will cause an exception:
+try:
+    import test_package.import_target as i
+    assert 0
+    i
+except AttributeError:
+    pass


### PR DESCRIPTION
Fix the scipy.weave issue (we didn't handle this circular-import-error correctly)
Don't require explicit annotations for constant null pointers in the llvm jit
- I didn't want to loosen the assertions, so instead it just adds the annotations for you.