### PR TITLE
AST: deallocate nodes

### DIFF
--- a/src/codegen/cpython_ast.cpp
+++ b/src/codegen/cpython_ast.cpp
@@ -41,7 +41,7 @@ while lines:
     elif l.startswith("}"):
         name = l[2:-1]
         print "case %s_kind: {" % name
-        print "auto r = new AST_%s();" % name
+        print "auto r = new (getAlloc()) AST_%s();" % name
         print "auto v = %s->v.%s;" % (type, name)
         for n in names:
             print "r->%s = convert(v.%s);" % (n, n)
@@ -64,6 +64,9 @@ private:
     int interactive = 0;
     int nestlevel = 0;
     llvm::StringRef fn;
+    std::unique_ptr<ASTAllocator> ast_allocator;
+
+    ASTAllocator& getAlloc() { return *ast_allocator; }
 
 public:
     Converter(llvm::StringRef fn) : fn(fn) {}
@@ -100,11 +103,11 @@ public:
     AST_Name* convertToName(identifier ident) {
         if (!ident)
             return NULL;
-        return new AST_Name(convert(ident), AST_TYPE::Store, -1, -1);
+        return new (getAlloc()) AST_Name(convert(ident), AST_TYPE::Store, -1, -1);
     }
 
     AST_arguments* convert(arguments_ty ident, AST* parent) {
-        auto r = new AST_arguments();
+        auto r = new (getAlloc()) AST_arguments();
 
         convertAll<expr_ty>(ident->args, r->args);
         convertAll<expr_ty>(ident->defaults, r->defaults);
@@ -221,14 +224,14 @@ public:
 #undef CASE
 
     AST_keyword* convert(keyword_ty keyword) {
-        auto r = new AST_keyword();
+        auto r = new (getAlloc()) AST_keyword();
         r->arg = convert(keyword->arg);
         r->value = convert(keyword->value);
         return r;
     }
 
     AST_comprehension* convert(comprehension_ty comprehension) {
-        auto r = new AST_comprehension();
+        auto r = new (getAlloc()) AST_comprehension();
         r->target = convert(comprehension->target);
         r->iter = convert(comprehension->iter);
         r->ifs = convert<expr_ty, AST_expr*>(comprehension->ifs);
@@ -238,7 +241,7 @@ public:
     AST_slice* convert(slice_ty slice) {
         switch (slice->kind) {
             case Slice_kind: {
-                auto r = new AST_Slice();
+                auto r = new (getAlloc()) AST_Slice();
                 auto v = slice->v.Slice;
                 r->lower = convert(v.lower);
                 r->upper = convert(v.upper);
@@ -246,19 +249,19 @@ public:
                 return r;
             }
             case ExtSlice_kind: {
-                auto r = new AST_ExtSlice();
+                auto r = new (getAlloc()) AST_ExtSlice();
                 auto v = slice->v.ExtSlice;
                 r->dims = convert<slice_ty, AST_slice*>(v.dims);
                 return r;
             }
             case Index_kind: {
-                auto r = new AST_Index();
+                auto r = new (getAlloc()) AST_Index();
                 auto v = slice->v.Index;
                 r->value = convert(v.value);
                 return r;
             }
             case Ellipsis_kind:
-                return new AST_Ellipsis();
+                return new (getAlloc()) AST_Ellipsis();
         }
         RELEASE_ASSERT(0, "invalid slice type: %d", slice->kind);
     }
@@ -266,14 +269,14 @@ public:
     AST_expr* _convert(expr_ty expr) {
         switch (expr->kind) {
             case BoolOp_kind: {
-                auto r = new AST_BoolOp();
+                auto r = new (getAlloc()) AST_BoolOp();
                 auto v = expr->v.BoolOp;
                 r->op_type = convert(v.op);
                 r->values = convert<expr_ty, AST_expr*>(v.values);
                 return r;
             }
             case BinOp_kind: {
-                auto r = new AST_BinOp();
+                auto r = new (getAlloc()) AST_BinOp();
                 auto v = expr->v.BinOp;
                 r->left = convert(v.left);
                 r->op_type = convert(v.op);
@@ -281,14 +284,14 @@ public:
                 return r;
             }
             case UnaryOp_kind: {
-                auto r = new AST_UnaryOp();
+                auto r = new (getAlloc()) AST_UnaryOp();
                 auto v = expr->v.UnaryOp;
                 r->op_type = convert(v.op);
                 r->operand = convert(v.operand);
                 return r;
             }
             case Lambda_kind: {
-                auto r = new AST_Lambda();
+                auto r = new (getAlloc()) AST_Lambda();
                 r->lineno = expr->lineno;
                 r->col_offset = expr->col_offset;
                 auto v = expr->v.Lambda;
@@ -297,7 +300,7 @@ public:
                 return r;
             }
             case IfExp_kind: {
-                auto r = new AST_IfExp();
+                auto r = new (getAlloc()) AST_IfExp();
                 auto v = expr->v.IfExp;
                 r->test = convert(v.test);
                 r->body = convert(v.body);
@@ -305,34 +308,34 @@ public:
                 return r;
             }
             case Dict_kind: {
-                auto r = new AST_Dict();
+                auto r = new (getAlloc()) AST_Dict();
                 auto v = expr->v.Dict;
                 r->keys = convert<expr_ty, AST_expr*>(v.keys);
                 r->values = convert<expr_ty, AST_expr*>(v.values);
                 return r;
             }
             case Set_kind: {
-                auto r = new AST_Set();
+                auto r = new (getAlloc()) AST_Set();
                 auto v = expr->v.Set;
                 r->elts = convert<expr_ty, AST_expr*>(v.elts);
                 return r;
             }
             case ListComp_kind: {
-                auto r = new AST_ListComp();
+                auto r = new (getAlloc()) AST_ListComp();
                 auto v = expr->v.ListComp;
                 r->elt = convert(v.elt);
                 r->generators = convert<comprehension_ty, AST_comprehension*>(v.generators);
                 return r;
             }
             case SetComp_kind: {
-                auto r = new AST_SetComp();
+                auto r = new (getAlloc()) AST_SetComp();
                 auto v = expr->v.SetComp;
                 r->elt = convert(v.elt);
                 r->generators = convert<comprehension_ty, AST_comprehension*>(v.generators);
                 return r;
             }
             case DictComp_kind: {
-                auto r = new AST_DictComp();
+                auto r = new (getAlloc()) AST_DictComp();
                 auto v = expr->v.DictComp;
                 r->key = convert(v.key);
                 r->value = convert(v.value);
@@ -340,20 +343,20 @@ public:
                 return r;
             }
             case GeneratorExp_kind: {
-                auto r = new AST_GeneratorExp();
+                auto r = new (getAlloc()) AST_GeneratorExp();
                 auto v = expr->v.GeneratorExp;
                 r->elt = convert(v.elt);
                 r->generators = convert<comprehension_ty, AST_comprehension*>(v.generators);
                 return r;
             }
             case Yield_kind: {
-                auto r = new AST_Yield();
+                auto r = new (getAlloc()) AST_Yield();
                 auto v = expr->v.Yield;
                 r->value = convert(v.value);
                 return r;
             }
             case Compare_kind: {
-                auto r = new AST_Compare();
+                auto r = new (getAlloc()) AST_Compare();
                 auto v = expr->v.Compare;
                 r->left = convert(v.left);
                 r->ops = convert<cmpop_ty, AST_TYPE::AST_TYPE>(v.ops);
@@ -361,7 +364,7 @@ public:
                 return r;
             }
             case Call_kind: {
-                auto r = new AST_Call();
+                auto r = new (getAlloc()) AST_Call();
                 auto v = expr->v.Call;
                 r->func = convert(v.func);
                 r->args = convert<expr_ty, AST_expr*>(v.args);
@@ -371,13 +374,13 @@ public:
                 return r;
             }
             case Repr_kind: {
-                auto r = new AST_Repr();
+                auto r = new (getAlloc()) AST_Repr();
                 auto v = expr->v.Repr;
                 r->value = convert(v.value);
                 return r;
             }
             case Attribute_kind: {
-                auto r = new AST_Attribute();
+                auto r = new (getAlloc()) AST_Attribute();
                 auto v = expr->v.Attribute;
                 r->value = convert(v.value);
                 r->attr = convert(v.attr);
@@ -385,7 +388,7 @@ public:
                 return r;
             }
             case Subscript_kind: {
-                auto r = new AST_Subscript();
+                auto r = new (getAlloc()) AST_Subscript();
                 auto v = expr->v.Subscript;
                 r->value = convert(v.value);
                 r->slice = convert(v.slice);
@@ -394,18 +397,18 @@ public:
             }
             case Name_kind: {
                 auto v = expr->v.Name;
-                auto r = new AST_Name(convert(v.id), convert(v.ctx), 0);
+                auto r = new (getAlloc()) AST_Name(convert(v.id), convert(v.ctx), 0);
                 return r;
             }
             case List_kind: {
-                auto r = new AST_List();
+                auto r = new (getAlloc()) AST_List();
                 auto v = expr->v.List;
                 r->elts = convert<expr_ty, AST_expr*>(v.elts);
                 r->ctx_type = convert(v.ctx);
                 return r;
             }
             case Tuple_kind: {
-                auto r = new AST_Tuple();
+                auto r = new (getAlloc()) AST_Tuple();
                 auto v = expr->v.Tuple;
                 r->elts = convert<expr_ty, AST_expr*>(v.elts);
                 r->ctx_type = convert(v.ctx);
@@ -414,19 +417,19 @@ public:
             case Num_kind: {
                 PyObject* o = expr->v.Num.n;
                 if (o->cls == int_cls) {
-                    auto r = new AST_Num();
+                    auto r = new (getAlloc()) AST_Num();
                     r->num_type = AST_Num::INT;
                     r->n_int = unboxInt(o);
                     return r;
                 }
                 if (o->cls == float_cls) {
-                    auto r = new AST_Num();
+                    auto r = new (getAlloc()) AST_Num();
                     r->num_type = AST_Num::FLOAT;
                     r->n_float = unboxFloat(o);
                     return r;
                 }
                 if (o->cls == long_cls) {
-                    auto r = new AST_Num();
+                    auto r = new (getAlloc()) AST_Num();
                     r->num_type = AST_Num::LONG;
                     // XXX This is pretty silly:
                     auto s = _PyLong_Format(o, 10, 0, 0);
@@ -436,7 +439,7 @@ public:
                     return r;
                 }
                 if (o->cls == complex_cls) {
-                    auto r = new AST_Num();
+                    auto r = new (getAlloc()) AST_Num();
                     r->num_type = AST_Num::COMPLEX;
 
                     double real = PyComplex_RealAsDouble(o);
@@ -450,11 +453,11 @@ public:
                         return r;
 
                     // TODO very silly:
-                    auto freal = new AST_Num();
+                    auto freal = new (getAlloc()) AST_Num();
                     freal->n_float = real;
                     freal->num_type = AST_Num::FLOAT;
 
-                    auto binop = new AST_BinOp();
+                    auto binop = new (getAlloc()) AST_BinOp();
                     binop->op_type = AST_TYPE::Add;
                     binop->left = freal;
                     binop->right = r;
@@ -470,14 +473,14 @@ public:
                     RELEASE_ASSERT(o, "");
                     AUTO_DECREF(o);
 
-                    auto r = new AST_Str();
+                    auto r = new (getAlloc()) AST_Str();
                     r->str_data = static_cast<BoxedString*>(o)->s();
                     r->str_type = AST_Str::UNICODE;
                     return r;
                 }
 
                 if (o->cls == str_cls) {
-                    return new AST_Str(static_cast<BoxedString*>(o)->s());
+                    return new (getAlloc()) AST_Str(static_cast<BoxedString*>(o)->s());
                 }
                 RELEASE_ASSERT(0, "unhandled str type: %s\n", o->cls->tp_name);
             }
@@ -500,7 +503,7 @@ public:
     AST_ExceptHandler* convert(excepthandler_ty eh) {
         assert(eh->kind == ExceptHandler_kind);
 
-        auto r = new AST_ExceptHandler();
+        auto r = new (getAlloc()) AST_ExceptHandler();
         auto v = eh->v.ExceptHandler;
         r->type = convert(v.type);
         r->name = convert(v.name);
@@ -510,12 +513,14 @@ public:
         return r;
     }
 
-    AST_alias* convert(alias_ty alias) { return new AST_alias(convert(alias->name), convert(alias->asname)); }
+    AST_alias* convert(alias_ty alias) {
+        return new (getAlloc()) AST_alias(convert(alias->name), convert(alias->asname));
+    }
 
     AST_stmt* _convert(stmt_ty stmt) {
         switch (stmt->kind) {
             case FunctionDef_kind: {
-                auto r = new AST_FunctionDef();
+                auto r = new (getAlloc()) AST_FunctionDef();
                 r->lineno = stmt->lineno;
                 r->col_offset = stmt->col_offset;
                 auto v = stmt->v.FunctionDef;
@@ -528,7 +533,7 @@ public:
                 return r;
             }
             case ClassDef_kind: {
-                auto r = new AST_ClassDef();
+                auto r = new (getAlloc()) AST_ClassDef();
                 auto v = stmt->v.ClassDef;
                 r->name = convert(v.name);
                 r->bases = convert<expr_ty, AST_expr*>(v.bases);
@@ -539,26 +544,26 @@ public:
                 return r;
             }
             case Return_kind: {
-                auto r = new AST_Return();
+                auto r = new (getAlloc()) AST_Return();
                 auto v = stmt->v.Return;
                 r->value = convert(v.value);
                 return r;
             }
             case Delete_kind: {
-                auto r = new AST_Delete();
+                auto r = new (getAlloc()) AST_Delete();
                 auto v = stmt->v.Delete;
                 r->targets = convert<expr_ty, AST_expr*>(v.targets);
                 return r;
             }
             case Assign_kind: {
-                auto r = new AST_Assign();
+                auto r = new (getAlloc()) AST_Assign();
                 auto v = stmt->v.Assign;
                 r->targets = convert<expr_ty, AST_expr*>(v.targets);
                 r->value = convert(v.value);
                 return r;
             }
             case AugAssign_kind: {
-                auto r = new AST_AugAssign();
+                auto r = new (getAlloc()) AST_AugAssign();
                 auto v = stmt->v.AugAssign;
                 r->target = convert(v.target);
                 r->op_type = convert(v.op);
@@ -566,7 +571,7 @@ public:
                 return r;
             }
             case Print_kind: {
-                auto r = new AST_Print();
+                auto r = new (getAlloc()) AST_Print();
                 auto v = stmt->v.Print;
                 r->dest = convert(v.dest);
                 r->values = convert<expr_ty, AST_expr*>(v.values);
@@ -574,7 +579,7 @@ public:
                 return r;
             }
             case For_kind: {
-                auto r = new AST_For();
+                auto r = new (getAlloc()) AST_For();
                 auto v = stmt->v.For;
                 r->target = convert(v.target);
                 r->iter = convert(v.iter);
@@ -588,7 +593,7 @@ public:
                 return r;
             }
             case While_kind: {
-                auto r = new AST_While();
+                auto r = new (getAlloc()) AST_While();
                 auto v = stmt->v.While;
                 r->test = convert(v.test);
                 auto fin = in_finally;
@@ -601,7 +606,7 @@ public:
                 return r;
             }
             case If_kind: {
-                auto r = new AST_If();
+                auto r = new (getAlloc()) AST_If();
                 auto v = stmt->v.If;
                 r->test = convert(v.test);
                 r->body = convert<stmt_ty, AST_stmt*>(v.body);
@@ -609,7 +614,7 @@ public:
                 return r;
             }
             case With_kind: {
-                auto r = new AST_With();
+                auto r = new (getAlloc()) AST_With();
                 auto v = stmt->v.With;
                 r->context_expr = convert(v.context_expr);
                 r->optional_vars = convert(v.optional_vars);
@@ -617,7 +622,7 @@ public:
                 return r;
             }
             case Raise_kind: {
-                auto r = new AST_Raise();
+                auto r = new (getAlloc()) AST_Raise();
                 auto v = stmt->v.Raise;
                 r->arg0 = convert(v.type);
                 r->arg1 = convert(v.inst);
@@ -625,7 +630,7 @@ public:
                 return r;
             }
             case TryExcept_kind: {
-                auto r = new AST_TryExcept();
+                auto r = new (getAlloc()) AST_TryExcept();
                 auto v = stmt->v.TryExcept;
                 r->body = convert<stmt_ty, AST_stmt*>(v.body);
                 r->handlers = convert<excepthandler_ty, AST_ExceptHandler*>(v.handlers);
@@ -633,7 +638,7 @@ public:
                 return r;
             }
             case TryFinally_kind: {
-                auto r = new AST_TryFinally();
+                auto r = new (getAlloc()) AST_TryFinally();
                 auto v = stmt->v.TryFinally;
                 r->body = convert<stmt_ty, AST_stmt*>(v.body);
                 in_finally++;
@@ -642,20 +647,20 @@ public:
                 return r;
             }
             case Assert_kind: {
-                auto r = new AST_Assert();
+                auto r = new (getAlloc()) AST_Assert();
                 auto v = stmt->v.Assert;
                 r->test = convert(v.test);
                 r->msg = convert(v.msg);
                 return r;
             }
             case Import_kind: {
-                auto r = new AST_Import();
+                auto r = new (getAlloc()) AST_Import();
                 auto v = stmt->v.Import;
                 r->names = convert<alias_ty, AST_alias*>(v.names);
                 return r;
             }
             case ImportFrom_kind: {
-                auto r = new AST_ImportFrom();
+                auto r = new (getAlloc()) AST_ImportFrom();
                 auto v = stmt->v.ImportFrom;
                 r->module = convert(v.module);
                 r->names = convert<alias_ty, AST_alias*>(v.names);
@@ -663,7 +668,7 @@ public:
                 return r;
             }
             case Exec_kind: {
-                auto r = new AST_Exec();
+                auto r = new (getAlloc()) AST_Exec();
                 auto v = stmt->v.Exec;
                 r->body = convert(v.body);
                 r->globals = convert(v.globals);
@@ -671,36 +676,36 @@ public:
                 return r;
             }
             case Global_kind: {
-                auto r = new AST_Global();
+                auto r = new (getAlloc()) AST_Global();
                 auto v = stmt->v.Global;
                 r->names = convert<identifier, InternedString>(v.names);
                 return r;
             }
             case Expr_kind: {
-                auto r = new AST_Expr();
+                auto r = new (getAlloc()) AST_Expr();
                 auto v = stmt->v.Expr;
                 r->value = convert(v.value);
                 if (interactive && nestlevel <= 0) {
-                    auto print_expr = new AST_LangPrimitive(AST_LangPrimitive::PRINT_EXPR);
+                    auto print_expr = new (getAlloc()) AST_LangPrimitive(AST_LangPrimitive::PRINT_EXPR);
                     print_expr->args.push_back(r->value);
                     r->value = print_expr;
                 }
                 return r;
             }
             case Pass_kind:
-                return new AST_Pass();
+                return new (getAlloc()) AST_Pass();
             case Break_kind:
                 // This is not really the right place to be handling this, but this whole thing is temporary anyway.
                 if (loop_depth == 0)
                     raiseSyntaxError("'break' outside loop", stmt->lineno, stmt->col_offset, fn, "", true);
-                return new AST_Break();
+                return new (getAlloc()) AST_Break();
             case Continue_kind:
                 if (loop_depth == 0)
                     raiseSyntaxError("'continue' not properly in loop", stmt->lineno, stmt->col_offset, fn, "", true);
                 if (in_finally)
                     raiseSyntaxError("'continue' not supported inside 'finally' clause", stmt->lineno, stmt->col_offset,
                                      fn, "", true);
-                return new AST_Continue();
+                return new (getAlloc()) AST_Continue();
         };
         // GCC wants this:
         RELEASE_ASSERT(0, "invalid statement type: %d", stmt->kind);
@@ -720,39 +725,40 @@ public:
         return r;
     }
 
-    AST* convert(mod_ty mod) {
+    std::pair<AST*, std::unique_ptr<ASTAllocator>> convert(mod_ty mod) {
+        ast_allocator.reset(new ASTAllocator);
         switch (mod->kind) {
             case Module_kind: {
-                AST_Module* rtn = new AST_Module(llvm::make_unique<InternedStringPool>());
+                AST_Module* rtn = new (getAlloc()) AST_Module(llvm::make_unique<InternedStringPool>());
                 rtn->lineno = 1;
                 assert(!this->pool);
                 this->pool = rtn->interned_strings.get();
                 convertAll<stmt_ty>(mod->v.Module.body, rtn->body);
-                return rtn;
+                return std::make_pair(rtn, std::move(ast_allocator));
             }
             case Interactive_kind: {
                 this->interactive = 1;
-                AST_Module* rtn = new AST_Module(llvm::make_unique<InternedStringPool>());
+                AST_Module* rtn = new (getAlloc()) AST_Module(llvm::make_unique<InternedStringPool>());
                 rtn->lineno = 1;
                 assert(!this->pool);
                 this->pool = rtn->interned_strings.get();
                 convertAll<stmt_ty>(mod->v.Interactive.body, rtn->body);
-                return rtn;
+                return std::make_pair(rtn, std::move(ast_allocator));
             }
             case Expression_kind: {
-                AST_Expression* rtn = new AST_Expression(llvm::make_unique<InternedStringPool>());
+                AST_Expression* rtn = new (getAlloc()) AST_Expression(llvm::make_unique<InternedStringPool>());
                 rtn->lineno = 1;
                 this->pool = rtn->interned_strings.get();
 
                 // instead of storing the expression inside the AST node we convert it directly to a return statement
                 AST_expr* expr = this->convert(mod->v.Expression.body);
-                auto rtn_stmt = new AST_Return;
+                auto rtn_stmt = new (getAlloc()) AST_Return;
                 rtn_stmt->lineno = expr->lineno;
                 rtn_stmt->col_offset = expr->col_offset;
                 rtn_stmt->value = expr;
 
                 rtn->body = rtn_stmt;
-                return rtn;
+                return std::make_pair(rtn, std::move(ast_allocator));
             }
             default:
                 RELEASE_ASSERT(0, "unhandled kind: %d\n", mod->kind);
@@ -760,7 +766,7 @@ public:
     }
 };
 
-AST* cpythonToPystonAST(mod_ty mod, llvm::StringRef fn) {
+std::pair<AST*, std::unique_ptr<ASTAllocator>> cpythonToPystonAST(mod_ty mod, llvm::StringRef fn) {
     Converter c(fn);
     return c.convert(mod);
 }

--- a/src/codegen/cpython_ast.h
+++ b/src/codegen/cpython_ast.h
@@ -25,7 +25,7 @@ namespace pyston {
 // Convert a CPython ast object to a Pyston ast object.
 // This will also check for certain kinds of "syntax errors" (ex continue not in loop) and will
 // throw them as C++ exceptions.
-AST* cpythonToPystonAST(mod_ty mod, llvm::StringRef fn);
+std::pair<AST*, std::unique_ptr<ASTAllocator>> cpythonToPystonAST(mod_ty mod, llvm::StringRef fn);
 }
 
 #endif

--- a/src/codegen/irgen/hooks.cpp
+++ b/src/codegen/irgen/hooks.cpp
@@ -292,7 +292,9 @@ extern "C" PyCodeObject* PyAST_Compile(struct _mod* _mod, const char* filename, 
                                        PyArena* arena) noexcept {
     try {
         mod_ty mod = _mod;
-        AST* parsed = cpythonToPystonAST(mod, filename);
+        std::unique_ptr<ASTAllocator> ast_allocator;
+        AST* parsed;
+        std::tie(parsed, ast_allocator) = cpythonToPystonAST(mod, filename);
         BoxedCode* code = NULL;
         switch (mod->kind) {
             case Module_kind:

--- a/src/codegen/parser.h
+++ b/src/codegen/parser.h
@@ -20,10 +20,11 @@
 namespace pyston {
 
 class AST_Module;
+class ASTAllocator;
 
-AST_Module* parse_string(const char* code, FutureFlags inherited_flags);
-AST_Module* parse_file(const char* fn, FutureFlags inherited_flags);
-AST_Module* caching_parse_file(const char* fn, FutureFlags inherited_flags);
+std::pair<AST_Module*, std::unique_ptr<ASTAllocator>> parse_string(const char* code, FutureFlags inherited_flags);
+std::pair<AST_Module*, std::unique_ptr<ASTAllocator>> parse_file(const char* fn, FutureFlags inherited_flags);
+std::pair<AST_Module*, std::unique_ptr<ASTAllocator>> caching_parse_file(const char* fn, FutureFlags inherited_flags);
 }
 
 #endif

--- a/src/jit.cpp
+++ b/src/jit.cpp
@@ -460,7 +460,9 @@ static int main(int argc, char** argv) noexcept {
         if (command != NULL) {
             try {
                 main_module = createModule(autoDecref(boxString("__main__")), "<string>");
-                AST_Module* m = parse_string(command, /* future_flags = */ 0);
+                AST_Module* m;
+                std::unique_ptr<ASTAllocator> ast_allocator;
+                std::tie(m, ast_allocator) = parse_string(command, /* future_flags = */ 0);
                 compileAndRunModule(m, main_module);
                 rtncode = 0;
             } catch (ExcInfo e) {
@@ -504,7 +506,10 @@ static int main(int argc, char** argv) noexcept {
                 free(real_path);
 
                 try {
-                    AST_Module* ast = parse_file(fn, /* future_flags = */ 0);
+                    std::unique_ptr<ASTAllocator> ast_allocator;
+                    AST_Module* ast;
+                    std::tie(ast, ast_allocator) = parse_file(fn, /* future_flags = */ 0);
+
                     compileAndRunModule(ast, main_module);
                     rtncode = 0;
                 } catch (ExcInfo e) {

--- a/src/runtime/capi.cpp
+++ b/src/runtime/capi.cpp
@@ -37,6 +37,7 @@
 #include "capi/types.h"
 #include "codegen/irgen/hooks.h"
 #include "codegen/unwinding.h"
+#include "core/ast.h"
 #include "core/threading.h"
 #include "core/types.h"
 #include "runtime/classobj.h"
@@ -847,8 +848,8 @@ extern "C" int PyRun_InteractiveOneFlags(FILE* fp, const char* filename, PyCompi
     bool failed = false;
     try {
         assert(mod->kind == Interactive_kind);
-        AST_Module* pyston_module = static_cast<AST_Module*>(cpythonToPystonAST(mod, filename));
-        compileAndRunModule(pyston_module, static_cast<BoxedModule*>(m));
+        auto res = cpythonToPystonAST(mod, filename);
+        compileAndRunModule((AST_Module*)res.first, static_cast<BoxedModule*>(m));
     } catch (ExcInfo e) {
         setCAPIException(e);
         failed = true;

--- a/test/unittests/analysis.cpp
+++ b/test/unittests/analysis.cpp
@@ -29,7 +29,9 @@ protected:
 #ifndef NDEBUG
 TEST_F(AnalysisTest, augassign) {
     const std::string fn("test/unittests/analysis_listcomp.py");
-    AST_Module* module = caching_parse_file(fn.c_str(), 0);
+    std::unique_ptr<ASTAllocator> ast_allocator;
+    AST_Module* module;
+    std::tie(module, ast_allocator) = caching_parse_file(fn.c_str(), 0);
     assert(module);
 
     FutureFlags future_flags = getFutureFlags(module->body, fn.c_str());
@@ -45,7 +47,7 @@ TEST_F(AnalysisTest, augassign) {
     ASSERT_NE(scope_info->getScopeTypeOfName(module->interned_strings->get("a")), ScopeInfo::VarScopeType::GLOBAL);
     ASSERT_FALSE(scope_info->getScopeTypeOfName(module->interned_strings->get("b")) == ScopeInfo::VarScopeType::GLOBAL);
 
-    AST_arguments* args = new AST_arguments();
+    AST_arguments* args = new (*ast_allocator) AST_arguments();
     ParamNames param_names(args, *module->interned_strings.get());
 
     // Hack to get at the cfg:
@@ -68,7 +70,9 @@ TEST_F(AnalysisTest, augassign) {
 
 void doOsrTest(bool is_osr, bool i_maybe_undefined) {
     const std::string fn("test/unittests/analysis_osr.py");
-    AST_Module* module = caching_parse_file(fn.c_str(), 0);
+    std::unique_ptr<ASTAllocator> ast_allocator;
+    AST_Module* module;
+    std::tie(module, ast_allocator) = caching_parse_file(fn.c_str(), 0);
     assert(module);
 
     ParamNames param_names(NULL, *module->interned_strings.get());


### PR DESCRIPTION
Use a bumpptr allocator to keep track of the AST nodes.
I could not use the LLVM one because it does not call the destructor on allocated elements.