### PR TITLE
ICSlotInfo: remove old invalidator entries

### DIFF
--- a/src/asm_writing/icinfo.h
+++ b/src/asm_writing/icinfo.h
@@ -71,7 +71,7 @@ public:
     std::vector<DecrefInfo> decref_infos;
     std::vector<ICInvalidator*> invalidators; // ICInvalidators that reference this slotinfo
 
-    void clear();
+    void clear(bool should_invalidate = true);
 };
 
 typedef BitSet<16> LiveOutSet;
@@ -120,10 +120,10 @@ public:
     const LiveOutSet& getLiveOuts() { return live_outs; }
 
     std::unique_ptr<ICSlotRewrite> startRewrite(const char* debug_name);
-    void clear(ICSlotInfo* entry);
+    void invalidate(ICSlotInfo* entry);
     void clearAll() {
         for (ICSlotInfo& slot_info : slots) {
-            clear(&slot_info);
+            slot_info.clear();
         }
     }
 

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -297,6 +297,7 @@ public:
     void addDependent(ICSlotInfo* icentry);
     int64_t version();
     void invalidateAll();
+    void remove(ICSlotInfo* icentry) { dependents.erase(icentry); }
 
     friend class ICInfo;
     friend class ICSlotInfo;


### PR DESCRIPTION
when we overwrote a existing IC slot we forgot to remove the old invalidator entries.
Took the opportunity to clean up the code a little bit