### PR TITLE
Fix evaluation order for dict operations

### DIFF
--- a/src/codegen/irgen/irgenerator.cpp
+++ b/src/codegen/irgen/irgenerator.cpp
@@ -1253,8 +1253,8 @@ private:
             static BoxedString* setitem_str = getStaticString("__setitem__");
             CompilerVariable* setitem = rtn->getattr(emitter, getEmptyOpInfo(unw_info), setitem_str, true);
             for (int i = 0; i < node->keys.size(); i++) {
-                CompilerVariable* key = evalExpr(node->keys[i], unw_info);
                 CompilerVariable* value = evalExpr(node->values[i], unw_info);
+                CompilerVariable* key = evalExpr(node->keys[i], unw_info);
                 assert(key);
                 assert(value);
 

--- a/src/core/cfg.cpp
+++ b/src/core/cfg.cpp
@@ -622,6 +622,24 @@ private:
         return compare;
     }
 
+    AST_Index* makeIndex(AST_expr* value) {
+        auto index = new AST_Index();
+        index->value = value;
+        index->lineno = value->lineno;
+        index->col_offset = value->col_offset;
+        return index;
+    }
+
+    AST_Subscript* makeSubscript(AST_TYPE::AST_TYPE ctx_type, AST_expr* value, AST_slice* slice) {
+        auto subscript = new AST_Subscript();
+        subscript->ctx_type = ctx_type;
+        subscript->value = value;
+        subscript->slice = slice;
+        subscript->lineno = slice->lineno;
+        subscript->col_offset = slice->col_offset;
+        return subscript;
+    }
+
     void pushAssign(AST_expr* target, AST_expr* val) {
         AST_Assign* assign = new AST_Assign();
         assign->value = val;
@@ -977,14 +995,18 @@ private:
         rtn->lineno = node->lineno;
         rtn->col_offset = node->col_offset;
 
-        for (auto k : node->keys) {
-            rtn->keys.push_back(remapExpr(k));
-        }
-        for (auto v : node->values) {
-            rtn->values.push_back(remapExpr(v));
+        InternedString dict_name = nodeName();
+
+        pushAssign(dict_name, rtn);
+
+        for (int i = 0; i < node->keys.size(); i++) {
+            AST_expr* value = remapExpr(node->values[i]);
+            AST_Index* index = makeIndex(node->keys[i]);
+            AST_Subscript* subscript = makeSubscript(AST_TYPE::Store, makeLoad(dict_name, node, false), index);
+            pushAssign(remapSubscript(subscript), value);
         }
 
-        return rtn;
+        return makeLoad(dict_name, node, true);
     }
 
     AST_slice* remapEllipsis(AST_Ellipsis* node) { return node; }

--- a/test/tests/literals_order.py
+++ b/test/tests/literals_order.py
@@ -1,5 +1,3 @@
-# expected: fail
-# - the CFG expands to the wrong code here
 
 class H(object):
     def __init__(self, n):


### PR DESCRIPTION
Fix literals_order issue #1191
not create temporary variables when remapExpr