### PR TITLE
delete the llvm module after code generation

### DIFF
--- a/src/codegen/compvars.cpp
+++ b/src/codegen/compvars.cpp
@@ -637,7 +637,8 @@ _call(IREmitter& emitter, const OpInfo& info, llvm::Value* func, ExceptionStyle 
         // Don't use the IRBuilder since we want to specifically put this in the entry block so it only gets called
         // once.
         // TODO we could take this further and use the same alloca for all function calls?
-        llvm::Instruction* insertion_point = emitter.currentFunction()->func->getEntryBlock().getFirstInsertionPt();
+        llvm::Instruction* insertion_point
+            = emitter.getBuilder()->GetInsertBlock()->getParent()->getEntryBlock().getFirstInsertionPt();
         arg_array = new llvm::AllocaInst(g.llvm_value_type_ptr, n_varargs, "arg_scratch", insertion_point);
 
         for (int i = 3; i < args.size(); i++) {
@@ -1928,7 +1929,7 @@ public:
         llvm::FunctionType* ft = llvm::FunctionType::get(cf->spec->rtn_type->llvmType(), arg_types, false);
 
         llvm::Value* linked_function;
-        if (cf->func) // for JITed functions we need to make the desination address relocatable.
+        if (cf->md->source) // for JITed functions we need to make the desination address relocatable.
             linked_function = embedRelocatablePtr(cf->code, ft->getPointerTo());
         else
             linked_function = embedConstantPtr(cf->code, ft->getPointerTo());

--- a/src/codegen/irgen.h
+++ b/src/codegen/irgen.h
@@ -137,9 +137,9 @@ extern const std::string PASSED_GENERATOR_NAME;
 InternedString getIsDefinedName(InternedString name, InternedStringPool& interned_strings);
 bool isIsDefinedName(llvm::StringRef name);
 
-CompiledFunction* doCompile(FunctionMetadata* md, SourceInfo* source, ParamNames* param_names,
-                            const OSREntryDescriptor* entry_descriptor, EffortLevel effort,
-                            ExceptionStyle exception_style, FunctionSpecialization* spec, llvm::StringRef nameprefix);
+std::pair<CompiledFunction*, llvm::Function*>
+doCompile(FunctionMetadata* md, SourceInfo* source, ParamNames* param_names, const OSREntryDescriptor* entry_descriptor,
+          EffortLevel effort, ExceptionStyle exception_style, FunctionSpecialization* spec, llvm::StringRef nameprefix);
 
 // A common pattern is to branch based off whether a variable is defined but only if it is
 // potentially-undefined.  If it is potentially-undefined, we have to generate control-flow

--- a/src/codegen/irgen/irgenerator.cpp
+++ b/src/codegen/irgen/irgenerator.cpp
@@ -44,11 +44,12 @@ extern "C" void dumpLLVM(void* _v) {
     v->dump();
 }
 
-IRGenState::IRGenState(FunctionMetadata* md, CompiledFunction* cf, SourceInfo* source_info,
+IRGenState::IRGenState(FunctionMetadata* md, CompiledFunction* cf, llvm::Function* func, SourceInfo* source_info,
                        std::unique_ptr<PhiAnalysis> phis, ParamNames* param_names, GCBuilder* gc,
                        llvm::MDNode* func_dbg_info, RefcountTracker* refcount_tracker)
     : md(md),
       cf(cf),
+      func(func),
       source_info(source_info),
       phis(std::move(phis)),
       param_names(param_names),
@@ -61,7 +62,7 @@ IRGenState::IRGenState(FunctionMetadata* md, CompiledFunction* cf, SourceInfo* s
       vregs(NULL),
       stmt(NULL),
       scratch_size(0) {
-    assert(cf->func);
+    assert(func);
     assert(cf->md->source.get() == source_info); // I guess this is duplicate now
 }
 

--- a/src/codegen/irgen/irgenerator.h
+++ b/src/codegen/irgen/irgenerator.h
@@ -63,6 +63,7 @@ private:
     // to md at the end of irgen.
     FunctionMetadata* md;
     CompiledFunction* cf;
+    llvm::Function* func;
     SourceInfo* source_info;
     std::unique_ptr<PhiAnalysis> phis;
     ParamNames* param_names;
@@ -82,8 +83,9 @@ private:
     int scratch_size;
 
 public:
-    IRGenState(FunctionMetadata* md, CompiledFunction* cf, SourceInfo* source_info, std::unique_ptr<PhiAnalysis> phis,
-               ParamNames* param_names, GCBuilder* gc, llvm::MDNode* func_dbg_info, RefcountTracker* refcount_tracker);
+    IRGenState(FunctionMetadata* md, CompiledFunction* cf, llvm::Function* func, SourceInfo* source_info,
+               std::unique_ptr<PhiAnalysis> phis, ParamNames* param_names, GCBuilder* gc, llvm::MDNode* func_dbg_info,
+               RefcountTracker* refcount_tracker);
     ~IRGenState();
 
     CFG* getCFG() { return getSourceInfo()->cfg; }
@@ -93,7 +95,7 @@ public:
 
     ExceptionStyle getExceptionStyle() { return cf->exception_style; }
 
-    llvm::Function* getLLVMFunction() { return cf->func; }
+    llvm::Function* getLLVMFunction() { return func; }
 
     EffortLevel getEffortLevel() { return cf->effort; }
 

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -335,7 +335,6 @@ struct CompiledFunction {
 private:
 public:
     FunctionMetadata* md;
-    llvm::Function* func; // the llvm IR object
 
     // Some compilation settings:
     EffortLevel effort;


### PR DESCRIPTION
this saves a lot of memory