### PR TITLE
Support empty lines on the repl

### DIFF
--- a/src/codegen/cpython_ast.cpp
+++ b/src/codegen/cpython_ast.cpp
@@ -710,6 +710,13 @@ public:
         auto r = _convert(stmt);
         r->lineno = stmt->lineno;
         r->col_offset = stmt->col_offset;
+
+        if (stmt->lineno == 0) {
+            // So far it looks like these can only be generated for empty lines on the repl
+            assert(stmt->kind == Pass_kind);
+            r->lineno = 1;
+        }
+
         return r;
     }
 


### PR DESCRIPTION
They end up generating "pass" statements with a lineno of 0, which
trips an assert later on.  This commit just sets them to have a lineno
of 1.