### PR TITLE
AST & BST: remove unnecessary nodes and fields + little less memory usage

### DIFF
--- a/src/analysis/scoping_analysis.cpp
+++ b/src/analysis/scoping_analysis.cpp
@@ -606,8 +606,6 @@ public:
     bool visit_while(AST_While* node) override { return false; }
     bool visit_with(AST_With* node) override { return false; }
     bool visit_yield(AST_Yield* node) override { return false; }
-    bool visit_branch(AST_Branch* node) override { return false; }
-    bool visit_jump(AST_Jump* node) override { return false; }
     bool visit_delete(AST_Delete* node) override { return false; }
 
     bool visit_global(AST_Global* node) override {

--- a/src/analysis/scoping_analysis.h
+++ b/src/analysis/scoping_analysis.h
@@ -65,7 +65,7 @@ public:
     //  import dis
     //  print dis.dis(g)
 
-    enum class VarScopeType {
+    enum class VarScopeType : unsigned char {
         FAST,
         GLOBAL,
         CLOSURE,

--- a/src/analysis/type_analysis.cpp
+++ b/src/analysis/type_analysis.cpp
@@ -297,21 +297,6 @@ private:
         return rtn;
     }
 
-    void* visit_boolop(BST_BoolOp* node) override {
-        int n = node->values.size();
-
-        CompilerType* rtn = NULL;
-        for (int i = 0; i < n; i++) {
-            CompilerType* t = getType(node->values[i]);
-            if (rtn == NULL)
-                rtn = t;
-            else if (rtn != t)
-                rtn = UNKNOWN;
-        }
-
-        return rtn;
-    }
-
     void* visit_call(BST_Call* node) override {
         CompilerType* func = getType(node->func);
 
@@ -349,29 +334,24 @@ private:
     }
 
     void* visit_compare(BST_Compare* node) override {
-        if (node->ops.size() == 1) {
-            CompilerType* left = getType(node->left);
-            CompilerType* right = getType(node->comparators[0]);
+        CompilerType* left = getType(node->left);
+        CompilerType* right = getType(node->comparator);
 
-            AST_TYPE::AST_TYPE op_type = node->ops[0];
-            if (op_type == AST_TYPE::Is || op_type == AST_TYPE::IsNot || op_type == AST_TYPE::In
-                || op_type == AST_TYPE::NotIn) {
-                assert(node->ops.size() == 1 && "I don't think this should happen");
-                return BOOL;
-            }
-
-            BoxedString* name = getOpName(node->ops[0]);
-            CompilerType* attr_type = left->getattrType(name, true);
-
-            if (attr_type == UNDEF)
-                attr_type = UNKNOWN;
-
-            std::vector<CompilerType*> arg_types;
-            arg_types.push_back(right);
-            return attr_type->callType(ArgPassSpec(2), arg_types, NULL);
-        } else {
-            return UNKNOWN;
+        AST_TYPE::AST_TYPE op_type = node->op;
+        if (op_type == AST_TYPE::Is || op_type == AST_TYPE::IsNot || op_type == AST_TYPE::In
+            || op_type == AST_TYPE::NotIn) {
+            return BOOL;
         }
+
+        BoxedString* name = getOpName(node->op);
+        CompilerType* attr_type = left->getattrType(name, true);
+
+        if (attr_type == UNDEF)
+            attr_type = UNKNOWN;
+
+        std::vector<CompilerType*> arg_types;
+        arg_types.push_back(right);
+        return attr_type->callType(ArgPassSpec(2), arg_types, NULL);
     }
 
     void* visit_dict(BST_Dict* node) override {
@@ -541,9 +521,7 @@ private:
 
     void visit_assign(BST_Assign* node) override {
         CompilerType* t = getType(node->value);
-        for (int i = 0; i < node->targets.size(); i++) {
-            _doSet(node->targets[i], t);
-        }
+        _doSet(node->target, t);
     }
 
     void visit_branch(BST_Branch* node) override {
@@ -569,27 +547,26 @@ private:
     }
 
     void visit_delete(BST_Delete* node) override {
-        for (BST_expr* target : node->targets) {
-            switch (target->type) {
-                case BST_TYPE::Subscript:
-                    getType(bst_cast<BST_Subscript>(target)->value);
-                    break;
-                case BST_TYPE::Attribute:
-                    getType(bst_cast<BST_Attribute>(target)->value);
-                    break;
-                case BST_TYPE::Name: {
-                    auto name = bst_cast<BST_Name>(target);
-                    assert(name->lookup_type != ScopeInfo::VarScopeType::UNKNOWN);
-                    if (name->lookup_type == ScopeInfo::VarScopeType::FAST
-                        || name->lookup_type == ScopeInfo::VarScopeType::CLOSURE) {
-                        sym_table[name->vreg] = NULL;
-                    } else
-                        assert(name->vreg == -1);
-                    break;
-                }
-                default:
-                    RELEASE_ASSERT(0, "%d", target->type);
+        BST_expr* target = node->target;
+        switch (target->type) {
+            case BST_TYPE::Subscript:
+                getType(bst_cast<BST_Subscript>(target)->value);
+                break;
+            case BST_TYPE::Attribute:
+                getType(bst_cast<BST_Attribute>(target)->value);
+                break;
+            case BST_TYPE::Name: {
+                auto name = bst_cast<BST_Name>(target);
+                assert(name->lookup_type != ScopeInfo::VarScopeType::UNKNOWN);
+                if (name->lookup_type == ScopeInfo::VarScopeType::FAST
+                    || name->lookup_type == ScopeInfo::VarScopeType::CLOSURE) {
+                    sym_table[name->vreg] = NULL;
+                } else
+                    assert(name->vreg == -1);
+                break;
             }
+            default:
+                RELEASE_ASSERT(0, "%d", target->type);
         }
     }
 
@@ -617,12 +594,6 @@ private:
         return t;
     }
 
-    void visit_global(BST_Global* node) override {}
-
-    void visit_import(BST_Import* node) override { assert(0 && "this should get removed by cfg"); }
-
-    void visit_importfrom(BST_ImportFrom* node) override { assert(0 && "this should get removed by cfg"); }
-
     void visit_exec(BST_Exec* node) override {
         getType(node->body);
         if (node->globals)
@@ -634,17 +605,13 @@ private:
     void visit_invoke(BST_Invoke* node) override { node->stmt->accept_stmt(this); }
 
     void visit_jump(BST_Jump* node) override {}
-    void visit_pass(BST_Pass* node) override {}
 
     void visit_print(BST_Print* node) override {
         if (node->dest)
             getType(node->dest);
 
-        if (EXPAND_UNNEEDED) {
-            for (int i = 0; i < node->values.size(); i++) {
-                getType(node->values[i]);
-            }
-        }
+        if (EXPAND_UNNEEDED && node->value)
+            getType(node->value);
     }
 
     void visit_raise(BST_Raise* node) override {

--- a/src/analysis/type_analysis.cpp
+++ b/src/analysis/type_analysis.cpp
@@ -219,8 +219,7 @@ private:
         }
 
         if (VERBOSITY() >= 2 && rtn == UNDEF) {
-            printf("Think %s.%s is undefined, at %d:%d\n", t->debugName().c_str(), node->attr.c_str(), node->lineno,
-                   node->col_offset);
+            printf("Think %s.%s is undefined, at %d\n", t->debugName().c_str(), node->attr.c_str(), node->lineno);
             print_bst(node);
             printf("\n");
         }
@@ -231,8 +230,7 @@ private:
         CompilerType* t = getType(node->value);
         CompilerType* rtn = t->getattrType(node->attr, true);
         if (VERBOSITY() >= 2 && rtn == UNDEF) {
-            printf("Think %s.%s is undefined, at %d:%d\n", t->debugName().c_str(), node->attr.c_str(), node->lineno,
-                   node->col_offset);
+            printf("Think %s.%s is undefined, at %d\n", t->debugName().c_str(), node->attr.c_str(), node->lineno);
             print_bst(node);
             printf("\n");
         }

--- a/src/codegen/irgen.cpp
+++ b/src/codegen/irgen.cpp
@@ -727,13 +727,12 @@ static void emitBBs(IRGenState* irstate, TypeAnalysis* types, const OSREntryDesc
 
                     if (stmt->type == BST_TYPE::Assign) {
                         auto asgn = bst_cast<BST_Assign>(stmt);
-                        assert(asgn->targets.size() == 1);
-                        if (asgn->targets[0]->type == BST_TYPE::Name) {
-                            auto asname = bst_cast<BST_Name>(asgn->targets[0]);
+                        if (asgn->target->type == BST_TYPE::Name) {
+                            auto asname = bst_cast<BST_Name>(asgn->target);
                             assert(asname->lookup_type != ScopeInfo::VarScopeType::UNKNOWN);
 
                             InternedString name = asname->id;
-                            int vreg = bst_cast<BST_Name>(asgn->targets[0])->vreg;
+                            int vreg = bst_cast<BST_Name>(asgn->target)->vreg;
                             assert(name.c_str()[0] == '#'); // it must be a temporary
                             // You might think I need to check whether `name' is being assigned globally or locally,
                             // since a global assign doesn't affect the symbol table. However, the CFG pass only

--- a/src/codegen/unwinding.cpp
+++ b/src/codegen/unwinding.cpp
@@ -490,7 +490,7 @@ static const LineInfo lineInfoForFrameInfo(FrameInfo* frame_info) {
     auto* code = frame_info->code;
     assert(code);
 
-    return LineInfo(current_stmt->lineno, current_stmt->col_offset, code->filename, code->name);
+    return LineInfo(current_stmt->lineno, code->filename, code->name);
 }
 
 // A class that converts a C stack trace to a Python stack trace.

--- a/src/core/ast.h
+++ b/src/core/ast.h
@@ -146,7 +146,7 @@ namespace AST_TYPE {
 #define GENERATE_ENUM(ENUM, N) ENUM = N,
 #define GENERATE_STRING(STRING, N) m[N] = #STRING;
 
-enum AST_TYPE { FOREACH_TYPE(GENERATE_ENUM) };
+enum AST_TYPE : unsigned char { FOREACH_TYPE(GENERATE_ENUM) };
 
 static const char* stringify(int n) {
     static std::map<int, const char*> m;
@@ -730,7 +730,7 @@ public:
 
 class AST_Num : public AST_expr {
 public:
-    enum NumType {
+    enum NumType : unsigned char {
         // These values must correspond to the values in parse_ast.py
         INT = 0x10,
         FLOAT = 0x20,
@@ -852,7 +852,7 @@ public:
 
 class AST_Str : public AST_expr {
 public:
-    enum StrType {
+    enum StrType : unsigned char {
         UNSET = 0x00,
         STR = 0x10,
         UNICODE = 0x20,
@@ -1007,7 +1007,7 @@ public:
 // These are basically bytecodes, framed as pseudo-AST-nodes.
 class AST_LangPrimitive : public AST_expr {
 public:
-    enum Opcodes {
+    enum Opcodes : unsigned char {
         LANDINGPAD, // grabs the info about the last raised exception
         LOCALS,
         GET_ITER,

--- a/src/core/bst.h
+++ b/src/core/bst.h
@@ -171,7 +171,7 @@ public:
     virtual ~BST() {}
 
     const BST_TYPE::BST_TYPE type;
-    uint32_t lineno, col_offset;
+    uint32_t lineno;
 
     virtual void accept(BSTVisitor* v) = 0;
 
@@ -185,10 +185,9 @@ private:
 public:
     BST(BST_TYPE::BST_TYPE type);
 #else
-    BST(BST_TYPE::BST_TYPE type) : type(type), lineno(0), col_offset(0) {}
+    BST(BST_TYPE::BST_TYPE type) : type(type), lineno(0) {}
 #endif
-    BST(BST_TYPE::BST_TYPE type, uint32_t lineno, uint32_t col_offset = 0)
-        : type(type), lineno(lineno), col_offset(col_offset) {}
+    BST(BST_TYPE::BST_TYPE type, uint32_t lineno) : type(type), lineno(lineno) {}
 };
 
 class BST_expr : public BST {
@@ -196,7 +195,7 @@ public:
     virtual void* accept_expr(ExprVisitor* v) = 0;
 
     BST_expr(BST_TYPE::BST_TYPE type) : BST(type) {}
-    BST_expr(BST_TYPE::BST_TYPE type, uint32_t lineno, uint32_t col_offset = 0) : BST(type, lineno, col_offset) {}
+    BST_expr(BST_TYPE::BST_TYPE type, uint32_t lineno) : BST(type, lineno) {}
 };
 
 class BST_stmt : public BST {
@@ -212,14 +211,14 @@ class BST_slice : public BST {
 public:
     virtual void* accept_slice(SliceVisitor* s) = 0;
     BST_slice(BST_TYPE::BST_TYPE type) : BST(type) {}
-    BST_slice(BST_TYPE::BST_TYPE type, uint32_t lineno, uint32_t col_offset = 0) : BST(type, lineno, col_offset) {}
+    BST_slice(BST_TYPE::BST_TYPE type, uint32_t lineno) : BST(type, lineno) {}
 };
 
 class BST_Name;
 
 class BST_arguments : public BST {
 public:
-    // no lineno, col_offset attributes
+    // no lineno attributes
     std::vector<BST_expr*> defaults;
 
     virtual void accept(BSTVisitor* v);
@@ -445,7 +444,7 @@ public:
 
 class BST_keyword : public BST {
 public:
-    // no lineno, col_offset attributes
+    // no lineno attributes
     BST_expr* value;
     InternedString arg;
 
@@ -493,8 +492,8 @@ public:
     virtual void accept(BSTVisitor* v);
     virtual void* accept_expr(ExprVisitor* v);
 
-    BST_Name(InternedString id, AST_TYPE::AST_TYPE ctx_type, int lineno, int col_offset = 0)
-        : BST_expr(BST_TYPE::Name, lineno, col_offset),
+    BST_Name(InternedString id, AST_TYPE::AST_TYPE ctx_type, int lineno)
+        : BST_expr(BST_TYPE::Name, lineno),
           ctx_type(ctx_type),
           id(id),
           lookup_type(ScopeInfo::VarScopeType::UNKNOWN),
@@ -676,8 +675,7 @@ public:
     virtual void accept(BSTVisitor* v);
     virtual void* accept_expr(ExprVisitor* v);
 
-    BST_MakeFunction(BST_FunctionDef* fd)
-        : BST_expr(BST_TYPE::MakeFunction, fd->lineno, fd->col_offset), function_def(fd) {}
+    BST_MakeFunction(BST_FunctionDef* fd) : BST_expr(BST_TYPE::MakeFunction, fd->lineno), function_def(fd) {}
 
     static const BST_TYPE::BST_TYPE TYPE = BST_TYPE::MakeFunction;
 };
@@ -689,7 +687,7 @@ public:
     virtual void accept(BSTVisitor* v);
     virtual void* accept_expr(ExprVisitor* v);
 
-    BST_MakeClass(BST_ClassDef* cd) : BST_expr(BST_TYPE::MakeClass, cd->lineno, cd->col_offset), class_def(cd) {}
+    BST_MakeClass(BST_ClassDef* cd) : BST_expr(BST_TYPE::MakeClass, cd->lineno), class_def(cd) {}
 
     static const BST_TYPE::BST_TYPE TYPE = BST_TYPE::MakeClass;
 };

--- a/src/core/bst.h
+++ b/src/core/bst.h
@@ -147,7 +147,7 @@ namespace BST_TYPE {
 #define GENERATE_ENUM(ENUM, N) ENUM = N,
 #define GENERATE_STRING(STRING, N) m[N] = #STRING;
 
-enum BST_TYPE { FOREACH_TYPE(GENERATE_ENUM) };
+enum BST_TYPE : unsigned char { FOREACH_TYPE(GENERATE_ENUM) };
 
 static const char* stringify(int n) {
     static std::map<int, const char*> m;
@@ -758,7 +758,7 @@ public:
 // These are basically bytecodes, framed as pseudo-BST-nodes.
 class BST_LangPrimitive : public BST_expr {
 public:
-    enum Opcodes {
+    enum Opcodes : unsigned char {
         LANDINGPAD, // grabs the info about the last raised exception
         LOCALS,
         GET_ITER,

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -997,11 +997,10 @@ void raiseSyntaxErrorHelper(llvm::StringRef file, llvm::StringRef func, AST* nod
 // A data structure used for storing information for tracebacks.
 struct LineInfo {
 public:
-    int line, column;
+    int line;
     BoxedString* file, *func;
 
-    LineInfo(int line, int column, BoxedString* file, BoxedString* func)
-        : line(line), column(column), file(file), func(func) {}
+    LineInfo(int line, BoxedString* file, BoxedString* func) : line(line), file(file), func(func) {}
 };
 
 // A data structure to simplify passing around all the data about a thrown exception.

--- a/src/runtime/cxx_unwind.cpp
+++ b/src/runtime/cxx_unwind.cpp
@@ -361,7 +361,7 @@ static void print_frame(unw_cursor_t* cursor, const unw_proc_info_t* pip) {
     if (frame_type == INTERPRETED && cf && cur_stmt) {
         auto source = cf->code_obj->source.get();
         // FIXME: dup'ed from lineInfoForFrame
-        LineInfo line(cur_stmt->lineno, cur_stmt->col_offset, cf->code_obj->filename, cf->code_obj->name);
+        LineInfo line(cur_stmt->lineno, cf->code_obj->filename, cf->code_obj->name);
         printf("      File \"%s\", line %d, in %s\n", line.file->c_str(), line.line, line.func->c_str());
     }
 }


### PR DESCRIPTION
this is mostly cleaning up stuff so it's easier to change the BST representation in the future.
also switched a few `std::vector<BST_expr*>` to   `BST_expr*` when we know it can only be a single element
