### PR TITLE
EH: correctly deregister EH frames and cleanup the code 

### DIFF
--- a/libunwind_patches/0003-use-a-sorted-array-for-registered-objects-and-do-a-b.patch
+++ b/libunwind_patches/0003-use-a-sorted-array-for-registered-objects-and-do-a-b.patch
@@ -89,7 +89,7 @@ index e784317..fedba3e 100644
 +      int i;
 +      for (i = 0; i < _U_dyn_info_list_size; i ++) {
 +          if (di == _U_dyn_info_list[i] && i < _U_dyn_info_list_size - 1) {
-+              memmove(_U_dyn_info_list[i], _U_dyn_info_list[i+1],
++              memmove(&_U_dyn_info_list[i], &_U_dyn_info_list[i+1],
 +                      sizeof(unw_dyn_info_t*) * (_U_dyn_info_list_size - i - 1));
 +              break;
 +          }

--- a/src/codegen/baseline_jit.h
+++ b/src/codegen/baseline_jit.h
@@ -177,6 +177,7 @@ private:
     // this contains all the decref infos the bjit generated inside the memory block,
     // this allows us to deregister them when we release the code
     std::vector<DecrefInfo> decref_infos;
+    RegisterEHFrame register_eh_info;
 
 public:
     JitCodeBlock(llvm::StringRef name);

--- a/src/codegen/memmgr.cpp
+++ b/src/codegen/memmgr.cpp
@@ -241,14 +241,4 @@ PystonMemoryManager::~PystonMemoryManager() {
 std::unique_ptr<llvm::RTDyldMemoryManager> createMemoryManager() {
     return std::unique_ptr<llvm::RTDyldMemoryManager>(new PystonMemoryManager());
 }
-
-// These functions exist as instance methods of the RTDyldMemoryManager class,
-// but it's tricky to access them since the class has pure-virtual methods.
-void registerEHFrames(uint8_t* addr, uint64_t load_addr, size_t size) {
-    PystonMemoryManager().registerEHFrames(addr, load_addr, size);
-}
-
-void deregisterEHFrames(uint8_t* addr, uint64_t load_addr, size_t size) {
-    PystonMemoryManager().deregisterEHFrames(addr, load_addr, size);
-}
 }

--- a/src/codegen/memmgr.h
+++ b/src/codegen/memmgr.h
@@ -26,8 +26,6 @@ class RTDyldMemoryManager;
 namespace pyston {
 
 std::unique_ptr<llvm::RTDyldMemoryManager> createMemoryManager();
-void registerEHFrames(uint8_t* addr, uint64_t load_addr, size_t size);
-void deregisterEHFrames(uint8_t* addr, uint64_t load_addr, size_t size);
 }
 
 #endif

--- a/src/codegen/unwinding.h
+++ b/src/codegen/unwinding.h
@@ -30,7 +30,24 @@ class BoxedDict;
 class BoxedModule;
 struct FrameInfo;
 
-void registerDynamicEhFrame(uint64_t code_addr, size_t code_size, uint64_t eh_frame_addr, size_t eh_frame_size);
+class RegisterEHFrame {
+private:
+    void* dyn_info;
+
+public:
+    RegisterEHFrame() : dyn_info(NULL) {}
+    ~RegisterEHFrame() { deregisterFrame(); }
+
+    // updates the EH info at eh_frame_addr to reference the passed code addr and code size and registers it
+    void updateAndRegisterFrameFromTemplate(uint64_t code_addr, size_t code_size, uint64_t eh_frame_addr,
+                                            size_t eh_frame_size);
+
+    void registerFrame(uint64_t code_addr, size_t code_size, uint64_t eh_frame_addr, size_t eh_frame_size);
+    void deregisterFrame();
+};
+
+void* registerDynamicEhFrame(uint64_t code_addr, size_t code_size, uint64_t eh_frame_addr, size_t eh_frame_size);
+void deregisterDynamicEhFrame(void* dyn_info);
 uint64_t getCXXUnwindSymbolAddress(llvm::StringRef sym);
 
 // use this instead of std::uncaught_exception.

--- a/src/runtime/ics.h
+++ b/src/runtime/ics.h
@@ -15,6 +15,7 @@
 #ifndef PYSTON_RUNTIME_ICS_H
 #define PYSTON_RUNTIME_ICS_H
 
+#include "codegen/unwinding.h" // RegisterEHFrame
 #include "core/common.h"
 #include "runtime/objmodel.h"
 
@@ -26,6 +27,7 @@ class RuntimeIC {
 private:
     void* addr; // points to function start not the start of the allocated memory block.
 
+    RegisterEHFrame register_eh_frame;
     std::unique_ptr<ICInfo> icinfo;
 
     RuntimeIC(const RuntimeIC&) = delete;


### PR DESCRIPTION
- previously we never deregistered the EH frame from libunwind (which exposed a bug)
- I removed the calls to register the EH info with gcc since we have our own unwinder which does not need this
- cleaned up the code and fixed some small memory leaks