### PR TITLE
switch from the SSE prefetch to __builtin_prefetch

### DIFF
--- a/src/runtime/types.h
+++ b/src/runtime/types.h
@@ -424,7 +424,7 @@ template <bool Nullable = false> inline void decrefArray(Box** array, int size) 
         for (int i = 0; i < size - 1; i++) {
             Box* cur = next;
             next = array[i + 1];
-            _mm_prefetch(next, _MM_HINT_T0);
+            __builtin_prefetch(next);
             if (Nullable)
                 Py_XDECREF(cur);
             else


### PR DESCRIPTION
`_mm_prefetch(next, _MM_HINT_T0)` expands to `__builtin_prefetch(next, 0, 3)` which are the defaults of `__builtin_prefetch(next)` too.
Reason for this change is that we did not include `xmmintrin.h` and instead of pulling this header in everywhere I thought it's better too just use the compiler intrinsic directly

