### PR TITLE
Be able to run an unmodified virtualenv

### DIFF
--- a/from_cpython/Lib/compileall.py
+++ b/from_cpython/Lib/compileall.py
@@ -82,6 +82,8 @@ def compile_file(fullname, ddir=None, force=0, rx=None, quiet=0):
     if os.path.isfile(fullname):
         head, tail = name[:-3], name[-3:]
         if tail == '.py':
+            # Pyston change: leave this to the parser
+            '''
             if not force:
                 try:
                     mtime = int(os.stat(fullname).st_mtime)
@@ -93,10 +95,11 @@ def compile_file(fullname, ddir=None, force=0, rx=None, quiet=0):
                         return success
                 except IOError:
                     pass
+            '''
             if not quiet:
                 print 'Compiling', fullname, '...'
             try:
-                ok = py_compile.compile(fullname, None, dfile, True)
+                ok = py_compile.compile(fullname, None, dfile, True, force=force)
             except py_compile.PyCompileError,err:
                 if quiet:
                     print 'Compiling', fullname, '...'

--- a/from_cpython/Lib/distutils/core.py
+++ b/from_cpython/Lib/distutils/core.py
@@ -100,6 +100,10 @@ def setup(**attrs):
     else:
         klass = Distribution
 
+    # Pyston change:
+    if "zip_safe" not in attrs:
+        attrs['zip_safe'] = False
+
     if 'script_name' not in attrs:
         attrs['script_name'] = os.path.basename(sys.argv[0])
     if 'script_args' not in attrs:

--- a/from_cpython/Lib/py_compile.py
+++ b/from_cpython/Lib/py_compile.py
@@ -94,7 +94,7 @@ def compile(file, cfile=None, dfile=None, doraise=False, force=False):
 
     # Pyston restrictions for things that we don't yet support
     assert cfile is None or cfile == file + "c"
-    assert dfile is None
+    assert dfile is None or dfile == file
 
     try:
         __pyston__.py_compile(file, force)

--- a/from_cpython/Lib/test/test_py_compile.py
+++ b/from_cpython/Lib/test/test_py_compile.py
@@ -1,4 +1,3 @@
-# expected: fail
 import imp
 import os
 import py_compile

--- a/from_cpython/Lib/test/test_sundry.py
+++ b/from_cpython/Lib/test/test_sundry.py
@@ -1,4 +1,3 @@
-# expected: fail
 """Do a minimal test of all the modules that aren't otherwise tested."""
 
 from test import test_support

--- a/from_cpython/Python/import.c
+++ b/from_cpython/Python/import.c
@@ -2949,14 +2949,12 @@ PyImport_Import(PyObject *module_name)
    importing modules.
 */
 
+// Pyston change: we don't support get_magic
+#if 0
 static PyObject *
 imp_get_magic(PyObject *self, PyObject *noargs)
 {
     char buf[4];
-
-    // Pyston change: we have different pyc
-    assert(0);
-    abort();
 
     buf[0] = (char) ((pyc_magic >>  0) & 0xff);
     buf[1] = (char) ((pyc_magic >>  8) & 0xff);
@@ -2965,6 +2963,7 @@ imp_get_magic(PyObject *self, PyObject *noargs)
 
     return PyString_FromStringAndSize(buf, 4);
 }
+#endif
 
 static PyObject *
 imp_get_suffixes(PyObject *self, PyObject *noargs)
