### PR TITLE
free bjit code after LLVM codegen

### DIFF
--- a/src/asm_writing/icinfo.h
+++ b/src/asm_writing/icinfo.h
@@ -102,6 +102,9 @@ private:
     // global ones.
     std::vector<Location> ic_global_decref_locations;
 
+    // associated AST node for this IC
+    AST* node;
+
     // for ICSlotRewrite:
     ICSlotInfo* pickEntryForRewrite(const char* debug_name);
 

--- a/src/codegen/codegen.h
+++ b/src/codegen/codegen.h
@@ -50,6 +50,7 @@ public:
     std::string getFuncNameAtAddress(void* addr, bool demangle, bool* out_success = NULL);
     llvm::Function* getLLVMFuncAtAddress(void* addr);
     void registerFunction(const std::string& name, void* addr, int length, llvm::Function* llvm_func);
+    void deregisterFunction(void* addr) { functions.erase(addr); }
     void dumpPerfMap();
 };
 

--- a/src/core/cfg.h
+++ b/src/core/cfg.h
@@ -67,7 +67,7 @@ public:
 
 class CFGBlock {
 public:
-    CFG* cfg;
+    CFG* const cfg;
 
     // Baseline JIT helper fields:
     // contains address to the start of the code of this basic block

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -477,6 +477,7 @@ public:
 
     // For use by the interpreter/baseline jit:
     int times_interpreted;
+    long bjit_num_inside = 0;
     std::vector<std::unique_ptr<JitCodeBlock>> code_blocks;
     ICInvalidator dependent_interp_callsites;
 
@@ -530,6 +531,9 @@ public:
                                     ExceptionStyle exception_style = CXX) {
         return create(f, rtn_type, nargs, false, false, param_names, exception_style);
     }
+
+    // tries to free the bjit allocated code. returns true on success
+    bool tryDeallocatingTheBJitCode();
 };
 
 


### PR DESCRIPTION
we free now the code blocks after a recompile in the LLVM tier (except for OSR frames) because
it is likely that we will not use the code anymore.
- we have to make sure we are not currently executing any code we will delete that's why I added bjit_num_inside
- there were some cases where we forgot to deregister stuff
- when profiling we don't actually unmap the code in order to not brake profiling