### PR TITLE
hidden classes: free classes of singleton type

### DIFF
--- a/src/runtime/hiddenclass.h
+++ b/src/runtime/hiddenclass.h
@@ -43,9 +43,10 @@ public:
 
 protected:
     HiddenClass(HCType type) : type(type) {}
-    virtual ~HiddenClass() = default;
 
 public:
+    virtual ~HiddenClass() = default;
+
     static HiddenClassSingleton* makeSingleton();
     static HiddenClassNormal* makeRoot();
     static HiddenClassDict* makeDictBacked();

--- a/src/runtime/objmodel.cpp
+++ b/src/runtime/objmodel.cpp
@@ -1317,6 +1317,9 @@ void HCAttrs::_clearRaw() noexcept {
     auto old_attr_list = this->attr_list;
     auto old_attr_list_size = hcls->attributeArraySize();
 
+    // singleton classes will not get reused so free it
+    if (hcls->type == HiddenClass::SINGLETON)
+        delete hcls;
     new ((void*)this) HCAttrs(NULL);
 
     if (old_attr_list) {


### PR DESCRIPTION
this fixes the huge (~350MB) leak in:
```
for i in xrange(1000000):
    class C(object):
        pass
```