@@ -3330,7 +3329,8 @@ On platforms without threads, this function does nothing.");
 static PyMethodDef imp_methods[] = {
     {"reload",           imp_reload,       METH_O,       doc_reload},
     {"find_module",      imp_find_module,  METH_VARARGS, doc_find_module},
-    {"get_magic",        imp_get_magic,    METH_NOARGS,  doc_get_magic},
+    // Pyston change: we don't support this function
+    // {"get_magic",        imp_get_magic,    METH_NOARGS,  doc_get_magic},
     {"get_suffixes", imp_get_suffixes, METH_NOARGS,  doc_get_suffixes},
     {"load_module",      imp_load_module,  METH_VARARGS, doc_load_module},
     {"new_module",       imp_new_module,   METH_VARARGS, doc_new_module},

--- a/src/codegen/parser.cpp
+++ b/src/codegen/parser.cpp
@@ -1104,7 +1104,8 @@ static std::vector<char> _reparse(const char* fn, const std::string& cache_fn, A
 // Parsing the file is somewhat expensive since we have to shell out to cpython;
 // it's not a huge deal right now, but this caching version can significantly cut down
 // on the startup time (40ms -> 10ms).
-std::pair<AST_Module*, std::unique_ptr<ASTAllocator>> caching_parse_file(const char* fn, FutureFlags inherited_flags) {
+std::pair<AST_Module*, std::unique_ptr<ASTAllocator>> caching_parse_file(const char* fn, FutureFlags inherited_flags,
+                                                                         bool force_reparse) {
     std::ostringstream oss;
 
     UNAVOIDABLE_STAT_TIMER(t0, "us_timer_caching_parse_file");

--- a/src/codegen/parser.h
+++ b/src/codegen/parser.h
@@ -15,6 +15,7 @@
 #ifndef PYSTON_CODEGEN_PARSER_H
 #define PYSTON_CODEGEN_PARSER_H
 
+#include "core/ast.h"
 #include "core/types.h"
 
 namespace pyston {
@@ -24,7 +25,8 @@ class ASTAllocator;
 
 std::pair<AST_Module*, std::unique_ptr<ASTAllocator>> parse_string(const char* code, FutureFlags inherited_flags);
 std::pair<AST_Module*, std::unique_ptr<ASTAllocator>> parse_file(const char* fn, FutureFlags inherited_flags);
-std::pair<AST_Module*, std::unique_ptr<ASTAllocator>> caching_parse_file(const char* fn, FutureFlags inherited_flags);
+std::pair<AST_Module*, std::unique_ptr<ASTAllocator>> caching_parse_file(const char* fn, FutureFlags inherited_flags,
+                                                                         bool force_reparse = false);
 }
 
 #endif

--- a/src/runtime/builtin_modules/builtins.cpp
+++ b/src/runtime/builtin_modules/builtins.cpp
@@ -2388,7 +2388,7 @@ void setupBuiltins() {
     builtins_module->giveAttrBorrowed("Ellipsis", Ellipsis);
     builtins_module->giveAttrBorrowed("None", Py_None);
 
-    builtins_module->giveAttrBorrowed("__debug__", Py_False);
+    builtins_module->giveAttrBorrowed("__debug__", Py_True);
 
     notimplemented_cls = BoxedClass::create(type_cls, object_cls, 0, 0, sizeof(Box), false, "NotImplementedType", false,
                                             NULL, NULL, false);

--- a/src/runtime/builtin_modules/sys.cpp
+++ b/src/runtime/builtin_modules/sys.cpp
@@ -847,8 +847,7 @@ void setupSys() {
                          new BoxedBuiltinFunctionOrMethod(BoxedCode::create(
                              (void*)sysGetRecursionLimit, UNKNOWN, 0, "getrecursionlimit", getrecursionlimit_doc)));
 
-    // As we don't support compile() etc yet force 'dont_write_bytecode' to true.
-    sys_module->giveAttrBorrowed("dont_write_bytecode", Py_True);
+    sys_module->giveAttr("dont_write_bytecode", boxBool(Py_DontWriteBytecodeFlag));
 
     sys_module->giveAttr("prefix", boxString(Py_GetPrefix()));
     sys_module->giveAttr("exec_prefix", boxString(Py_GetExecPrefix()));

--- a/src/runtime/builtin_modules/sys.cpp
+++ b/src/runtime/builtin_modules/sys.cpp
@@ -44,7 +44,11 @@ int Py_DivisionWarningFlag = 0;
 int Py_HashRandomizationFlag = 0;
 int Py_DebugFlag = 0;
 int _Py_QnewFlag = 0;
-int Py_DontWriteBytecodeFlag = 0;
+// Pyston change: set this by default to True
+// We can support many cases of users wanting to write bytecode, but there are some
+// that are much harder to support (py.test wants to write its own pyc files), and
+// this flag is one of the few levers we have to avoid hitting those paths.
+int Py_DontWriteBytecodeFlag = 1;
 int Py_NoUserSiteDirectory = 0;
 }
 

--- a/test/CPYTHON_TEST_NOTES.md
+++ b/test/CPYTHON_TEST_NOTES.md
@@ -51,7 +51,7 @@ test_codeop             [unknown]
 test_code               [unknown]
 test_coding             works when run from inside the from_cpython dir
 test_coercion           1**1L, divmod(1, 1L); some unknown bug
-test_compileall         [unknown]
+test_compileall         Not sure if this test makes sense for us (wants to check the details of pyc files)
 test_compiler           [unknown]
 test_compile            [unknown]
 test_copy               Please debug this test in VM.
@@ -131,7 +131,6 @@ test_pprint             [unknown]
 test_profile            [unknown]
 test_py3kwarn           [unknown]
 test_pyclbr             This test passes but takes a very long time in debug mode (60s vs 5s for release mode).
-test_py_compile         [unknown]
 test_pydoc              [unknown]
 test_random             long("invalid number")
 test_repr               complex.__hash__; some unknown issues
@@ -148,7 +147,6 @@ test_structmembers      [unknown]
 test_subprocess         exit code 141 [sigpipe?], no error message
 test_sunaudiodev        [unknown]
 test_sunau              [unknown]
-test_sundry             [unknown]
 test_support            [unknown]
 test_symtable           [unknown]
 test_syntax             [unknown]

--- a/test/extra/numpy_fulltest.py
+++ b/test/extra/numpy_fulltest.py
@@ -42,6 +42,7 @@ if not os.path.exists(CYTHON_DIR):
         subprocess.check_call([PYTHON_EXE, "-c", "import Cython"], cwd=CYTHON_DIR)
     except:
         subprocess.check_call(["rm", "-rf", CYTHON_DIR])
+        raise
 else:
     print ">>> Cython already installed."
 
@@ -62,6 +63,9 @@ try:
     # but they end up naming f2py "f2py_release"/"f2py_dbg"
 
     print_progress_header("Setting up NumPy...")
+    os.environ["CC"] = "ccache gcc"
+
+    print "\ndoing 'build'\n"
     subprocess.check_call([PYTHON_EXE, "setup.py", "build"], cwd=NUMPY_DIR, env=env)
 
     print_progress_header("Installing NumPy...")

--- a/test/integration/virtualenv_test.py
+++ b/test/integration/virtualenv_test.py
@@ -5,19 +5,21 @@ import shutil
 
 VIRTUALENV_SCRIPT = os.path.dirname(__file__) + "/../lib/virtualenv/virtualenv.py"
 
-if os.path.exists("test_env"):
-    print "Removing the existing 'test_env/' directory"
-    subprocess.check_call(["rm", "-rf", "test_env"])
-    # shutil follows symlinks to directories, and deletes whatever those contain.
-    # shutil.rmtree("test_env")
+ENV_NAME = "test_env_" + os.path.basename(sys.executable)
 
-args = [sys.executable, VIRTUALENV_SCRIPT, "-p", sys.executable, "test_env"]
+if os.path.exists(ENV_NAME):
+    print "Removing the existing '%s/' directory" % ENV_NAME
+    subprocess.check_call(["rm", "-rf", ENV_NAME])
+    # shutil follows symlinks to directories, and deletes whatever those contain.
+    # shutil.rmtree(ENV_NAME)
+
+args = [sys.executable, VIRTUALENV_SCRIPT, "-p", sys.executable, ENV_NAME]
 print "Running", args
 subprocess.check_call(args)
 
-sh_script = """
+sh_script = ("""
 set -e
-. test_env/bin/activate
+. %s/bin/activate
 set -ux
 python -c 'import __future__'
 python -c 'import sys; print sys.executable'
@@ -36,7 +38,7 @@ python -c 'import sqlalchemy; print "sqlalchemy imports"'
 python -c 'from PIL import Image; print "Pillow imports"'
 python -c 'import decorator; print "decorator imports"'
 python -c 'import oauth2client; print "oauth2client imports"'
-""".strip()
+""" % ENV_NAME).strip()
 
 # print sh_script
 subprocess.check_call(["sh", "-c", sh_script], stdout=sys.stderr)


### PR DESCRIPTION
Well, really an unmodified pip+setuptools

The last piece is py_compile.  Just shim that back into our parser
to get the parser to write out a pyc file.

It seems like we don't even need this -- most callers of py_compile
(or at least, virtualenv), don't seem to care if the compile step
passed or failed.  But while we're here, try to support it.