### PR TITLE
Turn off implicit-function check in release mode

### DIFF
--- a/from_cpython/Lib/distutils/ccompiler.py
+++ b/from_cpython/Lib/distutils/ccompiler.py
@@ -373,7 +373,9 @@ class CCompiler:
             cc_args[:0] = before
 
         if not any ('scipy' in s for s in pp_opts):
-            cc_args = cc_args + ["-Werror=implicit-function-declaration"]
+            import sysconfig
+            if '-DNDEBUG' not in sysconfig.get_config_var('CFLAGS'):
+                cc_args = cc_args + ["-Werror=implicit-function-declaration"]
         return cc_args
 
     def _fix_compile_args(self, output_dir, macros, include_dirs):

--- a/src/runtime/import.cpp
+++ b/src/runtime/import.cpp
@@ -138,23 +138,16 @@ extern "C" Box* import(int level, Box* from_imports, llvm::StringRef module_name
 
 BoxedModule* importCExtension(BoxedString* full_name, const std::string& last_name, const std::string& path) {
     void* handle = dlopen(path.c_str(), RTLD_NOW);
-    if (!handle) {
-        const char* s = dlerror();
-        // raiseExcHelper(ImportError, "%s", dlerror());
-        fprintf(stderr, "%s\n", s);
-        exit(1);
-    }
+    if (!handle)
+        raiseExcHelper(ImportError, "%s", dlerror());
     assert(handle);
 
     std::string initname = "init" + last_name;
     void (*init)() = (void (*)())dlsym(handle, initname.c_str());
 
     char* error;
-    if ((error = dlerror()) != NULL) {
-        // raiseExcHelper(ImportError, "%s", error);
-        fprintf(stderr, "%s\n", error);
-        exit(1);
-    }
+    if ((error = dlerror()) != NULL)
+        raiseExcHelper(ImportError, "%s", error);
 
     assert(init);
 


### PR DESCRIPTION
I'm still hoping that we can keep this on in some way, because it continues to find issues.
So let's try keeping it on for debug builds.

I'm not sure if this is weakening the check enough (there may be other cases like scipy),
but it's sounding like we need to have this check turned off in our releases regardless,
such as issue #1344.

@undingen what do you think?