### PR TITLE
microptimizations: use DEFAULT_CLASS_SIMPLE, non gc code object, fewer handleFrameExit calls 

### DIFF
--- a/src/capi/types.h
+++ b/src/capi/types.h
@@ -37,7 +37,7 @@ public:
         Py_XINCREF(module);
     }
 
-    DEFAULT_CLASS(capifunc_cls);
+    DEFAULT_CLASS_SIMPLE(capifunc_cls, true);
 
     PyCFunction getFunction() { return method_def->ml_meth; }
 

--- a/src/runtime/builtin_modules/builtins.cpp
+++ b/src/runtime/builtin_modules/builtins.cpp
@@ -1318,7 +1318,7 @@ public:
         Py_XINCREF(idx_long);
     }
 
-    DEFAULT_CLASS(enumerate_cls);
+    DEFAULT_CLASS_SIMPLE(enumerate_cls, true);
 
     static Box* new_(Box* cls, Box* obj, Box* start) {
         RELEASE_ASSERT(cls == enumerate_cls, "");

--- a/src/runtime/builtin_modules/thread.cpp
+++ b/src/runtime/builtin_modules/thread.cpp
@@ -126,7 +126,7 @@ private:
 public:
     BoxedThreadLock() { lock_lock = PyThread_allocate_lock(); }
 
-    DEFAULT_CLASS(thread_lock_cls);
+    DEFAULT_CLASS_SIMPLE(thread_lock_cls, false);
 
     static Box* acquire(Box* _self, Box* _waitflag) {
         RELEASE_ASSERT(_self->cls == thread_lock_cls, "");

--- a/src/runtime/code.cpp
+++ b/src/runtime/code.cpp
@@ -100,17 +100,8 @@ Box* BoxedCode::flags(Box* b, void*) noexcept {
     return boxInt(flags);
 }
 
-int BoxedCode::traverse(Box* self, visitproc visit, void* arg) noexcept {
-    BoxedCode* o = static_cast<BoxedCode*>(self);
-    Py_VISIT(o->_filename);
-    Py_VISIT(o->_name);
-    return 0;
-}
-
 void BoxedCode::dealloc(Box* b) noexcept {
     BoxedCode* o = static_cast<BoxedCode*>(b);
-
-    PyObject_GC_UnTrack(o);
 
     Py_XDECREF(o->_filename);
     Py_XDECREF(o->_name);
@@ -210,9 +201,8 @@ extern "C" int PyCode_HasFreeVars(PyCodeObject* _code) noexcept {
 }
 
 void setupCode() {
-    code_cls
-        = BoxedClass::create(type_cls, object_cls, 0, 0, sizeof(BoxedCode), false, "code", false,
-                             (destructor)BoxedCode::dealloc, NULL, true, (traverseproc)BoxedCode::traverse, NOCLEAR);
+    code_cls = BoxedClass::create(type_cls, object_cls, 0, 0, sizeof(BoxedCode), false, "code", false,
+                                  (destructor)BoxedCode::dealloc, NULL, false, (traverseproc)NULL, NOCLEAR);
 
     code_cls->giveAttrBorrowed("__new__", Py_None); // Hacky way of preventing users from instantiating this
 

--- a/src/runtime/code.h
+++ b/src/runtime/code.h
@@ -35,7 +35,7 @@ public:
         Py_XINCREF(name);
     }
 
-    DEFAULT_CLASS(code_cls);
+    DEFAULT_CLASS_SIMPLE(code_cls, false);
 
     // These need to be static functions rather than methods because function
     // pointers could point to them.
@@ -48,7 +48,6 @@ public:
     static Box* varnames(Box* b, void*) noexcept;
     static Box* flags(Box* b, void*) noexcept;
 
-    static int traverse(Box* self, visitproc visit, void* arg) noexcept;
     static void dealloc(Box* b) noexcept;
 };
 }

--- a/src/runtime/frame.cpp
+++ b/src/runtime/frame.cpp
@@ -271,6 +271,12 @@ extern "C" void deinitFrame(FrameInfo* frame_info) noexcept {
         PyErr_Clear();
     }
 
+    if (frame_info->exc.type) {
+        Py_CLEAR(frame_info->exc.type);
+        Py_CLEAR(frame_info->exc.value);
+        Py_CLEAR(frame_info->exc.traceback);
+    }
+
     assert(cur_thread_state.frame_info == frame_info);
     cur_thread_state.frame_info = frame_info->back;
     BoxedFrame* frame = frame_info->frame_obj;
@@ -288,12 +294,6 @@ extern "C" void deinitFrame(FrameInfo* frame_info) noexcept {
     decrefArray<true>(frame_info->vregs, num_vregs);
 
     Py_CLEAR(frame_info->boxedLocals);
-
-    if (frame_info->exc.type) {
-        Py_CLEAR(frame_info->exc.type);
-        Py_CLEAR(frame_info->exc.value);
-        Py_CLEAR(frame_info->exc.traceback);
-    }
 
     Py_CLEAR(frame_info->globals);
 

--- a/src/runtime/frame.cpp
+++ b/src/runtime/frame.cpp
@@ -163,7 +163,7 @@ public:
         assert(hasExited());
     }
 
-    DEFAULT_CLASS(frame_cls);
+    DEFAULT_CLASS_SIMPLE(frame_cls, true);
 
     static BORROWED(Box*) boxFrame(FrameInfo* fi) {
         if (fi->frame_obj == NULL)

--- a/src/runtime/generator.cpp
+++ b/src/runtime/generator.cpp
@@ -434,7 +434,8 @@ extern "C" BoxedGenerator* createGenerator(BoxedFunctionBase* function, Box* arg
 static uint64_t* generator_timer_counter = Stats::getStatCounter("us_timer_generator_toplevel");
 #endif
 extern "C" BoxedGenerator::BoxedGenerator(BoxedFunctionBase* function, Box* arg1, Box* arg2, Box* arg3, Box** args)
-    : function(function),
+    : weakreflist(NULL),
+      function(function),
       arg1(arg1),
       arg2(arg2),
       arg3(arg3),
@@ -442,6 +443,7 @@ extern "C" BoxedGenerator::BoxedGenerator(BoxedFunctionBase* function, Box* arg1
       entryExited(false),
       running(false),
       returnValue(nullptr),
+      iterated_from__hasnext__(false),
       exception(nullptr, nullptr, nullptr),
       context(nullptr),
       returnContext(nullptr),

--- a/src/runtime/inline/xrange.cpp
+++ b/src/runtime/inline/xrange.cpp
@@ -59,7 +59,7 @@ public:
 
     friend class BoxedXrangeIterator;
 
-    DEFAULT_CLASS(xrange_cls);
+    DEFAULT_CLASS_SIMPLE(xrange_cls, false);
 };
 
 class BoxedXrangeIterator : public Box {
@@ -87,7 +87,7 @@ public:
         cur = start;
     }
 
-    DEFAULT_CLASS(xrange_iterator_cls);
+    DEFAULT_CLASS_SIMPLE(xrange_iterator_cls, true);
 
     static llvm_compat_bool xrangeIteratorHasnextUnboxed(Box* s) __attribute__((visibility("default"))) {
         assert(s->cls == xrange_iterator_cls);

--- a/src/runtime/iterobject.h
+++ b/src/runtime/iterobject.h
@@ -76,7 +76,7 @@ public:
 
     BoxedIterWrapper(Box* iter) : iter(iter), next(NULL) { Py_INCREF(iter); }
 
-    DEFAULT_CLASS(iterwrapper_cls);
+    DEFAULT_CLASS_SIMPLE(iterwrapper_cls, true);
 
     static void dealloc(BoxedIterWrapper* o) noexcept {
         PyObject_GC_UnTrack(o);

--- a/src/runtime/set.cpp
+++ b/src/runtime/set.cpp
@@ -61,7 +61,7 @@ public:
 
     BoxedSetIterator(BoxedSet* s) : s(s), it(s->s.begin()), size(s->s.size()) { Py_INCREF(s); }
 
-    DEFAULT_CLASS(set_iterator_cls);
+    DEFAULT_CLASS_SIMPLE(set_iterator_cls, true);
 
     bool hasNext() { return it != s->s.end(); }
 

--- a/src/runtime/set.h
+++ b/src/runtime/set.h
@@ -31,11 +31,11 @@ public:
     Set s;
     Box** weakreflist; /* List of weak references */
 
-    BoxedSet() __attribute__((visibility("default"))) {}
+    BoxedSet() __attribute__((visibility("default"))) : weakreflist(NULL) {}
 
     template <typename T> __attribute__((visibility("default"))) BoxedSet(T&& s) : s(std::forward<T>(s)) {}
 
-    DEFAULT_CLASS(set_cls);
+    DEFAULT_CLASS_SIMPLE(set_cls, true);
 
     static void dealloc(Box* b) noexcept;
     static int traverse(Box* self, visitproc visit, void* arg) noexcept;

--- a/src/runtime/super.cpp
+++ b/src/runtime/super.cpp
@@ -38,7 +38,7 @@ public:
         Py_INCREF(obj_type);
     }
 
-    DEFAULT_CLASS(super_cls);
+    DEFAULT_CLASS_SIMPLE(super_cls, true);
 
     static void dealloc(Box* b) noexcept {
         BoxedSuper* self = (BoxedSuper*)b;

--- a/src/runtime/tuple.h
+++ b/src/runtime/tuple.h
@@ -27,7 +27,7 @@ public:
     int pos;
     BoxedTupleIterator(BoxedTuple* t);
 
-    DEFAULT_CLASS(tuple_iterator_cls);
+    DEFAULT_CLASS_SIMPLE(tuple_iterator_cls, true);
 
     static void dealloc(BoxedTupleIterator* o) noexcept {
         PyObject_GC_UnTrack(o);

--- a/src/runtime/types.cpp
+++ b/src/runtime/types.cpp
@@ -2265,14 +2265,13 @@ private:
 public:
     AttrWrapperIter(AttrWrapper* aw);
 
-    DEFAULT_CLASS(attrwrapperiter_cls);
+    DEFAULT_CLASS_SIMPLE(attrwrapperiter_cls, false);
 
     static Box* hasnext(Box* _self);
     static Box* next(Box* _self);
     static Box* next_capi(Box* _self) noexcept;
 
     static void dealloc(Box* b) noexcept;
-    static int traverse(Box* self, visitproc visit, void* arg) noexcept;
 };
 
 // A dictionary-like wrapper around the attributes array.

--- a/src/runtime/types.h
+++ b/src/runtime/types.h
@@ -1116,7 +1116,7 @@ public:
     BoxedBuiltinFunctionOrMethod(FunctionMetadata* f, const char* name, std::initializer_list<Box*> defaults,
                                  BoxedClosure* closure = NULL, const char* doc = NULL);
 
-    DEFAULT_CLASS(builtin_function_or_method_cls);
+    DEFAULT_CLASS_SIMPLE(builtin_function_or_method_cls, true);
 };
 
 extern "C" void _PyModule_Clear(PyObject*) noexcept;
@@ -1268,7 +1268,7 @@ public:
     void* stack_begin;
     FrameInfo* top_caller_frame_info; // The FrameInfo that called into this generator.
 
-    // For abandoned-generator collection -- WIP
+    // For abandoned-generator collection
     FrameInfo* paused_frame_info; // The FrameInfo the generator was on when it called yield (or NULL if the generator
                                   // hasn't started or has exited).
 
@@ -1281,7 +1281,7 @@ public:
 
     BoxedGenerator(BoxedFunctionBase* function, Box* arg1, Box* arg2, Box* arg3, Box** args);
 
-    DEFAULT_CLASS(generator_cls);
+    DEFAULT_CLASS_SIMPLE(generator_cls, true);
 };
 
 Box* objectSetattr(Box* obj, Box* attr, Box* value);


### PR DESCRIPTION
performance is about the same (mostly noise), I think the BoxedCode change could get more important in the near future when we start to create much more of them