### PR TITLE
hidden classes: split into subclasses to reduce memory consumption

### DIFF
--- a/src/core/types.h
+++ b/src/core/types.h
@@ -681,7 +681,8 @@ public:
 };
 
 class HiddenClass;
-extern HiddenClass* root_hcls;
+class HiddenClassNormal;
+extern HiddenClassNormal* root_hcls;
 
 struct SetattrRewriteArgs;
 struct GetattrRewriteArgs;


### PR DESCRIPTION
+ use pyston::DenseMap to save a little more memory

this saves about 5%-10% of peak memory on django