### PR TITLE
BST: convert all nodes to directly operate at vregs instead of names

### DIFF
--- a/src/analysis/function_analysis.h
+++ b/src/analysis/function_analysis.h
@@ -26,9 +26,7 @@
 
 namespace pyston {
 
-class BST_arguments;
 class BST_Jump;
-class BST_Name;
 class CFG;
 class CFGBlock;
 class LivenessBBVisitor;
@@ -46,9 +44,6 @@ private:
 public:
     LivenessAnalysis(CFG* cfg);
     ~LivenessAnalysis();
-
-    // we don't keep track of node->parent_block relationships, so you have to pass both:
-    bool isKill(BST_Name* node, CFGBlock* parent_block);
 
     bool isLiveAtEnd(int vreg, CFGBlock* block);
 };

--- a/src/analysis/scoping_analysis.cpp
+++ b/src/analysis/scoping_analysis.cpp
@@ -36,15 +36,10 @@ ScopingResults::ScopingResults(ScopeInfo* scope_info, bool globals_from_module)
     deref_info = scope_info->getAllDerefVarsAndInfo();
 }
 
-DerefInfo ScopingResults::getDerefInfo(BST_Name* node) const {
+DerefInfo ScopingResults::getDerefInfo(BST_LoadName* node) const {
     assert(node->lookup_type == ScopeInfo::VarScopeType::DEREF);
     assert(node->deref_info.offset != INT_MAX);
     return node->deref_info;
-}
-size_t ScopingResults::getClosureOffset(BST_Name* node) const {
-    assert(node->lookup_type == ScopeInfo::VarScopeType::CLOSURE);
-    assert(node->closure_offset != -1);
-    return node->closure_offset;
 }
 
 class YieldVisitor : public NoopASTVisitor {

--- a/src/analysis/type_analysis.h
+++ b/src/analysis/type_analysis.h
@@ -24,9 +24,9 @@
 namespace pyston {
 
 class CFGBlock;
+class ConstantVRegInfo;
 class BoxedClass;
-class BST_expr;
-class BST_slice;
+class BST_stmt_with_dest;
 class OSREntryDescriptor;
 
 class TypeAnalysis {
@@ -40,15 +40,14 @@ public:
 
     virtual ConcreteCompilerType* getTypeAtBlockStart(int vreg, CFGBlock* block) = 0;
     virtual ConcreteCompilerType* getTypeAtBlockEnd(int vreg, CFGBlock* block) = 0;
-    virtual BoxedClass* speculatedExprClass(BST_expr*) = 0;
-    virtual BoxedClass* speculatedExprClass(BST_slice*) = 0;
+    virtual BoxedClass* speculatedExprClass(BST_stmt_with_dest*) = 0;
 };
 
 TypeAnalysis* doTypeAnalysis(CFG* cfg, const ParamNames& param_names,
                              const std::vector<ConcreteCompilerType*>& arg_types, EffortLevel effort,
-                             TypeAnalysis::SpeculationLevel speculation);
+                             TypeAnalysis::SpeculationLevel speculation, const ConstantVRegInfo& constant_vregs);
 TypeAnalysis* doTypeAnalysis(const OSREntryDescriptor* entry_descriptor, EffortLevel effort,
-                             TypeAnalysis::SpeculationLevel speculation);
+                             TypeAnalysis::SpeculationLevel speculation, const ConstantVRegInfo& constant_vregs);
 }
 
 #endif

--- a/src/asm_writing/icinfo.cpp
+++ b/src/asm_writing/icinfo.cpp
@@ -341,7 +341,7 @@ ICSlotInfo* ICInfo::pickEntryForRewrite(const char* debug_name) {
 }
 
 static llvm::DenseMap<void*, ICInfo*> ics_by_return_addr;
-static llvm::DenseMap<BST*, ICInfo*> ics_by_ast_node;
+static llvm::DenseMap<BST_stmt*, ICInfo*> ics_by_ast_node;
 
 ICInfo::ICInfo(void* start_addr, void* slowpath_rtn_addr, void* continue_addr, StackInfo stack_info, int size,
                llvm::CallingConv::ID calling_conv, LiveOutSet _live_outs, assembler::GenericRegister return_register,
@@ -485,13 +485,13 @@ bool ICInfo::isMegamorphic() {
     return times_rewritten >= IC_MEGAMORPHIC_THRESHOLD;
 }
 
-ICInfo* ICInfo::getICInfoForNode(BST* node) {
+ICInfo* ICInfo::getICInfoForNode(BST_stmt* node) {
     auto&& it = ics_by_ast_node.find(node);
     if (it != ics_by_ast_node.end())
         return it->second;
     return NULL;
 }
-void ICInfo::associateNodeWithICInfo(BST* node, std::unique_ptr<TypeRecorder> type_recorder) {
+void ICInfo::associateNodeWithICInfo(BST_stmt* node, std::unique_ptr<TypeRecorder> type_recorder) {
     assert(!this->node);
     this->node = node;
     this->type_recorder = std::move(type_recorder);

--- a/src/asm_writing/icinfo.h
+++ b/src/asm_writing/icinfo.h
@@ -105,7 +105,7 @@ private:
     std::vector<Location> ic_global_decref_locations;
 
     // associated BST node for this IC
-    BST* node;
+    BST_stmt* node;
 
     // for ICSlotRewrite:
     ICSlotInfo* pickEntryForRewrite(const char* debug_name);
@@ -145,8 +145,8 @@ public:
 
     friend class ICSlotRewrite;
 
-    static ICInfo* getICInfoForNode(BST* node);
-    void associateNodeWithICInfo(BST* node, std::unique_ptr<TypeRecorder> type_recorder);
+    static ICInfo* getICInfoForNode(BST_stmt* node);
+    void associateNodeWithICInfo(BST_stmt* node, std::unique_ptr<TypeRecorder> type_recorder);
 
     void appendDecrefInfosTo(std::vector<DecrefInfo>& dest_decref_infos);
 };

--- a/src/codegen/ast_interpreter.cpp
+++ b/src/codegen/ast_interpreter.cpp
@@ -74,55 +74,64 @@ public:
     static Box* executeInner(ASTInterpreter& interpreter, CFGBlock* start_block, BST_stmt* start_at);
 
 private:
-    Value createFunction(BST_FunctionDef* node, BST_arguments* args);
-    Value doBinOp(BST_expr* node, Value left, Value right, int op, BinExpType exp_type);
-    void doStore(BST_expr* node, STOLEN(Value) value);
-    void doStore(BST_Name* name, STOLEN(Value) value);
+    Value createFunction(BST_FunctionDef* node);
+    Value doBinOp(BST_stmt* node, Value left, Value right, int op, BinExpType exp_type);
+    void doStore(int vreg, STOLEN(Value) value);
+    void doStoreArg(BST_Name* name, STOLEN(Value) value);
     Box* doOSR(BST_Jump* node);
     Value getNone();
 
-    Value visit_assert(BST_Assert* node);
-    Value visit_assign(BST_Assign* node);
+    Value getVReg(int vreg, bool kill = true);
+
+    Value visit_augBinOp(BST_AugBinOp* node);
     Value visit_binop(BST_BinOp* node);
     Value visit_call(BST_Call* node);
+    Value visit_checkexcmatch(BST_CheckExcMatch* node);
     Value visit_compare(BST_Compare* node);
-    Value visit_delete(BST_Delete* node);
-    Value visit_exec(BST_Exec* node);
-    Value visit_print(BST_Print* node);
-    Value visit_raise(BST_Raise* node);
-    Value visit_return(BST_Return* node);
-    Value visit_stmt(BST_stmt* node);
-    Value visit_unaryop(BST_UnaryOp* node);
-
-    Value visit_attribute(BST_Attribute* node);
+    Value visit_copyvreg(BST_CopyVReg* node);
     Value visit_dict(BST_Dict* node);
-    Value visit_ellipsis(BST_Ellipsis* node);
-    Value visit_expr(BST_expr* node);
-    Value visit_expr(BST_Expr* node);
-    Value visit_extslice(BST_ExtSlice* node);
-    Value visit_index(BST_Index* node);
-    Value visit_list(BST_List* node);
-    Value visit_name(BST_Name* node);
-    Value visit_num(BST_Num* node);
-    Value visit_repr(BST_Repr* node);
-    Value visit_set(BST_Set* node);
-    Value visit_str(BST_Str* node);
-    Value visit_subscript(BST_Subscript* node);
-    Value visit_slice(BST_Slice* node);
-    Value visit_slice(BST_slice* node);
-    Value visit_tuple(BST_Tuple* node);
-    Value visit_yield(BST_Yield* node);
-
-    Value visit_makeClass(BST_MakeClass* node);
-    Value visit_makeFunction(BST_MakeFunction* node);
-
-    // pseudo
-    Value visit_augBinOp(BST_AugBinOp* node);
-    Value visit_branch(BST_Branch* node);
-    Value visit_clsAttribute(BST_ClsAttribute* node);
+    Value visit_getiter(BST_GetIter* node);
+    Value visit_hasnext(BST_HasNext* node);
+    Value visit_importfrom(BST_ImportFrom* node);
+    Value visit_importname(BST_ImportName* node);
+    Value visit_importstar(BST_ImportStar* node);
     Value visit_invoke(BST_Invoke* node);
     Value visit_jump(BST_Jump* node);
-    Value visit_langPrimitive(BST_LangPrimitive* node);
+    Value visit_landingpad(BST_Landingpad* node);
+    Value visit_list(BST_List* node);
+    Value visit_loadattr(BST_LoadAttr* node);
+    Value visit_loadname(BST_LoadName* node);
+    Value visit_loadsub(BST_LoadSub* node);
+    Value visit_loadsubslice(BST_LoadSubSlice* node);
+    Value visit_locals(BST_Locals* node);
+    Value visit_makeClass(BST_MakeClass* node);
+    Value visit_makeFunction(BST_MakeFunction* node);
+    Value visit_makeslice(BST_MakeSlice* node);
+    Value visit_nonzero(BST_Nonzero* node);
+    Value visit_repr(BST_Repr* node);
+    Value visit_return(BST_Return* node);
+    Value visit_set(BST_Set* node);
+    Value visit_stmt(BST_stmt* node);
+    Value visit_tuple(BST_Tuple* node);
+    Value visit_unaryop(BST_UnaryOp* node);
+    Value visit_yield(BST_Yield* node);
+    void visit_assert(BST_Assert* node);
+    void visit_branch(BST_Branch* node);
+    void visit_deleteattr(BST_DeleteAttr* node);
+    void visit_deletename(BST_DeleteName* node);
+    void visit_deletesub(BST_DeleteSub* node);
+    void visit_deletesubslice(BST_DeleteSubSlice* node);
+    void visit_exec(BST_Exec* node);
+    void visit_print(BST_Print* node);
+    void visit_printexpr(BST_PrintExpr* node);
+    void visit_raise(BST_Raise* node);
+    void visit_setexcinfo(BST_SetExcInfo* node);
+    void visit_storeattr(BST_StoreAttr* node);
+    void visit_storename(BST_StoreName* node);
+    void visit_storesub(BST_StoreSub* node);
+    void visit_storesubslice(BST_StoreSubSlice* node);
+    void visit_uncacheexcinfo(BST_UncacheExcInfo* node);
+    void visit_unpackintoarray(BST_UnpackIntoArray* node);
 
     // for doc on 'exit_offset' have a look at JitFragmentWriter::num_bytes_exit and num_bytes_overlapping
     void startJITing(CFGBlock* block, int exit_offset = 0,
@@ -155,7 +164,7 @@ public:
     const VRegInfo& getVRegInfo() const { return source_info->cfg->getVRegInfo(); }
 
 #ifndef NDEBUG
-    const llvm::DenseMap<InternedString, DefaultedInt<-1>>& getSymVRegMap() const {
+    const llvm::DenseMap<InternedString, DefaultedInt<VREG_UNDEFINED>>& getSymVRegMap() const {
         return getVRegInfo().getSymVRegMap();
     }
 #endif
@@ -172,6 +181,7 @@ public:
     BoxedClosure* getPassedClosure() { return frame_info.passed_closure; }
     Box** getVRegs() { return vregs; }
     const ScopingResults& getScopeInfo() { return scope_info; }
+    const ConstantVRegInfo& getConstantVRegInfo() { return getCode()->constant_vregs; }
 
     void addSymbol(int vreg, Box* value, bool allow_duplicates);
     void setGenerator(Box* gen);
@@ -268,11 +278,11 @@ void ASTInterpreter::initArguments(BoxedClosure* _closure, BoxedGenerator* _gene
 
     int i = 0;
     for (auto& name : param_names.argsAsName()) {
-        doStore(name, Value(incref(getArg(i++, arg1, arg2, arg3, args)), 0));
+        doStoreArg(name, Value(incref(getArg(i++, arg1, arg2, arg3, args)), 0));
     }
 
     if (param_names.has_vararg_name)
-        doStore(param_names.varArgAsName(), Value(incref(getArg(i++, arg1, arg2, arg3, args)), 0));
+        doStoreArg(param_names.varArgAsName(), Value(incref(getArg(i++, arg1, arg2, arg3, args)), 0));
 
     if (param_names.has_kwarg_name) {
         Box* val = getArg(i++, arg1, arg2, arg3, args);
@@ -280,7 +290,7 @@ void ASTInterpreter::initArguments(BoxedClosure* _closure, BoxedGenerator* _gene
             val = createDict();
         else
             Py_INCREF(val);
-        doStore(param_names.kwArgAsName(), Value(val, 0));
+        doStoreArg(param_names.kwArgAsName(), Value(val, 0));
     }
     assert(i == param_names.totalParameters());
 }
@@ -304,7 +314,8 @@ void ASTInterpreter::startJITing(CFGBlock* block, int exit_offset, llvm::DenseSe
     if (block == block->cfg->getStartingBlock() && block->predecessors.empty()) {
         auto param_names = getCode()->param_names;
         for (auto&& arg : param_names.allArgsAsName()) {
-            known_non_null_vregs.insert(arg->vreg);
+            if (arg->vreg >= 0)
+                known_non_null_vregs.insert(arg->vreg);
         }
     }
     jit = code_block->newFragment(block, exit_offset, std::move(known_non_null_vregs));
@@ -457,7 +468,7 @@ Box* ASTInterpreter::execute(ASTInterpreter& interpreter, CFGBlock* start_block,
     return executeInnerAndSetupFrame(interpreter, start_block, start_at);
 }
 
-Value ASTInterpreter::doBinOp(BST_expr* node, Value left, Value right, int op, BinExpType exp_type) {
+Value ASTInterpreter::doBinOp(BST_stmt* node, Value left, Value right, int op, BinExpType exp_type) {
     switch (exp_type) {
         case BinExpType::AugBinOp:
             return Value(augbinop(left.o, right.o, op), jit ? jit->emitAugbinop(node, left, right, op) : NULL);
@@ -468,39 +479,42 @@ Value ASTInterpreter::doBinOp(BST_expr* node, Value left, Value right, int op, B
         default:
             RELEASE_ASSERT(0, "not implemented");
     }
-    return Value();
 }
 
-void ASTInterpreter::doStore(BST_Name* node, STOLEN(Value) value) {
+void ASTInterpreter::doStore(int vreg, STOLEN(Value) value) {
+    if (vreg == VREG_UNDEFINED) {
+        Py_DECREF(value.o);
+        return;
+    }
+    if (jit) {
+        bool is_live = source_info->getLiveness()->isLiveAtEnd(vreg, current_block);
+        if (is_live)
+            jit->emitSetLocal(vreg, value);
+        else
+            jit->emitSetBlockLocal(vreg, value);
+    }
+
+    frame_info.num_vregs = std::max(frame_info.num_vregs, vreg + 1);
+    Box* prev = vregs[vreg];
+    vregs[vreg] = value.o;
+    Py_XDECREF(prev);
+}
+
+void ASTInterpreter::doStoreArg(BST_Name* node, STOLEN(Value) value) {
+    assert(!jit);
     assert(node->lookup_type != ScopeInfo::VarScopeType::UNKNOWN);
 
     InternedString name = node->id;
     ScopeInfo::VarScopeType vst = node->lookup_type;
-    if (vst == ScopeInfo::VarScopeType::GLOBAL) {
-        if (jit)
-            jit->emitSetGlobal(name.getBox(), value, getCode()->source->scoping.areGlobalsFromModule());
-        setGlobal(frame_info.globals, name.getBox(), value.o);
-    } else if (vst == ScopeInfo::VarScopeType::NAME) {
-        if (jit)
-            jit->emitSetItemName(name.getBox(), value);
+    if (vst == ScopeInfo::VarScopeType::NAME) {
         assert(frame_info.boxedLocals != NULL);
         // TODO should probably pre-box the names when it's a scope that usesNameLookup
         AUTO_DECREF(value.o);
         setitem(frame_info.boxedLocals, name.getBox(), value.o);
-    } else {
+    } else if (vst == ScopeInfo::VarScopeType::FAST || vst == ScopeInfo::VarScopeType::CLOSURE) {
         bool closure = vst == ScopeInfo::VarScopeType::CLOSURE;
-        if (jit) {
-            bool is_live = true;
-            if (!closure)
-                is_live = source_info->getLiveness()->isLiveAtEnd(node->vreg, current_block);
-            if (is_live)
-                jit->emitSetLocal(node, closure, value);
-            else
-                jit->emitSetBlockLocal(node, value);
-        }
-
         if (closure) {
-            ASTInterpreterJitInterface::setLocalClosureHelper(this, node, value.o);
+            ASTInterpreterJitInterface::setLocalClosureHelper(this, node->vreg, node->closure_offset, value.o);
         } else {
             assert(getVRegInfo().getVReg(node->id) == node->vreg);
             frame_info.num_vregs = std::max(frame_info.num_vregs, node->vreg + 1);
@@ -508,89 +522,8 @@ void ASTInterpreter::doStore(BST_Name* node, STOLEN(Value) value) {
             vregs[node->vreg] = value.o;
             Py_XDECREF(prev);
         }
-    }
-}
-
-void ASTInterpreter::doStore(BST_expr* node, STOLEN(Value) value) {
-    if (node->type == BST_TYPE::Name) {
-        BST_Name* name = (BST_Name*)node;
-        doStore(name, value);
-    } else if (node->type == BST_TYPE::Attribute) {
-        BST_Attribute* attr = (BST_Attribute*)node;
-        Value o = visit_expr(attr->value);
-        if (jit) {
-            jit->emitSetAttr(node, o, attr->attr.getBox(), value);
-        }
-        AUTO_DECREF(o.o);
-        pyston::setattr(o.o, attr->attr.getBox(), value.o);
-    } else if (node->type == BST_TYPE::Tuple) {
-        AUTO_DECREF(value.o);
-
-        BST_Tuple* tuple = (BST_Tuple*)node;
-        Box* keep_alive;
-        Box** array = unpackIntoArray(value.o, tuple->elts.size(), &keep_alive);
-        AUTO_DECREF(keep_alive);
-
-        std::vector<RewriterVar*> array_vars;
-        if (jit) {
-            array_vars = jit->emitUnpackIntoArray(value, tuple->elts.size());
-            assert(array_vars.size() == tuple->elts.size());
-        }
-
-        unsigned i = 0;
-        for (BST_expr* e : tuple->elts) {
-            doStore(e, Value(array[i], jit ? array_vars[i] : NULL));
-            ++i;
-        }
-    } else if (node->type == BST_TYPE::List) {
-        AUTO_DECREF(value.o);
-
-        BST_List* list = (BST_List*)node;
-        Box* keep_alive;
-        Box** array = unpackIntoArray(value.o, list->elts.size(), &keep_alive);
-        AUTO_DECREF(keep_alive);
-
-        std::vector<RewriterVar*> array_vars;
-        if (jit) {
-            array_vars = jit->emitUnpackIntoArray(value, list->elts.size());
-            assert(array_vars.size() == list->elts.size());
-        }
-
-        unsigned i = 0;
-        for (BST_expr* e : list->elts) {
-            doStore(e, Value(array[i], jit ? array_vars[i] : NULL));
-            ++i;
-        }
-    } else if (node->type == BST_TYPE::Subscript) {
-        AUTO_DECREF(value.o);
-        BST_Subscript* subscript = (BST_Subscript*)node;
-
-        Value target = visit_expr(subscript->value);
-        AUTO_DECREF(target.o);
-
-        bool is_slice = (subscript->slice->type == BST_TYPE::Slice) && (((BST_Slice*)subscript->slice)->step == NULL);
-        if (is_slice) {
-            BST_Slice* slice = (BST_Slice*)subscript->slice;
-            Value lower = slice->lower ? visit_expr(slice->lower) : Value();
-            AUTO_XDECREF(lower.o);
-            Value upper = slice->upper ? visit_expr(slice->upper) : Value();
-            AUTO_XDECREF(upper.o);
-            assert(slice->step == NULL);
-
-            if (jit)
-                jit->emitAssignSlice(target, lower, upper, value);
-            assignSlice(target.o, lower.o, upper.o, value.o);
-        } else {
-            Value slice = visit_slice(subscript->slice);
-
-            AUTO_DECREF(slice.o);
-
-            if (jit)
-                jit->emitSetItem(target, slice, value);
-            setitem(target.o, slice.o, value.o);
-        }
     } else {
-        RELEASE_ASSERT(0, "not implemented");
+        RELEASE_ASSERT(0, "");
     }
 }
 
@@ -603,7 +536,7 @@ Value ASTInterpreter::getNone() {
 }
 
 Value ASTInterpreter::visit_unaryop(BST_UnaryOp* node) {
-    Value operand = visit_expr(node->operand);
+    Value operand = getVReg(node->vreg_operand);
     AUTO_DECREF(operand.o);
     if (node->op_type == AST_TYPE::Not)
         return Value(boxBool(!nonzero(operand.o)), jit ? jit->emitNotNonzero(operand) : NULL);
@@ -611,41 +544,39 @@ Value ASTInterpreter::visit_unaryop(BST_UnaryOp* node) {
         return Value(unaryop(operand.o, node->op_type), jit ? jit->emitUnaryop(operand, node->op_type) : NULL);
 }
 
+void ASTInterpreter::visit_unpackintoarray(BST_UnpackIntoArray* node) {
+    Value value = getVReg(node->vreg_src);
+    AUTO_DECREF(value.o);
+
+    Box* keep_alive;
+    Box** array = unpackIntoArray(value.o, node->num_elts, &keep_alive);
+    AUTO_DECREF(keep_alive);
+
+    std::vector<RewriterVar*> array_vars;
+    if (jit) {
+        array_vars = jit->emitUnpackIntoArray(value, node->num_elts);
+        assert(array_vars.size() == node->num_elts);
+    }
+
+    for (int i = 0; i < node->num_elts; ++i) {
+        doStore(node->vreg_dst[i], Value(array[i], jit ? array_vars[i] : NULL));
+    }
+}
+
 Value ASTInterpreter::visit_binop(BST_BinOp* node) {
-    Value left = visit_expr(node->left);
+    Value left = getVReg(node->vreg_left);
     AUTO_DECREF(left.o);
-    Value right = visit_expr(node->right);
+    Value right = getVReg(node->vreg_right);
     AUTO_DECREF(right.o);
     return doBinOp(node, left, right, node->op_type, BinExpType::BinOp);
 }
 
-Value ASTInterpreter::visit_slice(BST_slice* node) {
-    switch (node->type) {
-        case BST_TYPE::ExtSlice:
-            return visit_extslice(static_cast<BST_ExtSlice*>(node));
-        case BST_TYPE::Ellipsis:
-            return visit_ellipsis(static_cast<BST_Ellipsis*>(node));
-            break;
-        case BST_TYPE::Index:
-            return visit_index(static_cast<BST_Index*>(node));
-        case BST_TYPE::Slice:
-            return visit_slice(static_cast<BST_Slice*>(node));
-        default:
-            RELEASE_ASSERT(0, "Attempt to handle invalid slice type");
-    }
-    return Value();
-}
-
-Value ASTInterpreter::visit_ellipsis(BST_Ellipsis* node) {
-    return Value(incref(Ellipsis), jit ? jit->imm(Ellipsis) : NULL);
-}
-
-Value ASTInterpreter::visit_slice(BST_Slice* node) {
-    Value lower = node->lower ? visit_expr(node->lower) : getNone();
+Value ASTInterpreter::visit_makeslice(BST_MakeSlice* node) {
+    Value lower = node->vreg_lower != VREG_UNDEFINED ? getVReg(node->vreg_lower) : getNone();
     AUTO_DECREF(lower.o);
-    Value upper = node->upper ? visit_expr(node->upper) : getNone();
+    Value upper = node->vreg_upper != VREG_UNDEFINED ? getVReg(node->vreg_upper) : getNone();
     AUTO_DECREF(upper.o);
-    Value step = node->step ? visit_expr(node->step) : getNone();
+    Value step = node->vreg_step != VREG_UNDEFINED ? getVReg(node->vreg_step) : getNone();
     AUTO_DECREF(step.o);
 
     Value v;
@@ -655,22 +586,8 @@ Value ASTInterpreter::visit_slice(BST_Slice* node) {
     return v;
 }
 
-Value ASTInterpreter::visit_extslice(BST_ExtSlice* node) {
-    llvm::SmallVector<RewriterVar*, 8> items;
-
-    int num_slices = node->dims.size();
-    BoxedTuple* rtn = BoxedTuple::create(num_slices);
-    for (int i = 0; i < num_slices; ++i) {
-        Value v = visit_slice(node->dims[i]);
-        rtn->elts[i] = v.o;
-        items.push_back(v);
-    }
-
-    return Value(rtn, jit ? jit->emitCreateTuple(items) : NULL);
-}
-
-Value ASTInterpreter::visit_branch(BST_Branch* node) {
-    Value v = visit_expr(node->test);
+void ASTInterpreter::visit_branch(BST_Branch* node) {
+    Value v = getVReg(node->vreg_test);
     ASSERT(v.o == Py_True || v.o == Py_False, "Should have called NONZERO before this branch");
 
     // TODO could potentially avoid doing this if we skip the incref in NONZERO
@@ -692,8 +609,6 @@ Value ASTInterpreter::visit_branch(BST_Branch* node) {
         jit->emitJump(next_block);
         finishJITing(next_block);
     }
-
-    return Value();
 }
 
 Value ASTInterpreter::visit_jump(BST_Jump* node) {
@@ -869,130 +784,112 @@ Value ASTInterpreter::visit_invoke(BST_Invoke* node) {
     return v;
 }
 
-Value ASTInterpreter::visit_clsAttribute(BST_ClsAttribute* node) {
-    Value obj = visit_expr(node->value);
-    BoxedString* attr = node->attr.getBox();
-    AUTO_DECREF(obj.o);
-    return Value(getclsattr(obj.o, attr), jit ? jit->emitGetClsAttr(obj, attr) : NULL);
-}
-
 Value ASTInterpreter::visit_augBinOp(BST_AugBinOp* node) {
     assert(node->op_type != AST_TYPE::Is && node->op_type != AST_TYPE::IsNot && "not tested yet");
 
-    Value left = visit_expr(node->left);
+    Value left = getVReg(node->vreg_left);
     AUTO_DECREF(left.o);
-    Value right = visit_expr(node->right);
+    Value right = getVReg(node->vreg_right);
     AUTO_DECREF(right.o);
     return doBinOp(node, left, right, node->op_type, BinExpType::AugBinOp);
 }
 
-Value ASTInterpreter::visit_langPrimitive(BST_LangPrimitive* node) {
+Value ASTInterpreter::visit_landingpad(BST_Landingpad* node) {
+    assert(last_exception.type);
+    return Value(ASTInterpreterJitInterface::landingpadHelper(this), jit ? jit->emitLandingpad() : NULL);
+}
+
+Value ASTInterpreter::visit_locals(BST_Locals* node) {
+    assert(frame_info.boxedLocals != NULL);
+    return Value(incref(frame_info.boxedLocals), jit ? jit->emitGetBoxedLocals() : NULL);
+}
+
+Value ASTInterpreter::visit_getiter(BST_GetIter* node) {
+    Value val = getVReg(node->vreg_value);
+    AUTO_DECREF(val.o);
+    return Value(getPystonIter(val.o), jit ? jit->emitGetPystonIter(val) : NULL);
+}
+
+Value ASTInterpreter::visit_importfrom(BST_ImportFrom* node) {
+    Value module = getVReg(node->vreg_module);
+    AUTO_DECREF(module.o);
+
+    Value name_boxed = getVReg(node->vreg_name);
+    AUTO_DECREF(name_boxed.o);
+
     Value v;
-    if (node->opcode == BST_LangPrimitive::GET_ITER) {
-        assert(node->args.size() == 1);
-        Value val = visit_expr(node->args[0]);
-        AUTO_DECREF(val.o);
-        v = Value(getPystonIter(val.o), jit ? jit->emitGetPystonIter(val) : NULL);
-    } else if (node->opcode == BST_LangPrimitive::IMPORT_FROM) {
-        assert(node->args.size() == 2);
-        assert(node->args[0]->type == BST_TYPE::Name);
-        assert(node->args[1]->type == BST_TYPE::Str);
-
-        Value module = visit_expr(node->args[0]);
-        AUTO_DECREF(module.o);
-
-        auto ast_str = bst_cast<BST_Str>(node->args[1]);
-        assert(ast_str->str_type == AST_Str::STR);
-        const std::string& name = ast_str->str_data;
-        assert(name.size());
-        BORROWED(BoxedString*)name_boxed = source_info->parent_module->getStringConstant(name, true);
-
-        if (jit)
-            v.var = jit->emitImportFrom(module, name_boxed);
-        v.o = importFrom(module.o, name_boxed);
-    } else if (node->opcode == BST_LangPrimitive::IMPORT_NAME) {
-        assert(node->args.size() == 3);
-        assert(node->args[0]->type == BST_TYPE::Num);
-        assert(static_cast<BST_Num*>(node->args[0])->num_type == AST_Num::INT);
-        assert(node->args[2]->type == BST_TYPE::Str);
-
-        int level = static_cast<BST_Num*>(node->args[0])->n_int;
-        Value froms = visit_expr(node->args[1]);
-        AUTO_DECREF(froms.o);
-        auto ast_str = bst_cast<BST_Str>(node->args[2]);
-        assert(ast_str->str_type == AST_Str::STR);
-        const std::string& module_name = ast_str->str_data;
-        if (jit)
-            v.var = jit->emitImportName(level, froms, module_name);
-        v.o = import(level, froms.o, module_name);
-    } else if (node->opcode == BST_LangPrimitive::IMPORT_STAR) {
-        assert(node->args.size() == 1);
-        assert(node->args[0]->type == BST_TYPE::Name);
-
-        RELEASE_ASSERT(source_info->ast_type == BST_TYPE::Module || source_info->ast_type == BST_TYPE::Suite,
-                       "import * not supported in functions");
-
-        Value module = visit_expr(node->args[0]);
-        AUTO_DECREF(module.o);
-        v = Value(importStar(module.o, frame_info.globals), jit ? jit->emitImportStar(module) : NULL);
-    } else if (node->opcode == BST_LangPrimitive::NONE) {
-        v = getNone();
-    } else if (node->opcode == BST_LangPrimitive::LANDINGPAD) {
-        assert(last_exception.type);
-        v = Value(ASTInterpreterJitInterface::landingpadHelper(this), jit ? jit->emitLandingpad() : NULL);
-    } else if (node->opcode == BST_LangPrimitive::CHECK_EXC_MATCH) {
-        assert(node->args.size() == 2);
-        Value obj = visit_expr(node->args[0]);
-        AUTO_DECREF(obj.o);
-        Value cls = visit_expr(node->args[1]);
-        AUTO_DECREF(cls.o);
-        v = Value(boxBool(exceptionMatches(obj.o, cls.o)), jit ? jit->emitExceptionMatches(obj, cls) : NULL);
-    } else if (node->opcode == BST_LangPrimitive::LOCALS) {
-        assert(frame_info.boxedLocals != NULL);
-        v = Value(incref(frame_info.boxedLocals), jit ? jit->emitGetBoxedLocals() : NULL);
-    } else if (node->opcode == BST_LangPrimitive::NONZERO) {
-        assert(node->args.size() == 1);
-        Value obj = visit_expr(node->args[0]);
-        AUTO_DECREF(obj.o);
-        v = Value(boxBool(nonzero(obj.o)), jit ? jit->emitNonzero(obj) : NULL);
-    } else if (node->opcode == BST_LangPrimitive::SET_EXC_INFO) {
-        assert(node->args.size() == 3);
-
-        Value type = visit_expr(node->args[0]);
-        assert(type.o);
-        Value value = visit_expr(node->args[1]);
-        assert(value.o);
-        Value traceback = visit_expr(node->args[2]);
-        assert(traceback.o);
-
-        if (jit)
-            jit->emitSetExcInfo(type, value, traceback);
-        setFrameExcInfo(getFrameInfo(), type.o, value.o, traceback.o);
-        v = getNone();
-    } else if (node->opcode == BST_LangPrimitive::UNCACHE_EXC_INFO) {
-        assert(node->args.empty());
-        if (jit)
-            jit->emitUncacheExcInfo();
-        setFrameExcInfo(getFrameInfo(), NULL, NULL, NULL);
-        v = getNone();
-    } else if (node->opcode == BST_LangPrimitive::HASNEXT) {
-        assert(node->args.size() == 1);
-        Value obj = visit_expr(node->args[0]);
-        AUTO_DECREF(obj.o);
-        v = Value(boxBool(hasnext(obj.o)), jit ? jit->emitHasnext(obj) : NULL);
-    } else if (node->opcode == BST_LangPrimitive::PRINT_EXPR) {
-        abortJITing();
-        Value obj = visit_expr(node->args[0]);
-        AUTO_DECREF(obj.o);
-        printExprHelper(obj.o);
-        v = getNone();
-    } else
-        RELEASE_ASSERT(0, "unknown opcode %d", node->opcode);
+    if (jit)
+        v.var = jit->emitImportFrom(module, name_boxed);
+    v.o = importFrom(module.o, (BoxedString*)name_boxed.o);
+    return v;
+}
+Value ASTInterpreter::visit_importname(BST_ImportName* node) {
+    int level = node->level;
+    Value froms = getVReg(node->vreg_from);
+    AUTO_DECREF(froms.o);
+    Value module_name = getVReg(node->vreg_name);
+    AUTO_DECREF(module_name.o);
+    Value v;
+    if (jit)
+        v.var = jit->emitImportName(level, froms, module_name);
+    v.o = import(level, froms.o, (BoxedString*)module_name.o);
     return v;
 }
 
+Value ASTInterpreter::visit_importstar(BST_ImportStar* node) {
+    Value module = getVReg(node->vreg_name);
+    AUTO_DECREF(module.o);
+    return Value(importStar(module.o, frame_info.globals), jit ? jit->emitImportStar(module) : NULL);
+}
+
+Value ASTInterpreter::visit_nonzero(BST_Nonzero* node) {
+    Value obj = getVReg(node->vreg_value);
+    AUTO_DECREF(obj.o);
+    return Value(boxBool(nonzero(obj.o)), jit ? jit->emitNonzero(obj) : NULL);
+}
+
+Value ASTInterpreter::visit_checkexcmatch(BST_CheckExcMatch* node) {
+    Value obj = getVReg(node->vreg_value);
+    AUTO_DECREF(obj.o);
+    Value cls = getVReg(node->vreg_cls);
+    AUTO_DECREF(cls.o);
+    return Value(boxBool(exceptionMatches(obj.o, cls.o)), jit ? jit->emitExceptionMatches(obj, cls) : NULL);
+}
+
+void ASTInterpreter::visit_setexcinfo(BST_SetExcInfo* node) {
+    Value type = getVReg(node->vreg_type);
+    assert(type.o);
+    Value value = getVReg(node->vreg_value);
+    assert(value.o);
+    Value traceback = getVReg(node->vreg_traceback);
+    assert(traceback.o);
+
+    if (jit)
+        jit->emitSetExcInfo(type, value, traceback);
+    setFrameExcInfo(getFrameInfo(), type.o, value.o, traceback.o);
+}
+
+void ASTInterpreter::visit_uncacheexcinfo(BST_UncacheExcInfo* node) {
+    if (jit)
+        jit->emitUncacheExcInfo();
+    setFrameExcInfo(getFrameInfo(), NULL, NULL, NULL);
+}
+
+Value ASTInterpreter::visit_hasnext(BST_HasNext* node) {
+    Value obj = getVReg(node->vreg_value);
+    AUTO_DECREF(obj.o);
+    return Value(boxBool(hasnext(obj.o)), jit ? jit->emitHasnext(obj) : NULL);
+}
+
+void ASTInterpreter::visit_printexpr(BST_PrintExpr* node) {
+    abortJITing();
+    Value obj = getVReg(node->vreg_value);
+    AUTO_DECREF(obj.o);
+    printExprHelper(obj.o);
+}
+
 Value ASTInterpreter::visit_yield(BST_Yield* node) {
-    Value value = node->value ? visit_expr(node->value) : getNone();
+    Value value = node->vreg_value != VREG_UNDEFINED ? getVReg(node->vreg_value) : getNone();
     return Value(ASTInterpreterJitInterface::yieldHelper(this, value.o), jit ? jit->emitYield(value) : NULL);
 }
 
@@ -1003,51 +900,49 @@ Value ASTInterpreter::visit_stmt(BST_stmt* node) {
 
     if (0) {
         printf("%20s % 2d ", getCode()->name->c_str(), current_block->idx);
-        print_bst(node);
+        print_bst(node, getConstantVRegInfo());
         printf("\n");
     }
 
-    Value rtn;
+    // Any statement that returns a value needs
+    // to be careful to wrap pendingCallsCheckHelper, and it can signal that it was careful
+    // by returning from the function instead of breaking.
+
     switch (node->type) {
         case BST_TYPE::Assert:
-            rtn = visit_assert((BST_Assert*)node);
+            visit_assert((BST_Assert*)node);
             ASTInterpreterJitInterface::pendingCallsCheckHelper();
             break;
-        case BST_TYPE::Assign:
-            rtn = visit_assign((BST_Assign*)node);
+        case BST_TYPE::DeleteAttr:
+            visit_deleteattr((BST_DeleteAttr*)node);
             ASTInterpreterJitInterface::pendingCallsCheckHelper();
             break;
-        case BST_TYPE::Delete:
-            rtn = visit_delete((BST_Delete*)node);
+        case BST_TYPE::DeleteSub:
+            visit_deletesub((BST_DeleteSub*)node);
+            ASTInterpreterJitInterface::pendingCallsCheckHelper();
+            break;
+        case BST_TYPE::DeleteSubSlice:
+            visit_deletesubslice((BST_DeleteSubSlice*)node);
+            ASTInterpreterJitInterface::pendingCallsCheckHelper();
+            break;
+        case BST_TYPE::DeleteName:
+            visit_deletename((BST_DeleteName*)node);
             ASTInterpreterJitInterface::pendingCallsCheckHelper();
             break;
         case BST_TYPE::Exec:
-            rtn = visit_exec((BST_Exec*)node);
+            visit_exec((BST_Exec*)node);
             ASTInterpreterJitInterface::pendingCallsCheckHelper();
             break;
-        case BST_TYPE::Expr:
-            // docstrings are str constant expression statements.
-            // ignore those while interpreting.
-            if ((((BST_Expr*)node)->value)->type != BST_TYPE::Str) {
-                rtn = visit_expr((BST_Expr*)node);
-                Py_DECREF(rtn.o);
-                rtn = Value();
-                ASTInterpreterJitInterface::pendingCallsCheckHelper();
-            }
-            break;
-        case BST_TYPE::Pass:
-            ASTInterpreterJitInterface::pendingCallsCheckHelper();
-            break; // nothing todo
         case BST_TYPE::Print:
-            rtn = visit_print((BST_Print*)node);
+            visit_print((BST_Print*)node);
             ASTInterpreterJitInterface::pendingCallsCheckHelper();
             break;
         case BST_TYPE::Raise:
-            rtn = visit_raise((BST_Raise*)node);
+            visit_raise((BST_Raise*)node);
             ASTInterpreterJitInterface::pendingCallsCheckHelper();
             break;
-        case BST_TYPE::Return:
-            rtn = visit_return((BST_Return*)node);
+        case BST_TYPE::Return: {
+            Value rtn = visit_return((BST_Return*)node);
             try {
                 ASTInterpreterJitInterface::pendingCallsCheckHelper();
             } catch (ExcInfo e) {
@@ -1055,32 +950,152 @@ Value ASTInterpreter::visit_stmt(BST_stmt* node) {
                 throw e;
             }
             return rtn;
-
-        // pseudo
+        }
+        case BST_TYPE::StoreName:
+            visit_storename((BST_StoreName*)node);
+            ASTInterpreterJitInterface::pendingCallsCheckHelper();
+            break;
+        case BST_TYPE::StoreAttr:
+            visit_storeattr((BST_StoreAttr*)node);
+            ASTInterpreterJitInterface::pendingCallsCheckHelper();
+            break;
+        case BST_TYPE::StoreSub:
+            visit_storesub((BST_StoreSub*)node);
+            ASTInterpreterJitInterface::pendingCallsCheckHelper();
+            break;
+        case BST_TYPE::StoreSubSlice:
+            visit_storesubslice((BST_StoreSubSlice*)node);
+            ASTInterpreterJitInterface::pendingCallsCheckHelper();
+            break;
+        case BST_TYPE::UnpackIntoArray:
+            visit_unpackintoarray((BST_UnpackIntoArray*)node);
+            ASTInterpreterJitInterface::pendingCallsCheckHelper();
+            break;
         case BST_TYPE::Branch:
-            rtn = visit_branch((BST_Branch*)node);
+            visit_branch((BST_Branch*)node);
             break;
         case BST_TYPE::Jump:
-            rtn = visit_jump((BST_Jump*)node);
-            return rtn;
+            return visit_jump((BST_Jump*)node);
         case BST_TYPE::Invoke:
-            rtn = visit_invoke((BST_Invoke*)node);
+            visit_invoke((BST_Invoke*)node);
             break;
-        default:
-            RELEASE_ASSERT(0, "not implemented");
+        case BST_TYPE::SetExcInfo:
+            visit_setexcinfo((BST_SetExcInfo*)node);
+            ASTInterpreterJitInterface::pendingCallsCheckHelper();
+            break;
+        case BST_TYPE::UncacheExcInfo:
+            visit_uncacheexcinfo((BST_UncacheExcInfo*)node);
+            ASTInterpreterJitInterface::pendingCallsCheckHelper();
+            break;
+        case BST_TYPE::PrintExpr:
+            visit_printexpr((BST_PrintExpr*)node);
+            ASTInterpreterJitInterface::pendingCallsCheckHelper();
+            break;
+
+        // Handle all cases which are derived from BST_stmt_with_dest
+        default: {
+            Value v;
+            switch (node->type) {
+                case BST_TYPE::CopyVReg:
+                    v = visit_copyvreg((BST_CopyVReg*)node);
+                    break;
+                case BST_TYPE::AugBinOp:
+                    v = visit_augBinOp((BST_AugBinOp*)node);
+                    break;
+                case BST_TYPE::CallFunc:
+                case BST_TYPE::CallAttr:
+                case BST_TYPE::CallClsAttr:
+                    v = visit_call((BST_Call*)node);
+                    break;
+                case BST_TYPE::Compare:
+                    v = visit_compare((BST_Compare*)node);
+                    break;
+                case BST_TYPE::BinOp:
+                    v = visit_binop((BST_BinOp*)node);
+                    break;
+                case BST_TYPE::Dict:
+                    v = visit_dict((BST_Dict*)node);
+                    break;
+                case BST_TYPE::List:
+                    v = visit_list((BST_List*)node);
+                    break;
+                case BST_TYPE::Repr:
+                    v = visit_repr((BST_Repr*)node);
+                    break;
+                case BST_TYPE::Set:
+                    v = visit_set((BST_Set*)node);
+                    break;
+                case BST_TYPE::Tuple:
+                    v = visit_tuple((BST_Tuple*)node);
+                    break;
+                case BST_TYPE::UnaryOp:
+                    v = visit_unaryop((BST_UnaryOp*)node);
+                    break;
+                case BST_TYPE::Yield:
+                    v = visit_yield((BST_Yield*)node);
+                    break;
+                case BST_TYPE::Landingpad:
+                    v = visit_landingpad((BST_Landingpad*)node);
+                    break;
+                case BST_TYPE::Locals:
+                    v = visit_locals((BST_Locals*)node);
+                    break;
+                case BST_TYPE::LoadName:
+                    v = visit_loadname((BST_LoadName*)node);
+                    break;
+                case BST_TYPE::LoadAttr:
+                    v = visit_loadattr((BST_LoadAttr*)node);
+                    break;
+                case BST_TYPE::GetIter:
+                    v = visit_getiter((BST_GetIter*)node);
+                    break;
+                case BST_TYPE::ImportFrom:
+                    v = visit_importfrom((BST_ImportFrom*)node);
+                    break;
+                case BST_TYPE::ImportName:
+                    v = visit_importname((BST_ImportName*)node);
+                    break;
+                case BST_TYPE::ImportStar:
+                    v = visit_importstar((BST_ImportStar*)node);
+                    break;
+                case BST_TYPE::Nonzero:
+                    v = visit_nonzero((BST_Nonzero*)node);
+                    break;
+                case BST_TYPE::CheckExcMatch:
+                    v = visit_checkexcmatch((BST_CheckExcMatch*)node);
+                    break;
+                case BST_TYPE::HasNext:
+                    v = visit_hasnext((BST_HasNext*)node);
+                    break;
+                case BST_TYPE::MakeClass:
+                    v = visit_makeClass((BST_MakeClass*)node);
+                    break;
+                case BST_TYPE::MakeFunction:
+                    v = visit_makeFunction((BST_MakeFunction*)node);
+                    break;
+                case BST_TYPE::LoadSub:
+                    v = visit_loadsub((BST_LoadSub*)node);
+                    break;
+                case BST_TYPE::LoadSubSlice:
+                    v = visit_loadsubslice((BST_LoadSubSlice*)node);
+                    break;
+                case BST_TYPE::MakeSlice:
+                    v = visit_makeslice((BST_MakeSlice*)node);
+                    break;
+                default:
+                    RELEASE_ASSERT(0, "not implemented %d", node->type);
+            };
+            doStore(((BST_stmt_with_dest*)node)->vreg_dst, v);
+            ASTInterpreterJitInterface::pendingCallsCheckHelper();
+            break;
+        }
     };
 
-    // This assertion tries to make sure that we are refcount-safe if an exception
-    // is thrown from pendingCallsCheckHelper.  Any statement that returns a value needs
-    // to be careful to wrap pendingCallsCheckHelper, and it can signal that it was careful
-    // by returning from the function instead of breaking.
-    assert(!rtn.o);
-
-    return rtn;
+    return Value();
 }
 
 Value ASTInterpreter::visit_return(BST_Return* node) {
-    Value s = node->value ? visit_expr(node->value) : getNone();
+    Value s = node->vreg_value != VREG_UNDEFINED ? getVReg(node->vreg_value) : getNone();
 
     if (jit) {
         jit->emitReturn(s);
@@ -1109,26 +1124,25 @@ Value ASTInterpreter::visit_return(BST_Return* node) {
     return s;
 }
 
-Value ASTInterpreter::createFunction(BST_FunctionDef* node, BST_arguments* args) {
+Value ASTInterpreter::createFunction(BST_FunctionDef* node) {
     BoxedCode* code = node->code;
     assert(code);
 
     std::vector<Box*> defaults;
     llvm::SmallVector<RewriterVar*, 4> defaults_vars;
-    defaults.reserve(args->defaults.size());
+    defaults.reserve(node->num_defaults);
 
     RewriterVar* defaults_var = NULL;
     if (jit) {
-        defaults_var = args->defaults.size() ? jit->allocate(args->defaults.size()) : jit->imm(0ul);
-        defaults_vars.reserve(args->defaults.size());
+        defaults_var = node->num_defaults ? jit->allocate(node->num_defaults) : jit->imm(0ul);
+        defaults_vars.reserve(node->num_defaults);
     }
 
-    int i = 0;
-    for (BST_expr* d : args->defaults) {
-        Value v = visit_expr(d);
+    for (int i = 0; i < node->num_defaults; ++i) {
+        Value v = getVReg(node->elts[node->num_decorator + i]);
         defaults.push_back(v.o);
         if (jit) {
-            defaults_var->setAttr(i++ * sizeof(void*), v, RewriterVar::SetattrType::REF_USED);
+            defaults_var->setAttr(i * sizeof(void*), v, RewriterVar::SetattrType::REF_USED);
             defaults_vars.push_back(v.var);
         }
     }
@@ -1181,7 +1195,7 @@ Value ASTInterpreter::createFunction(BST_FunctionDef* node, BST_arguments* args)
             passed_globals_var = jit->imm(0ul);
         // TODO: have to track this GC ref
         rtn.var = jit->call(false, (void*)createFunctionFromMetadata, { jit->imm(code), closure_var, passed_globals_var,
-                                                                        defaults_var, jit->imm(args->defaults.size()) },
+                                                                        defaults_var, jit->imm(node->num_defaults) },
                             {}, defaults_vars)->setType(RefType::OWNED);
     }
 
@@ -1192,14 +1206,13 @@ Value ASTInterpreter::createFunction(BST_FunctionDef* node, BST_arguments* args)
 
 Value ASTInterpreter::visit_makeFunction(BST_MakeFunction* mkfn) {
     BST_FunctionDef* node = mkfn->function_def;
-    BST_arguments* args = node->args;
 
     std::vector<Value> decorators;
-    decorators.reserve(node->decorator_list.size());
-    for (BST_expr* d : node->decorator_list)
-        decorators.push_back(visit_expr(d));
+    decorators.reserve(node->num_decorator);
+    for (int i = 0; i < node->num_decorator; ++i)
+        decorators.push_back(getVReg(node->elts[i]));
 
-    Value func = createFunction(node, args);
+    Value func = createFunction(node);
 
     for (int i = decorators.size() - 1; i >= 0; i--) {
         func.o = runtimeCall(autoDecref(decorators[i].o), ArgPassSpec(1), autoDecref(func.o), 0, 0, 0, 0);
@@ -1217,17 +1230,15 @@ Value ASTInterpreter::visit_makeClass(BST_MakeClass* mkclass) {
     BST_ClassDef* node = mkclass->class_def;
 
 
-    BoxedTuple* basesTuple = BoxedTuple::create(node->bases.size());
-    AUTO_DECREF(basesTuple);
-    int base_idx = 0;
-    for (BST_expr* b : node->bases) {
-        basesTuple->elts[base_idx++] = visit_expr(b).o;
-    }
+    BoxedTuple* bases_tuple = (BoxedTuple*)getVReg(node->vreg_bases_tuple).o;
+    assert(bases_tuple->cls == tuple_cls);
+    AUTO_DECREF(bases_tuple);
 
     std::vector<Box*> decorators;
-    decorators.reserve(node->decorator_list.size());
-    for (BST_expr* d : node->decorator_list)
-        decorators.push_back(visit_expr(d).o);
+    decorators.reserve(node->num_decorator);
+    for (int i = 0; i < node->num_decorator; ++i) {
+        decorators.push_back(getVReg(node->decorator[i]).o);
+    }
 
     BoxedCode* code = node->code;
     assert(code);
@@ -1250,7 +1261,7 @@ Value ASTInterpreter::visit_makeClass(BST_MakeClass* mkclass) {
                                 ArgPassSpec(0), 0, 0, 0, 0, 0);
     AUTO_DECREF(attrDict);
 
-    Box* classobj = createUserClass(node->name.getBox(), basesTuple, attrDict);
+    Box* classobj = createUserClass(node->name.getBox(), bases_tuple, attrDict);
 
     for (int i = decorators.size() - 1; i >= 0; i--) {
         classobj = runtimeCall(autoDecref(decorators[i]), ArgPassSpec(1), autoDecref(classobj), 0, 0, 0, 0);
@@ -1259,10 +1270,10 @@ Value ASTInterpreter::visit_makeClass(BST_MakeClass* mkclass) {
     return Value(classobj, NULL);
 }
 
-Value ASTInterpreter::visit_raise(BST_Raise* node) {
-    if (node->arg0 == NULL) {
-        assert(!node->arg1);
-        assert(!node->arg2);
+void ASTInterpreter::visit_raise(BST_Raise* node) {
+    if (node->vreg_arg0 == VREG_UNDEFINED) {
+        assert(node->vreg_arg1 == VREG_UNDEFINED);
+        assert(node->vreg_arg2 == VREG_UNDEFINED);
 
         if (jit) {
             jit->emitRaise0();
@@ -1272,9 +1283,9 @@ Value ASTInterpreter::visit_raise(BST_Raise* node) {
         ASTInterpreterJitInterface::raise0Helper(this);
     }
 
-    Value arg0 = node->arg0 ? visit_expr(node->arg0) : getNone();
-    Value arg1 = node->arg1 ? visit_expr(node->arg1) : getNone();
-    Value arg2 = node->arg2 ? visit_expr(node->arg2) : getNone();
+    Value arg0 = node->vreg_arg0 != VREG_UNDEFINED ? getVReg(node->vreg_arg0) : getNone();
+    Value arg1 = node->vreg_arg1 != VREG_UNDEFINED ? getVReg(node->vreg_arg1) : getNone();
+    Value arg2 = node->vreg_arg2 != VREG_UNDEFINED ? getVReg(node->vreg_arg2) : getNone();
 
     if (jit) {
         jit->emitRaise3(arg0, arg1, arg2);
@@ -1282,206 +1293,124 @@ Value ASTInterpreter::visit_raise(BST_Raise* node) {
     }
 
     raise3(arg0.o, arg1.o, arg2.o);
-    return Value();
 }
 
-Value ASTInterpreter::visit_assert(BST_Assert* node) {
+void ASTInterpreter::visit_assert(BST_Assert* node) {
     abortJITing();
-#ifndef NDEBUG
-    // Currently we only generate "assert 0" statements
-    Value v = visit_expr(node->test);
-    assert(v.o->cls == int_cls && static_cast<BoxedInt*>(v.o)->n == 0);
-    Py_DECREF(v.o);
-#endif
 
     static BoxedString* AssertionError_str = getStaticString("AssertionError");
     Box* assertion_type = getGlobal(frame_info.globals, AssertionError_str);
     AUTO_DECREF(assertion_type);
-    Box* msg = node->msg ? visit_expr(node->msg).o : 0;
+    Box* msg = node->vreg_msg != VREG_UNDEFINED ? getVReg(node->vreg_msg).o : 0;
     AUTO_XDECREF(msg);
     assertFail(assertion_type, msg);
-
-    return Value();
 }
 
-Value ASTInterpreter::visit_delete(BST_Delete* node) {
-    BST_expr* target_ = node->target;
-    switch (target_->type) {
-        case BST_TYPE::Subscript: {
-            BST_Subscript* sub = (BST_Subscript*)target_;
-            Value value = visit_expr(sub->value);
-            AUTO_DECREF(value.o);
+void ASTInterpreter::visit_deleteattr(BST_DeleteAttr* node) {
+    Value target = getVReg(node->vreg_value);
+    AUTO_DECREF(target.o);
+    BoxedString* str = node->attr.getBox();
+    if (jit)
+        jit->emitDelAttr(target, str);
+    delattr(target.o, str);
+}
 
-            bool is_slice = (sub->slice->type == BST_TYPE::Slice) && (((BST_Slice*)sub->slice)->step == NULL);
-            if (is_slice) {
-                BST_Slice* slice = (BST_Slice*)sub->slice;
-                Value lower = slice->lower ? visit_expr(slice->lower) : Value();
-                AUTO_XDECREF(lower.o);
-                Value upper = slice->upper ? visit_expr(slice->upper) : Value();
-                AUTO_XDECREF(upper.o);
-                assert(slice->step == NULL);
+void ASTInterpreter::visit_deletesub(BST_DeleteSub* node) {
+    Value value = getVReg(node->vreg_value);
+    AUTO_DECREF(value.o);
+    Value slice = getVReg(node->vreg_slice);
+    AUTO_DECREF(slice.o);
+    if (jit)
+        jit->emitDelItem(value, slice);
+    delitem(value.o, slice.o);
+}
 
-                if (jit)
-                    jit->emitAssignSlice(value, lower, upper, jit->imm(0ul));
-                assignSlice(value.o, lower.o, upper.o, NULL);
-            } else {
-                Value slice = visit_slice(sub->slice);
-                AUTO_DECREF(slice.o);
-                if (jit)
-                    jit->emitDelItem(value, slice);
-                delitem(value.o, slice.o);
-            }
-            break;
-        }
-        case BST_TYPE::Attribute: {
-            BST_Attribute* attr = (BST_Attribute*)target_;
-            Value target = visit_expr(attr->value);
-            AUTO_DECREF(target.o);
-            BoxedString* str = attr->attr.getBox();
+void ASTInterpreter::visit_deletesubslice(BST_DeleteSubSlice* node) {
+    Value value = getVReg(node->vreg_value);
+    AUTO_DECREF(value.o);
+    Value lower = node->vreg_lower != VREG_UNDEFINED ? getVReg(node->vreg_lower) : Value();
+    AUTO_XDECREF(lower.o);
+    Value upper = node->vreg_upper != VREG_UNDEFINED ? getVReg(node->vreg_upper) : Value();
+    AUTO_XDECREF(upper.o);
+
+    if (jit)
+        jit->emitAssignSlice(value, lower, upper, jit->imm(0ul));
+    assignSlice(value.o, lower.o, upper.o, NULL);
+}
+
+void ASTInterpreter::visit_deletename(BST_DeleteName* target) {
+    assert(target->lookup_type != ScopeInfo::VarScopeType::UNKNOWN);
+
+    ScopeInfo::VarScopeType vst = target->lookup_type;
+    if (vst == ScopeInfo::VarScopeType::GLOBAL) {
+        if (jit)
+            jit->emitDelGlobal(target->id.getBox());
+        delGlobal(frame_info.globals, target->id.getBox());
+    } else if (vst == ScopeInfo::VarScopeType::NAME) {
+        if (jit)
+            jit->emitDelName(target->id);
+        ASTInterpreterJitInterface::delNameHelper(this, target->id);
+    } else {
+        assert(vst == ScopeInfo::VarScopeType::FAST);
+
+        assert(getVRegInfo().getVReg(target->id) == target->vreg);
+
+        if (target->id.s()[0] == '#') {
+            assert(vregs[target->vreg] != NULL);
             if (jit)
-                jit->emitDelAttr(target, str);
-            delattr(target.o, str);
-            break;
-        }
-        case BST_TYPE::Name: {
-            BST_Name* target = (BST_Name*)target_;
-            assert(target->lookup_type != ScopeInfo::VarScopeType::UNKNOWN);
-
-            ScopeInfo::VarScopeType vst = target->lookup_type;
-            if (vst == ScopeInfo::VarScopeType::GLOBAL) {
-                if (jit)
-                    jit->emitDelGlobal(target->id.getBox());
-                delGlobal(frame_info.globals, target->id.getBox());
-                break;
-            } else if (vst == ScopeInfo::VarScopeType::NAME) {
-                if (jit)
-                    jit->emitDelName(target->id);
-                ASTInterpreterJitInterface::delNameHelper(this, target->id);
-            } else {
-                assert(vst == ScopeInfo::VarScopeType::FAST);
-
-                assert(getVRegInfo().getVReg(target->id) == target->vreg);
-
-                if (target->id.s()[0] == '#') {
-                    assert(vregs[target->vreg] != NULL);
-                    if (jit)
-                        jit->emitKillTemporary(target);
-                } else {
-                    abortJITing();
-                    if (vregs[target->vreg] == 0) {
-                        assertNameDefined(0, target->id.c_str(), NameError, true /* local_var_msg */);
-                        return Value();
-                    }
-                }
-
-                frame_info.num_vregs = std::max(frame_info.num_vregs, target->vreg + 1);
-                Py_DECREF(vregs[target->vreg]);
-                vregs[target->vreg] = NULL;
+                jit->emitKillTemporary(target->vreg);
+        } else {
+            abortJITing();
+            if (vregs[target->vreg] == 0) {
+                assertNameDefined(0, target->id.c_str(), NameError, true /* local_var_msg */);
+                return;
             }
-            break;
         }
-        default:
-            ASSERT(0, "Unsupported del target: %d", target_->type);
-            abort();
+
+        frame_info.num_vregs = std::max(frame_info.num_vregs, target->vreg + 1);
+        Py_DECREF(vregs[target->vreg]);
+        vregs[target->vreg] = NULL;
     }
-    return Value();
 }
 
-Value ASTInterpreter::visit_assign(BST_Assign* node) {
-    Value v = visit_expr(node->value);
-    doStore(node->target, v);
-    return Value();
+Value ASTInterpreter::visit_copyvreg(BST_CopyVReg* node) {
+    return getVReg(node->vreg_src, false /* don't kill */);
 }
 
-Value ASTInterpreter::visit_print(BST_Print* node) {
-    Value dest = node->dest ? visit_expr(node->dest) : Value();
-    Value var = node->value ? visit_expr(node->value) : Value();
+void ASTInterpreter::visit_print(BST_Print* node) {
+    Value dest = node->vreg_dest != VREG_UNDEFINED ? getVReg(node->vreg_dest) : Value();
+    Value var = node->vreg_value != VREG_UNDEFINED ? getVReg(node->vreg_value) : Value();
 
     if (jit)
         jit->emitPrint(dest, var, node->nl);
 
-    if (node->dest)
+    if (node->vreg_dest != VREG_UNDEFINED)
         printHelper(autoDecref(dest.o), autoXDecref(var.o), node->nl);
     else
         printHelper(NULL, autoXDecref(var.o), node->nl);
-
-    return Value();
 }
 
-Value ASTInterpreter::visit_exec(BST_Exec* node) {
+void ASTInterpreter::visit_exec(BST_Exec* node) {
     // TODO implement the locals and globals arguments
-    Value code = visit_expr(node->body);
+    Value code = getVReg(node->vreg_body);
     AUTO_DECREF(code.o);
-    Value globals = node->globals == NULL ? Value() : visit_expr(node->globals);
+    Value globals = node->vreg_globals == VREG_UNDEFINED ? Value() : getVReg(node->vreg_globals);
     AUTO_XDECREF(globals.o);
-    Value locals = node->locals == NULL ? Value() : visit_expr(node->locals);
+    Value locals = node->vreg_locals == VREG_UNDEFINED ? Value() : getVReg(node->vreg_locals);
     AUTO_XDECREF(locals.o);
 
     if (jit)
         jit->emitExec(code, globals, locals, this->source_info->future_flags);
     exec(code.o, globals.o, locals.o, this->source_info->future_flags);
-
-    return Value();
 }
 
 Value ASTInterpreter::visit_compare(BST_Compare* node) {
-    Value left = visit_expr(node->left);
+    Value left = getVReg(node->vreg_left);
     AUTO_DECREF(left.o);
-    Value right = visit_expr(node->comparator);
+    Value right = getVReg(node->vreg_comparator);
     AUTO_DECREF(right.o);
     return doBinOp(node, left, right, node->op, BinExpType::Compare);
 }
-
-Value ASTInterpreter::visit_expr(BST_expr* node) {
-    switch (node->type) {
-        case BST_TYPE::Attribute:
-            return visit_attribute((BST_Attribute*)node);
-        case BST_TYPE::BinOp:
-            return visit_binop((BST_BinOp*)node);
-        case BST_TYPE::Call:
-            return visit_call((BST_Call*)node);
-        case BST_TYPE::Compare:
-            return visit_compare((BST_Compare*)node);
-        case BST_TYPE::Dict:
-            return visit_dict((BST_Dict*)node);
-        case BST_TYPE::List:
-            return visit_list((BST_List*)node);
-        case BST_TYPE::Name:
-            return visit_name((BST_Name*)node);
-        case BST_TYPE::Num:
-            return visit_num((BST_Num*)node);
-        case BST_TYPE::Repr:
-            return visit_repr((BST_Repr*)node);
-        case BST_TYPE::Set:
-            return visit_set((BST_Set*)node);
-        case BST_TYPE::Str:
-            return visit_str((BST_Str*)node);
-        case BST_TYPE::Subscript:
-            return visit_subscript((BST_Subscript*)node);
-        case BST_TYPE::Tuple:
-            return visit_tuple((BST_Tuple*)node);
-        case BST_TYPE::UnaryOp:
-            return visit_unaryop((BST_UnaryOp*)node);
-        case BST_TYPE::Yield:
-            return visit_yield((BST_Yield*)node);
-
-        // pseudo
-        case BST_TYPE::AugBinOp:
-            return visit_augBinOp((BST_AugBinOp*)node);
-        case BST_TYPE::ClsAttribute:
-            return visit_clsAttribute((BST_ClsAttribute*)node);
-        case BST_TYPE::LangPrimitive:
-            return visit_langPrimitive((BST_LangPrimitive*)node);
-        case BST_TYPE::MakeClass:
-            return visit_makeClass((BST_MakeClass*)node);
-        case BST_TYPE::MakeFunction:
-            return visit_makeFunction((BST_MakeFunction*)node);
-        default:
-            RELEASE_ASSERT(0, "");
-    };
-    return Value();
-}
-
 
 Value ASTInterpreter::visit_call(BST_Call* node) {
     Value v;
@@ -1491,60 +1420,60 @@ Value ASTInterpreter::visit_call(BST_Call* node) {
 
     bool is_callattr = false;
     bool callattr_clsonly = false;
-    if (node->func->type == BST_TYPE::Attribute) {
+    int* vreg_elts = NULL;
+    if (node->type == BST_TYPE::CallAttr) {
         is_callattr = true;
         callattr_clsonly = false;
-        BST_Attribute* attr_ast = bst_cast<BST_Attribute>(node->func);
-        func = visit_expr(attr_ast->value);
+        auto* attr_ast = bst_cast<BST_CallAttr>(node);
+        func = getVReg(attr_ast->vreg_value);
         attr = attr_ast->attr;
-    } else if (node->func->type == BST_TYPE::ClsAttribute) {
+        vreg_elts = bst_cast<BST_CallAttr>(node)->elts;
+    } else if (node->type == BST_TYPE::CallClsAttr) {
         is_callattr = true;
         callattr_clsonly = true;
-        BST_ClsAttribute* attr_ast = bst_cast<BST_ClsAttribute>(node->func);
-        func = visit_expr(attr_ast->value);
+        auto* attr_ast = bst_cast<BST_CallClsAttr>(node);
+        func = getVReg(attr_ast->vreg_value);
         attr = attr_ast->attr;
+        vreg_elts = bst_cast<BST_CallClsAttr>(node)->elts;
     } else {
-        func = visit_expr(node->func);
+        auto* attr_ast = bst_cast<BST_CallFunc>(node);
+        func = getVReg(attr_ast->vreg_func);
+        vreg_elts = bst_cast<BST_CallFunc>(node)->elts;
     }
 
     AUTO_DECREF(func.o);
 
     llvm::SmallVector<Box*, 8> args;
     llvm::SmallVector<RewriterVar*, 8> args_vars;
-    args.reserve(node->args.size());
-    args_vars.reserve(node->args.size());
+    args.reserve(node->num_args + node->num_keywords);
+    args_vars.reserve(node->num_args + node->num_keywords);
 
-    for (BST_expr* e : node->args) {
-        Value v = visit_expr(e);
+    for (int i = 0; i < node->num_args + node->num_keywords; ++i) {
+        Value v = getVReg(vreg_elts[i]);
         args.push_back(v.o);
         args_vars.push_back(v);
     }
 
     std::vector<BoxedString*>* keyword_names = NULL;
-    if (node->keywords.size())
-        keyword_names = getKeywordNameStorage(node);
+    if (node->num_keywords)
+        keyword_names = node->keywords_names.get();
 
-    for (BST_keyword* k : node->keywords) {
-        Value v = visit_expr(k->value);
+    if (node->vreg_starargs != VREG_UNDEFINED) {
+        Value v = getVReg(node->vreg_starargs);
         args.push_back(v.o);
         args_vars.push_back(v);
     }
 
-    if (node->starargs) {
-        Value v = visit_expr(node->starargs);
-        args.push_back(v.o);
-        args_vars.push_back(v);
-    }
-
-    if (node->kwargs) {
-        Value v = visit_expr(node->kwargs);
+    if (node->vreg_kwargs != VREG_UNDEFINED) {
+        Value v = getVReg(node->vreg_kwargs);
         args.push_back(v.o);
         args_vars.push_back(v);
     }
 
     AUTO_DECREF_ARRAY(args.data(), args.size());
 
-    ArgPassSpec argspec(node->args.size(), node->keywords.size(), node->starargs, node->kwargs);
+    ArgPassSpec argspec(node->num_args, node->num_keywords, node->vreg_starargs != VREG_UNDEFINED,
+                        node->vreg_kwargs != VREG_UNDEFINED);
 
     if (is_callattr) {
         CallattrFlags callattr_flags{.cls_only = callattr_clsonly, .null_on_nonexistent = false, .argspec = argspec };
@@ -1566,56 +1495,15 @@ Value ASTInterpreter::visit_call(BST_Call* node) {
     return v;
 }
 
-
-Value ASTInterpreter::visit_expr(BST_Expr* node) {
-    return visit_expr(node->value);
-}
-
-Value ASTInterpreter::visit_num(BST_Num* node) {
-    Box* o = NULL;
-    if (node->num_type == AST_Num::INT) {
-        o = parent_module->getIntConstant(node->n_int);
-    } else if (node->num_type == AST_Num::FLOAT) {
-        o = parent_module->getFloatConstant(node->n_float);
-    } else if (node->num_type == AST_Num::LONG) {
-        o = parent_module->getLongConstant(node->n_long);
-    } else if (node->num_type == AST_Num::COMPLEX) {
-        o = parent_module->getPureImaginaryConstant(node->n_float);
-    } else
-        RELEASE_ASSERT(0, "not implemented");
-    Py_INCREF(o);
-    RewriterVar* v = NULL;
-    if (jit) {
-        v = jit->imm(o)->setType(RefType::BORROWED);
-    }
-    return Value(o, v);
-}
-
-Value ASTInterpreter::visit_index(BST_Index* node) {
-    return visit_expr(node->value);
-}
-
 Value ASTInterpreter::visit_repr(BST_Repr* node) {
-    Value v = visit_expr(node->value);
+    Value v = getVReg(node->vreg_value);
     AUTO_DECREF(v.o);
     return Value(repr(v.o), jit ? jit->emitRepr(v) : NULL);
 }
 
 Value ASTInterpreter::visit_dict(BST_Dict* node) {
-    RELEASE_ASSERT(node->keys.size() == node->values.size(), "not implemented");
-
     BoxedDict* dict = new BoxedDict();
     RewriterVar* r_dict = jit ? jit->emitCreateDict() : NULL;
-    for (size_t i = 0; i < node->keys.size(); ++i) {
-        Value v = visit_expr(node->values[i]);
-        Value k = visit_expr(node->keys[i]);
-
-        dictSetInternal(dict, k.o, v.o);
-        if (jit) {
-            jit->emitDictSet(r_dict, k, v);
-        }
-    }
-
     return Value(dict, r_dict);
 }
 
@@ -1625,8 +1513,8 @@ Value ASTInterpreter::visit_set(BST_Set* node) {
         // insert the elements in reverse like cpython does
         // important for {1, 1L}
         llvm::SmallVector<RewriterVar*, 8> items;
-        for (auto it = node->elts.rbegin(), it_end = node->elts.rend(); it != it_end; ++it) {
-            Value v = visit_expr(*it);
+        for (int i = node->num_elts - 1; i >= 0; --i) {
+            Value v = getVReg(node->elts[i]);
             _setAddStolen(set, v.o);
             items.push_back(v);
         }
@@ -1637,25 +1525,59 @@ Value ASTInterpreter::visit_set(BST_Set* node) {
     }
 }
 
-Value ASTInterpreter::visit_str(BST_Str* node) {
-    Box* o = NULL;
-    if (node->str_type == AST_Str::STR) {
-        o = parent_module->getStringConstant(node->str_data, true);
-    } else if (node->str_type == AST_Str::UNICODE) {
-        o = parent_module->getUnicodeConstant(node->str_data);
-    } else {
-        RELEASE_ASSERT(0, "%d", node->str_type);
+Value ASTInterpreter::getVReg(int vreg, bool is_kill) {
+    assert(vreg != VREG_UNDEFINED);
+    if (vreg < 0) {
+        Box* o = getConstantVRegInfo().getConstant(vreg);
+        return Value(incref(o), jit ? jit->imm(o)->setType(RefType::BORROWED) : NULL);
     }
-    Py_INCREF(o);
-    return Value(o, jit ? jit->imm(o)->setType(RefType::BORROWED) : NULL);
+
+    Value v;
+    if (jit) {
+        bool is_live = true;
+        if (is_kill) {
+            is_live = false;
+        } else {
+            is_live = source_info->getLiveness()->isLiveAtEnd(vreg, current_block);
+        }
+
+        if (is_live) {
+            assert(!is_kill);
+            v.var = jit->emitGetLocalMustExist(vreg);
+        } else {
+            v.var = jit->emitGetBlockLocalMustExist(vreg);
+            if (is_kill)
+                jit->emitKillTemporary(vreg);
+        }
+    }
+
+    frame_info.num_vregs = std::max(frame_info.num_vregs, vreg + 1);
+    Box* val = vregs[vreg];
+
+    if (val) {
+        v.o = val;
+        if (is_kill)
+            vregs[vreg] = NULL;
+        else
+            Py_INCREF(val);
+        return v;
+    }
+
+
+    current_block->print(getConstantVRegInfo());
+    printf("vreg: %d num cross: %d\n", vreg, getVRegInfo().getNumOfCrossBlockVRegs());
+    printf("\n\n");
+    current_block->cfg->print(getConstantVRegInfo());
+
+    assert(0);
+    return Value();
 }
 
-Value ASTInterpreter::visit_name(BST_Name* node) {
+Value ASTInterpreter::visit_loadname(BST_LoadName* node) {
     assert(node->lookup_type != ScopeInfo::VarScopeType::UNKNOWN);
 
     switch (node->lookup_type) {
         case ScopeInfo::VarScopeType::GLOBAL: {
-            assert(!node->is_kill);
             Value v;
             if (jit)
                 v.var = jit->emitGetGlobal(node->id.getBox());
@@ -1664,7 +1586,6 @@ Value ASTInterpreter::visit_name(BST_Name* node) {
             return v;
         }
         case ScopeInfo::VarScopeType::DEREF: {
-            assert(!node->is_kill);
             return Value(ASTInterpreterJitInterface::derefHelper(this, node), jit ? jit->emitDeref(node) : NULL);
         }
         case ScopeInfo::VarScopeType::FAST:
@@ -1672,23 +1593,15 @@ Value ASTInterpreter::visit_name(BST_Name* node) {
             Value v;
             if (jit) {
                 bool is_live = true;
-                if (node->is_kill) {
-                    is_live = false;
-                } else if (node->lookup_type == ScopeInfo::VarScopeType::FAST) {
-                    assert(node->vreg != -1);
+                if (node->lookup_type == ScopeInfo::VarScopeType::FAST) {
+                    assert(node->vreg >= 0);
                     is_live = source_info->getLiveness()->isLiveAtEnd(node->vreg, current_block);
                 }
 
-                if (is_live) {
-                    assert(!node->is_kill);
-                    v.var = jit->emitGetLocal(node);
-                } else {
-                    v.var = jit->emitGetBlockLocal(node);
-                    if (node->is_kill) {
-                        assert(node->id.s()[0] == '#');
-                        jit->emitKillTemporary(node);
-                    }
-                }
+                if (is_live)
+                    v.var = jit->emitGetLocal(node->id, node->vreg);
+                else
+                    v.var = jit->emitGetBlockLocal(node->id, node->vreg);
             }
 
             assert(node->vreg >= 0);
@@ -1698,10 +1611,7 @@ Value ASTInterpreter::visit_name(BST_Name* node) {
 
             if (val) {
                 v.o = val;
-                if (node->is_kill)
-                    vregs[node->vreg] = NULL;
-                else
-                    Py_INCREF(val);
+                Py_INCREF(val);
                 return v;
             }
 
@@ -1709,7 +1619,6 @@ Value ASTInterpreter::visit_name(BST_Name* node) {
             RELEASE_ASSERT(0, "should be unreachable");
         }
         case ScopeInfo::VarScopeType::NAME: {
-            assert(!node->is_kill && "we might need to support this");
             Value v;
             if (jit)
                 v.var = jit->emitGetBoxedLocal(node->id.getBox());
@@ -1721,44 +1630,146 @@ Value ASTInterpreter::visit_name(BST_Name* node) {
     }
 }
 
-Value ASTInterpreter::visit_subscript(BST_Subscript* node) {
-    Value value = visit_expr(node->value);
+Value ASTInterpreter::visit_loadattr(BST_LoadAttr* node) {
+    Value v = getVReg(node->vreg_value);
+    AUTO_DECREF(v.o);
+
+    BoxedString* attr = node->attr.getBox();
+    Value r;
+    if (node->clsonly)
+        r = Value(getclsattr(v.o, attr), jit ? jit->emitGetClsAttr(v, attr) : NULL);
+    else
+        r = Value(pyston::getattr(v.o, attr), jit ? jit->emitGetAttr(node, v, attr) : NULL);
+    return r;
+}
+
+
+Value ASTInterpreter::visit_loadsub(BST_LoadSub* node) {
+    Value value = getVReg(node->vreg_value);
     AUTO_DECREF(value.o);
 
-    bool is_slice = (node->slice->type == BST_TYPE::Slice) && (((BST_Slice*)node->slice)->step == NULL);
-    if (is_slice) {
-        BST_Slice* slice = (BST_Slice*)node->slice;
-        Value lower = slice->lower ? visit_expr(slice->lower) : Value();
-        AUTO_XDECREF(lower.o);
-        Value upper = slice->upper ? visit_expr(slice->upper) : Value();
-        AUTO_XDECREF(upper.o);
-        assert(slice->step == NULL);
+    Value slice = getVReg(node->vreg_slice);
+    AUTO_DECREF(slice.o);
 
-        Value v;
+    Value v;
+    if (jit)
+        v.var = jit->emitGetItem(node, value, slice);
+    v.o = getitem(value.o, slice.o);
+    return v;
+}
+
+Value ASTInterpreter::visit_loadsubslice(BST_LoadSubSlice* node) {
+    Value value = getVReg(node->vreg_value);
+    AUTO_DECREF(value.o);
+    Value lower = node->vreg_lower != VREG_UNDEFINED ? getVReg(node->vreg_lower) : Value();
+    AUTO_XDECREF(lower.o);
+    Value upper = node->vreg_upper != VREG_UNDEFINED ? getVReg(node->vreg_upper) : Value();
+    AUTO_XDECREF(upper.o);
+
+    Value v;
+    if (jit)
+        v.var = jit->emitApplySlice(value, lower, upper);
+    v.o = applySlice(value.o, lower.o, upper.o);
+    return v;
+}
+
+void ASTInterpreter::visit_storename(BST_StoreName* node) {
+    Value value = getVReg(node->vreg_value);
+
+    assert(node->lookup_type != ScopeInfo::VarScopeType::UNKNOWN);
+
+    InternedString name = node->id;
+    ScopeInfo::VarScopeType vst = node->lookup_type;
+    if (vst == ScopeInfo::VarScopeType::GLOBAL) {
         if (jit)
-            v.var = jit->emitApplySlice(value, lower, upper);
-        v.o = applySlice(value.o, lower.o, upper.o);
-        return v;
+            jit->emitSetGlobal(name.getBox(), value, getCode()->source->scoping.areGlobalsFromModule());
+        setGlobal(frame_info.globals, name.getBox(), value.o);
+    } else if (vst == ScopeInfo::VarScopeType::NAME) {
+        if (jit)
+            jit->emitSetItemName(name.getBox(), value);
+        assert(frame_info.boxedLocals != NULL);
+        // TODO should probably pre-box the names when it's a scope that usesNameLookup
+        AUTO_DECREF(value.o);
+        setitem(frame_info.boxedLocals, name.getBox(), value.o);
     } else {
-        Value slice = visit_slice(node->slice);
-        AUTO_DECREF(slice.o);
+        bool closure = vst == ScopeInfo::VarScopeType::CLOSURE;
+        if (jit) {
+            bool is_live = true;
+            if (!closure)
+                is_live = source_info->getLiveness()->isLiveAtEnd(node->vreg, current_block);
+            if (is_live) {
+                if (closure) {
+                    jit->emitSetLocalClosure(node, value);
+                } else
+                    jit->emitSetLocal(node->vreg, value);
+            } else
+                jit->emitSetBlockLocal(node->vreg, value);
+        }
 
-        Value v;
-        if (jit)
-            v.var = jit->emitGetItem(node, value, slice);
-        v.o = getitem(value.o, slice.o);
-        return v;
+        if (closure) {
+            ASTInterpreterJitInterface::setLocalClosureHelper(this, node->vreg, node->closure_offset, value.o);
+        } else {
+            assert(getVRegInfo().getVReg(node->id) == node->vreg);
+            frame_info.num_vregs = std::max(frame_info.num_vregs, node->vreg + 1);
+            Box* prev = vregs[node->vreg];
+            vregs[node->vreg] = value.o;
+            Py_XDECREF(prev);
+        }
     }
+}
+
+
+void ASTInterpreter::visit_storeattr(BST_StoreAttr* node) {
+    Value value = getVReg(node->vreg_value);
+    Value o = getVReg(node->vreg_target);
+    if (jit) {
+        jit->emitSetAttr(node, o, node->attr.getBox(), value);
+    }
+    AUTO_DECREF(o.o);
+    pyston::setattr(o.o, node->attr.getBox(), value.o);
+}
+
+void ASTInterpreter::visit_storesub(BST_StoreSub* node) {
+    Value value = getVReg(node->vreg_value);
+    AUTO_DECREF(value.o);
+
+    Value target = getVReg(node->vreg_target);
+    AUTO_DECREF(target.o);
+
+    Value slice = getVReg(node->vreg_slice);
+
+    AUTO_DECREF(slice.o);
+
+    if (jit)
+        jit->emitSetItem(target, slice, value);
+    setitem(target.o, slice.o, value.o);
+}
+
+void ASTInterpreter::visit_storesubslice(BST_StoreSubSlice* node) {
+    Value value = getVReg(node->vreg_value);
+    AUTO_DECREF(value.o);
+
+    Value target = getVReg(node->vreg_target);
+    AUTO_DECREF(target.o);
+
+    Value lower = node->vreg_lower != VREG_UNDEFINED ? getVReg(node->vreg_lower) : Value();
+    AUTO_XDECREF(lower.o);
+    Value upper = node->vreg_upper != VREG_UNDEFINED ? getVReg(node->vreg_upper) : Value();
+    AUTO_XDECREF(upper.o);
+
+    if (jit)
+        jit->emitAssignSlice(target, lower, upper, value);
+    assignSlice(target.o, lower.o, upper.o, value.o);
 }
 
 Value ASTInterpreter::visit_list(BST_List* node) {
     llvm::SmallVector<RewriterVar*, 8> items;
 
     BoxedList* list = new BoxedList();
-    list->ensure(node->elts.size());
-    for (BST_expr* e : node->elts) {
+    list->ensure(node->num_elts);
+    for (int i = 0; i < node->num_elts; ++i) {
         try {
-            Value v = visit_expr(e);
+            Value v = getVReg(node->elts[i]);
             items.push_back(v);
             listAppendInternalStolen(list, v.o);
         } catch (ExcInfo e) {
@@ -1776,22 +1787,14 @@ Value ASTInterpreter::visit_list(BST_List* node) {
 Value ASTInterpreter::visit_tuple(BST_Tuple* node) {
     llvm::SmallVector<RewriterVar*, 8> items;
 
-    BoxedTuple* rtn = BoxedTuple::create(node->elts.size());
-    int rtn_idx = 0;
-    for (BST_expr* e : node->elts) {
-        Value v = visit_expr(e);
-        rtn->elts[rtn_idx++] = v.o;
+    BoxedTuple* rtn = BoxedTuple::create(node->num_elts);
+    for (int i = 0; i < node->num_elts; ++i) {
+        Value v = getVReg(node->elts[i]);
+        rtn->elts[i] = v.o;
         items.push_back(v);
     }
 
     return Value(rtn, jit ? jit->emitCreateTuple(items) : NULL);
-}
-
-Value ASTInterpreter::visit_attribute(BST_Attribute* node) {
-    Value v = visit_expr(node->value);
-    AUTO_DECREF(v.o);
-    Value r(pyston::getattr(v.o, node->attr.getBox()), jit ? jit->emitGetAttr(v, node->attr.getBox(), node) : NULL);
-    return r;
 }
 }
 
@@ -1845,7 +1848,7 @@ void ASTInterpreterJitInterface::delNameHelper(void* _interpreter, InternedStrin
     }
 }
 
-Box* ASTInterpreterJitInterface::derefHelper(void* _interpreter, BST_Name* node) {
+Box* ASTInterpreterJitInterface::derefHelper(void* _interpreter, BST_LoadName* node) {
     ASTInterpreter* interpreter = (ASTInterpreter*)_interpreter;
     DerefInfo deref_info = interpreter->scope_info.getDerefInfo(node);
     assert(interpreter->getPassedClosure());
@@ -1888,16 +1891,12 @@ void ASTInterpreterJitInterface::setExcInfoHelper(void* _interpreter, STOLEN(Box
     setFrameExcInfo(interpreter->getFrameInfo(), type, value, traceback);
 }
 
-void ASTInterpreterJitInterface::setLocalClosureHelper(void* _interpreter, BST_Name* name, Box* v) {
-    assert(name->lookup_type == ScopeInfo::VarScopeType::CLOSURE);
-
+void ASTInterpreterJitInterface::setLocalClosureHelper(void* _interpreter, int vreg, int closure_offset, Box* v) {
     ASTInterpreter* interpreter = (ASTInterpreter*)_interpreter;
 
-    auto vreg = name->vreg;
     interpreter->frame_info.num_vregs = std::max(interpreter->frame_info.num_vregs, (int)vreg + 1);
     Box* prev = interpreter->vregs[vreg];
     interpreter->vregs[vreg] = v;
-    auto closure_offset = interpreter->scope_info.getClosureOffset(name);
     Box* prev_closure_elt = interpreter->created_closure->elts[closure_offset];
     interpreter->created_closure->elts[closure_offset] = incref(v);
     Py_XDECREF(prev);
@@ -2054,14 +2053,13 @@ Box* astInterpretFunctionEval(BoxedCode* code, Box* globals, Box* boxedLocals) {
 }
 
 // caution when changing the function arguments: this function gets called from an assembler wrapper!
-extern "C" Box* astInterpretDeoptFromASM(BoxedCode* code, BST_expr* after_expr, BST_stmt* enclosing_stmt, Box* expr_val,
+extern "C" Box* astInterpretDeoptFromASM(BoxedCode* code, BST_stmt* enclosing_stmt, Box* expr_val,
                                          STOLEN(FrameStackState) frame_state) {
     static_assert(sizeof(FrameStackState) <= 2 * 8, "astInterpretDeopt assumes that all args get passed in regs!");
 
     assert(code);
     assert(enclosing_stmt);
     assert(frame_state.locals);
-    assert(after_expr);
     assert(expr_val);
 
     SourceInfo* source_info = code->source.get();
@@ -2106,27 +2104,18 @@ extern "C" Box* astInterpretDeoptFromASM(BoxedCode* code, BST_expr* after_expr, 
     CFGBlock* start_block = NULL;
     BST_stmt* starting_statement = NULL;
     while (true) {
-        if (enclosing_stmt->type == BST_TYPE::Assign) {
-            auto asgn = bst_cast<BST_Assign>(enclosing_stmt);
-            RELEASE_ASSERT(asgn->value == after_expr, "%p %p", asgn->value, after_expr);
-            assert(asgn->target->type == BST_TYPE::Name);
-            auto name = bst_cast<BST_Name>(asgn->target);
-            assert(name->id.s()[0] == '#');
-            interpreter.addSymbol(name->vreg, expr_val, true);
-            break;
-        } else if (enclosing_stmt->type == BST_TYPE::Expr) {
-            auto expr = bst_cast<BST_Expr>(enclosing_stmt);
-            RELEASE_ASSERT(expr->value == after_expr, "%p %p", expr->value, after_expr);
-            assert(expr->value == after_expr);
-            break;
-        } else if (enclosing_stmt->type == BST_TYPE::Invoke) {
+        if (enclosing_stmt->type == BST_TYPE::Invoke) {
             auto invoke = bst_cast<BST_Invoke>(enclosing_stmt);
             start_block = invoke->normal_dest;
             starting_statement = start_block->body[0];
             enclosing_stmt = invoke->stmt;
+        } else if (enclosing_stmt->has_dest_vreg()) {
+            int vreg_dst = ((BST_stmt_with_dest*)enclosing_stmt)->vreg_dst;
+            if (vreg_dst != VREG_UNDEFINED)
+                interpreter.addSymbol(vreg_dst, expr_val, true);
+            break;
         } else {
-            RELEASE_ASSERT(0, "should not be able to reach here with anything other than an Assign (got %d)",
-                           enclosing_stmt->type);
+            RELEASE_ASSERT(0, "encountered an yet unimplemented opcode (got %d)", enclosing_stmt->type);
         }
     }
 

--- a/src/codegen/ast_interpreter.cpp
+++ b/src/codegen/ast_interpreter.cpp
@@ -366,7 +366,7 @@ Box* ASTInterpreter::execJITedBlock(CFGBlock* b) {
 
         assert(getPythonFrameInfo(0) == getFrameInfo());
 
-        stmt->cxx_exception_count++;
+        ++getCode()->cxx_exception_count[stmt];
         caughtCxxException(&e);
 
         next_block = ((BST_Invoke*)stmt)->exc_dest;
@@ -774,7 +774,7 @@ Value ASTInterpreter::visit_invoke(BST_Invoke* node) {
 
         assert(getPythonFrameInfo(0) == getFrameInfo());
 
-        node->cxx_exception_count++;
+        ++getCode()->cxx_exception_count[node];
         caughtCxxException(&e);
 
         next_block = node->exc_dest;

--- a/src/codegen/ast_interpreter.h
+++ b/src/codegen/ast_interpreter.h
@@ -23,7 +23,6 @@ namespace gc {
 class GCVisitor;
 }
 
-class BST_expr;
 class BST_stmt;
 class BST_Jump;
 class Box;
@@ -46,11 +45,11 @@ struct ASTInterpreterJitInterface {
     static int getGlobalsOffset();
 
     static void delNameHelper(void* _interpreter, InternedString name);
-    static Box* derefHelper(void* interp, BST_Name* node);
+    static Box* derefHelper(void* interp, BST_LoadName* node);
     static Box* landingpadHelper(void* interp);
     static void pendingCallsCheckHelper();
     static void setExcInfoHelper(void* interp, STOLEN(Box*) type, STOLEN(Box*) value, STOLEN(Box*) traceback);
-    static void setLocalClosureHelper(void* interp, BST_Name* name, Box* v);
+    static void setLocalClosureHelper(void* interp, int vreg, int closure_offset, Box* v);
     static void uncacheExcInfoHelper(void* interp);
     static void raise0Helper(void* interp) __attribute__((noreturn));
     static Box* yieldHelper(void* interp, STOLEN(Box*) value);
@@ -79,7 +78,7 @@ Box* astInterpretFunction(BoxedCode* f, Box* closure, Box* generator, Box* globa
                           Box** args);
 Box* astInterpretFunctionEval(BoxedCode* cf, Box* globals, Box* boxedLocals);
 // this function is implemented in the src/codegen/ast_interpreter_exec.S assembler file
-extern "C" Box* astInterpretDeopt(BoxedCode* cf, BST_expr* after_expr, BST_stmt* enclosing_stmt, Box* expr_val,
+extern "C" Box* astInterpretDeopt(BoxedCode* cf, BST_stmt* enclosing_stmt, Box* expr_val,
                                   STOLEN(FrameStackState) frame_state);
 
 struct FrameInfo;

--- a/src/codegen/ast_interpreter_exec.S
+++ b/src/codegen/ast_interpreter_exec.S
@@ -43,7 +43,7 @@ executeInnerAndSetupFrame:
 // Our unwinder must be able to detect deopt frames and by writting this wrapper in assembler we can be sure to correctly
 // detect the frame independent of compiler optimizations because this function will always appear in the call stack.
 //
-// Box* astInterpretDeopt(FunctionMetadata* cf, AST_expr* after_expr, AST_stmt* enclosing_stmt, Box* expr_val,
+// Box* astInterpretDeopt(FunctionMetadata* cf, AST_stmt* enclosing_stmt, Box* expr_val,
 //                        FrameStackState frame_state);
 .text
 .globl astInterpretDeopt

--- a/src/codegen/baseline_jit.h
+++ b/src/codegen/baseline_jit.h
@@ -231,7 +231,7 @@ private:
     JitCodeBlock& code_block;
     RewriterVar* interp;
     RewriterVar* vregs_array;
-    llvm::DenseMap<InternedString, RewriterVar*> local_syms;
+    llvm::DenseMap<int /*vreg*/, RewriterVar*> local_syms;
     // keeps track which non block local vregs are known to have a non NULL value
     llvm::DenseSet<int> known_non_null_vregs;
 
@@ -249,7 +249,7 @@ private:
         uint8_t* end_addr;
         std::unique_ptr<ICSetupInfo> ic;
         StackInfo stack_info;
-        BST* node;
+        BST_stmt* node;
         std::vector<Location> decref_infos;
         std::unique_ptr<TypeRecorder> type_recorder;
     };
@@ -266,39 +266,41 @@ public:
     RewriterVar* imm(uint64_t val);
     RewriterVar* imm(void* val);
 
-    RewriterVar* emitAugbinop(BST_expr* node, RewriterVar* lhs, RewriterVar* rhs, int op_type);
+    RewriterVar* emitAugbinop(BST_stmt* node, RewriterVar* lhs, RewriterVar* rhs, int op_type);
     RewriterVar* emitApplySlice(RewriterVar* target, RewriterVar* lower, RewriterVar* upper);
-    RewriterVar* emitBinop(BST_expr* node, RewriterVar* lhs, RewriterVar* rhs, int op_type);
-    RewriterVar* emitCallattr(BST_expr* node, RewriterVar* obj, BoxedString* attr, CallattrFlags flags,
+    RewriterVar* emitBinop(BST_stmt* node, RewriterVar* lhs, RewriterVar* rhs, int op_type);
+    RewriterVar* emitCallattr(BST_stmt* node, RewriterVar* obj, BoxedString* attr, CallattrFlags flags,
                               const llvm::ArrayRef<RewriterVar*> args, std::vector<BoxedString*>* keyword_names);
-    RewriterVar* emitCompare(BST_expr* node, RewriterVar* lhs, RewriterVar* rhs, int op_type);
+    RewriterVar* emitCompare(BST_stmt* node, RewriterVar* lhs, RewriterVar* rhs, int op_type);
     RewriterVar* emitCreateDict();
     void emitDictSet(RewriterVar* dict, RewriterVar* k, RewriterVar* v);
     RewriterVar* emitCreateList(const llvm::ArrayRef<STOLEN(RewriterVar*)> values);
     RewriterVar* emitCreateSet(const llvm::ArrayRef<RewriterVar*> values);
     RewriterVar* emitCreateSlice(RewriterVar* start, RewriterVar* stop, RewriterVar* step);
     RewriterVar* emitCreateTuple(const llvm::ArrayRef<RewriterVar*> values);
-    RewriterVar* emitDeref(BST_Name* name);
+    RewriterVar* emitDeref(BST_LoadName* name);
     RewriterVar* emitExceptionMatches(RewriterVar* v, RewriterVar* cls);
-    RewriterVar* emitGetAttr(RewriterVar* obj, BoxedString* s, BST_expr* node);
-    RewriterVar* emitGetBlockLocal(BST_Name* name);
-    void emitKillTemporary(BST_Name* name);
+    RewriterVar* emitGetAttr(BST_stmt* node, RewriterVar* obj, BoxedString* s);
+    RewriterVar* emitGetBlockLocal(InternedString name, int vreg);
+    RewriterVar* emitGetBlockLocalMustExist(int vreg);
+    void emitKillTemporary(int vreg);
     RewriterVar* emitGetBoxedLocal(BoxedString* s);
     RewriterVar* emitGetBoxedLocals();
     RewriterVar* emitGetClsAttr(RewriterVar* obj, BoxedString* s);
     RewriterVar* emitGetGlobal(BoxedString* s);
-    RewriterVar* emitGetItem(BST_expr* node, RewriterVar* value, RewriterVar* slice);
-    RewriterVar* emitGetLocal(BST_Name* name);
+    RewriterVar* emitGetItem(BST_stmt* node, RewriterVar* value, RewriterVar* slice);
+    RewriterVar* emitGetLocal(InternedString name, int vreg);
+    RewriterVar* emitGetLocalMustExist(int vreg);
     RewriterVar* emitGetPystonIter(RewriterVar* v);
     RewriterVar* emitHasnext(RewriterVar* v);
-    RewriterVar* emitImportFrom(RewriterVar* module, BoxedString* name);
-    RewriterVar* emitImportName(int level, RewriterVar* from_imports, llvm::StringRef module_name);
+    RewriterVar* emitImportFrom(RewriterVar* module, RewriterVar* name);
+    RewriterVar* emitImportName(int level, RewriterVar* from_imports, RewriterVar* module_name);
     RewriterVar* emitImportStar(RewriterVar* module);
     RewriterVar* emitLandingpad();
     RewriterVar* emitNonzero(RewriterVar* v);
     RewriterVar* emitNotNonzero(RewriterVar* v);
     RewriterVar* emitRepr(RewriterVar* v);
-    RewriterVar* emitRuntimeCall(BST_expr* node, RewriterVar* obj, ArgPassSpec argspec,
+    RewriterVar* emitRuntimeCall(BST_stmt* node, RewriterVar* obj, ArgPassSpec argspec,
                                  const llvm::ArrayRef<RewriterVar*> args, std::vector<BoxedString*>* keyword_names);
     RewriterVar* emitUnaryop(RewriterVar* v, int op_type);
     std::vector<RewriterVar*> emitUnpackIntoArray(RewriterVar* v, uint64_t num);
@@ -317,14 +319,15 @@ public:
     void emitRaise0();
     void emitRaise3(RewriterVar* arg0, RewriterVar* arg1, RewriterVar* arg2);
     void emitReturn(RewriterVar* v);
-    void emitSetAttr(BST_expr* node, RewriterVar* obj, BoxedString* s, STOLEN(RewriterVar*) attr);
-    void emitSetBlockLocal(BST_Name* name, STOLEN(RewriterVar*) v);
+    void emitSetAttr(BST_stmt* node, RewriterVar* obj, BoxedString* s, STOLEN(RewriterVar*) attr);
+    void emitSetBlockLocal(int vreg, STOLEN(RewriterVar*) v);
     void emitSetCurrentInst(BST_stmt* node);
     void emitSetExcInfo(RewriterVar* type, RewriterVar* value, RewriterVar* traceback);
     void emitSetGlobal(BoxedString* s, STOLEN(RewriterVar*) v, bool are_globals_from_module);
     void emitSetItemName(BoxedString* s, RewriterVar* v);
     void emitSetItem(RewriterVar* target, RewriterVar* slice, RewriterVar* value);
-    void emitSetLocal(BST_Name* name, bool set_closure, STOLEN(RewriterVar*) v);
+    void emitSetLocal(int vreg, STOLEN(RewriterVar*) v);
+    void emitSetLocalClosure(BST_StoreName* name, STOLEN(RewriterVar*) v);
     // emitSideExit steals a full ref from v, not just a vref
     void emitSideExit(STOLEN(RewriterVar*) v, Box* cmp_value, CFGBlock* next_block);
     void emitUncacheExcInfo();
@@ -351,7 +354,7 @@ private:
                                            const llvm::ArrayRef<RewriterVar*> additional_uses);
     std::pair<RewriterVar*, RewriterAction*> emitPPCall(void* func_addr, llvm::ArrayRef<RewriterVar*> args,
                                                         unsigned short pp_size, bool should_record_type = false,
-                                                        BST* bst_node = NULL,
+                                                        BST_stmt* bst_node = NULL,
                                                         llvm::ArrayRef<RewriterVar*> additional_uses = {});
 
     static void assertNameDefinedHelper(const char* id);
@@ -371,7 +374,7 @@ private:
     void _emitJump(CFGBlock* b, RewriterVar* block_next, ExitInfo& exit_info);
     void _emitOSRPoint();
     void _emitPPCall(RewriterVar* result, void* func_addr, llvm::ArrayRef<RewriterVar*> args, unsigned short pp_size,
-                     BST* bst_node, llvm::ArrayRef<RewriterVar*> vars_to_bump);
+                     BST_stmt* bst_node, llvm::ArrayRef<RewriterVar*> vars_to_bump);
     void _emitRecordType(RewriterVar* obj_cls_var);
     void _emitReturn(RewriterVar* v);
     void _emitSideExit(STOLEN(RewriterVar*) var, RewriterVar* val_constant, CFGBlock* next_block,

--- a/src/codegen/codegen.h
+++ b/src/codegen/codegen.h
@@ -73,7 +73,7 @@ struct GlobalState {
     llvm::Type* llvm_value_type, *llvm_value_type_ptr, *llvm_value_type_ptr_ptr;
     llvm::Type* llvm_class_type, *llvm_class_type_ptr;
     llvm::Type* llvm_opaque_type;
-    llvm::Type* llvm_boxedstring_type_ptr, *llvm_dict_type_ptr, *llvm_bststmt_type_ptr, *llvm_bstexpr_type_ptr;
+    llvm::Type* llvm_boxedstring_type_ptr, *llvm_dict_type_ptr, *llvm_bststmt_type_ptr;
     llvm::Type* llvm_frame_info_type;
     llvm::Type* llvm_code_type_ptr, *llvm_closure_type_ptr, *llvm_generator_type_ptr;
     llvm::Type* llvm_module_type_ptr, *llvm_bool_type_ptr;

--- a/src/codegen/compvars.cpp
+++ b/src/codegen/compvars.cpp
@@ -2762,6 +2762,15 @@ public:
 
         return new ConcreteCompilerVariable(SLICE, rtn);
     }
+
+    CompilerVariable* dup(VAR* v, DupCache& cache) override {
+        // TODO copied from UnknownType
+        auto& rtn = cache[v];
+        if (rtn == NULL) {
+            rtn = new VAR(this, v->getValue());
+        }
+        return rtn;
+    }
 } _UNBOXED_SLICE;
 CompilerType* UNBOXED_SLICE = &_UNBOXED_SLICE;
 

--- a/src/codegen/irgen.h
+++ b/src/codegen/irgen.h
@@ -29,7 +29,6 @@
 
 namespace pyston {
 
-class BST_expr;
 class BST_stmt;
 class CFGBlock;
 class GCBuilder;
@@ -119,7 +118,7 @@ public:
     // virtual void checkAndPropagateCapiException(const UnwindInfo& unw_info, llvm::Value* returned_val,
     // llvm::Value* exc_val, bool double_check = false) = 0;
 
-    virtual llvm::Value* createDeopt(BST_stmt* current_stmt, BST_expr* node, llvm::Value* node_value) = 0;
+    virtual llvm::Value* createDeopt(BST_stmt* current_stmt, llvm::Value* node_value) = 0;
 
     virtual BORROWED(Box*) getIntConstant(int64_t n) = 0;
     virtual BORROWED(Box*) getFloatConstant(double d) = 0;

--- a/src/codegen/irgen.h
+++ b/src/codegen/irgen.h
@@ -36,6 +36,7 @@ class IREmitter;
 
 struct UnwindInfo {
 public:
+    BoxedCode* code;
     BST_stmt* current_stmt;
 
     llvm::BasicBlock* exc_dest;
@@ -45,15 +46,15 @@ public:
 
     bool hasHandler() const { return exc_dest != NULL; }
 
-    UnwindInfo(BST_stmt* current_stmt, llvm::BasicBlock* exc_dest, bool is_after_deopt = false)
-        : current_stmt(current_stmt), exc_dest(exc_dest), is_after_deopt(is_after_deopt) {}
+    UnwindInfo(BoxedCode* code, BST_stmt* current_stmt, llvm::BasicBlock* exc_dest, bool is_after_deopt = false)
+        : code(code), current_stmt(current_stmt), exc_dest(exc_dest), is_after_deopt(is_after_deopt) {}
 
     ExceptionStyle preferredExceptionStyle() const;
 
     // Risky!  This means that we can't unwind from this location, and should be used in the
     // rare case that there are language-specific reasons that the statement should not unwind
     // (ex: loading function arguments into the appropriate scopes).
-    static UnwindInfo cantUnwind() { return UnwindInfo(NULL, NULL); }
+    static UnwindInfo cantUnwind() { return UnwindInfo(NULL, NULL, NULL); }
 };
 
 // TODO get rid of this

--- a/src/codegen/irgen/irgenerator.h
+++ b/src/codegen/irgen/irgenerator.h
@@ -203,8 +203,6 @@ class BST_Call;
 IREmitter* createIREmitter(IRGenState* irstate, llvm::BasicBlock*& curblock, IRGenerator* irgenerator = NULL);
 IRGenerator* createIRGenerator(IRGenState* irstate, std::unordered_map<CFGBlock*, llvm::BasicBlock*>& entry_blocks,
                                CFGBlock* myblock, TypeAnalysis* types);
-
-std::vector<BoxedString*>* getKeywordNameStorage(BST_Call* node);
 }
 
 #endif

--- a/src/codegen/runtime_hooks.cpp
+++ b/src/codegen/runtime_hooks.cpp
@@ -151,10 +151,6 @@ void initGlobalFuncs(GlobalState& g) {
     assert(g.llvm_bststmt_type_ptr);
     g.llvm_bststmt_type_ptr = g.llvm_bststmt_type_ptr->getPointerTo();
 
-    g.llvm_bstexpr_type_ptr = g.stdlib_module->getTypeByName("class.pyston::BST_expr");
-    assert(g.llvm_bstexpr_type_ptr);
-    g.llvm_bstexpr_type_ptr = g.llvm_bstexpr_type_ptr->getPointerTo();
-
     // The LLVM vector type for the arguments that we pass to runtimeCall and related functions.
     // It will be a pointer to a type named something like class.std::vector or
     // class.std::vector.##. We can figure out exactly what it is by looking at the last

--- a/src/codegen/type_recording.cpp
+++ b/src/codegen/type_recording.cpp
@@ -42,7 +42,7 @@ Box* recordType(TypeRecorder* self, Box* obj) {
     return obj;
 }
 
-BoxedClass* predictClassFor(BST* node) {
+BoxedClass* predictClassFor(BST_stmt* node) {
     ICInfo* ic = ICInfo::getICInfoForNode(node);
     if (!ic || !ic->getTypeRecorder())
         return NULL;

--- a/src/codegen/type_recording.h
+++ b/src/codegen/type_recording.h
@@ -19,7 +19,7 @@
 
 namespace pyston {
 
-class BST;
+class BST_stmt;
 class Box;
 class BoxedClass;
 
@@ -44,7 +44,7 @@ public:
     friend Box* recordType(TypeRecorder*, Box*);
 };
 
-BoxedClass* predictClassFor(BST* node);
+BoxedClass* predictClassFor(BST_stmt* node);
 }
 
 #endif

--- a/src/codegen/unwinding.cpp
+++ b/src/codegen/unwinding.cpp
@@ -636,7 +636,7 @@ public:
 
             if (!getIsReraiseFlag()) {
                 // TODO: shouldn't fetch this multiple times?
-                frame_iter.getCurrentStatement()->cxx_exception_count++;
+                ++frame_iter.getFrameInfo()->code->cxx_exception_count[frame_iter.getCurrentStatement()];
                 exceptionAtLine(&exc_info.traceback);
             } else
                 getIsReraiseFlag() = false;

--- a/src/core/bst.cpp
+++ b/src/core/bst.cpp
@@ -28,9 +28,9 @@
 namespace pyston {
 
 #ifdef DEBUG_LINE_NUMBERS
-int BST::next_lineno = 100000;
+int BST_stmt::next_lineno = 100000;
 
-BST::BST(BST_TYPE::BST_TYPE type) : type(type), lineno(++next_lineno) {
+BST_stmt::BST_stmt(BST_TYPE::BST_TYPE type) : type(type), lineno(++next_lineno) {
     // if (lineno == 100644)
     // raise(SIGTRAP);
 }
@@ -49,39 +49,29 @@ static void visitCFG(CFG* cfg, BSTVisitor* v) {
             e->accept(v);
 }
 
-void BST_arguments::accept(BSTVisitor* v) {
-    bool skip = v->visit_arguments(this);
-    if (skip)
-        return;
-
-    visitVector(defaults, v);
-}
-
 void BST_Assert::accept(BSTVisitor* v) {
     bool skip = v->visit_assert(this);
     if (skip)
         return;
 
-    test->accept(v);
-    if (msg)
-        msg->accept(v);
+    v->visit_vreg(&vreg_msg);
 }
 
 void BST_Assert::accept_stmt(StmtVisitor* v) {
     v->visit_assert(this);
 }
 
-void BST_Assign::accept(BSTVisitor* v) {
-    bool skip = v->visit_assign(this);
+void BST_CopyVReg::accept(BSTVisitor* v) {
+    bool skip = v->visit_copyvreg(this);
     if (skip)
         return;
 
-    value->accept(v);
-    target->accept(v);
+    v->visit_vreg(&vreg_src);
+    v->visit_vreg(&vreg_dst, true);
 }
 
-void BST_Assign::accept_stmt(StmtVisitor* v) {
-    v->visit_assign(this);
+void BST_CopyVReg::accept_stmt(StmtVisitor* v) {
+    v->visit_copyvreg(this);
 }
 
 void BST_AugBinOp::accept(BSTVisitor* v) {
@@ -89,24 +79,13 @@ void BST_AugBinOp::accept(BSTVisitor* v) {
     if (skip)
         return;
 
-    left->accept(v);
-    right->accept(v);
+    v->visit_vreg(&vreg_left);
+    v->visit_vreg(&vreg_right);
+    v->visit_vreg(&vreg_dst, true);
 }
 
-void* BST_AugBinOp::accept_expr(ExprVisitor* v) {
+void BST_AugBinOp::accept_stmt(StmtVisitor* v) {
     return v->visit_augbinop(this);
-}
-
-void BST_Attribute::accept(BSTVisitor* v) {
-    bool skip = v->visit_attribute(this);
-    if (skip)
-        return;
-
-    value->accept(v);
-}
-
-void* BST_Attribute::accept_expr(ExprVisitor* v) {
-    return v->visit_attribute(this);
 }
 
 void BST_BinOp::accept(BSTVisitor* v) {
@@ -114,30 +93,67 @@ void BST_BinOp::accept(BSTVisitor* v) {
     if (skip)
         return;
 
-    left->accept(v);
-    right->accept(v);
+    v->visit_vreg(&vreg_left);
+    v->visit_vreg(&vreg_right);
+    v->visit_vreg(&vreg_dst, true);
 }
 
-void* BST_BinOp::accept_expr(ExprVisitor* v) {
+void BST_BinOp::accept_stmt(StmtVisitor* v) {
     return v->visit_binop(this);
 }
 
-void BST_Call::accept(BSTVisitor* v) {
-    bool skip = v->visit_call(this);
+void BST_CallFunc::accept(BSTVisitor* v) {
+    bool skip = v->visit_callfunc(this);
     if (skip)
         return;
 
-    func->accept(v);
-    visitVector(args, v);
-    visitVector(keywords, v);
-    if (starargs)
-        starargs->accept(v);
-    if (kwargs)
-        kwargs->accept(v);
+    v->visit_vreg(&vreg_func);
+    for (int i = 0; i < num_args + num_keywords; ++i) {
+        v->visit_vreg(&elts[i]);
+    }
+    v->visit_vreg(&vreg_starargs);
+    v->visit_vreg(&vreg_kwargs);
+    v->visit_vreg(&vreg_dst, true);
 }
 
-void* BST_Call::accept_expr(ExprVisitor* v) {
-    return v->visit_call(this);
+void BST_CallFunc::accept_stmt(StmtVisitor* v) {
+    return v->visit_callfunc(this);
+}
+
+void BST_CallAttr::accept(BSTVisitor* v) {
+    bool skip = v->visit_callattr(this);
+    if (skip)
+        return;
+
+    v->visit_vreg(&vreg_value);
+    for (int i = 0; i < num_args + num_keywords; ++i) {
+        v->visit_vreg(&elts[i]);
+    }
+    v->visit_vreg(&vreg_starargs);
+    v->visit_vreg(&vreg_kwargs);
+    v->visit_vreg(&vreg_dst, true);
+}
+
+void BST_CallAttr::accept_stmt(StmtVisitor* v) {
+    return v->visit_callattr(this);
+}
+
+void BST_CallClsAttr::accept(BSTVisitor* v) {
+    bool skip = v->visit_callclsattr(this);
+    if (skip)
+        return;
+
+    v->visit_vreg(&vreg_value);
+    for (int i = 0; i < num_args + num_keywords; ++i) {
+        v->visit_vreg(&elts[i]);
+    }
+    v->visit_vreg(&vreg_starargs);
+    v->visit_vreg(&vreg_kwargs);
+    v->visit_vreg(&vreg_dst, true);
+}
+
+void BST_CallClsAttr::accept_stmt(StmtVisitor* v) {
+    return v->visit_callclsattr(this);
 }
 
 void BST_Compare::accept(BSTVisitor* v) {
@@ -145,11 +161,12 @@ void BST_Compare::accept(BSTVisitor* v) {
     if (skip)
         return;
 
-    left->accept(v);
-    comparator->accept(v);
+    v->visit_vreg(&vreg_left);
+    v->visit_vreg(&vreg_comparator);
+    v->visit_vreg(&vreg_dst, true);
 }
 
-void* BST_Compare::accept_expr(ExprVisitor* v) {
+void BST_Compare::accept_stmt(StmtVisitor* v) {
     return v->visit_compare(this);
 }
 
@@ -158,50 +175,79 @@ void BST_ClassDef::accept(BSTVisitor* v) {
     if (skip)
         return;
 
-    visitVector(this->bases, v);
-    visitVector(this->decorator_list, v);
-    visitCFG(this->code->source->cfg, v);
+    v->visit_vreg(&vreg_bases_tuple);
+    for (int i = 0; i < num_decorator; ++i) {
+        v->visit_vreg(&decorator[i]);
+    }
+
+    if (!v->skip_visit_child_cfg)
+        visitCFG(this->code->source->cfg, v);
 }
 
 void BST_ClassDef::accept_stmt(StmtVisitor* v) {
     v->visit_classdef(this);
 }
 
-void BST_Delete::accept(BSTVisitor* v) {
-    bool skip = v->visit_delete(this);
+void BST_DeleteAttr::accept(BSTVisitor* v) {
+    bool skip = v->visit_deleteattr(this);
     if (skip)
         return;
 
-    target->accept(v);
+    v->visit_vreg(&vreg_value);
 }
 
-void BST_Delete::accept_stmt(StmtVisitor* v) {
-    v->visit_delete(this);
+void BST_DeleteAttr::accept_stmt(StmtVisitor* v) {
+    v->visit_deleteattr(this);
+}
+
+void BST_DeleteSub::accept(BSTVisitor* v) {
+    bool skip = v->visit_deletesub(this);
+    if (skip)
+        return;
+
+    v->visit_vreg(&vreg_value);
+    v->visit_vreg(&vreg_slice);
+}
+
+void BST_DeleteSub::accept_stmt(StmtVisitor* v) {
+    v->visit_deletesub(this);
+}
+
+void BST_DeleteSubSlice::accept(BSTVisitor* v) {
+    bool skip = v->visit_deletesubslice(this);
+    if (skip)
+        return;
+
+    v->visit_vreg(&vreg_value);
+    v->visit_vreg(&vreg_lower);
+    v->visit_vreg(&vreg_upper);
+}
+
+void BST_DeleteSubSlice::accept_stmt(StmtVisitor* v) {
+    v->visit_deletesubslice(this);
+}
+
+
+void BST_DeleteName::accept(BSTVisitor* v) {
+    bool skip = v->visit_deletename(this);
+    if (skip)
+        return;
+    v->visit_vreg(&vreg);
+}
+
+void BST_DeleteName::accept_stmt(StmtVisitor* v) {
+    v->visit_deletename(this);
 }
 
 void BST_Dict::accept(BSTVisitor* v) {
     bool skip = v->visit_dict(this);
     if (skip)
         return;
-
-    for (int i = 0; i < keys.size(); i++) {
-        keys[i]->accept(v);
-        values[i]->accept(v);
-    }
+    v->visit_vreg(&vreg_dst, true);
 }
 
-void* BST_Dict::accept_expr(ExprVisitor* v) {
+void BST_Dict::accept_stmt(StmtVisitor* v) {
     return v->visit_dict(this);
-}
-
-void BST_Ellipsis::accept(BSTVisitor* v) {
-    bool skip = v->visit_ellipsis(this);
-    if (skip)
-        return;
-}
-
-void* BST_Ellipsis::accept_slice(SliceVisitor* v) {
-    return v->visit_ellipsis(this);
 }
 
 void BST_Exec::accept(BSTVisitor* v) {
@@ -209,40 +255,13 @@ void BST_Exec::accept(BSTVisitor* v) {
     if (skip)
         return;
 
-    if (body)
-        body->accept(v);
-    if (globals)
-        globals->accept(v);
-    if (locals)
-        locals->accept(v);
+    v->visit_vreg(&vreg_body);
+    v->visit_vreg(&vreg_globals);
+    v->visit_vreg(&vreg_locals);
 }
 
 void BST_Exec::accept_stmt(StmtVisitor* v) {
     v->visit_exec(this);
-}
-
-void BST_Expr::accept(BSTVisitor* v) {
-    bool skip = v->visit_expr(this);
-    if (skip)
-        return;
-
-    value->accept(v);
-}
-
-void BST_Expr::accept_stmt(StmtVisitor* v) {
-    v->visit_expr(this);
-}
-
-
-void BST_ExtSlice::accept(BSTVisitor* v) {
-    bool skip = v->visit_extslice(this);
-    if (skip)
-        return;
-    visitVector(dims, v);
-}
-
-void* BST_ExtSlice::accept_slice(SliceVisitor* v) {
-    return v->visit_extslice(this);
 }
 
 void BST_FunctionDef::accept(BSTVisitor* v) {
@@ -250,25 +269,15 @@ void BST_FunctionDef::accept(BSTVisitor* v) {
     if (skip)
         return;
 
-    visitVector(decorator_list, v);
-    args->accept(v);
-    visitCFG(code->source->cfg, v);
+    for (int i = 0; i < num_decorator + num_defaults; ++i) {
+        v->visit_vreg(&elts[i]);
+    }
+    if (!v->skip_visit_child_cfg)
+        visitCFG(code->source->cfg, v);
 }
 
 void BST_FunctionDef::accept_stmt(StmtVisitor* v) {
     v->visit_functiondef(this);
-}
-
-void BST_Index::accept(BSTVisitor* v) {
-    bool skip = v->visit_index(this);
-    if (skip)
-        return;
-
-    this->value->accept(v);
-}
-
-void* BST_Index::accept_slice(SliceVisitor* v) {
-    return v->visit_index(this);
 }
 
 void BST_Invoke::accept(BSTVisitor* v) {
@@ -283,24 +292,155 @@ void BST_Invoke::accept_stmt(StmtVisitor* v) {
     return v->visit_invoke(this);
 }
 
-void BST_keyword::accept(BSTVisitor* v) {
-    bool skip = v->visit_keyword(this);
+void BST_Landingpad::accept(BSTVisitor* v) {
+    bool skip = v->visit_landingpad(this);
+    if (skip)
+        return;
+    v->visit_vreg(&vreg_dst, true);
+}
+
+void BST_Landingpad::accept_stmt(StmtVisitor* v) {
+    return v->visit_landingpad(this);
+}
+
+void BST_Locals::accept(BSTVisitor* v) {
+    bool skip = v->visit_locals(this);
+    if (skip)
+        return;
+    v->visit_vreg(&vreg_dst, true);
+}
+
+void BST_Locals::accept_stmt(StmtVisitor* v) {
+    return v->visit_locals(this);
+}
+
+void BST_GetIter::accept(BSTVisitor* v) {
+    bool skip = v->visit_getiter(this);
     if (skip)
         return;
 
-    value->accept(v);
+    v->visit_vreg(&vreg_value);
+    v->visit_vreg(&vreg_dst, true);
 }
 
-void BST_LangPrimitive::accept(BSTVisitor* v) {
-    bool skip = v->visit_langprimitive(this);
+void BST_GetIter::accept_stmt(StmtVisitor* v) {
+    return v->visit_getiter(this);
+}
+
+void BST_ImportFrom::accept(BSTVisitor* v) {
+    bool skip = v->visit_importfrom(this);
     if (skip)
         return;
 
-    visitVector(args, v);
+    v->visit_vreg(&vreg_module);
+    v->visit_vreg(&vreg_name);
+    v->visit_vreg(&vreg_dst, true);
 }
 
-void* BST_LangPrimitive::accept_expr(ExprVisitor* v) {
-    return v->visit_langprimitive(this);
+void BST_ImportFrom::accept_stmt(StmtVisitor* v) {
+    return v->visit_importfrom(this);
+}
+
+void BST_ImportName::accept(BSTVisitor* v) {
+    bool skip = v->visit_importname(this);
+    if (skip)
+        return;
+
+    v->visit_vreg(&vreg_from);
+    v->visit_vreg(&vreg_name);
+    v->visit_vreg(&vreg_dst, true);
+}
+
+void BST_ImportName::accept_stmt(StmtVisitor* v) {
+    return v->visit_importname(this);
+}
+
+void BST_ImportStar::accept(BSTVisitor* v) {
+    bool skip = v->visit_importstar(this);
+    if (skip)
+        return;
+
+    v->visit_vreg(&vreg_name);
+    v->visit_vreg(&vreg_dst, true);
+}
+
+void BST_ImportStar::accept_stmt(StmtVisitor* v) {
+    return v->visit_importstar(this);
+}
+
+void BST_Nonzero::accept(BSTVisitor* v) {
+    bool skip = v->visit_nonzero(this);
+    if (skip)
+        return;
+
+    v->visit_vreg(&vreg_value);
+    v->visit_vreg(&vreg_dst, true);
+}
+
+void BST_Nonzero::accept_stmt(StmtVisitor* v) {
+    return v->visit_nonzero(this);
+}
+
+void BST_CheckExcMatch::accept(BSTVisitor* v) {
+    bool skip = v->visit_checkexcmatch(this);
+    if (skip)
+        return;
+
+    v->visit_vreg(&vreg_value);
+    v->visit_vreg(&vreg_cls);
+    v->visit_vreg(&vreg_dst, true);
+}
+
+void BST_CheckExcMatch::accept_stmt(StmtVisitor* v) {
+    return v->visit_checkexcmatch(this);
+}
+
+void BST_SetExcInfo::accept(BSTVisitor* v) {
+    bool skip = v->visit_setexcinfo(this);
+    if (skip)
+        return;
+
+    v->visit_vreg(&vreg_type);
+    v->visit_vreg(&vreg_value);
+    v->visit_vreg(&vreg_traceback);
+}
+
+void BST_SetExcInfo::accept_stmt(StmtVisitor* v) {
+    return v->visit_setexcinfo(this);
+}
+
+void BST_UncacheExcInfo::accept(BSTVisitor* v) {
+    bool skip = v->visit_uncacheexcinfo(this);
+    if (skip)
+        return;
+}
+
+void BST_UncacheExcInfo::accept_stmt(StmtVisitor* v) {
+    return v->visit_uncacheexcinfo(this);
+}
+
+void BST_HasNext::accept(BSTVisitor* v) {
+    bool skip = v->visit_hasnext(this);
+    if (skip)
+        return;
+    v->visit_vreg(&vreg_value);
+    v->visit_vreg(&vreg_dst, true);
+}
+
+void BST_HasNext::accept_stmt(StmtVisitor* v) {
+    return v->visit_hasnext(this);
+}
+
+void BST_PrintExpr::accept(BSTVisitor* v) {
+    bool skip = v->visit_printexpr(this);
+    if (skip)
+        return;
+
+    v->visit_vreg(&vreg_value);
+}
+
+void BST_PrintExpr::accept_stmt(StmtVisitor* v) {
+    return v->visit_printexpr(this);
 }
 
 void BST_List::accept(BSTVisitor* v) {
@@ -308,27 +448,124 @@ void BST_List::accept(BSTVisitor* v) {
     if (skip)
         return;
 
-    visitVector(elts, v);
+    for (int i = 0; i < num_elts; ++i)
+        v->visit_vreg(&elts[i]);
+    v->visit_vreg(&vreg_dst, true);
 }
 
-void* BST_List::accept_expr(ExprVisitor* v) {
+void BST_List::accept_stmt(StmtVisitor* v) {
     return v->visit_list(this);
 }
 
-void BST_Name::accept(BSTVisitor* v) {
-    bool skip = v->visit_name(this);
+void BST_LoadName::accept(BSTVisitor* v) {
+    bool skip = v->visit_loadname(this);
+    if (skip)
+        return;
+
+    if (lookup_type == ScopeInfo::VarScopeType::FAST || lookup_type == ScopeInfo::VarScopeType::CLOSURE)
+        v->visit_vreg(&vreg);
+    v->visit_vreg(&vreg_dst, true);
 }
 
-void* BST_Name::accept_expr(ExprVisitor* v) {
-    return v->visit_name(this);
+void BST_LoadName::accept_stmt(StmtVisitor* v) {
+    v->visit_loadname(this);
 }
 
-void BST_Num::accept(BSTVisitor* v) {
-    bool skip = v->visit_num(this);
+void BST_LoadAttr::accept(BSTVisitor* v) {
+    bool skip = v->visit_loadattr(this);
+    if (skip)
+        return;
+
+    v->visit_vreg(&vreg_value);
+    v->visit_vreg(&vreg_dst, true);
 }
 
-void* BST_Num::accept_expr(ExprVisitor* v) {
-    return v->visit_num(this);
+void BST_LoadAttr::accept_stmt(StmtVisitor* v) {
+    v->visit_loadattr(this);
+}
+
+void BST_LoadSub::accept(BSTVisitor* v) {
+    bool skip = v->visit_loadsub(this);
+    if (skip)
+        return;
+    v->visit_vreg(&vreg_value);
+    v->visit_vreg(&vreg_slice);
+    v->visit_vreg(&vreg_dst, true);
+}
+
+void BST_LoadSub::accept_stmt(StmtVisitor* v) {
+    v->visit_loadsub(this);
+}
+
+void BST_LoadSubSlice::accept(BSTVisitor* v) {
+    bool skip = v->visit_loadsubslice(this);
+    if (skip)
+        return;
+
+    v->visit_vreg(&vreg_value);
+    v->visit_vreg(&vreg_lower);
+    v->visit_vreg(&vreg_upper);
+    v->visit_vreg(&vreg_dst, true);
+}
+
+void BST_LoadSubSlice::accept_stmt(StmtVisitor* v) {
+    v->visit_loadsubslice(this);
+}
+
+void BST_StoreName::accept(BSTVisitor* v) {
+    bool skip = v->visit_storename(this);
+    if (skip)
+        return;
+
+    if (lookup_type == ScopeInfo::VarScopeType::FAST || lookup_type == ScopeInfo::VarScopeType::CLOSURE)
+        v->visit_vreg(&vreg, true);
+    v->visit_vreg(&vreg_value);
+}
+
+void BST_StoreName::accept_stmt(StmtVisitor* v) {
+    v->visit_storename(this);
+}
+
+void BST_StoreAttr::accept(BSTVisitor* v) {
+    bool skip = v->visit_storeattr(this);
+    if (skip)
+        return;
+
+    v->visit_vreg(&vreg_value);
+    v->visit_vreg(&vreg_target);
+}
+
+void BST_StoreAttr::accept_stmt(StmtVisitor* v) {
+    v->visit_storeattr(this);
+}
+
+void BST_StoreSub::accept(BSTVisitor* v) {
+    bool skip = v->visit_storesub(this);
+    if (skip)
+        return;
+
+    v->visit_vreg(&vreg_target);
+    v->visit_vreg(&vreg_slice);
+    v->visit_vreg(&vreg_value);
+}
+
+void BST_StoreSub::accept_stmt(StmtVisitor* v) {
+    v->visit_storesub(this);
+}
+
+void BST_StoreSubSlice::accept(BSTVisitor* v) {
+    bool skip = v->visit_storesubslice(this);
+    if (skip)
+        return;
+
+    v->visit_vreg(&vreg_target);
+    v->visit_vreg(&vreg_lower);
+    v->visit_vreg(&vreg_upper);
+    v->visit_vreg(&vreg_value);
+}
+
+void BST_StoreSubSlice::accept_stmt(StmtVisitor* v) {
+    v->visit_storesubslice(this);
 }
 
 void BST_Print::accept(BSTVisitor* v) {
@@ -336,11 +573,8 @@ void BST_Print::accept(BSTVisitor* v) {
     if (skip)
         return;
 
-    if (dest)
-        dest->accept(v);
-
-    if (value)
-        value->accept(v);
+    v->visit_vreg(&vreg_dest);
+    v->visit_vreg(&vreg_value);
 }
 
 void BST_Print::accept_stmt(StmtVisitor* v) {
@@ -352,12 +586,9 @@ void BST_Raise::accept(BSTVisitor* v) {
     if (skip)
         return;
 
-    if (arg0)
-        arg0->accept(v);
-    if (arg1)
-        arg1->accept(v);
-    if (arg2)
-        arg2->accept(v);
+    v->visit_vreg(&vreg_arg0);
+    v->visit_vreg(&vreg_arg1);
+    v->visit_vreg(&vreg_arg2);
 }
 
 void BST_Raise::accept_stmt(StmtVisitor* v) {
@@ -369,10 +600,11 @@ void BST_Repr::accept(BSTVisitor* v) {
     if (skip)
         return;
 
-    value->accept(v);
+    v->visit_vreg(&vreg_value);
+    v->visit_vreg(&vreg_dst, true);
 }
 
-void* BST_Repr::accept_expr(ExprVisitor* v) {
+void BST_Repr::accept_stmt(StmtVisitor* v) {
     return v->visit_repr(this);
 }
 
@@ -381,8 +613,7 @@ void BST_Return::accept(BSTVisitor* v) {
     if (skip)
         return;
 
-    if (value)
-        value->accept(v);
+    v->visit_vreg(&vreg_value);
 }
 
 void BST_Return::accept_stmt(StmtVisitor* v) {
@@ -394,51 +625,14 @@ void BST_Set::accept(BSTVisitor* v) {
     if (skip)
         return;
 
-    visitVector(elts, v);
+    for (int i = 0; i < num_elts; ++i) {
+        v->visit_vreg(&elts[i]);
+    }
+    v->visit_vreg(&vreg_dst, true);
 }
 
-void* BST_Set::accept_expr(ExprVisitor* v) {
+void BST_Set::accept_stmt(StmtVisitor* v) {
     return v->visit_set(this);
-}
-
-void BST_Slice::accept(BSTVisitor* v) {
-    bool skip = v->visit_slice(this);
-    if (skip)
-        return;
-
-    if (lower)
-        lower->accept(v);
-    if (upper)
-        upper->accept(v);
-    if (step)
-        step->accept(v);
-}
-
-void* BST_Slice::accept_slice(SliceVisitor* v) {
-    return v->visit_slice(this);
-}
-
-void BST_Str::accept(BSTVisitor* v) {
-    bool skip = v->visit_str(this);
-    if (skip)
-        return;
-}
-
-void* BST_Str::accept_expr(ExprVisitor* v) {
-    return v->visit_str(this);
-}
-
-void BST_Subscript::accept(BSTVisitor* v) {
-    bool skip = v->visit_subscript(this);
-    if (skip)
-        return;
-
-    this->value->accept(v);
-    this->slice->accept(v);
-}
-
-void* BST_Subscript::accept_expr(ExprVisitor* v) {
-    return v->visit_subscript(this);
 }
 
 void BST_Tuple::accept(BSTVisitor* v) {
@@ -446,10 +640,13 @@ void BST_Tuple::accept(BSTVisitor* v) {
     if (skip)
         return;
 
-    visitVector(elts, v);
+    for (int i = 0; i < num_elts; ++i) {
+        v->visit_vreg(&elts[i]);
+    }
+    v->visit_vreg(&vreg_dst, true);
 }
 
-void* BST_Tuple::accept_expr(ExprVisitor* v) {
+void BST_Tuple::accept_stmt(StmtVisitor* v) {
     return v->visit_tuple(this);
 }
 
@@ -458,11 +655,27 @@ void BST_UnaryOp::accept(BSTVisitor* v) {
     if (skip)
         return;
 
-    operand->accept(v);
+    v->visit_vreg(&vreg_operand);
+    v->visit_vreg(&vreg_dst, true);
 }
 
-void* BST_UnaryOp::accept_expr(ExprVisitor* v) {
+void BST_UnaryOp::accept_stmt(StmtVisitor* v) {
     return v->visit_unaryop(this);
+}
+
+void BST_UnpackIntoArray::accept(BSTVisitor* v) {
+    bool skip = v->visit_unpackintoarray(this);
+    if (skip)
+        return;
+
+    v->visit_vreg(&vreg_src);
+    for (int i = 0; i < num_elts; ++i) {
+        v->visit_vreg(&vreg_dst[i], true);
+    }
+}
+
+void BST_UnpackIntoArray::accept_stmt(StmtVisitor* v) {
+    return v->visit_unpackintoarray(this);
 }
 
 void BST_Yield::accept(BSTVisitor* v) {
@@ -470,11 +683,11 @@ void BST_Yield::accept(BSTVisitor* v) {
     if (skip)
         return;
 
-    if (value)
-        value->accept(v);
+    v->visit_vreg(&vreg_value);
+    v->visit_vreg(&vreg_dst, true);
 }
 
-void* BST_Yield::accept_expr(ExprVisitor* v) {
+void BST_Yield::accept_stmt(StmtVisitor* v) {
     return v->visit_yield(this);
 }
 
@@ -483,7 +696,7 @@ void BST_Branch::accept(BSTVisitor* v) {
     if (skip)
         return;
 
-    test->accept(v);
+    v->visit_vreg(&vreg_test);
 }
 
 void BST_Branch::accept_stmt(StmtVisitor* v) {
@@ -500,27 +713,16 @@ void BST_Jump::accept_stmt(StmtVisitor* v) {
     v->visit_jump(this);
 }
 
-void BST_ClsAttribute::accept(BSTVisitor* v) {
-    bool skip = v->visit_clsattribute(this);
-    if (skip)
-        return;
-
-    value->accept(v);
-}
-
-void* BST_ClsAttribute::accept_expr(ExprVisitor* v) {
-    return v->visit_clsattribute(this);
-}
-
 void BST_MakeFunction::accept(BSTVisitor* v) {
     bool skip = v->visit_makefunction(this);
     if (skip)
         return;
 
     function_def->accept(v);
+    v->visit_vreg(&vreg_dst, true);
 }
 
-void* BST_MakeFunction::accept_expr(ExprVisitor* v) {
+void BST_MakeFunction::accept_stmt(StmtVisitor* v) {
     return v->visit_makefunction(this);
 }
 
@@ -530,14 +732,30 @@ void BST_MakeClass::accept(BSTVisitor* v) {
         return;
 
     class_def->accept(v);
+    v->visit_vreg(&vreg_dst, true);
 }
 
-void* BST_MakeClass::accept_expr(ExprVisitor* v) {
+void BST_MakeClass::accept_stmt(StmtVisitor* v) {
     return v->visit_makeclass(this);
 }
 
-void print_bst(BST* bst) {
-    PrintVisitor v;
+void BST_MakeSlice::accept(BSTVisitor* v) {
+    bool skip = v->visit_makeslice(this);
+    if (skip)
+        return;
+
+    v->visit_vreg(&vreg_lower);
+    v->visit_vreg(&vreg_upper);
+    v->visit_vreg(&vreg_step);
+    v->visit_vreg(&vreg_dst, true);
+}
+
+void BST_MakeSlice::accept_stmt(StmtVisitor* v) {
+    return v->visit_makeslice(this);
+}
+
+void print_bst(BST_stmt* bst, const ConstantVRegInfo& constant_vregs) {
+    PrintVisitor v(constant_vregs, 0, llvm::outs());
     bst->accept(&v);
     v.flush();
 }
@@ -548,125 +766,135 @@ void PrintVisitor::printIndent() {
     }
 }
 
-bool PrintVisitor::visit_arguments(BST_arguments* node) {
-    int ndefault = node->defaults.size();
-    for (int i = 0; i < ndefault; i++) {
-        if (i > 0)
-            stream << ", ";
+extern "C" BoxedString* repr(Box* obj);
+bool PrintVisitor::visit_vreg(int* vreg, bool is_dst) {
+    if (*vreg != VREG_UNDEFINED) {
+        stream << "%" << *vreg;
+        if (*vreg < 0)
+            stream << "|" << autoDecref(repr(constant_vregs.getConstant(*vreg)))->s() << "|";
+    } else
+        stream << "%undef";
 
-        stream << "<default " << i << ">=";
-        node->defaults[i]->accept(this);
-    }
+    if (is_dst)
+        stream << " = ";
+
     return true;
 }
 
 bool PrintVisitor::visit_assert(BST_Assert* node) {
-    stream << "assert ";
-    node->test->accept(this);
-    if (node->msg) {
+    stream << "assert 0";
+    if (node->vreg_msg != VREG_UNDEFINED) {
         stream << ", ";
-        node->msg->accept(this);
+        visit_vreg(&node->vreg_msg);
     }
     return true;
 }
 
-bool PrintVisitor::visit_assign(BST_Assign* node) {
-    node->target->accept(this);
-    stream << " = ";
-    node->value->accept(this);
+bool PrintVisitor::visit_copyvreg(BST_CopyVReg* node) {
+    visit_vreg(&node->vreg_dst, true);
+    stream << "nokill ";
+    visit_vreg(&node->vreg_src);
     return true;
-}
-
-void PrintVisitor::printOp(AST_TYPE::AST_TYPE op_type) {
-    switch (op_type) {
-        case BST_TYPE::Add:
-            stream << '+';
-            break;
-        case BST_TYPE::BitAnd:
-            stream << '&';
-            break;
-        case BST_TYPE::BitOr:
-            stream << '|';
-            break;
-        case BST_TYPE::BitXor:
-            stream << '^';
-            break;
-        case BST_TYPE::Div:
-            stream << '/';
-            break;
-        case BST_TYPE::LShift:
-            stream << "<<";
-            break;
-        case BST_TYPE::RShift:
-            stream << ">>";
-            break;
-        case BST_TYPE::Pow:
-            stream << "**";
-            break;
-        case BST_TYPE::Mod:
-            stream << '%';
-            break;
-        case BST_TYPE::Mult:
-            stream << '*';
-            break;
-        case BST_TYPE::Sub:
-            stream << '-';
-            break;
-        default:
-            stream << "<" << (int)op_type << ">";
-            break;
-    }
 }
 
 bool PrintVisitor::visit_augbinop(BST_AugBinOp* node) {
-    node->left->accept(this);
-    stream << '=';
-    printOp(node->op_type);
-    node->right->accept(this);
-    return true;
-}
-
-bool PrintVisitor::visit_attribute(BST_Attribute* node) {
-    node->value->accept(this);
-    stream << '.';
-    stream << node->attr.s();
+    visit_vreg(&node->vreg_dst, true);
+    visit_vreg(&node->vreg_left);
+    stream << " =" << getOpSymbol(node->op_type) << " ";
+    visit_vreg(&node->vreg_right);
     return true;
 }
 
 bool PrintVisitor::visit_binop(BST_BinOp* node) {
-    node->left->accept(this);
-    printOp(node->op_type);
-    node->right->accept(this);
+    visit_vreg(&node->vreg_dst, true);
+    visit_vreg(&node->vreg_left);
+    stream << " " << getOpSymbol(node->op_type) << " ";
+    visit_vreg(&node->vreg_right);
     return true;
 }
 
-bool PrintVisitor::visit_call(BST_Call* node) {
-    node->func->accept(this);
+bool PrintVisitor::visit_callfunc(BST_CallFunc* node) {
+    visit_vreg(&node->vreg_dst, true);
+    visit_vreg(&node->vreg_func);
     stream << "(";
 
     bool prevarg = false;
-    for (int i = 0; i < node->args.size(); i++) {
+    for (int i = 0; i < node->num_args + node->num_keywords; ++i) {
         if (prevarg)
             stream << ", ";
-        node->args[i]->accept(this);
+        visit_vreg(&node->elts[i]);
         prevarg = true;
     }
-    for (int i = 0; i < node->keywords.size(); i++) {
+    if (node->vreg_starargs != VREG_UNDEFINED) {
         if (prevarg)
             stream << ", ";
-        node->keywords[i]->accept(this);
+        visit_vreg(&node->vreg_starargs);
         prevarg = true;
     }
-    if (node->starargs) {
+    if (node->vreg_kwargs != VREG_UNDEFINED) {
         if (prevarg)
             stream << ", ";
-        node->starargs->accept(this);
+        visit_vreg(&node->vreg_kwargs);
         prevarg = true;
     }
-    if (node->kwargs) {
+    stream << ")";
+    return true;
+}
+
+bool PrintVisitor::visit_callattr(BST_CallAttr* node) {
+    visit_vreg(&node->vreg_dst, true);
+    visit_vreg(&node->vreg_value);
+    stream << ".";
+    stream << node->attr.s();
+    stream << "(";
+
+    bool prevarg = false;
+    for (int i = 0; i < node->num_args + node->num_keywords; ++i) {
         if (prevarg)
             stream << ", ";
-        node->kwargs->accept(this);
+        visit_vreg(&node->elts[i]);
+        prevarg = true;
+    }
+    if (node->vreg_starargs != VREG_UNDEFINED) {
+        if (prevarg)
+            stream << ", ";
+        visit_vreg(&node->vreg_starargs);
+        prevarg = true;
+    }
+    if (node->vreg_kwargs != VREG_UNDEFINED) {
+        if (prevarg)
+            stream << ", ";
+        visit_vreg(&node->vreg_kwargs);
+        prevarg = true;
+    }
+    stream << ")";
+    return true;
+}
+
+bool PrintVisitor::visit_callclsattr(BST_CallClsAttr* node) {
+    visit_vreg(&node->vreg_dst, true);
+    visit_vreg(&node->vreg_value);
+    stream << ":";
+    stream << node->attr.s();
+    stream << "(";
+
+    bool prevarg = false;
+    for (int i = 0; i < node->num_args + node->num_keywords; ++i) {
+        if (prevarg)
+            stream << ", ";
+        visit_vreg(&node->elts[i]);
+        prevarg = true;
+    }
+    if (node->vreg_starargs != VREG_UNDEFINED) {
+        if (prevarg)
+            stream << ", ";
+        visit_vreg(&node->vreg_starargs);
+        prevarg = true;
+    }
+    if (node->vreg_kwargs != VREG_UNDEFINED) {
+        if (prevarg)
+            stream << ", ";
+        visit_vreg(&node->vreg_kwargs);
         prevarg = true;
     }
     stream << ")";
@@ -674,26 +902,23 @@ bool PrintVisitor::visit_call(BST_Call* node) {
 }
 
 bool PrintVisitor::visit_compare(BST_Compare* node) {
-    node->left->accept(this);
+    visit_vreg(&node->vreg_dst, true);
+    visit_vreg(&node->vreg_left);
     stream << " " << getOpSymbol(node->op) << " ";
-    node->comparator->accept(this);
+    visit_vreg(&node->vreg_comparator);
 
     return true;
 }
 
 bool PrintVisitor::visit_classdef(BST_ClassDef* node) {
-    for (int i = 0, n = node->decorator_list.size(); i < n; i++) {
+    for (int i = 0, n = node->num_decorator; i < n; i++) {
         stream << "@";
-        node->decorator_list[i]->accept(this);
+        visit_vreg(&node->decorator[i]);
         stream << "\n";
         printIndent();
     }
     stream << "class " << node->name.s() << "(";
-    for (int i = 0, n = node->bases.size(); i < n; i++) {
-        if (i)
-            stream << ", ";
-        node->bases[i]->accept(this);
-    }
+    visit_vreg(&node->vreg_bases_tuple);
     stream << ")";
 
     indent += 4;
@@ -712,64 +937,71 @@ bool PrintVisitor::visit_classdef(BST_ClassDef* node) {
     return true;
 }
 
-bool PrintVisitor::visit_delete(BST_Delete* node) {
+bool PrintVisitor::visit_deletesub(BST_DeleteSub* node) {
     stream << "del ";
-    node->target->accept(this);
+    visit_vreg(&node->vreg_value);
+    stream << "[";
+    visit_vreg(&node->vreg_slice);
+    stream << "]";
+    return true;
+}
+bool PrintVisitor::visit_deletesubslice(BST_DeleteSubSlice* node) {
+    stream << "del ";
+    visit_vreg(&node->vreg_value);
+    stream << "[";
+    if (node->vreg_lower != VREG_UNDEFINED)
+        visit_vreg(&node->vreg_lower);
+    if (node->vreg_upper != VREG_UNDEFINED) {
+        stream << ":";
+        visit_vreg(&node->vreg_upper);
+    }
+    stream << "]";
+    return true;
+}
+bool PrintVisitor::visit_deleteattr(BST_DeleteAttr* node) {
+    stream << "del ";
+    visit_vreg(&node->vreg_value);
+    stream << '.';
+    stream << node->attr.s();
+    return true;
+}
+bool PrintVisitor::visit_deletename(BST_DeleteName* node) {
+    stream << "del ";
+    if (node->lookup_type == ScopeInfo::VarScopeType::FAST || node->lookup_type == ScopeInfo::VarScopeType::CLOSURE) {
+        visit_vreg(&node->vreg);
+        stream << " ";
+    }
+    stream << node->id.s();
     return true;
 }
 
 bool PrintVisitor::visit_dict(BST_Dict* node) {
-    stream << "{";
-    for (int i = 0; i < node->keys.size(); i++) {
-        if (i > 0)
-            stream << ", ";
-        node->keys[i]->accept(this);
-        stream << ":";
-        node->values[i]->accept(this);
-    }
-    stream << "}";
-    return true;
-}
-
-bool PrintVisitor::visit_ellipsis(BST_Ellipsis*) {
-    stream << "...";
+    visit_vreg(&node->vreg_dst, true);
+    stream << "{}";
     return true;
 }
 
 bool PrintVisitor::visit_exec(BST_Exec* node) {
     stream << "exec ";
 
-    node->body->accept(this);
-    if (node->globals) {
+    visit_vreg(&node->vreg_body);
+    if (node->vreg_globals != VREG_UNDEFINED) {
         stream << " in ";
-        node->globals->accept(this);
+        visit_vreg(&node->vreg_globals);
 
-        if (node->locals) {
+        if (node->vreg_locals != VREG_UNDEFINED) {
             stream << ", ";
-            node->locals->accept(this);
+            visit_vreg(&node->vreg_locals);
         }
     }
     stream << "\n";
     return true;
 }
 
-bool PrintVisitor::visit_expr(BST_Expr* node) {
-    return false;
-}
-
-bool PrintVisitor::visit_extslice(BST_ExtSlice* node) {
-    for (int i = 0; i < node->dims.size(); ++i) {
-        if (i > 0)
-            stream << ", ";
-        node->dims[i]->accept(this);
-    }
-    return true;
-}
-
 bool PrintVisitor::visit_functiondef(BST_FunctionDef* node) {
-    for (auto d : node->decorator_list) {
+    for (int i = 0; i < node->num_decorator; ++i) {
         stream << "@";
-        d->accept(this);
+        visit_vreg(&node->elts[i]);
         stream << "\n";
         printIndent();
     }
@@ -780,7 +1012,15 @@ bool PrintVisitor::visit_functiondef(BST_FunctionDef* node) {
     else
         stream << "<lambda>";
     stream << "(";
-    node->args->accept(this);
+
+    for (int i = 0; i < node->num_defaults; ++i) {
+        if (i > 0)
+            stream << ", ";
+
+        stream << "<default " << i << ">=";
+        visit_vreg(&node->elts[node->num_decorator + i]);
+    }
+
     stream << ")";
 
     indent += 4;
@@ -798,135 +1038,119 @@ bool PrintVisitor::visit_functiondef(BST_FunctionDef* node) {
     return true;
 }
 
-bool PrintVisitor::visit_index(BST_Index* node) {
-    return false;
-}
-
 bool PrintVisitor::visit_invoke(BST_Invoke* node) {
     stream << "invoke " << node->normal_dest->idx << " " << node->exc_dest->idx << ": ";
     node->stmt->accept(this);
     return true;
 }
 
-bool PrintVisitor::visit_langprimitive(BST_LangPrimitive* node) {
-    stream << ":";
-    switch (node->opcode) {
-        case BST_LangPrimitive::CHECK_EXC_MATCH:
-            stream << "CHECK_EXC_MATCH";
-            break;
-        case BST_LangPrimitive::LANDINGPAD:
-            stream << "LANDINGPAD";
-            break;
-        case BST_LangPrimitive::LOCALS:
-            stream << "LOCALS";
-            break;
-        case BST_LangPrimitive::GET_ITER:
-            stream << "GET_ITER";
-            break;
-        case BST_LangPrimitive::IMPORT_FROM:
-            stream << "IMPORT_FROM";
-            break;
-        case BST_LangPrimitive::IMPORT_NAME:
-            stream << "IMPORT_NAME";
-            break;
-        case BST_LangPrimitive::IMPORT_STAR:
-            stream << "IMPORT_STAR";
-            break;
-        case BST_LangPrimitive::NONE:
-            stream << "NONE";
-            break;
-        case BST_LangPrimitive::NONZERO:
-            stream << "NONZERO";
-            break;
-        case BST_LangPrimitive::SET_EXC_INFO:
-            stream << "SET_EXC_INFO";
-            break;
-        case BST_LangPrimitive::UNCACHE_EXC_INFO:
-            stream << "UNCACHE_EXC_INFO";
-            break;
-        case BST_LangPrimitive::HASNEXT:
-            stream << "HASNEXT";
-            break;
-        case BST_LangPrimitive::PRINT_EXPR:
-            stream << "PRINT_EXPR";
-            break;
-        default:
-            RELEASE_ASSERT(0, "%d", node->opcode);
-    }
-    stream << "(";
-    for (int i = 0, n = node->args.size(); i < n; ++i) {
-        if (i > 0)
-            stream << ", ";
-        node->args[i]->accept(this);
-    }
+bool PrintVisitor::visit_landingpad(BST_Landingpad* node) {
+    visit_vreg(&node->vreg_dst, true);
+    stream << ":LANDINGPAD()";
+    return true;
+}
+bool PrintVisitor::visit_locals(BST_Locals* node) {
+    visit_vreg(&node->vreg_dst, true);
+    stream << ":LOCALS()";
+    return true;
+}
+bool PrintVisitor::visit_getiter(BST_GetIter* node) {
+    visit_vreg(&node->vreg_dst, true);
+    stream << ":GET_ITER(";
+    visit_vreg(&node->vreg_value);
+    stream << ")";
+    return true;
+}
+bool PrintVisitor::visit_importfrom(BST_ImportFrom* node) {
+    visit_vreg(&node->vreg_dst, true);
+    stream << ":IMPORT_FROM(";
+    visit_vreg(&node->vreg_module);
+    stream << ", ";
+    visit_vreg(&node->vreg_name);
+    stream << ")";
+    return true;
+}
+bool PrintVisitor::visit_importname(BST_ImportName* node) {
+    visit_vreg(&node->vreg_dst, true);
+    stream << ":IMPORT_NAME(";
+    visit_vreg(&node->vreg_from);
+    stream << ", ";
+    visit_vreg(&node->vreg_name);
+    stream << ", " << node->level << ")";
+    return true;
+}
+bool PrintVisitor::visit_importstar(BST_ImportStar* node) {
+    visit_vreg(&node->vreg_dst, true);
+    stream << ":IMPORT_STAR(";
+    visit_vreg(&node->vreg_name);
+    stream << ")";
+    return true;
+}
+bool PrintVisitor::visit_nonzero(BST_Nonzero* node) {
+    visit_vreg(&node->vreg_dst, true);
+    stream << ":NONZERO(";
+    visit_vreg(&node->vreg_value);
+    stream << ")";
+    return true;
+}
+bool PrintVisitor::visit_checkexcmatch(BST_CheckExcMatch* node) {
+    visit_vreg(&node->vreg_dst, true);
+    stream << ":CHECK_EXC_MATCH(";
+    visit_vreg(&node->vreg_value);
+    stream << ", ";
+    visit_vreg(&node->vreg_cls);
+    stream << ")";
+    return true;
+}
+bool PrintVisitor::visit_setexcinfo(BST_SetExcInfo* node) {
+    stream << ":SET_EXC_INFO(";
+    visit_vreg(&node->vreg_value);
+    stream << ", ";
+    visit_vreg(&node->vreg_type);
+    stream << ", ";
+    visit_vreg(&node->vreg_traceback);
+    stream << ")";
+    return true;
+}
+bool PrintVisitor::visit_uncacheexcinfo(BST_UncacheExcInfo* node) {
+    stream << ":UNCACHE_EXC_INFO()";
+    return true;
+}
+bool PrintVisitor::visit_hasnext(BST_HasNext* node) {
+    visit_vreg(&node->vreg_dst, true);
+    stream << ":HAS_NEXT(";
+    visit_vreg(&node->vreg_value);
+    stream << ")";
+    return true;
+}
+bool PrintVisitor::visit_printexpr(BST_PrintExpr* node) {
+    stream << ":PRINT_EXPR(";
+    visit_vreg(&node->vreg_value);
     stream << ")";
     return true;
 }
 
 bool PrintVisitor::visit_list(BST_List* node) {
+    visit_vreg(&node->vreg_dst, true);
     stream << "[";
-    for (int i = 0, n = node->elts.size(); i < n; ++i) {
+    for (int i = 0, n = node->num_elts; i < n; ++i) {
         if (i > 0)
             stream << ", ";
-        node->elts[i]->accept(this);
+        visit_vreg(&node->elts[i]);
     }
     stream << "]";
     return true;
 }
 
-bool PrintVisitor::visit_keyword(BST_keyword* node) {
-    stream << node->arg.s() << "=";
-    node->value->accept(this);
-    return true;
-}
-
-bool PrintVisitor::visit_name(BST_Name* node) {
-    stream << node->id.s();
-#if 0
-    if (node->lookup_type == ScopeInfo::VarScopeType::UNKNOWN)
-        stream << "<U>";
-    else if (node->lookup_type == ScopeInfo::VarScopeType::FAST)
-        stream << "<F>";
-    else if (node->lookup_type == ScopeInfo::VarScopeType::DEREF)
-        stream << "<D>";
-    else if (node->lookup_type == ScopeInfo::VarScopeType::CLOSURE)
-        stream << "<C>";
-    else if (node->lookup_type == ScopeInfo::VarScopeType::GLOBAL)
-        stream << "<G>";
-    else
-        stream << "<?>";
-#endif
-
-#if 0
-    if (node->is_kill) stream << "<k>";
-#endif
-    return false;
-}
-
-bool PrintVisitor::visit_num(BST_Num* node) {
-    if (node->num_type == AST_Num::INT) {
-        stream << node->n_int;
-    } else if (node->num_type == AST_Num::LONG) {
-        stream << node->n_long << "L";
-    } else if (node->num_type == AST_Num::FLOAT) {
-        stream << node->n_float;
-    } else if (node->num_type == AST_Num::COMPLEX) {
-        stream << node->n_float << "j";
-    } else {
-        RELEASE_ASSERT(0, "");
-    }
-    return false;
-}
-
 bool PrintVisitor::visit_print(BST_Print* node) {
     stream << "print ";
-    if (node->dest) {
+    if (node->vreg_dest != VREG_UNDEFINED) {
         stream << ">>";
-        node->dest->accept(this);
+        visit_vreg(&node->vreg_dest);
         stream << ", ";
     }
-    if (node->value)
-        node->value->accept(this);
+    if (node->vreg_value != VREG_UNDEFINED)
+        visit_vreg(&node->vreg_value);
     if (!node->nl)
         stream << ",";
     return true;
@@ -934,97 +1158,165 @@ bool PrintVisitor::visit_print(BST_Print* node) {
 
 bool PrintVisitor::visit_raise(BST_Raise* node) {
     stream << "raise";
-    if (node->arg0) {
+    if (node->vreg_arg0 != VREG_UNDEFINED) {
         stream << " ";
-        node->arg0->accept(this);
+        visit_vreg(&node->vreg_arg0);
     }
-    if (node->arg1) {
+    if (node->vreg_arg1 != VREG_UNDEFINED) {
         stream << ", ";
-        node->arg1->accept(this);
+        visit_vreg(&node->vreg_arg1);
     }
-    if (node->arg2) {
+    if (node->vreg_arg2 != VREG_UNDEFINED) {
         stream << ", ";
-        node->arg2->accept(this);
+        visit_vreg(&node->vreg_arg2);
     }
     return true;
 }
 
 bool PrintVisitor::visit_repr(BST_Repr* node) {
+    visit_vreg(&node->vreg_dst, true);
     stream << "`";
-    node->value->accept(this);
+    visit_vreg(&node->vreg_value);
     stream << "`";
     return true;
 }
 
 bool PrintVisitor::visit_return(BST_Return* node) {
     stream << "return ";
-    return false;
+    if (node->vreg_value != VREG_UNDEFINED)
+        visit_vreg(&node->vreg_value);
+    return true;
 }
 
 bool PrintVisitor::visit_set(BST_Set* node) {
+    visit_vreg(&node->vreg_dst, true);
     // An empty set literal is not writeable in Python (it's a dictionary),
     // but we sometimes generate it (ex in set comprehension lowering).
     // Just to make it clear when printing, print empty set literals as "SET{}".
-    if (!node->elts.size())
+    if (!node->num_elts)
         stream << "SET";
 
     stream << "{";
 
     bool first = true;
-    for (auto e : node->elts) {
+    for (int i = 0; i < node->num_elts; ++i) {
         if (!first)
             stream << ", ";
         first = false;
 
-        e->accept(this);
+        visit_vreg(&node->num_elts[&i]);
     }
 
     stream << "}";
     return true;
 }
 
-bool PrintVisitor::visit_slice(BST_Slice* node) {
+bool PrintVisitor::visit_makeslice(BST_MakeSlice* node) {
+    visit_vreg(&node->vreg_dst, true);
     stream << "<slice>(";
-    if (node->lower)
-        node->lower->accept(this);
-    if (node->upper || node->step)
+    if (node->vreg_lower != VREG_UNDEFINED)
+        visit_vreg(&node->vreg_lower);
+    if (node->vreg_upper != VREG_UNDEFINED || node->vreg_step != VREG_UNDEFINED)
         stream << ':';
-    if (node->upper)
-        node->upper->accept(this);
-    if (node->step) {
+    if (node->vreg_upper != VREG_UNDEFINED)
+        visit_vreg(&node->vreg_upper);
+    if (node->vreg_step != VREG_UNDEFINED) {
         stream << ':';
-        node->step->accept(this);
+        visit_vreg(&node->vreg_step);
     }
     stream << ")";
     return true;
 }
 
-bool PrintVisitor::visit_str(BST_Str* node) {
-    if (node->str_type == AST_Str::STR) {
-        stream << "\"" << node->str_data << "\"";
-    } else if (node->str_type == AST_Str::UNICODE) {
-        stream << "<unicode value>";
-    } else {
-        RELEASE_ASSERT(0, "%d", node->str_type);
+bool PrintVisitor::visit_loadname(BST_LoadName* node) {
+    visit_vreg(&node->vreg_dst, true);
+    if (node->lookup_type == ScopeInfo::VarScopeType::FAST || node->lookup_type == ScopeInfo::VarScopeType::CLOSURE) {
+        visit_vreg(&node->vreg);
+        stream << " ";
     }
-    return false;
+    stream << node->id.s();
+    return true;
 }
 
-bool PrintVisitor::visit_subscript(BST_Subscript* node) {
-    node->value->accept(this);
+bool PrintVisitor::visit_loadattr(BST_LoadAttr* node) {
+    visit_vreg(&node->vreg_dst, true);
+    visit_vreg(&node->vreg_value);
+    stream << (node->clsonly ? ':' : '.') << node->attr.s();
+    return true;
+}
+
+bool PrintVisitor::visit_loadsub(BST_LoadSub* node) {
+    visit_vreg(&node->vreg_dst, true);
+    visit_vreg(&node->vreg_value);
     stream << "[";
-    node->slice->accept(this);
+    visit_vreg(&node->vreg_slice);
     stream << "]";
     return true;
 }
 
+bool PrintVisitor::visit_loadsubslice(BST_LoadSubSlice* node) {
+    visit_vreg(&node->vreg_dst, true);
+    visit_vreg(&node->vreg_value);
+    stream << "[";
+    if (node->vreg_lower != VREG_UNDEFINED)
+        visit_vreg(&node->vreg_lower);
+    if (node->vreg_upper != VREG_UNDEFINED) {
+        stream << ":";
+        visit_vreg(&node->vreg_upper);
+    }
+    stream << "]";
+    return true;
+}
+
+bool PrintVisitor::visit_storename(BST_StoreName* node) {
+    if (node->lookup_type == ScopeInfo::VarScopeType::FAST || node->lookup_type == ScopeInfo::VarScopeType::CLOSURE) {
+        visit_vreg(&node->vreg);
+        stream << " ";
+    }
+    stream << node->id.s();
+    stream << " = ";
+    visit_vreg(&node->vreg_value);
+    return true;
+}
+
+bool PrintVisitor::visit_storeattr(BST_StoreAttr* node) {
+    visit_vreg(&node->vreg_target);
+    stream << "." << node->attr.s() << " = ";
+    visit_vreg(&node->vreg_value);
+    return true;
+}
+
+bool PrintVisitor::visit_storesub(BST_StoreSub* node) {
+    visit_vreg(&node->vreg_target);
+    stream << "[";
+    visit_vreg(&node->vreg_slice);
+    stream << "] = ";
+    visit_vreg(&node->vreg_value);
+    return true;
+}
+
+bool PrintVisitor::visit_storesubslice(BST_StoreSubSlice* node) {
+    visit_vreg(&node->vreg_target);
+    stream << "[";
+    if (node->vreg_lower != VREG_UNDEFINED)
+        visit_vreg(&node->vreg_lower);
+    if (node->vreg_upper != VREG_UNDEFINED) {
+        stream << ":";
+        visit_vreg(&node->vreg_upper);
+    }
+    stream << "] = ";
+    visit_vreg(&node->vreg_value);
+    return true;
+}
+
 bool PrintVisitor::visit_tuple(BST_Tuple* node) {
+    visit_vreg(&node->vreg_dst, true);
     stream << "(";
-    int n = node->elts.size();
+    int n = node->num_elts;
     for (int i = 0; i < n; i++) {
         if (i)
             stream << ", ";
-        node->elts[i]->accept(this);
+        visit_vreg(&node->elts[i]);
     }
     if (n == 1)
         stream << ",";
@@ -1033,17 +1325,18 @@ bool PrintVisitor::visit_tuple(BST_Tuple* node) {
 }
 
 bool PrintVisitor::visit_unaryop(BST_UnaryOp* node) {
+    visit_vreg(&node->vreg_dst, true);
     switch (node->op_type) {
-        case BST_TYPE::Invert:
+        case AST_TYPE::Invert:
             stream << "~";
             break;
-        case BST_TYPE::Not:
+        case AST_TYPE::Not:
             stream << "not ";
             break;
-        case BST_TYPE::UAdd:
+        case AST_TYPE::UAdd:
             stream << "+";
             break;
-        case BST_TYPE::USub:
+        case AST_TYPE::USub:
             stream << "-";
             break;
         default:
@@ -1051,21 +1344,36 @@ bool PrintVisitor::visit_unaryop(BST_UnaryOp* node) {
             break;
     }
     stream << "(";
-    node->operand->accept(this);
+    // node->operand->accept(this);
+    visit_vreg(&node->vreg_operand);
     stream << ")";
     return true;
 }
 
+bool PrintVisitor::visit_unpackintoarray(BST_UnpackIntoArray* node) {
+    stream << "(";
+    for (int i = 0; i < node->num_elts; ++i) {
+        visit_vreg(&node->vreg_dst[i]);
+        if (i + 1 < node->num_elts || i == 0)
+            stream << ", ";
+    }
+    stream << ") = ";
+
+    visit_vreg(&node->vreg_src);
+    return true;
+}
+
 bool PrintVisitor::visit_yield(BST_Yield* node) {
+    visit_vreg(&node->vreg_dst, true);
     stream << "yield ";
-    if (node->value)
-        node->value->accept(this);
+    if (node->vreg_value != VREG_UNDEFINED)
+        visit_vreg(&node->vreg_value);
     return true;
 }
 
 bool PrintVisitor::visit_branch(BST_Branch* node) {
     stream << "if ";
-    node->test->accept(this);
+    visit_vreg(&node->vreg_test);
     stream << " goto " << node->iftrue->idx << " else goto " << node->iffalse->idx;
     return true;
 }
@@ -1075,21 +1383,14 @@ bool PrintVisitor::visit_jump(BST_Jump* node) {
     return true;
 }
 
-bool PrintVisitor::visit_clsattribute(BST_ClsAttribute* node) {
-    // printf("getclsattr(");
-    // node->value->accept(this);
-    // printf(", '%s')", node->attr.c_str());
-    node->value->accept(this);
-    stream << ":" << node->attr.s();
-    return true;
-}
-
 bool PrintVisitor::visit_makefunction(BST_MakeFunction* node) {
+    visit_vreg(&node->vreg_dst, true);
     stream << "make_";
     return false;
 }
 
 bool PrintVisitor::visit_makeclass(BST_MakeClass* node) {
+    visit_vreg(&node->vreg_dst, true);
     stream << "make_";
     return false;
 }
@@ -1097,23 +1398,23 @@ bool PrintVisitor::visit_makeclass(BST_MakeClass* node) {
 namespace {
 class FlattenVisitor : public BSTVisitor {
 private:
-    std::vector<BST*>* output;
+    std::vector<BST_stmt*>* output;
     bool expand_scopes;
 
 public:
-    FlattenVisitor(std::vector<BST*>* output, bool expand_scopes) : output(output), expand_scopes(expand_scopes) {
+    FlattenVisitor(std::vector<BST_stmt*>* output, bool expand_scopes)
+        : BSTVisitor(false /* visit child CFG */), output(output), expand_scopes(expand_scopes) {
         assert(expand_scopes && "not sure if this works properly");
     }
 
-    virtual bool visit_arguments(BST_arguments* node) {
-        output->push_back(node);
-        return false;
-    }
+    virtual bool visit_vreg(int* vreg, bool is_dst = false) { return false; }
+
+
     virtual bool visit_assert(BST_Assert* node) {
         output->push_back(node);
         return false;
     }
-    virtual bool visit_assign(BST_Assign* node) {
+    virtual bool visit_copyvreg(BST_CopyVReg* node) {
         output->push_back(node);
         return false;
     }
@@ -1121,18 +1422,23 @@ public:
         output->push_back(node);
         return false;
     }
-    virtual bool visit_attribute(BST_Attribute* node) {
-        output->push_back(node);
-        return false;
-    }
     virtual bool visit_binop(BST_BinOp* node) {
         output->push_back(node);
         return false;
     }
-    virtual bool visit_call(BST_Call* node) {
+    virtual bool visit_callfunc(BST_CallFunc* node) {
         output->push_back(node);
         return false;
     }
+    virtual bool visit_callattr(BST_CallAttr* node) {
+        output->push_back(node);
+        return false;
+    }
+    virtual bool visit_callclsattr(BST_CallClsAttr* node) {
+        output->push_back(node);
+        return false;
+    }
+
     virtual bool visit_classdef(BST_ClassDef* node) {
         output->push_back(node);
         return !expand_scopes;
@@ -1141,7 +1447,19 @@ public:
         output->push_back(node);
         return false;
     }
-    virtual bool visit_delete(BST_Delete* node) {
+    virtual bool visit_deletesub(BST_DeleteSub* node) {
+        output->push_back(node);
+        return false;
+    }
+    virtual bool visit_deletesubslice(BST_DeleteSubSlice* node) {
+        output->push_back(node);
+        return false;
+    }
+    virtual bool visit_deleteattr(BST_DeleteAttr* node) {
+        output->push_back(node);
+        return false;
+    }
+    virtual bool visit_deletename(BST_DeleteName* node) {
         output->push_back(node);
         return false;
     }
@@ -1149,19 +1467,7 @@ public:
         output->push_back(node);
         return false;
     }
-    virtual bool visit_ellipsis(BST_Ellipsis* node) {
-        output->push_back(node);
-        return false;
-    }
     virtual bool visit_exec(BST_Exec* node) {
-        output->push_back(node);
-        return false;
-    }
-    virtual bool visit_expr(BST_Expr* node) {
-        output->push_back(node);
-        return false;
-    }
-    virtual bool visit_extslice(BST_ExtSlice* node) {
         output->push_back(node);
         return false;
     }
@@ -1169,31 +1475,11 @@ public:
         output->push_back(node);
         return !expand_scopes;
     }
-    virtual bool visit_index(BST_Index* node) {
-        output->push_back(node);
-        return false;
-    }
     virtual bool visit_invoke(BST_Invoke* node) {
         output->push_back(node);
         return false;
     }
-    virtual bool visit_keyword(BST_keyword* node) {
-        output->push_back(node);
-        return false;
-    }
-    virtual bool visit_langprimitive(BST_LangPrimitive* node) {
-        output->push_back(node);
-        return false;
-    }
     virtual bool visit_list(BST_List* node) {
-        output->push_back(node);
-        return false;
-    }
-    virtual bool visit_name(BST_Name* node) {
-        output->push_back(node);
-        return false;
-    }
-    virtual bool visit_num(BST_Num* node) {
         output->push_back(node);
         return false;
     }
@@ -1217,23 +1503,15 @@ public:
         output->push_back(node);
         return false;
     }
-    virtual bool visit_slice(BST_Slice* node) {
-        output->push_back(node);
-        return false;
-    }
-    virtual bool visit_str(BST_Str* node) {
-        output->push_back(node);
-        return false;
-    }
-    virtual bool visit_subscript(BST_Subscript* node) {
-        output->push_back(node);
-        return false;
-    }
     virtual bool visit_tuple(BST_Tuple* node) {
         output->push_back(node);
         return false;
     }
     virtual bool visit_unaryop(BST_UnaryOp* node) {
+        output->push_back(node);
+        return false;
+    }
+    virtual bool visit_unpackintoarray(BST_UnpackIntoArray* node) {
         output->push_back(node);
         return false;
     }
@@ -1250,10 +1528,6 @@ public:
         output->push_back(node);
         return false;
     }
-    virtual bool visit_clsattribute(BST_ClsAttribute* node) {
-        output->push_back(node);
-        return false;
-    }
 
     virtual bool visit_makeclass(BST_MakeClass* node) {
         output->push_back(node);
@@ -1263,20 +1537,99 @@ public:
         output->push_back(node);
         return false;
     }
+    virtual bool visit_makeslice(BST_MakeSlice* node) {
+        output->push_back(node);
+        return false;
+    }
+
+    virtual bool visit_landingpad(BST_Landingpad* node) override {
+        output->push_back(node);
+        return false;
+    }
+    virtual bool visit_locals(BST_Locals* node) override {
+        output->push_back(node);
+        return false;
+    }
+    virtual bool visit_getiter(BST_GetIter* node) override {
+        output->push_back(node);
+        return false;
+    }
+    virtual bool visit_importfrom(BST_ImportFrom* node) override {
+        output->push_back(node);
+        return false;
+    }
+    virtual bool visit_importname(BST_ImportName* node) override {
+        output->push_back(node);
+        return false;
+    }
+    virtual bool visit_importstar(BST_ImportStar* node) override {
+        output->push_back(node);
+        return false;
+    }
+    virtual bool visit_nonzero(BST_Nonzero* node) override {
+        output->push_back(node);
+        return false;
+    }
+    virtual bool visit_checkexcmatch(BST_CheckExcMatch* node) override {
+        output->push_back(node);
+        return false;
+    }
+    virtual bool visit_setexcinfo(BST_SetExcInfo* node) override {
+        output->push_back(node);
+        return false;
+    }
+    virtual bool visit_uncacheexcinfo(BST_UncacheExcInfo* node) override {
+        output->push_back(node);
+        return false;
+    }
+    virtual bool visit_hasnext(BST_HasNext* node) override {
+        output->push_back(node);
+        return false;
+    }
+    virtual bool visit_printexpr(BST_PrintExpr* node) override {
+        output->push_back(node);
+        return false;
+    }
+    virtual bool visit_loadname(BST_LoadName* node) override {
+        output->push_back(node);
+        return false;
+    }
+    virtual bool visit_loadattr(BST_LoadAttr* node) override {
+        output->push_back(node);
+        return false;
+    }
+    virtual bool visit_loadsub(BST_LoadSub* node) override {
+        output->push_back(node);
+        return false;
+    }
+    virtual bool visit_loadsubslice(BST_LoadSubSlice* node) override {
+        output->push_back(node);
+        return false;
+    }
+    virtual bool visit_storename(BST_StoreName* node) override {
+        output->push_back(node);
+        return false;
+    }
+    virtual bool visit_storesub(BST_StoreSub* node) override {
+        output->push_back(node);
+        return false;
+    }
+    virtual bool visit_storesubslice(BST_StoreSubSlice* node) override {
+        output->push_back(node);
+        return false;
+    }
+    virtual bool visit_storeattr(BST_StoreAttr* node) override {
+        output->push_back(node);
+        return false;
+    }
 };
 }
 
-void flatten(llvm::ArrayRef<BST_stmt*> roots, std::vector<BST*>& output, bool expand_scopes) {
+void flatten(llvm::ArrayRef<BST_stmt*> roots, std::vector<BST_stmt*>& output, bool expand_scopes) {
     FlattenVisitor visitor(&output, expand_scopes);
 
     for (int i = 0; i < roots.size(); i++) {
         roots[i]->accept(&visitor);
     }
-}
-
-void flatten(BST_expr* root, std::vector<BST*>& output, bool expand_scopes) {
-    FlattenVisitor visitor(&output, expand_scopes);
-
-    root->accept(&visitor);
 }
 }

--- a/src/core/bst.h
+++ b/src/core/bst.h
@@ -33,116 +33,60 @@
 namespace pyston {
 
 namespace BST_TYPE {
-// These are in a pretty random order (started off alphabetical but then I had to add more).
-// These can be changed freely as long as parse_ast.py is also updated
+
 #define FOREACH_TYPE(X)                                                                                                \
-    X(alias, 1)                                                                                                        \
-    X(arguments, 2)                                                                                                    \
-    X(Assert, 3)                                                                                                       \
-    X(Assign, 4)                                                                                                       \
-    X(Attribute, 5)                                                                                                    \
-    X(AugAssign, 6)                                                                                                    \
-    X(BinOp, 7)                                                                                                        \
-    X(BoolOp, 8)                                                                                                       \
-    X(Call, 9)                                                                                                         \
-    X(ClassDef, 10)                                                                                                    \
-    X(Compare, 11)                                                                                                     \
-    X(comprehension, 12)                                                                                               \
-    X(Delete, 13)                                                                                                      \
-    X(Dict, 14)                                                                                                        \
-    X(Exec, 16)                                                                                                        \
-    X(ExceptHandler, 17)                                                                                               \
-    X(ExtSlice, 18)                                                                                                    \
-    X(Expr, 19)                                                                                                        \
-    X(For, 20)                                                                                                         \
-    X(FunctionDef, 21)                                                                                                 \
-    X(GeneratorExp, 22)                                                                                                \
-    X(Global, 23)                                                                                                      \
-    X(If, 24)                                                                                                          \
-    X(IfExp, 25)                                                                                                       \
-    X(Import, 26)                                                                                                      \
-    X(ImportFrom, 27)                                                                                                  \
-    X(Index, 28)                                                                                                       \
-    X(keyword, 29)                                                                                                     \
-    X(Lambda, 30)                                                                                                      \
-    X(List, 31)                                                                                                        \
-    X(ListComp, 32)                                                                                                    \
-    X(Module, 33)                                                                                                      \
-    X(Num, 34)                                                                                                         \
-    X(Name, 35)                                                                                                        \
-    X(Pass, 37)                                                                                                        \
-    X(Pow, 38)                                                                                                         \
-    X(Print, 39)                                                                                                       \
-    X(Raise, 40)                                                                                                       \
-    X(Repr, 41)                                                                                                        \
-    X(Return, 42)                                                                                                      \
-    X(Slice, 44)                                                                                                       \
-    X(Str, 45)                                                                                                         \
-    X(Subscript, 46)                                                                                                   \
-    X(TryExcept, 47)                                                                                                   \
-    X(TryFinally, 48)                                                                                                  \
-    X(Tuple, 49)                                                                                                       \
-    X(UnaryOp, 50)                                                                                                     \
-    X(With, 51)                                                                                                        \
-    X(While, 52)                                                                                                       \
-    X(Yield, 53)                                                                                                       \
-    X(Store, 54)                                                                                                       \
-    X(Load, 55)                                                                                                        \
-    X(Param, 56)                                                                                                       \
-    X(Not, 57)                                                                                                         \
-    X(In, 58)                                                                                                          \
-    X(Is, 59)                                                                                                          \
-    X(IsNot, 60)                                                                                                       \
-    X(Or, 61)                                                                                                          \
-    X(And, 62)                                                                                                         \
-    X(Eq, 63)                                                                                                          \
-    X(NotEq, 64)                                                                                                       \
-    X(NotIn, 65)                                                                                                       \
-    X(GtE, 66)                                                                                                         \
-    X(Gt, 67)                                                                                                          \
-    X(Mod, 68)                                                                                                         \
-    X(Add, 69)                                                                                                         \
-    X(Continue, 70)                                                                                                    \
-    X(Lt, 71)                                                                                                          \
-    X(LtE, 72)                                                                                                         \
-    X(Break, 73)                                                                                                       \
-    X(Sub, 74)                                                                                                         \
-    X(Del, 75)                                                                                                         \
-    X(Mult, 76)                                                                                                        \
-    X(Div, 77)                                                                                                         \
-    X(USub, 78)                                                                                                        \
-    X(BitAnd, 79)                                                                                                      \
-    X(BitOr, 80)                                                                                                       \
-    X(BitXor, 81)                                                                                                      \
-    X(RShift, 82)                                                                                                      \
-    X(LShift, 83)                                                                                                      \
-    X(Invert, 84)                                                                                                      \
-    X(UAdd, 85)                                                                                                        \
-    X(FloorDiv, 86)                                                                                                    \
-    X(DictComp, 15)                                                                                                    \
-    X(Set, 43)                                                                                                         \
-    X(Ellipsis, 87)                                                                                                    \
-    /* like Module, but used for eval. */                                                                              \
-    X(Expression, 88)                                                                                                  \
-    X(SetComp, 89)                                                                                                     \
-    X(Suite, 90)                                                                                                       \
-                                                                                                                       \
-    /* Pseudo-nodes that are specific to this compiler: */                                                             \
-    X(Branch, 200)                                                                                                     \
-    X(Jump, 201)                                                                                                       \
-    X(ClsAttribute, 202)                                                                                               \
-    X(AugBinOp, 203)                                                                                                   \
-    X(Invoke, 204)                                                                                                     \
-    X(LangPrimitive, 205)                                                                                              \
-    /* wraps a ClassDef to make it an expr */                                                                          \
-    X(MakeClass, 206)                                                                                                  \
-    /* wraps a FunctionDef to make it an expr */                                                                       \
-    X(MakeFunction, 207)                                                                                               \
-                                                                                                                       \
-    /* These aren't real BST types, but since we use BST types to represent binexp types */                            \
-    /* and divmod+truediv are essentially types of binops, we add them here (at least for now): */                     \
-    X(DivMod, 250)                                                                                                     \
-    X(TrueDiv, 251)
+    X(Assert, 1)                                                                                                       \
+    X(AugBinOp, 2)                                                                                                     \
+    X(BinOp, 3)                                                                                                        \
+    X(Branch, 4)                                                                                                       \
+    X(CallAttr, 5)                                                                                                     \
+    X(CallClsAttr, 6)                                                                                                  \
+    X(CallFunc, 7)                                                                                                     \
+    X(CheckExcMatch, 8)                                                                                                \
+    X(ClassDef, 9)                                                                                                     \
+    X(Compare, 10)                                                                                                     \
+    X(CopyVReg, 11)                                                                                                    \
+    X(DeleteAttr, 12)                                                                                                  \
+    X(DeleteName, 13)                                                                                                  \
+    X(DeleteSub, 14)                                                                                                   \
+    X(DeleteSubSlice, 15)                                                                                              \
+    X(Dict, 16)                                                                                                        \
+    X(Exec, 17)                                                                                                        \
+    X(FunctionDef, 18)                                                                                                 \
+    X(GetIter, 19)                                                                                                     \
+    X(HasNext, 20)                                                                                                     \
+    X(ImportFrom, 21)                                                                                                  \
+    X(ImportName, 22)                                                                                                  \
+    X(ImportStar, 23)                                                                                                  \
+    X(Invoke, 24)                                                                                                      \
+    X(Jump, 25)                                                                                                        \
+    X(Landingpad, 26)                                                                                                  \
+    X(List, 27)                                                                                                        \
+    X(LoadAttr, 28)                                                                                                    \
+    X(LoadName, 29)                                                                                                    \
+    X(LoadSub, 30)                                                                                                     \
+    X(LoadSubSlice, 31)                                                                                                \
+    X(Locals, 32)                                                                                                      \
+    X(MakeClass, 33)                                                                                                   \
+    X(MakeFunction, 34)                                                                                                \
+    X(MakeSlice, 35)                                                                                                   \
+    X(Nonzero, 36)                                                                                                     \
+    X(Print, 37)                                                                                                       \
+    X(PrintExpr, 38)                                                                                                   \
+    X(Raise, 39)                                                                                                       \
+    X(Repr, 40)                                                                                                        \
+    X(Return, 41)                                                                                                      \
+    X(Set, 42)                                                                                                         \
+    X(SetExcInfo, 43)                                                                                                  \
+    X(StoreAttr, 44)                                                                                                   \
+    X(StoreName, 45)                                                                                                   \
+    X(StoreSub, 46)                                                                                                    \
+    X(StoreSubSlice, 47)                                                                                               \
+    X(Tuple, 48)                                                                                                       \
+    X(UnaryOp, 49)                                                                                                     \
+    X(UncacheExcInfo, 50)                                                                                              \
+    X(UnpackIntoArray, 51)                                                                                             \
+    X(Yield, 52)
 
 #define GENERATE_ENUM(ENUM, N) ENUM = N,
 #define GENERATE_STRING(STRING, N) m[N] = #STRING;
@@ -163,17 +107,39 @@ static const char* stringify(int n) {
 class BSTVisitor;
 class ExprVisitor;
 class StmtVisitor;
-class SliceVisitor;
-class BST_keyword;
 
-class BST {
+// Most nodes got a destination vreg and one or more source vregs. Currently all of them are 32bit long. Some nodes
+// support a variable size of operands (e.g. the tuple node) but the size can't change after creating the node.
+// In general all instructions except CopyVReg kill the source operand vregs except if the source is a constant. If one
+// needs the preserve the source vreg on needs to create a new temporary using the CopyVReg opcode.
+
+// There is a special vreg number: VREG_UNDEFINED
+static constexpr int VREG_UNDEFINED = std::numeric_limits<int>::min();
+// - when it's set as an operand vreg: it means that this is a not-set optional argument.
+//   e.g. for a slice which only has lower set: upper would be VREG_UNDEFINED
+// - if it's the destination it's means the result value should get immediately killed
+//   e.g. "invoke 15 16: %undef = %11(%14)"
+//    this is a call whose result gets ignored
+//
+// all other negative vreg numbers are indices into a constant table (after adding 1 and making them positive).
+// Constants can be all str and numeric types, None and Ellipis. Every constant will only get stored once in the table.
+// e.g. (4, 2, 'lala') generates: "%undef = (%-1|4|, %-2|2|, %-3|'lala'|)"
+//  this creates a tuple whose elements are the constant idx -1, -2 and -3.
+//  in order to make it easier for a human to understand we print the actual value of the constant between | characters.
+
+
+class BST_stmt {
 public:
-    virtual ~BST() {}
+    virtual ~BST_stmt() {}
 
     const BST_TYPE::BST_TYPE type;
     uint32_t lineno;
+    int cxx_exception_count = 0;
 
     virtual void accept(BSTVisitor* v) = 0;
+    virtual void accept_stmt(StmtVisitor* v) = 0;
+
+    virtual bool has_dest_vreg() const { return false; }
 
 // #define DEBUG_LINE_NUMBERS 1
 #ifdef DEBUG_LINE_NUMBERS
@@ -183,54 +149,76 @@ private:
     static int next_lineno;
 
 public:
-    BST(BST_TYPE::BST_TYPE type);
+    BST_stmt(BST_TYPE::BST_TYPE type);
 #else
-    BST(BST_TYPE::BST_TYPE type) : type(type), lineno(0) {}
+    BST_stmt(BST_TYPE::BST_TYPE type) : type(type), lineno(0) {}
 #endif
-    BST(BST_TYPE::BST_TYPE type, uint32_t lineno) : type(type), lineno(lineno) {}
+    BST_stmt(BST_TYPE::BST_TYPE type, uint32_t lineno) : type(type), lineno(lineno) {}
 };
 
-class BST_expr : public BST {
+// base class of all nodes which have a single destination vreg
+class BST_stmt_with_dest : public BST_stmt {
 public:
-    virtual void* accept_expr(ExprVisitor* v) = 0;
+    int vreg_dst = VREG_UNDEFINED;
+    BST_stmt_with_dest(BST_TYPE::BST_TYPE type) : BST_stmt(type) {}
+    BST_stmt_with_dest(BST_TYPE::BST_TYPE type, int lineno) : BST_stmt(type, lineno) {}
 
-    BST_expr(BST_TYPE::BST_TYPE type) : BST(type) {}
-    BST_expr(BST_TYPE::BST_TYPE type, uint32_t lineno) : BST(type, lineno) {}
+    bool has_dest_vreg() const override { return true; }
 };
 
-class BST_stmt : public BST {
-public:
-    virtual void accept_stmt(StmtVisitor* v) = 0;
+#define BSTVARVREGS(opcode, base_class, num_elts, vreg_dst)                                                            \
+public:                                                                                                                \
+    static BST_##opcode* create(int num_elts) { return new (num_elts) BST_##opcode(num_elts); }                        \
+    static void operator delete(void* ptr) { ::operator delete[](ptr); }                                               \
+                                                                                                                       \
+private:                                                                                                               \
+    static void* operator new(size_t, int num_elts) {                                                                  \
+        return ::new char[offsetof(BST_##opcode, vreg_dst) + num_elts * sizeof(int)];                                  \
+    }                                                                                                                  \
+    BST_##opcode(int num_elts) : base_class(BST_TYPE::opcode), num_elts(num_elts) {                                    \
+        for (int i = 0; i < num_elts; ++i) {                                                                           \
+            vreg_dst[i] = VREG_UNDEFINED;                                                                              \
+        }                                                                                                              \
+    }
 
-    int cxx_exception_count = 0;
+#define BSTVARVREGS2(opcode, base_class, num_elts, num_elts2, vreg_dst)                                                \
+public:                                                                                                                \
+    static BST_##opcode* create(int num_elts, int num_elts2) {                                                         \
+        return new (num_elts + num_elts2) BST_##opcode(num_elts, num_elts2);                                           \
+    }                                                                                                                  \
+    static void operator delete(void* ptr) { ::operator delete[](ptr); }                                               \
+                                                                                                                       \
+private:                                                                                                               \
+    static void* operator new(size_t, int num_elts_total) {                                                            \
+        return ::new char[offsetof(BST_##opcode, vreg_dst) + num_elts_total * sizeof(int)];                            \
+    }                                                                                                                  \
+    BST_##opcode(int num_elts, int num_elts2)                                                                          \
+        : base_class(BST_TYPE::opcode), num_elts(num_elts), num_elts2(num_elts2) {                                     \
+        for (int i = 0; i < num_elts + num_elts2; ++i) {                                                               \
+            vreg_dst[i] = VREG_UNDEFINED;                                                                              \
+        }                                                                                                              \
+    }
 
-    BST_stmt(BST_TYPE::BST_TYPE type) : BST(type) {}
-};
-
-class BST_slice : public BST {
-public:
-    virtual void* accept_slice(SliceVisitor* s) = 0;
-    BST_slice(BST_TYPE::BST_TYPE type) : BST(type) {}
-    BST_slice(BST_TYPE::BST_TYPE type, uint32_t lineno) : BST(type, lineno) {}
-};
-
-class BST_Name;
-
-class BST_arguments : public BST {
-public:
-    // no lineno attributes
-    std::vector<BST_expr*> defaults;
-
-    virtual void accept(BSTVisitor* v);
-
-    BST_arguments() : BST(BST_TYPE::arguments) {}
-
-    static const BST_TYPE::BST_TYPE TYPE = BST_TYPE::arguments;
-};
+#define BSTVARVREGS2CALL(opcode, num_elts, num_elts2, vreg_dst)                                                        \
+public:                                                                                                                \
+    static BST_##opcode* create(int num_elts, int num_elts2) {                                                         \
+        return new (num_elts + num_elts2) BST_##opcode(num_elts, num_elts2);                                           \
+    }                                                                                                                  \
+    static void operator delete(void* ptr) { ::operator delete[](ptr); }                                               \
+                                                                                                                       \
+private:                                                                                                               \
+    static void* operator new(size_t, int num_elts_total) {                                                            \
+        return ::new char[offsetof(BST_##opcode, vreg_dst) + num_elts_total * sizeof(int)];                            \
+    }                                                                                                                  \
+    BST_##opcode(int num_elts, int num_elts2) : BST_Call(BST_TYPE::opcode, num_elts, num_elts2) {                      \
+        for (int i = 0; i < num_elts + num_elts2; ++i) {                                                               \
+            vreg_dst[i] = VREG_UNDEFINED;                                                                              \
+        }                                                                                                              \
+    }
 
 class BST_Assert : public BST_stmt {
 public:
-    BST_expr* msg, *test;
+    int vreg_msg = VREG_UNDEFINED;
 
     virtual void accept(BSTVisitor* v);
     virtual void accept_stmt(StmtVisitor* v);
@@ -240,89 +228,251 @@ public:
     static const BST_TYPE::BST_TYPE TYPE = BST_TYPE::Assert;
 };
 
-class BST_Assign : public BST_stmt {
+class BST_UnpackIntoArray : public BST_stmt {
 public:
-    BST_expr* target;
-    BST_expr* value;
+    int vreg_src = VREG_UNDEFINED;
+    const int num_elts;
+    int vreg_dst[1];
 
     virtual void accept(BSTVisitor* v);
     virtual void accept_stmt(StmtVisitor* v);
 
-    BST_Assign() : BST_stmt(BST_TYPE::Assign) {}
+    static const BST_TYPE::BST_TYPE TYPE = BST_TYPE::UnpackIntoArray;
 
-    static const BST_TYPE::BST_TYPE TYPE = BST_TYPE::Assign;
+    BSTVARVREGS(UnpackIntoArray, BST_stmt, num_elts, vreg_dst)
 };
 
-class BST_AugBinOp : public BST_expr {
+// This is a special instruction which copies a vreg without destroying the source.
+// All other instructions always kill the operands (except if they are a constant) so if one needs the operand to stay
+// alive one has to create a copy usning CopyVReg first.
+class BST_CopyVReg : public BST_stmt_with_dest {
 public:
-    AST_TYPE::AST_TYPE op_type;
-    BST_expr* left, *right;
+    int vreg_src = VREG_UNDEFINED; // this vreg will not get killed!
 
     virtual void accept(BSTVisitor* v);
-    virtual void* accept_expr(ExprVisitor* v);
+    virtual void accept_stmt(StmtVisitor* v);
 
-    BST_AugBinOp() : BST_expr(BST_TYPE::AugBinOp) {}
+    BST_CopyVReg() : BST_stmt_with_dest(BST_TYPE::CopyVReg) {}
+
+    static const BST_TYPE::BST_TYPE TYPE = BST_TYPE::CopyVReg;
+};
+
+
+class BST_StoreName : public BST_stmt {
+public:
+    int vreg_value = VREG_UNDEFINED;
+
+    InternedString id;
+    ScopeInfo::VarScopeType lookup_type;
+    int vreg = VREG_UNDEFINED;
+
+    // Only valid for lookup_type == DEREF:
+    DerefInfo deref_info = DerefInfo({ INT_MAX, INT_MAX });
+    // Only valid for lookup_type == CLOSURE:
+    int closure_offset = -1;
+
+
+    virtual void accept(BSTVisitor* v);
+    virtual void accept_stmt(StmtVisitor* v);
+
+    BST_StoreName() : BST_stmt(BST_TYPE::StoreName) {}
+
+    static const BST_TYPE::BST_TYPE TYPE = BST_TYPE::StoreName;
+};
+
+class BST_StoreAttr : public BST_stmt {
+public:
+    InternedString attr;
+    int vreg_target = VREG_UNDEFINED;
+    int vreg_value = VREG_UNDEFINED;
+
+    virtual void accept(BSTVisitor* v);
+    virtual void accept_stmt(StmtVisitor* v);
+
+    BST_StoreAttr() : BST_stmt(BST_TYPE::StoreAttr) {}
+
+    static const BST_TYPE::BST_TYPE TYPE = BST_TYPE::StoreAttr;
+};
+
+class BST_StoreSub : public BST_stmt {
+public:
+    int vreg_target = VREG_UNDEFINED;
+    int vreg_slice = VREG_UNDEFINED;
+    int vreg_value = VREG_UNDEFINED;
+
+    virtual void accept(BSTVisitor* v);
+    virtual void accept_stmt(StmtVisitor* v);
+
+    BST_StoreSub() : BST_stmt(BST_TYPE::StoreSub) {}
+
+    static const BST_TYPE::BST_TYPE TYPE = BST_TYPE::StoreSub;
+};
+
+class BST_StoreSubSlice : public BST_stmt {
+public:
+    int vreg_target = VREG_UNDEFINED;
+    int vreg_lower = VREG_UNDEFINED, vreg_upper = VREG_UNDEFINED;
+    int vreg_value = VREG_UNDEFINED;
+
+    virtual void accept(BSTVisitor* v);
+    virtual void accept_stmt(StmtVisitor* v);
+
+    BST_StoreSubSlice() : BST_stmt(BST_TYPE::StoreSubSlice) {}
+
+    static const BST_TYPE::BST_TYPE TYPE = BST_TYPE::StoreSubSlice;
+};
+
+class BST_LoadName : public BST_stmt_with_dest {
+public:
+    InternedString id;
+    ScopeInfo::VarScopeType lookup_type;
+    // LoadName does not kill this vreg
+    int vreg = VREG_UNDEFINED;
+
+    // Only valid for lookup_type == DEREF:
+    DerefInfo deref_info = DerefInfo({ INT_MAX, INT_MAX });
+    // Only valid for lookup_type == CLOSURE:
+    int closure_offset = -1;
+
+    virtual void accept(BSTVisitor* v);
+    virtual void accept_stmt(StmtVisitor* v);
+
+    BST_LoadName() : BST_stmt_with_dest(BST_TYPE::LoadName) {}
+
+    static const BST_TYPE::BST_TYPE TYPE = BST_TYPE::LoadName;
+};
+
+class BST_LoadAttr : public BST_stmt_with_dest {
+public:
+    InternedString attr;
+    int vreg_value = VREG_UNDEFINED;
+    bool clsonly = false;
+
+    virtual void accept(BSTVisitor* v);
+    virtual void accept_stmt(StmtVisitor* v);
+
+    BST_LoadAttr() : BST_stmt_with_dest(BST_TYPE::LoadAttr) {}
+
+    static const BST_TYPE::BST_TYPE TYPE = BST_TYPE::LoadAttr;
+};
+
+class BST_LoadSub : public BST_stmt_with_dest {
+public:
+    int vreg_value = VREG_UNDEFINED;
+    int vreg_slice = VREG_UNDEFINED;
+
+    virtual void accept(BSTVisitor* v);
+    virtual void accept_stmt(StmtVisitor* v);
+
+    BST_LoadSub() : BST_stmt_with_dest(BST_TYPE::LoadSub) {}
+
+    static const BST_TYPE::BST_TYPE TYPE = BST_TYPE::LoadSub;
+};
+
+class BST_LoadSubSlice : public BST_stmt_with_dest {
+public:
+    int vreg_value = VREG_UNDEFINED;
+    int vreg_lower = VREG_UNDEFINED, vreg_upper = VREG_UNDEFINED;
+
+    virtual void accept(BSTVisitor* v);
+    virtual void accept_stmt(StmtVisitor* v);
+
+    BST_LoadSubSlice() : BST_stmt_with_dest(BST_TYPE::LoadSubSlice) {}
+
+    static const BST_TYPE::BST_TYPE TYPE = BST_TYPE::LoadSubSlice;
+};
+
+class BST_AugBinOp : public BST_stmt_with_dest {
+public:
+    AST_TYPE::AST_TYPE op_type;
+    int vreg_left = VREG_UNDEFINED, vreg_right = VREG_UNDEFINED;
+
+    virtual void accept(BSTVisitor* v);
+    virtual void accept_stmt(StmtVisitor* v);
+
+    BST_AugBinOp() : BST_stmt_with_dest(BST_TYPE::AugBinOp) {}
 
     static const BST_TYPE::BST_TYPE TYPE = BST_TYPE::AugBinOp;
 };
 
-class BST_Attribute : public BST_expr {
-public:
-    BST_expr* value;
-    AST_TYPE::AST_TYPE ctx_type;
-    InternedString attr;
-
-    virtual void accept(BSTVisitor* v);
-    virtual void* accept_expr(ExprVisitor* v);
-
-    BST_Attribute() : BST_expr(BST_TYPE::Attribute) {}
-
-    BST_Attribute(BST_expr* value, AST_TYPE::AST_TYPE ctx_type, InternedString attr)
-        : BST_expr(BST_TYPE::Attribute), value(value), ctx_type(ctx_type), attr(attr) {}
-
-    static const BST_TYPE::BST_TYPE TYPE = BST_TYPE::Attribute;
-};
-
-class BST_BinOp : public BST_expr {
+class BST_BinOp : public BST_stmt_with_dest {
 public:
     AST_TYPE::AST_TYPE op_type;
-    BST_expr* left, *right;
+    int vreg_left = VREG_UNDEFINED, vreg_right = VREG_UNDEFINED;
 
     virtual void accept(BSTVisitor* v);
-    virtual void* accept_expr(ExprVisitor* v);
+    virtual void accept_stmt(StmtVisitor* v);
 
-    BST_BinOp() : BST_expr(BST_TYPE::BinOp) {}
+    BST_BinOp() : BST_stmt_with_dest(BST_TYPE::BinOp) {}
 
     static const BST_TYPE::BST_TYPE TYPE = BST_TYPE::BinOp;
 };
 
-class BST_Call : public BST_expr {
+class BST_Call : public BST_stmt_with_dest {
 public:
-    BST_expr* starargs, *kwargs, *func;
-    std::vector<BST_expr*> args;
-    std::vector<BST_keyword*> keywords;
+    int vreg_starargs = VREG_UNDEFINED, vreg_kwargs = VREG_UNDEFINED;
+    const int num_args;
+    const int num_keywords;
 
     // used during execution stores all keyword names
     std::unique_ptr<std::vector<BoxedString*>> keywords_names;
 
-    virtual void accept(BSTVisitor* v);
-    virtual void* accept_expr(ExprVisitor* v);
-
-    BST_Call() : BST_expr(BST_TYPE::Call) {}
-
-    static const BST_TYPE::BST_TYPE TYPE = BST_TYPE::Call;
+    BST_Call(BST_TYPE::BST_TYPE type, int num_args, int num_keywords)
+        : BST_stmt_with_dest(type), num_args(num_args), num_keywords(num_keywords) {}
 };
 
-class BST_Compare : public BST_expr {
+class BST_CallFunc : public BST_Call {
 public:
-    AST_TYPE::AST_TYPE op;
-    BST_expr* comparator;
-    BST_expr* left;
+    int vreg_func = VREG_UNDEFINED;
+    int elts[1];
 
     virtual void accept(BSTVisitor* v);
-    virtual void* accept_expr(ExprVisitor* v);
+    virtual void accept_stmt(StmtVisitor* v);
 
-    BST_Compare() : BST_expr(BST_TYPE::Compare) {}
+    static const BST_TYPE::BST_TYPE TYPE = BST_TYPE::CallFunc;
+
+    BSTVARVREGS2CALL(CallFunc, num_args, num_keywords, elts)
+};
+
+class BST_CallAttr : public BST_Call {
+public:
+    int vreg_value = VREG_UNDEFINED;
+    InternedString attr;
+    int elts[1];
+
+    virtual void accept(BSTVisitor* v);
+    virtual void accept_stmt(StmtVisitor* v);
+
+    static const BST_TYPE::BST_TYPE TYPE = BST_TYPE::CallAttr;
+
+    BSTVARVREGS2CALL(CallAttr, num_args, num_keywords, elts)
+};
+
+class BST_CallClsAttr : public BST_Call {
+public:
+    int vreg_value = VREG_UNDEFINED;
+    InternedString attr;
+    int elts[1];
+
+    virtual void accept(BSTVisitor* v);
+    virtual void accept_stmt(StmtVisitor* v);
+
+    static const BST_TYPE::BST_TYPE TYPE = BST_TYPE::CallClsAttr;
+
+    BSTVARVREGS2CALL(CallClsAttr, num_args, num_keywords, elts)
+};
+
+
+class BST_Compare : public BST_stmt_with_dest {
+public:
+    AST_TYPE::AST_TYPE op;
+    int vreg_comparator = VREG_UNDEFINED;
+    int vreg_left = VREG_UNDEFINED;
+
+    virtual void accept(BSTVisitor* v);
+    virtual void accept_stmt(StmtVisitor* v);
+
+    BST_Compare() : BST_stmt_with_dest(BST_TYPE::Compare) {}
 
     static const BST_TYPE::BST_TYPE TYPE = BST_TYPE::Compare;
 };
@@ -332,67 +482,93 @@ public:
     virtual void accept(BSTVisitor* v);
     virtual void accept_stmt(StmtVisitor* v);
 
-    std::vector<BST_expr*> bases, decorator_list;
-    InternedString name;
-
     BoxedCode* code;
 
-    BST_ClassDef() : BST_stmt(BST_TYPE::ClassDef) {}
+    InternedString name;
+    int vreg_bases_tuple;
+    const int num_decorator;
+    int decorator[1];
 
     static const BST_TYPE::BST_TYPE TYPE = BST_TYPE::ClassDef;
+
+    BSTVARVREGS(ClassDef, BST_stmt, num_decorator, decorator)
 };
 
-class BST_Dict : public BST_expr {
+class BST_Dict : public BST_stmt_with_dest {
 public:
-    std::vector<BST_expr*> keys, values;
-
     virtual void accept(BSTVisitor* v);
-    virtual void* accept_expr(ExprVisitor* v);
+    virtual void accept_stmt(StmtVisitor* v);
 
-    BST_Dict() : BST_expr(BST_TYPE::Dict) {}
+    BST_Dict() : BST_stmt_with_dest(BST_TYPE::Dict) {}
 
     static const BST_TYPE::BST_TYPE TYPE = BST_TYPE::Dict;
 };
 
-class BST_Delete : public BST_stmt {
+class BST_DeleteAttr : public BST_stmt {
 public:
-    BST_expr* target;
-    virtual void accept(BSTVisitor* v);
-    virtual void accept_stmt(StmtVisitor* v);
-
-    BST_Delete() : BST_stmt(BST_TYPE::Delete) {}
-
-    static const BST_TYPE::BST_TYPE TYPE = BST_TYPE::Delete;
-};
-
-class BST_Ellipsis : public BST_slice {
-public:
-    virtual void accept(BSTVisitor* v);
-    virtual void* accept_slice(SliceVisitor* v);
-
-    BST_Ellipsis() : BST_slice(BST_TYPE::Ellipsis) {}
-
-    static const BST_TYPE::BST_TYPE TYPE = BST_TYPE::Ellipsis;
-};
-
-class BST_Expr : public BST_stmt {
-public:
-    BST_expr* value;
+    int vreg_value = VREG_UNDEFINED;
+    InternedString attr;
 
     virtual void accept(BSTVisitor* v);
     virtual void accept_stmt(StmtVisitor* v);
 
-    BST_Expr() : BST_stmt(BST_TYPE::Expr) {}
-    BST_Expr(BST_expr* value) : BST_stmt(BST_TYPE::Expr), value(value) {}
+    BST_DeleteAttr() : BST_stmt(BST_TYPE::DeleteAttr) {}
 
-    static const BST_TYPE::BST_TYPE TYPE = BST_TYPE::Expr;
+    static const BST_TYPE::BST_TYPE TYPE = BST_TYPE::DeleteAttr;
+};
+
+class BST_DeleteName : public BST_stmt {
+public:
+    InternedString id;
+    ScopeInfo::VarScopeType lookup_type;
+    int vreg = VREG_UNDEFINED;
+
+    // Only valid for lookup_type == DEREF:
+    DerefInfo deref_info = DerefInfo({ INT_MAX, INT_MAX });
+    // Only valid for lookup_type == CLOSURE:
+    int closure_offset = -1;
+
+
+    virtual void accept(BSTVisitor* v);
+    virtual void accept_stmt(StmtVisitor* v);
+
+    BST_DeleteName() : BST_stmt(BST_TYPE::DeleteName) {}
+
+    static const BST_TYPE::BST_TYPE TYPE = BST_TYPE::DeleteName;
+};
+
+class BST_DeleteSub : public BST_stmt {
+public:
+    int vreg_value = VREG_UNDEFINED;
+    int vreg_slice = VREG_UNDEFINED;
+
+    virtual void accept(BSTVisitor* v);
+    virtual void accept_stmt(StmtVisitor* v);
+
+    BST_DeleteSub() : BST_stmt(BST_TYPE::DeleteSub) {}
+
+    static const BST_TYPE::BST_TYPE TYPE = BST_TYPE::DeleteSub;
+};
+
+class BST_DeleteSubSlice : public BST_stmt {
+public:
+    int vreg_value = VREG_UNDEFINED;
+    int vreg_lower = VREG_UNDEFINED;
+    int vreg_upper = VREG_UNDEFINED;
+
+    virtual void accept(BSTVisitor* v);
+    virtual void accept_stmt(StmtVisitor* v);
+
+    BST_DeleteSubSlice() : BST_stmt(BST_TYPE::DeleteSubSlice) {}
+
+    static const BST_TYPE::BST_TYPE TYPE = BST_TYPE::DeleteSubSlice;
 };
 
 class BST_Exec : public BST_stmt {
 public:
-    BST_expr* body;
-    BST_expr* globals;
-    BST_expr* locals;
+    int vreg_body = VREG_UNDEFINED;
+    int vreg_globals = VREG_UNDEFINED;
+    int vreg_locals = VREG_UNDEFINED;
 
     virtual void accept(BSTVisitor* v);
     virtual void accept_stmt(StmtVisitor* v);
@@ -402,147 +578,61 @@ public:
     static const BST_TYPE::BST_TYPE TYPE = BST_TYPE::Exec;
 };
 
-class BST_ExtSlice : public BST_slice {
-public:
-    std::vector<BST_slice*> dims;
-
-    virtual void accept(BSTVisitor* v);
-    virtual void* accept_slice(SliceVisitor* v);
-
-    BST_ExtSlice() : BST_slice(BST_TYPE::ExtSlice) {}
-
-    static const BST_TYPE::BST_TYPE TYPE = BST_TYPE::ExtSlice;
-};
-
 class BST_FunctionDef : public BST_stmt {
 public:
-    std::vector<BST_expr*> decorator_list;
     InternedString name; // if the name is not set this is a lambda
-    BST_arguments* args;
 
     BoxedCode* code;
+
+    const int num_decorator;
+    const int num_defaults;
+
+    int elts[1]; // decorators followed by defaults
 
     virtual void accept(BSTVisitor* v);
     virtual void accept_stmt(StmtVisitor* v);
 
-    BST_FunctionDef() : BST_stmt(BST_TYPE::FunctionDef) {}
 
     static const BST_TYPE::BST_TYPE TYPE = BST_TYPE::FunctionDef;
+
+    BSTVARVREGS2(FunctionDef, BST_stmt, num_decorator, num_defaults, elts)
 };
 
-class BST_Index : public BST_slice {
+class BST_List : public BST_stmt_with_dest {
 public:
-    BST_expr* value;
+    const int num_elts;
+    int elts[1];
 
     virtual void accept(BSTVisitor* v);
-    virtual void* accept_slice(SliceVisitor* v);
-
-    BST_Index() : BST_slice(BST_TYPE::Index) {}
-
-    static const BST_TYPE::BST_TYPE TYPE = BST_TYPE::Index;
-};
-
-class BST_keyword : public BST {
-public:
-    // no lineno attributes
-    BST_expr* value;
-    InternedString arg;
-
-    virtual void accept(BSTVisitor* v);
-
-    BST_keyword() : BST(BST_TYPE::keyword) {}
-
-    static const BST_TYPE::BST_TYPE TYPE = BST_TYPE::keyword;
-};
-
-class BST_List : public BST_expr {
-public:
-    std::vector<BST_expr*> elts;
-    AST_TYPE::AST_TYPE ctx_type;
-
-    virtual void accept(BSTVisitor* v);
-    virtual void* accept_expr(ExprVisitor* v);
-
-    BST_List() : BST_expr(BST_TYPE::List) {}
+    virtual void accept_stmt(StmtVisitor* v);
 
     static const BST_TYPE::BST_TYPE TYPE = BST_TYPE::List;
+
+    BSTVARVREGS(List, BST_stmt_with_dest, num_elts, elts)
 };
 
-class BST_Name : public BST_expr {
+class BST_Repr : public BST_stmt_with_dest {
 public:
-    AST_TYPE::AST_TYPE ctx_type;
-    InternedString id;
-
-    // The resolved scope of this name.  Kind of hacky to be storing it in the BST node;
-    // in CPython it ends up getting "cached" by being translated into one of a number of
-    // different bytecodes.
-    ScopeInfo::VarScopeType lookup_type;
-
-    // These are only valid for lookup_type == FAST or CLOSURE
-    // The interpreter and baseline JIT store variables with FAST and CLOSURE scopes in an array (vregs) this specifies
-    // the zero based index of this variable inside the vregs array. If uninitialized it's value is -1.
-    int vreg;
-    bool is_kill = false;
-
-    // Only valid for lookup_type == DEREF:
-    DerefInfo deref_info = DerefInfo({ INT_MAX, INT_MAX });
-    // Only valid for lookup_type == CLOSURE:
-    int closure_offset = -1;
+    int vreg_value = VREG_UNDEFINED;
 
     virtual void accept(BSTVisitor* v);
-    virtual void* accept_expr(ExprVisitor* v);
+    virtual void accept_stmt(StmtVisitor* v);
 
-    BST_Name(InternedString id, AST_TYPE::AST_TYPE ctx_type, int lineno)
-        : BST_expr(BST_TYPE::Name, lineno),
-          ctx_type(ctx_type),
-          id(id),
-          lookup_type(ScopeInfo::VarScopeType::UNKNOWN),
-          vreg(-1) {}
-
-    static const BST_TYPE::BST_TYPE TYPE = BST_TYPE::Name;
-};
-
-class BST_Num : public BST_expr {
-public:
-    AST_Num::NumType num_type;
-
-    // TODO: these should just be Boxed objects now
-    union {
-        int64_t n_int;
-        double n_float;
-    };
-    std::string n_long;
-
-    virtual void accept(BSTVisitor* v);
-    virtual void* accept_expr(ExprVisitor* v);
-
-    BST_Num() : BST_expr(BST_TYPE::Num) {}
-
-    static const BST_TYPE::BST_TYPE TYPE = BST_TYPE::Num;
-};
-
-class BST_Repr : public BST_expr {
-public:
-    BST_expr* value;
-
-    virtual void accept(BSTVisitor* v);
-    virtual void* accept_expr(ExprVisitor* v);
-
-    BST_Repr() : BST_expr(BST_TYPE::Repr) {}
+    BST_Repr() : BST_stmt_with_dest(BST_TYPE::Repr) {}
 
     static const BST_TYPE::BST_TYPE TYPE = BST_TYPE::Repr;
 };
 
 class BST_Print : public BST_stmt {
 public:
-    BST_expr* dest;
+    int vreg_dest = VREG_UNDEFINED;
     bool nl;
-    BST_expr* value;
+    int vreg_value = VREG_UNDEFINED;
 
     virtual void accept(BSTVisitor* v);
     virtual void accept_stmt(StmtVisitor* v);
 
-    BST_Print() : BST_stmt(BST_TYPE::Print), value(NULL) {}
+    BST_Print() : BST_stmt(BST_TYPE::Print) {}
 
     static const BST_TYPE::BST_TYPE TYPE = BST_TYPE::Print;
 };
@@ -553,19 +643,19 @@ public:
     // Renaming to arg{0..2} since I find that confusing, since they are filled in
     // sequentially rather than semantically.
     // Ie "raise Exception()" will have type==Exception(), inst==None, tback==None
-    BST_expr* arg0, *arg1, *arg2;
+    int vreg_arg0 = VREG_UNDEFINED, vreg_arg1 = VREG_UNDEFINED, vreg_arg2 = VREG_UNDEFINED;
 
     virtual void accept(BSTVisitor* v);
     virtual void accept_stmt(StmtVisitor* v);
 
-    BST_Raise() : BST_stmt(BST_TYPE::Raise), arg0(NULL), arg1(NULL), arg2(NULL) {}
+    BST_Raise() : BST_stmt(BST_TYPE::Raise) {}
 
     static const BST_TYPE::BST_TYPE TYPE = BST_TYPE::Raise;
 };
 
 class BST_Return : public BST_stmt {
 public:
-    BST_expr* value;
+    int vreg_value = VREG_UNDEFINED;
 
     virtual void accept(BSTVisitor* v);
     virtual void accept_stmt(StmtVisitor* v);
@@ -575,119 +665,89 @@ public:
     static const BST_TYPE::BST_TYPE TYPE = BST_TYPE::Return;
 };
 
-class BST_Set : public BST_expr {
+class BST_Set : public BST_stmt_with_dest {
 public:
-    std::vector<BST_expr*> elts;
+    const int num_elts;
+    int elts[1];
 
     virtual void accept(BSTVisitor* v);
-    virtual void* accept_expr(ExprVisitor* v);
-
-    BST_Set() : BST_expr(BST_TYPE::Set) {}
+    virtual void accept_stmt(StmtVisitor* v);
 
     static const BST_TYPE::BST_TYPE TYPE = BST_TYPE::Set;
+
+    BSTVARVREGS(Set, BST_stmt_with_dest, num_elts, elts)
 };
 
-class BST_Slice : public BST_slice {
+class BST_MakeSlice : public BST_stmt_with_dest {
 public:
-    BST_expr* lower, *upper, *step;
+    int vreg_lower = VREG_UNDEFINED, vreg_upper = VREG_UNDEFINED, vreg_step = VREG_UNDEFINED;
 
     virtual void accept(BSTVisitor* v);
-    virtual void* accept_slice(SliceVisitor* v);
+    virtual void accept_stmt(StmtVisitor* v);
 
-    BST_Slice() : BST_slice(BST_TYPE::Slice) {}
+    BST_MakeSlice() : BST_stmt_with_dest(BST_TYPE::MakeSlice) {}
 
-    static const BST_TYPE::BST_TYPE TYPE = BST_TYPE::Slice;
+    static const BST_TYPE::BST_TYPE TYPE = BST_TYPE::MakeSlice;
 };
 
-class BST_Str : public BST_expr {
+class BST_Tuple : public BST_stmt_with_dest {
 public:
-    AST_Str::StrType str_type;
-
-    // The meaning of str_data depends on str_type.  For STR, it's just the bytes value.
-    // For UNICODE, it's the utf-8 encoded value.
-    std::string str_data;
+    const int num_elts;
+    int elts[1];
 
     virtual void accept(BSTVisitor* v);
-    virtual void* accept_expr(ExprVisitor* v);
-
-    BST_Str() : BST_expr(BST_TYPE::Str), str_type(AST_Str::UNSET) {}
-    BST_Str(std::string s) : BST_expr(BST_TYPE::Str), str_type(AST_Str::STR), str_data(std::move(s)) {}
-
-    static const BST_TYPE::BST_TYPE TYPE = BST_TYPE::Str;
-};
-
-class BST_Subscript : public BST_expr {
-public:
-    BST_expr* value;
-    BST_slice* slice;
-    AST_TYPE::AST_TYPE ctx_type;
-
-    virtual void accept(BSTVisitor* v);
-    virtual void* accept_expr(ExprVisitor* v);
-
-    BST_Subscript() : BST_expr(BST_TYPE::Subscript) {}
-
-    static const BST_TYPE::BST_TYPE TYPE = BST_TYPE::Subscript;
-};
-
-class BST_Tuple : public BST_expr {
-public:
-    std::vector<BST_expr*> elts;
-    AST_TYPE::AST_TYPE ctx_type;
-
-    virtual void accept(BSTVisitor* v);
-    virtual void* accept_expr(ExprVisitor* v);
-
-    BST_Tuple() : BST_expr(BST_TYPE::Tuple) {}
+    virtual void accept_stmt(StmtVisitor* v);
 
     static const BST_TYPE::BST_TYPE TYPE = BST_TYPE::Tuple;
+
+    BSTVARVREGS(Tuple, BST_stmt_with_dest, num_elts, elts)
 };
 
-class BST_UnaryOp : public BST_expr {
+class BST_UnaryOp : public BST_stmt_with_dest {
 public:
-    BST_expr* operand;
+    int vreg_operand = VREG_UNDEFINED;
     AST_TYPE::AST_TYPE op_type;
 
     virtual void accept(BSTVisitor* v);
-    virtual void* accept_expr(ExprVisitor* v);
+    virtual void accept_stmt(StmtVisitor* v);
 
-    BST_UnaryOp() : BST_expr(BST_TYPE::UnaryOp) {}
+    BST_UnaryOp() : BST_stmt_with_dest(BST_TYPE::UnaryOp) {}
 
     static const BST_TYPE::BST_TYPE TYPE = BST_TYPE::UnaryOp;
 };
 
-class BST_Yield : public BST_expr {
+class BST_Yield : public BST_stmt_with_dest {
 public:
-    BST_expr* value;
+    int vreg_value = VREG_UNDEFINED;
 
     virtual void accept(BSTVisitor* v);
-    virtual void* accept_expr(ExprVisitor* v);
+    virtual void accept_stmt(StmtVisitor* v);
 
-    BST_Yield() : BST_expr(BST_TYPE::Yield) {}
+    BST_Yield() : BST_stmt_with_dest(BST_TYPE::Yield) {}
 
     static const BST_TYPE::BST_TYPE TYPE = BST_TYPE::Yield;
 };
 
-class BST_MakeFunction : public BST_expr {
+class BST_MakeFunction : public BST_stmt_with_dest {
 public:
     BST_FunctionDef* function_def;
 
     virtual void accept(BSTVisitor* v);
-    virtual void* accept_expr(ExprVisitor* v);
+    virtual void accept_stmt(StmtVisitor* v);
 
-    BST_MakeFunction(BST_FunctionDef* fd) : BST_expr(BST_TYPE::MakeFunction, fd->lineno), function_def(fd) {}
+    BST_MakeFunction(BST_FunctionDef* fd) : BST_stmt_with_dest(BST_TYPE::MakeFunction, fd->lineno), function_def(fd) {}
 
     static const BST_TYPE::BST_TYPE TYPE = BST_TYPE::MakeFunction;
 };
 
-class BST_MakeClass : public BST_expr {
+class BST_MakeClass : public BST_stmt_with_dest {
 public:
     BST_ClassDef* class_def;
 
     virtual void accept(BSTVisitor* v);
-    virtual void* accept_expr(ExprVisitor* v);
+    virtual void accept_stmt(StmtVisitor* v);
 
-    BST_MakeClass(BST_ClassDef* cd) : BST_expr(BST_TYPE::MakeClass, cd->lineno), class_def(cd) {}
+    BST_MakeClass(BST_ClassDef* cd) : BST_stmt_with_dest(BST_TYPE::MakeClass, cd->lineno), class_def(cd) {}
 
     static const BST_TYPE::BST_TYPE TYPE = BST_TYPE::MakeClass;
 };
@@ -700,7 +760,7 @@ class CFGBlock;
 
 class BST_Branch : public BST_stmt {
 public:
-    BST_expr* test;
+    int vreg_test = VREG_UNDEFINED;
     CFGBlock* iftrue, *iffalse;
 
     virtual void accept(BSTVisitor* v);
@@ -723,19 +783,6 @@ public:
     static const BST_TYPE::BST_TYPE TYPE = BST_TYPE::Jump;
 };
 
-class BST_ClsAttribute : public BST_expr {
-public:
-    BST_expr* value;
-    InternedString attr;
-
-    virtual void accept(BSTVisitor* v);
-    virtual void* accept_expr(ExprVisitor* v);
-
-    BST_ClsAttribute() : BST_expr(BST_TYPE::ClsAttribute) {}
-
-    static const BST_TYPE::BST_TYPE TYPE = BST_TYPE::ClsAttribute;
-};
-
 class BST_Invoke : public BST_stmt {
 public:
     BST_stmt* stmt;
@@ -750,163 +797,305 @@ public:
     static const BST_TYPE::BST_TYPE TYPE = BST_TYPE::Invoke;
 };
 
-// "LangPrimitive" represents operations that "primitive" to the language,
-// but aren't directly *exactly* representable as normal Python.
-// ClsAttribute would fall into this category.
-// These are basically bytecodes, framed as pseudo-BST-nodes.
-class BST_LangPrimitive : public BST_expr {
+
+// grabs the info about the last raised exception
+class BST_Landingpad : public BST_stmt_with_dest {
 public:
-    enum Opcodes : unsigned char {
-        LANDINGPAD, // grabs the info about the last raised exception
-        LOCALS,
-        GET_ITER,
-        IMPORT_FROM,
-        IMPORT_NAME,
-        IMPORT_STAR,
-        NONE,
-        NONZERO, // determines whether something is "true" for purposes of `if' and so forth
-        CHECK_EXC_MATCH,
-        SET_EXC_INFO,
-        UNCACHE_EXC_INFO,
-        HASNEXT,
-        PRINT_EXPR,
-    } opcode;
-    std::vector<BST_expr*> args;
-
     virtual void accept(BSTVisitor* v);
-    virtual void* accept_expr(ExprVisitor* v);
+    virtual void accept_stmt(StmtVisitor* v);
 
-    BST_LangPrimitive(Opcodes opcode) : BST_expr(BST_TYPE::LangPrimitive), opcode(opcode) {}
+    BST_Landingpad() : BST_stmt_with_dest(BST_TYPE::Landingpad) {}
 
-    static const BST_TYPE::BST_TYPE TYPE = BST_TYPE::LangPrimitive;
+    static const BST_TYPE::BST_TYPE TYPE = BST_TYPE::Landingpad;
 };
 
-template <typename T> T* bst_cast(BST* node) {
+class BST_Locals : public BST_stmt_with_dest {
+public:
+    virtual void accept(BSTVisitor* v);
+    virtual void accept_stmt(StmtVisitor* v);
+
+    BST_Locals() : BST_stmt_with_dest(BST_TYPE::Locals) {}
+
+    static const BST_TYPE::BST_TYPE TYPE = BST_TYPE::Locals;
+};
+
+class BST_GetIter : public BST_stmt_with_dest {
+public:
+    int vreg_value = VREG_UNDEFINED;
+
+    virtual void accept(BSTVisitor* v);
+    virtual void accept_stmt(StmtVisitor* v);
+
+    BST_GetIter() : BST_stmt_with_dest(BST_TYPE::GetIter) {}
+
+    static const BST_TYPE::BST_TYPE TYPE = BST_TYPE::GetIter;
+};
+
+class BST_ImportFrom : public BST_stmt_with_dest {
+public:
+    int vreg_module = VREG_UNDEFINED;
+    int vreg_name = VREG_UNDEFINED;
+
+    virtual void accept(BSTVisitor* v);
+    virtual void accept_stmt(StmtVisitor* v);
+
+    BST_ImportFrom() : BST_stmt_with_dest(BST_TYPE::ImportFrom) {}
+
+    static const BST_TYPE::BST_TYPE TYPE = BST_TYPE::ImportFrom;
+};
+
+class BST_ImportName : public BST_stmt_with_dest {
+public:
+    int vreg_from = VREG_UNDEFINED;
+    int level = VREG_UNDEFINED;
+    int vreg_name = VREG_UNDEFINED;
+
+
+    virtual void accept(BSTVisitor* v);
+    virtual void accept_stmt(StmtVisitor* v);
+
+    BST_ImportName() : BST_stmt_with_dest(BST_TYPE::ImportName) {}
+
+    static const BST_TYPE::BST_TYPE TYPE = BST_TYPE::ImportName;
+};
+
+class BST_ImportStar : public BST_stmt_with_dest {
+public:
+    int vreg_name = VREG_UNDEFINED;
+
+    virtual void accept(BSTVisitor* v);
+    virtual void accept_stmt(StmtVisitor* v);
+
+    BST_ImportStar() : BST_stmt_with_dest(BST_TYPE::ImportStar) {}
+
+    static const BST_TYPE::BST_TYPE TYPE = BST_TYPE::ImportStar;
+};
+
+// determines whether something is "true" for purposes of `if' and so forth
+class BST_Nonzero : public BST_stmt_with_dest {
+public:
+    int vreg_value = VREG_UNDEFINED;
+
+    virtual void accept(BSTVisitor* v);
+    virtual void accept_stmt(StmtVisitor* v);
+
+    BST_Nonzero() : BST_stmt_with_dest(BST_TYPE::Nonzero) {}
+
+    static const BST_TYPE::BST_TYPE TYPE = BST_TYPE::Nonzero;
+};
+
+class BST_CheckExcMatch : public BST_stmt_with_dest {
+public:
+    int vreg_value = VREG_UNDEFINED;
+    int vreg_cls = VREG_UNDEFINED;
+
+    virtual void accept(BSTVisitor* v);
+    virtual void accept_stmt(StmtVisitor* v);
+
+    BST_CheckExcMatch() : BST_stmt_with_dest(BST_TYPE::CheckExcMatch) {}
+
+    static const BST_TYPE::BST_TYPE TYPE = BST_TYPE::CheckExcMatch;
+};
+
+class BST_SetExcInfo : public BST_stmt {
+public:
+    int vreg_type = VREG_UNDEFINED;
+    int vreg_value = VREG_UNDEFINED;
+    int vreg_traceback = VREG_UNDEFINED;
+
+    virtual void accept(BSTVisitor* v);
+    virtual void accept_stmt(StmtVisitor* v);
+
+    BST_SetExcInfo() : BST_stmt(BST_TYPE::SetExcInfo) {}
+
+    static const BST_TYPE::BST_TYPE TYPE = BST_TYPE::SetExcInfo;
+};
+
+class BST_UncacheExcInfo : public BST_stmt {
+public:
+    virtual void accept(BSTVisitor* v);
+    virtual void accept_stmt(StmtVisitor* v);
+
+    BST_UncacheExcInfo() : BST_stmt(BST_TYPE::UncacheExcInfo) {}
+
+    static const BST_TYPE::BST_TYPE TYPE = BST_TYPE::UncacheExcInfo;
+};
+
+class BST_HasNext : public BST_stmt_with_dest {
+public:
+    int vreg_value = VREG_UNDEFINED;
+
+    virtual void accept(BSTVisitor* v);
+    virtual void accept_stmt(StmtVisitor* v);
+
+    BST_HasNext() : BST_stmt_with_dest(BST_TYPE::HasNext) {}
+
+    static const BST_TYPE::BST_TYPE TYPE = BST_TYPE::HasNext;
+};
+
+class BST_PrintExpr : public BST_stmt {
+public:
+    int vreg_value = VREG_UNDEFINED;
+
+    virtual void accept(BSTVisitor* v);
+    virtual void accept_stmt(StmtVisitor* v);
+
+    BST_PrintExpr() : BST_stmt(BST_TYPE::PrintExpr) {}
+
+    static const BST_TYPE::BST_TYPE TYPE = BST_TYPE::PrintExpr;
+};
+
+
+// this is not a real bytecode it's only used to initalize arguments
+class BST_Name {
+public:
+    InternedString id;
+
+    // The resolved scope of this name.  Kind of hacky to be storing it in the BST node;
+    // in CPython it ends up getting "cached" by being translated into one of a number of
+    // different bytecodes.
+    ScopeInfo::VarScopeType lookup_type;
+
+    // These are only valid for lookup_type == FAST or CLOSURE
+    // The interpreter and baseline JIT store variables with FAST and CLOSURE scopes in an array (vregs) this specifies
+    // the zero based index of this variable inside the vregs array. If uninitialized it's value is VREG_UNDEFINED.
+    int vreg;
+
+    // Only valid for lookup_type == CLOSURE:
+    int closure_offset = -1;
+
+    BST_Name(InternedString id, int lineno)
+        : id(id), lookup_type(ScopeInfo::VarScopeType::UNKNOWN), vreg(VREG_UNDEFINED) {}
+};
+
+template <typename T> T* bst_cast(BST_stmt* node) {
     ASSERT(!node || node->type == T::TYPE, "%d", node ? node->type : 0);
     return static_cast<T*>(node);
 }
 
 
-
 class BSTVisitor {
-protected:
 public:
+    const bool skip_visit_child_cfg;
+    // if skip_visit_child_cfg is set function and class defs will not visit their body nodes.
+    BSTVisitor(bool skip_visit_child_cfg) : skip_visit_child_cfg(skip_visit_child_cfg) {}
     virtual ~BSTVisitor() {}
 
-    virtual bool visit_arguments(BST_arguments* node) { RELEASE_ASSERT(0, ""); }
+    // pseudo
+    virtual bool visit_vreg(int* vreg, bool is_dst = false) { RELEASE_ASSERT(0, ""); }
+
     virtual bool visit_assert(BST_Assert* node) { RELEASE_ASSERT(0, ""); }
-    virtual bool visit_assign(BST_Assign* node) { RELEASE_ASSERT(0, ""); }
     virtual bool visit_augbinop(BST_AugBinOp* node) { RELEASE_ASSERT(0, ""); }
-    virtual bool visit_attribute(BST_Attribute* node) { RELEASE_ASSERT(0, ""); }
     virtual bool visit_binop(BST_BinOp* node) { RELEASE_ASSERT(0, ""); }
-    virtual bool visit_call(BST_Call* node) { RELEASE_ASSERT(0, ""); }
-    virtual bool visit_clsattribute(BST_ClsAttribute* node) { RELEASE_ASSERT(0, ""); }
-    virtual bool visit_compare(BST_Compare* node) { RELEASE_ASSERT(0, ""); }
+    virtual bool visit_branch(BST_Branch* node) { RELEASE_ASSERT(0, ""); }
+    virtual bool visit_callattr(BST_CallAttr* node) { RELEASE_ASSERT(0, ""); }
+    virtual bool visit_callclsattr(BST_CallClsAttr* node) { RELEASE_ASSERT(0, ""); }
+    virtual bool visit_callfunc(BST_CallFunc* node) { RELEASE_ASSERT(0, ""); }
+    virtual bool visit_checkexcmatch(BST_CheckExcMatch* node) { RELEASE_ASSERT(0, ""); }
     virtual bool visit_classdef(BST_ClassDef* node) { RELEASE_ASSERT(0, ""); }
-    virtual bool visit_delete(BST_Delete* node) { RELEASE_ASSERT(0, ""); }
+    virtual bool visit_compare(BST_Compare* node) { RELEASE_ASSERT(0, ""); }
+    virtual bool visit_copyvreg(BST_CopyVReg* node) { RELEASE_ASSERT(0, ""); }
+    virtual bool visit_deleteattr(BST_DeleteAttr* node) { RELEASE_ASSERT(0, ""); }
+    virtual bool visit_deletename(BST_DeleteName* node) { RELEASE_ASSERT(0, ""); }
+    virtual bool visit_deletesub(BST_DeleteSub* node) { RELEASE_ASSERT(0, ""); }
+    virtual bool visit_deletesubslice(BST_DeleteSubSlice* node) { RELEASE_ASSERT(0, ""); }
     virtual bool visit_dict(BST_Dict* node) { RELEASE_ASSERT(0, ""); }
-    virtual bool visit_ellipsis(BST_Ellipsis* node) { RELEASE_ASSERT(0, ""); }
     virtual bool visit_exec(BST_Exec* node) { RELEASE_ASSERT(0, ""); }
-    virtual bool visit_expr(BST_Expr* node) { RELEASE_ASSERT(0, ""); }
-    virtual bool visit_extslice(BST_ExtSlice* node) { RELEASE_ASSERT(0, ""); }
     virtual bool visit_functiondef(BST_FunctionDef* node) { RELEASE_ASSERT(0, ""); }
-    virtual bool visit_index(BST_Index* node) { RELEASE_ASSERT(0, ""); }
+    virtual bool visit_getiter(BST_GetIter* node) { RELEASE_ASSERT(0, ""); }
+    virtual bool visit_hasnext(BST_HasNext* node) { RELEASE_ASSERT(0, ""); }
+    virtual bool visit_importfrom(BST_ImportFrom* node) { RELEASE_ASSERT(0, ""); }
+    virtual bool visit_importname(BST_ImportName* node) { RELEASE_ASSERT(0, ""); }
+    virtual bool visit_importstar(BST_ImportStar* node) { RELEASE_ASSERT(0, ""); }
     virtual bool visit_invoke(BST_Invoke* node) { RELEASE_ASSERT(0, ""); }
-    virtual bool visit_keyword(BST_keyword* node) { RELEASE_ASSERT(0, ""); }
-    virtual bool visit_langprimitive(BST_LangPrimitive* node) { RELEASE_ASSERT(0, ""); }
+    virtual bool visit_jump(BST_Jump* node) { RELEASE_ASSERT(0, ""); }
+    virtual bool visit_landingpad(BST_Landingpad* node) { RELEASE_ASSERT(0, ""); }
     virtual bool visit_list(BST_List* node) { RELEASE_ASSERT(0, ""); }
-    virtual bool visit_name(BST_Name* node) { RELEASE_ASSERT(0, ""); }
-    virtual bool visit_num(BST_Num* node) { RELEASE_ASSERT(0, ""); }
+    virtual bool visit_loadattr(BST_LoadAttr* node) { RELEASE_ASSERT(0, ""); }
+    virtual bool visit_loadname(BST_LoadName* node) { RELEASE_ASSERT(0, ""); }
+    virtual bool visit_loadsub(BST_LoadSub* node) { RELEASE_ASSERT(0, ""); }
+    virtual bool visit_loadsubslice(BST_LoadSubSlice* node) { RELEASE_ASSERT(0, ""); }
+    virtual bool visit_locals(BST_Locals* node) { RELEASE_ASSERT(0, ""); }
+    virtual bool visit_makeclass(BST_MakeClass* node) { RELEASE_ASSERT(0, ""); }
+    virtual bool visit_makefunction(BST_MakeFunction* node) { RELEASE_ASSERT(0, ""); }
+    virtual bool visit_makeslice(BST_MakeSlice* node) { RELEASE_ASSERT(0, ""); }
+    virtual bool visit_nonzero(BST_Nonzero* node) { RELEASE_ASSERT(0, ""); }
     virtual bool visit_print(BST_Print* node) { RELEASE_ASSERT(0, ""); }
+    virtual bool visit_printexpr(BST_PrintExpr* node) { RELEASE_ASSERT(0, ""); }
     virtual bool visit_raise(BST_Raise* node) { RELEASE_ASSERT(0, ""); }
     virtual bool visit_repr(BST_Repr* node) { RELEASE_ASSERT(0, ""); }
     virtual bool visit_return(BST_Return* node) { RELEASE_ASSERT(0, ""); }
     virtual bool visit_set(BST_Set* node) { RELEASE_ASSERT(0, ""); }
-    virtual bool visit_slice(BST_Slice* node) { RELEASE_ASSERT(0, ""); }
-    virtual bool visit_str(BST_Str* node) { RELEASE_ASSERT(0, ""); }
-    virtual bool visit_subscript(BST_Subscript* node) { RELEASE_ASSERT(0, ""); }
+    virtual bool visit_setexcinfo(BST_SetExcInfo* node) { RELEASE_ASSERT(0, ""); }
+    virtual bool visit_storeattr(BST_StoreAttr* node) { RELEASE_ASSERT(0, ""); }
+    virtual bool visit_storename(BST_StoreName* node) { RELEASE_ASSERT(0, ""); }
+    virtual bool visit_storesub(BST_StoreSub* node) { RELEASE_ASSERT(0, ""); }
+    virtual bool visit_storesubslice(BST_StoreSubSlice* node) { RELEASE_ASSERT(0, ""); }
     virtual bool visit_tuple(BST_Tuple* node) { RELEASE_ASSERT(0, ""); }
     virtual bool visit_unaryop(BST_UnaryOp* node) { RELEASE_ASSERT(0, ""); }
+    virtual bool visit_uncacheexcinfo(BST_UncacheExcInfo* node) { RELEASE_ASSERT(0, ""); }
+    virtual bool visit_unpackintoarray(BST_UnpackIntoArray* node) { RELEASE_ASSERT(0, ""); }
     virtual bool visit_yield(BST_Yield* node) { RELEASE_ASSERT(0, ""); }
-
-    virtual bool visit_makeclass(BST_MakeClass* node) { RELEASE_ASSERT(0, ""); }
-    virtual bool visit_makefunction(BST_MakeFunction* node) { RELEASE_ASSERT(0, ""); }
-    virtual bool visit_branch(BST_Branch* node) { RELEASE_ASSERT(0, ""); }
-    virtual bool visit_jump(BST_Jump* node) { RELEASE_ASSERT(0, ""); }
 };
 
 class NoopBSTVisitor : public BSTVisitor {
 protected:
 public:
+    NoopBSTVisitor(bool skip_visit_child_cfg) : BSTVisitor(skip_visit_child_cfg) {}
     virtual ~NoopBSTVisitor() {}
 
-    virtual bool visit_arguments(BST_arguments* node) { return false; }
-    virtual bool visit_assert(BST_Assert* node) { return false; }
-    virtual bool visit_assign(BST_Assign* node) { return false; }
-    virtual bool visit_augbinop(BST_AugBinOp* node) { return false; }
-    virtual bool visit_attribute(BST_Attribute* node) { return false; }
-    virtual bool visit_binop(BST_BinOp* node) { return false; }
-    virtual bool visit_call(BST_Call* node) { return false; }
-    virtual bool visit_clsattribute(BST_ClsAttribute* node) { return false; }
-    virtual bool visit_compare(BST_Compare* node) { return false; }
-    virtual bool visit_classdef(BST_ClassDef* node) { return false; }
-    virtual bool visit_delete(BST_Delete* node) { return false; }
-    virtual bool visit_dict(BST_Dict* node) { return false; }
-    virtual bool visit_ellipsis(BST_Ellipsis* node) { return false; }
-    virtual bool visit_exec(BST_Exec* node) { return false; }
-    virtual bool visit_expr(BST_Expr* node) { return false; }
-    virtual bool visit_extslice(BST_ExtSlice* node) { return false; }
-    virtual bool visit_functiondef(BST_FunctionDef* node) { return false; }
-    virtual bool visit_index(BST_Index* node) { return false; }
-    virtual bool visit_invoke(BST_Invoke* node) { return false; }
-    virtual bool visit_keyword(BST_keyword* node) { return false; }
-    virtual bool visit_langprimitive(BST_LangPrimitive* node) { return false; }
-    virtual bool visit_list(BST_List* node) { return false; }
-    virtual bool visit_name(BST_Name* node) { return false; }
-    virtual bool visit_num(BST_Num* node) { return false; }
-    virtual bool visit_print(BST_Print* node) { return false; }
-    virtual bool visit_raise(BST_Raise* node) { return false; }
-    virtual bool visit_repr(BST_Repr* node) { return false; }
-    virtual bool visit_return(BST_Return* node) { return false; }
-    virtual bool visit_set(BST_Set* node) { return false; }
-    virtual bool visit_slice(BST_Slice* node) { return false; }
-    virtual bool visit_str(BST_Str* node) { return false; }
-    virtual bool visit_subscript(BST_Subscript* node) { return false; }
-    virtual bool visit_tuple(BST_Tuple* node) { return false; }
-    virtual bool visit_unaryop(BST_UnaryOp* node) { return false; }
-    virtual bool visit_yield(BST_Yield* node) { return false; }
-
-    virtual bool visit_branch(BST_Branch* node) { return false; }
-    virtual bool visit_jump(BST_Jump* node) { return false; }
-    virtual bool visit_makeclass(BST_MakeClass* node) { return false; }
-    virtual bool visit_makefunction(BST_MakeFunction* node) { return false; }
-};
-
-class ExprVisitor {
-protected:
-public:
-    virtual ~ExprVisitor() {}
-
-    virtual void* visit_augbinop(BST_AugBinOp* node) { RELEASE_ASSERT(0, ""); }
-    virtual void* visit_attribute(BST_Attribute* node) { RELEASE_ASSERT(0, ""); }
-    virtual void* visit_binop(BST_BinOp* node) { RELEASE_ASSERT(0, ""); }
-    virtual void* visit_call(BST_Call* node) { RELEASE_ASSERT(0, ""); }
-    virtual void* visit_clsattribute(BST_ClsAttribute* node) { RELEASE_ASSERT(0, ""); }
-    virtual void* visit_compare(BST_Compare* node) { RELEASE_ASSERT(0, ""); }
-    virtual void* visit_dict(BST_Dict* node) { RELEASE_ASSERT(0, ""); }
-    virtual void* visit_langprimitive(BST_LangPrimitive* node) { RELEASE_ASSERT(0, ""); }
-    virtual void* visit_list(BST_List* node) { RELEASE_ASSERT(0, ""); }
-    virtual void* visit_name(BST_Name* node) { RELEASE_ASSERT(0, ""); }
-    virtual void* visit_num(BST_Num* node) { RELEASE_ASSERT(0, ""); }
-    virtual void* visit_repr(BST_Repr* node) { RELEASE_ASSERT(0, ""); }
-    virtual void* visit_set(BST_Set* node) { RELEASE_ASSERT(0, ""); }
-    virtual void* visit_str(BST_Str* node) { RELEASE_ASSERT(0, ""); }
-    virtual void* visit_subscript(BST_Subscript* node) { RELEASE_ASSERT(0, ""); }
-    virtual void* visit_tuple(BST_Tuple* node) { RELEASE_ASSERT(0, ""); }
-    virtual void* visit_unaryop(BST_UnaryOp* node) { RELEASE_ASSERT(0, ""); }
-    virtual void* visit_yield(BST_Yield* node) { RELEASE_ASSERT(0, ""); }
-    virtual void* visit_makeclass(BST_MakeClass* node) { RELEASE_ASSERT(0, ""); }
-    virtual void* visit_makefunction(BST_MakeFunction* node) { RELEASE_ASSERT(0, ""); }
+    virtual bool visit_assert(BST_Assert* node) override { return false; }
+    virtual bool visit_augbinop(BST_AugBinOp* node) override { return false; }
+    virtual bool visit_binop(BST_BinOp* node) override { return false; }
+    virtual bool visit_branch(BST_Branch* node) override { return false; }
+    virtual bool visit_callattr(BST_CallAttr* node) override { return false; }
+    virtual bool visit_callclsattr(BST_CallClsAttr* node) override { return false; }
+    virtual bool visit_callfunc(BST_CallFunc* node) override { return false; }
+    virtual bool visit_checkexcmatch(BST_CheckExcMatch* node) override { return false; }
+    virtual bool visit_classdef(BST_ClassDef* node) override { return false; }
+    virtual bool visit_compare(BST_Compare* node) override { return false; }
+    virtual bool visit_copyvreg(BST_CopyVReg* node) override { return false; }
+    virtual bool visit_deleteattr(BST_DeleteAttr* node) override { return false; }
+    virtual bool visit_deletename(BST_DeleteName* node) override { return false; }
+    virtual bool visit_deletesub(BST_DeleteSub* node) override { return false; }
+    virtual bool visit_deletesubslice(BST_DeleteSubSlice* node) override { return false; }
+    virtual bool visit_dict(BST_Dict* node) override { return false; }
+    virtual bool visit_exec(BST_Exec* node) override { return false; }
+    virtual bool visit_functiondef(BST_FunctionDef* node) override { return false; }
+    virtual bool visit_getiter(BST_GetIter* node) override { return false; }
+    virtual bool visit_hasnext(BST_HasNext* node) override { return false; }
+    virtual bool visit_importfrom(BST_ImportFrom* node) override { return false; }
+    virtual bool visit_importname(BST_ImportName* node) override { return false; }
+    virtual bool visit_importstar(BST_ImportStar* node) override { return false; }
+    virtual bool visit_invoke(BST_Invoke* node) override { return false; }
+    virtual bool visit_jump(BST_Jump* node) override { return false; }
+    virtual bool visit_landingpad(BST_Landingpad* node) override { return false; }
+    virtual bool visit_list(BST_List* node) override { return false; }
+    virtual bool visit_loadattr(BST_LoadAttr* node) override { return false; }
+    virtual bool visit_loadname(BST_LoadName* node) override { return false; }
+    virtual bool visit_loadsub(BST_LoadSub* node) override { return false; }
+    virtual bool visit_loadsubslice(BST_LoadSubSlice* node) override { return false; }
+    virtual bool visit_locals(BST_Locals* node) override { return false; }
+    virtual bool visit_makeclass(BST_MakeClass* node) override { return false; }
+    virtual bool visit_makefunction(BST_MakeFunction* node) override { return false; }
+    virtual bool visit_makeslice(BST_MakeSlice* node) override { return false; }
+    virtual bool visit_nonzero(BST_Nonzero* node) override { return false; }
+    virtual bool visit_print(BST_Print* node) override { return false; }
+    virtual bool visit_printexpr(BST_PrintExpr* node) override { return false; }
+    virtual bool visit_raise(BST_Raise* node) override { return false; }
+    virtual bool visit_repr(BST_Repr* node) override { return false; }
+    virtual bool visit_return(BST_Return* node) override { return false; }
+    virtual bool visit_set(BST_Set* node) override { return false; }
+    virtual bool visit_setexcinfo(BST_SetExcInfo* node) override { return false; }
+    virtual bool visit_storeattr(BST_StoreAttr* node) override { return false; }
+    virtual bool visit_storename(BST_StoreName* node) override { return false; }
+    virtual bool visit_storesub(BST_StoreSub* node) override { return false; }
+    virtual bool visit_storesubslice(BST_StoreSubSlice* node) override { return false; }
+    virtual bool visit_tuple(BST_Tuple* node) override { return false; }
+    virtual bool visit_unaryop(BST_UnaryOp* node) override { return false; }
+    virtual bool visit_uncacheexcinfo(BST_UncacheExcInfo* node) override { return false; }
+    virtual bool visit_unpackintoarray(BST_UnpackIntoArray* node) override { return false; }
+    virtual bool visit_yield(BST_Yield* node) override { return false; }
 };
 
 class StmtVisitor {
@@ -915,90 +1104,136 @@ public:
     virtual ~StmtVisitor() {}
 
     virtual void visit_assert(BST_Assert* node) { RELEASE_ASSERT(0, ""); }
-    virtual void visit_assign(BST_Assign* node) { RELEASE_ASSERT(0, ""); }
-    virtual void visit_classdef(BST_ClassDef* node) { RELEASE_ASSERT(0, ""); }
-    virtual void visit_delete(BST_Delete* node) { RELEASE_ASSERT(0, ""); }
-    virtual void visit_exec(BST_Exec* node) { RELEASE_ASSERT(0, ""); }
-    virtual void visit_expr(BST_Expr* node) { RELEASE_ASSERT(0, ""); }
-    virtual void visit_functiondef(BST_FunctionDef* node) { RELEASE_ASSERT(0, ""); }
-    virtual void visit_invoke(BST_Invoke* node) { RELEASE_ASSERT(0, ""); }
-    virtual void visit_print(BST_Print* node) { RELEASE_ASSERT(0, ""); }
-    virtual void visit_raise(BST_Raise* node) { RELEASE_ASSERT(0, ""); }
-    virtual void visit_return(BST_Return* node) { RELEASE_ASSERT(0, ""); }
-
+    virtual void visit_augbinop(BST_AugBinOp* node) { RELEASE_ASSERT(0, ""); }
+    virtual void visit_binop(BST_BinOp* node) { RELEASE_ASSERT(0, ""); }
     virtual void visit_branch(BST_Branch* node) { RELEASE_ASSERT(0, ""); }
+    virtual void visit_callattr(BST_CallAttr* node) { RELEASE_ASSERT(0, ""); }
+    virtual void visit_callclsattr(BST_CallClsAttr* node) { RELEASE_ASSERT(0, ""); }
+    virtual void visit_callfunc(BST_CallFunc* node) { RELEASE_ASSERT(0, ""); }
+    virtual void visit_checkexcmatch(BST_CheckExcMatch* node) { RELEASE_ASSERT(0, ""); }
+    virtual void visit_classdef(BST_ClassDef* node) { RELEASE_ASSERT(0, ""); }
+    virtual void visit_compare(BST_Compare* node) { RELEASE_ASSERT(0, ""); }
+    virtual void visit_copyvreg(BST_CopyVReg* node) { RELEASE_ASSERT(0, ""); }
+    virtual void visit_deleteattr(BST_DeleteAttr* node) { RELEASE_ASSERT(0, ""); }
+    virtual void visit_deletename(BST_DeleteName* node) { RELEASE_ASSERT(0, ""); }
+    virtual void visit_deletesub(BST_DeleteSub* node) { RELEASE_ASSERT(0, ""); }
+    virtual void visit_deletesubslice(BST_DeleteSubSlice* node) { RELEASE_ASSERT(0, ""); }
+    virtual void visit_dict(BST_Dict* node) { RELEASE_ASSERT(0, ""); }
+    virtual void visit_exec(BST_Exec* node) { RELEASE_ASSERT(0, ""); }
+    virtual void visit_functiondef(BST_FunctionDef* node) { RELEASE_ASSERT(0, ""); }
+    virtual void visit_getiter(BST_GetIter* node) { RELEASE_ASSERT(0, ""); }
+    virtual void visit_hasnext(BST_HasNext* node) { RELEASE_ASSERT(0, ""); }
+    virtual void visit_importfrom(BST_ImportFrom* node) { RELEASE_ASSERT(0, ""); }
+    virtual void visit_importname(BST_ImportName* node) { RELEASE_ASSERT(0, ""); }
+    virtual void visit_importstar(BST_ImportStar* node) { RELEASE_ASSERT(0, ""); }
+    virtual void visit_invoke(BST_Invoke* node) { RELEASE_ASSERT(0, ""); }
     virtual void visit_jump(BST_Jump* node) { RELEASE_ASSERT(0, ""); }
+    virtual void visit_landingpad(BST_Landingpad* node) { RELEASE_ASSERT(0, ""); }
+    virtual void visit_list(BST_List* node) { RELEASE_ASSERT(0, ""); }
+    virtual void visit_loadattr(BST_LoadAttr* node) { RELEASE_ASSERT(0, ""); }
+    virtual void visit_loadname(BST_LoadName* node) { RELEASE_ASSERT(0, ""); }
+    virtual void visit_loadsub(BST_LoadSub* node) { RELEASE_ASSERT(0, ""); }
+    virtual void visit_loadsubslice(BST_LoadSubSlice* node) { RELEASE_ASSERT(0, ""); }
+    virtual void visit_locals(BST_Locals* node) { RELEASE_ASSERT(0, ""); }
+    virtual void visit_makeclass(BST_MakeClass* node) { RELEASE_ASSERT(0, ""); }
+    virtual void visit_makefunction(BST_MakeFunction* node) { RELEASE_ASSERT(0, ""); }
+    virtual void visit_makeslice(BST_MakeSlice* node) { RELEASE_ASSERT(0, ""); }
+    virtual void visit_nonzero(BST_Nonzero* node) { RELEASE_ASSERT(0, ""); }
+    virtual void visit_print(BST_Print* node) { RELEASE_ASSERT(0, ""); }
+    virtual void visit_printexpr(BST_PrintExpr* node) { RELEASE_ASSERT(0, ""); }
+    virtual void visit_raise(BST_Raise* node) { RELEASE_ASSERT(0, ""); }
+    virtual void visit_repr(BST_Repr* node) { RELEASE_ASSERT(0, ""); }
+    virtual void visit_return(BST_Return* node) { RELEASE_ASSERT(0, ""); }
+    virtual void visit_set(BST_Set* node) { RELEASE_ASSERT(0, ""); }
+    virtual void visit_setexcinfo(BST_SetExcInfo* node) { RELEASE_ASSERT(0, ""); }
+    virtual void visit_storeattr(BST_StoreAttr* node) { RELEASE_ASSERT(0, ""); }
+    virtual void visit_storename(BST_StoreName* node) { RELEASE_ASSERT(0, ""); }
+    virtual void visit_storesub(BST_StoreSub* node) { RELEASE_ASSERT(0, ""); }
+    virtual void visit_storesubslice(BST_StoreSubSlice* node) { RELEASE_ASSERT(0, ""); }
+    virtual void visit_tuple(BST_Tuple* node) { RELEASE_ASSERT(0, ""); }
+    virtual void visit_unaryop(BST_UnaryOp* node) { RELEASE_ASSERT(0, ""); }
+    virtual void visit_uncacheexcinfo(BST_UncacheExcInfo* node) { RELEASE_ASSERT(0, ""); }
+    virtual void visit_unpackintoarray(BST_UnpackIntoArray* node) { RELEASE_ASSERT(0, ""); }
+    virtual void visit_yield(BST_Yield* node) { RELEASE_ASSERT(0, ""); }
 };
 
-class SliceVisitor {
-public:
-    virtual ~SliceVisitor() {}
-    virtual void* visit_ellipsis(BST_Ellipsis* node) { RELEASE_ASSERT(0, ""); }
-    virtual void* visit_extslice(BST_ExtSlice* node) { RELEASE_ASSERT(0, ""); }
-    virtual void* visit_index(BST_Index* node) { RELEASE_ASSERT(0, ""); }
-    virtual void* visit_slice(BST_Slice* node) { RELEASE_ASSERT(0, ""); }
-};
+class ConstantVRegInfo;
+void print_bst(BST_stmt* bst, const ConstantVRegInfo& constant_vregs);
 
-void print_bst(BST* bst);
 class PrintVisitor : public BSTVisitor {
 private:
     llvm::raw_ostream& stream;
+    const ConstantVRegInfo& constant_vregs;
     int indent;
     void printIndent();
     void printOp(AST_TYPE::AST_TYPE op_type);
 
 public:
-    PrintVisitor(int indent = 0, llvm::raw_ostream& stream = llvm::outs()) : stream(stream), indent(indent) {}
+    PrintVisitor(const ConstantVRegInfo& constant_vregs, int indent, llvm::raw_ostream& stream)
+        : BSTVisitor(false /* visit child CFG */), stream(stream), constant_vregs(constant_vregs), indent(indent) {}
     virtual ~PrintVisitor() {}
     void flush() { stream.flush(); }
 
-    virtual bool visit_arguments(BST_arguments* node);
+    virtual bool visit_vreg(int* vreg, bool is_dst = false);
+
     virtual bool visit_assert(BST_Assert* node);
-    virtual bool visit_assign(BST_Assign* node);
     virtual bool visit_augbinop(BST_AugBinOp* node);
-    virtual bool visit_attribute(BST_Attribute* node);
     virtual bool visit_binop(BST_BinOp* node);
-    virtual bool visit_call(BST_Call* node);
-    virtual bool visit_compare(BST_Compare* node);
+    virtual bool visit_branch(BST_Branch* node);
+    virtual bool visit_callattr(BST_CallAttr* node);
+    virtual bool visit_callclsattr(BST_CallClsAttr* node);
+    virtual bool visit_callfunc(BST_CallFunc* node);
+    virtual bool visit_checkexcmatch(BST_CheckExcMatch* node);
     virtual bool visit_classdef(BST_ClassDef* node);
-    virtual bool visit_clsattribute(BST_ClsAttribute* node);
-    virtual bool visit_delete(BST_Delete* node);
+    virtual bool visit_compare(BST_Compare* node);
+    virtual bool visit_copyvreg(BST_CopyVReg* node);
+    virtual bool visit_deleteattr(BST_DeleteAttr* node);
+    virtual bool visit_deletename(BST_DeleteName* node);
+    virtual bool visit_deletesub(BST_DeleteSub* node);
+    virtual bool visit_deletesubslice(BST_DeleteSubSlice* node);
     virtual bool visit_dict(BST_Dict* node);
-    virtual bool visit_ellipsis(BST_Ellipsis* node);
     virtual bool visit_exec(BST_Exec* node);
-    virtual bool visit_expr(BST_Expr* node);
-    virtual bool visit_extslice(BST_ExtSlice* node);
     virtual bool visit_functiondef(BST_FunctionDef* node);
-    virtual bool visit_index(BST_Index* node);
+    virtual bool visit_getiter(BST_GetIter* node);
+    virtual bool visit_hasnext(BST_HasNext* node);
+    virtual bool visit_importfrom(BST_ImportFrom* node);
+    virtual bool visit_importname(BST_ImportName* node);
+    virtual bool visit_importstar(BST_ImportStar* node);
     virtual bool visit_invoke(BST_Invoke* node);
-    virtual bool visit_keyword(BST_keyword* node);
-    virtual bool visit_langprimitive(BST_LangPrimitive* node);
+    virtual bool visit_jump(BST_Jump* node);
+    virtual bool visit_landingpad(BST_Landingpad* node);
     virtual bool visit_list(BST_List* node);
-    virtual bool visit_name(BST_Name* node);
-    virtual bool visit_num(BST_Num* node);
+    virtual bool visit_loadattr(BST_LoadAttr* node);
+    virtual bool visit_loadname(BST_LoadName* node);
+    virtual bool visit_loadsub(BST_LoadSub* node);
+    virtual bool visit_loadsubslice(BST_LoadSubSlice* node);
+    virtual bool visit_locals(BST_Locals* node);
+    virtual bool visit_makeclass(BST_MakeClass* node);
+    virtual bool visit_makefunction(BST_MakeFunction* node);
+    virtual bool visit_makeslice(BST_MakeSlice* node);
+    virtual bool visit_nonzero(BST_Nonzero* node);
     virtual bool visit_print(BST_Print* node);
+    virtual bool visit_printexpr(BST_PrintExpr* node);
     virtual bool visit_raise(BST_Raise* node);
     virtual bool visit_repr(BST_Repr* node);
     virtual bool visit_return(BST_Return* node);
     virtual bool visit_set(BST_Set* node);
-    virtual bool visit_slice(BST_Slice* node);
-    virtual bool visit_str(BST_Str* node);
-    virtual bool visit_subscript(BST_Subscript* node);
+    virtual bool visit_setexcinfo(BST_SetExcInfo* node);
+    virtual bool visit_storeattr(BST_StoreAttr* node);
+    virtual bool visit_storename(BST_StoreName* node);
+    virtual bool visit_storesub(BST_StoreSub* node);
+    virtual bool visit_storesubslice(BST_StoreSubSlice* node);
     virtual bool visit_tuple(BST_Tuple* node);
     virtual bool visit_unaryop(BST_UnaryOp* node);
+    virtual bool visit_uncacheexcinfo(BST_UncacheExcInfo* node);
+    virtual bool visit_unpackintoarray(BST_UnpackIntoArray* node);
     virtual bool visit_yield(BST_Yield* node);
-
-    virtual bool visit_branch(BST_Branch* node);
-    virtual bool visit_jump(BST_Jump* node);
-    virtual bool visit_makefunction(BST_MakeFunction* node);
-    virtual bool visit_makeclass(BST_MakeClass* node);
 };
 
 // Given an BST node, return a vector of the node plus all its descendents.
 // This is useful for analyses that care more about the constituent nodes than the
 // exact tree structure; ex, finding all "global" directives.
-void flatten(llvm::ArrayRef<BST_stmt*> roots, std::vector<BST*>& output, bool expand_scopes);
-void flatten(BST_expr* root, std::vector<BST*>& output, bool expand_scopes);
+void flatten(llvm::ArrayRef<BST_stmt*> roots, std::vector<BST_stmt*>& output, bool expand_scopes);
 };
 
 #endif

--- a/src/core/bst.h
+++ b/src/core/bst.h
@@ -134,7 +134,6 @@ public:
 
     const BST_TYPE::BST_TYPE type;
     uint32_t lineno;
-    int cxx_exception_count = 0;
 
     virtual void accept(BSTVisitor* v) = 0;
     virtual void accept_stmt(StmtVisitor* v) = 0;

--- a/src/core/cfg.h
+++ b/src/core/cfg.h
@@ -88,8 +88,7 @@ public:
     void unconnectFrom(CFGBlock* successor);
 
     void push_back(BST_stmt* node) { body.push_back(node); }
-    void print(llvm::raw_ostream& stream = llvm::outs());
-    void _print() { print(); }
+    void print(const ConstantVRegInfo& constant_vregs, llvm::raw_ostream& stream = llvm::outs());
 };
 
 // the vregs are split into three parts.
@@ -110,8 +109,8 @@ class VRegInfo {
 private:
 #ifndef NDEBUG
     // this maps use too much memory, we only use them in the debug build for asserts
-    llvm::DenseMap<InternedString, DefaultedInt<-1>> sym_vreg_map_user_visible;
-    llvm::DenseMap<InternedString, DefaultedInt<-1>> sym_vreg_map;
+    llvm::DenseMap<InternedString, DefaultedInt<VREG_UNDEFINED>> sym_vreg_map_user_visible;
+    llvm::DenseMap<InternedString, DefaultedInt<VREG_UNDEFINED>> sym_vreg_map;
 #endif
 
     // Reverse map, from vreg->symbol name.
@@ -126,8 +125,8 @@ public:
 #ifndef NDEBUG
     // map of all assigned names. if the name is block local the vreg number is not unique because this vregs get reused
     // between blocks.
-    const llvm::DenseMap<InternedString, DefaultedInt<-1>>& getSymVRegMap() const { return sym_vreg_map; }
-    const llvm::DenseMap<InternedString, DefaultedInt<-1>>& getUserVisibleSymVRegMap() const {
+    const llvm::DenseMap<InternedString, DefaultedInt<VREG_UNDEFINED>>& getSymVRegMap() const { return sym_vreg_map; }
+    const llvm::DenseMap<InternedString, DefaultedInt<VREG_UNDEFINED>>& getUserVisibleSymVRegMap() const {
         return sym_vreg_map_user_visible;
     }
 
@@ -169,7 +168,7 @@ public:
     int getNumOfCrossBlockVRegs() const { return num_vregs_cross_block; }
 
     bool hasVRegsAssigned() const { return num_vregs != -1; }
-    void assignVRegs(CFG* cfg, const ParamNames& param_names);
+    void assignVRegs(CFG* cfg, const ParamNames& param_names, llvm::DenseMap<int*, InternedString>& id_vreg);
 };
 
 // Control Flow Graph
@@ -211,7 +210,7 @@ public:
         blocks.push_back(block);
     }
 
-    void print(llvm::raw_ostream& stream = llvm::outs());
+    void print(const ConstantVRegInfo& constant_vregs, llvm::raw_ostream& stream = llvm::outs());
 };
 
 class VRegSet {
@@ -332,7 +331,7 @@ public:
 
 BoxedCode* computeAllCFGs(AST* ast, bool globals_from_module, FutureFlags future_flags, BoxedString* fn,
                           BoxedModule* bm);
-void printCFG(CFG* cfg);
+void printCFG(CFG* cfg, const ConstantVRegInfo& constant_vregs);
 }
 
 #endif

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -154,11 +154,11 @@ struct ICSlotInfo;
 
 class CFG;
 class AST;
-class BST;
 class BST_FunctionDef;
 class AST_arguments;
-class BST_expr;
 class BST_Name;
+class BST_LoadName;
+class BST_StoreName;
 class BST_stmt;
 
 class PhiAnalysis;
@@ -478,8 +478,7 @@ public:
         return closure_size;
     }
     const std::vector<std::pair<InternedString, DerefInfo>>& getAllDerefVarsAndInfo() const { return deref_info; }
-    DerefInfo getDerefInfo(BST_Name*) const;
-    size_t getClosureOffset(BST_Name*) const;
+    DerefInfo getDerefInfo(BST_LoadName*) const;
 
     ScopingResults(ScopeInfo* scope_info, bool globals_from_module);
 };

--- a/src/runtime/code.cpp
+++ b/src/runtime/code.cpp
@@ -113,9 +113,10 @@ void BoxedCode::dealloc(Box* b) noexcept {
 }
 
 BoxedCode::BoxedCode(int num_args, bool takes_varargs, bool takes_kwargs, int firstlineno,
-                     std::unique_ptr<SourceInfo> source, ParamNames param_names, BoxedString* filename,
-                     BoxedString* name, Box* doc)
+                     std::unique_ptr<SourceInfo> source, ConstantVRegInfo constant_vregs, ParamNames param_names,
+                     BoxedString* filename, BoxedString* name, Box* doc)
     : source(std::move(source)),
+      constant_vregs(std::move(constant_vregs)),
       filename(incref(filename)),
       name(incref(name)),
       firstlineno(firstlineno),

--- a/src/runtime/import.cpp
+++ b/src/runtime/import.cpp
@@ -133,8 +133,10 @@ extern "C" PyObject* PyImport_ExecCodeModuleEx(const char* name, PyObject* co, c
     }
 }
 
-extern "C" Box* import(int level, Box* from_imports, llvm::StringRef module_name) {
-    Box* rtn = PyImport_ImportModuleLevel(module_name.str().c_str(), getGlobalsDict(), NULL, from_imports, level);
+extern "C" Box* import(int level, Box* from_imports, Box* _module_name) {
+    assert(_module_name->cls == str_cls);
+    BoxedString* module_name = (BoxedString*)_module_name;
+    Box* rtn = PyImport_ImportModuleLevel(module_name->c_str(), getGlobalsDict(), NULL, from_imports, level);
     if (!rtn)
         throwCAPIException();
     return rtn;

--- a/src/runtime/import.h
+++ b/src/runtime/import.h
@@ -20,7 +20,7 @@
 namespace pyston {
 
 extern "C" PyObject* PyImport_GetImporter(PyObject* path) noexcept;
-extern "C" Box* import(int level, Box* from_imports, llvm::StringRef module_name);
+extern "C" Box* import(int level, Box* from_imports, Box* module_name);
 BoxedModule* importCExtension(BoxedString* full_name, const std::string& last_name, const std::string& path);
 
 #ifdef Py_REF_DEBUG

--- a/src/runtime/objmodel.cpp
+++ b/src/runtime/objmodel.cpp
@@ -136,7 +136,7 @@ extern "C" void xdecrefAndRethrow(void* cxa_ptr, int num, ...) {
     rawReraise(e.type, e.value, e.traceback);
 }
 
-extern "C" Box* deopt(BST_expr* expr, Box* value) {
+extern "C" Box* deopt(Box* value) {
     ASSERT(ENABLE_FRAME_INTROSPECTION, "deopt will not work with frame introspection turned off");
 
     STAT_TIMER(t0, "us_timer_deopt", 10);
@@ -156,7 +156,7 @@ extern "C" Box* deopt(BST_expr* expr, Box* value) {
         deopt_state.frame_state.frame_info->exc.value = NULL;
     }
 
-    return astInterpretDeopt(deopt_state.cf->code_obj, expr, deopt_state.current_stmt, value, deopt_state.frame_state);
+    return astInterpretDeopt(deopt_state.cf->code_obj, deopt_state.current_stmt, value, deopt_state.frame_state);
 }
 
 extern "C" void printHelper(Box* w, Box* v, bool nl) {
@@ -7442,8 +7442,11 @@ extern "C" void setGlobal(Box* globals, BoxedString* name, STOLEN(Box*) value) {
     }
 }
 
-extern "C" Box* importFrom(Box* _m, BoxedString* name) {
+extern "C" Box* importFrom(Box* _m, Box* _name) {
     STAT_TIMER(t0, "us_timer_importFrom", 10);
+
+    assert(_name->cls == str_cls);
+    BoxedString* name = (BoxedString*)_name;
 
     Box* r = getattrInternal<CXX>(_m, name);
     if (r)

--- a/src/runtime/objmodel.h
+++ b/src/runtime/objmodel.h
@@ -45,7 +45,7 @@ void _printStacktrace();
 // to see if they are getting called from jitted code.  If we inline them into a function that
 // got called from jitted code, they might incorrectly think that they are a rewritable entrypoint.
 
-extern "C" Box* deopt(BST_expr* expr, Box* value) __attribute__((noinline));
+extern "C" Box* deopt(Box* value) __attribute__((noinline));
 
 // helper function for raising from the runtime:
 void raiseExcHelper(BoxedClass*, const char* fmt, ...) __attribute__((__noreturn__))
@@ -94,7 +94,7 @@ extern "C" void assignSlice(PyObject* u, PyObject* v, PyObject* w, PyObject* x);
 extern "C" Box* getclsattr(Box* obj, BoxedString* attr) __attribute__((noinline));
 extern "C" Box* getclsattrMaybeNonstring(Box* obj, Box* attr) __attribute__((noinline));
 extern "C" Box* unaryop(Box* operand, int op_type) __attribute__((noinline));
-extern "C" Box* importFrom(Box* obj, BoxedString* attr) __attribute__((noinline));
+extern "C" Box* importFrom(Box* obj, Box* attr) __attribute__((noinline));
 extern "C" Box* importStar(Box* from_module, Box* to_globals) __attribute__((noinline));
 extern "C" Box** unpackIntoArray(Box* obj, int64_t expected_size, Box** out_keep_alive);
 extern "C" void assertNameDefined(bool b, const char* name, BoxedClass* exc_cls, bool local_var_msg);

--- a/src/runtime/types.h
+++ b/src/runtime/types.h
@@ -1120,6 +1120,7 @@ public:
     long bjit_num_inside = 0;
     std::vector<std::unique_ptr<JitCodeBlock>> code_blocks;
     ICInvalidator dependent_interp_callsites;
+    llvm::DenseMap<BST_stmt*, int> cxx_exception_count;
 
 
     // Functions can provide an "internal" version, which will get called instead

--- a/src/runtime/util.cpp
+++ b/src/runtime/util.cpp
@@ -254,7 +254,7 @@ extern "C" void dumpEx(void* p, int levels) {
                 printf("Defined at %s:%d\n", code->filename->c_str(), code->firstlineno);
 
                 if (code->source->cfg && levels > 0) {
-                    code->source->cfg->print();
+                    code->source->cfg->print(code->constant_vregs);
                 }
             } else {
                 printf("A builtin function\n");


### PR DESCRIPTION
**basic design:**
This PR changes our BST nodes to directly operate on vregs instead of pointers to other nodes and names (except a few exceptions: `BST_Invoke`, `BST_MakeFunction` and `BST_MakeClass` which still needs to get converted).
Most nodes got a destination vreg and one or more source vregs. Currently all of them are 32bit long but I plan to store them more compact very soon. Some nodes support a variable size of operands (e.g. the tuple node) but the size can't change after creating the node. I removed several unneeded opcodes and split a lot of nodes into separate opcodes (it may make sense to split them even further in the future). 
Generally all instructions except `CopyVReg` kill the source operand vregs except if the source is a ref to a constant. If one needs the preserve the source vreg on needs to create a new temporary using the `CopyVReg` opcode.

There is a special vreg number: `VREG_UNDEFINED = std::numeric_limits<int>::min()`.
- when it's set as an operand vreg: it means that this is a not-set optional argument. (e.g. for a slice which only has `lower` set, `upper` would be `VREG_UNDEFINED`)
- if it's the destination it's means the result value should get immediately killed (e.g. `invoke 15 16: %undef = %11(%14)` this is a call whose result gets ignored)

all other negative vreg numbers are indices into a constant table (after adding 1 and making them positive).
(e.g. `(4, 2, 'lala')` generates:  `%undef = (%-1|4|, %-2|2|, %-3|'lala'|)` this creates a tuple whose elements are the constant idx -1, -2 and -3. In order to make it easier for a human to understand we print the actual value of the constant between | characters)
- constants can be all str and numeric types and 'None'.
- every constant will only get stored once in the table

this reduces the total memory usage by about 20% currently but I'm very sure with the future changes it will be significantly lower.

**near future:**
- change the jump and branch instruction to reference `CFGBlocks` by index.
- store all `InternedString` inside a table and use indices into the the table to access them.
- remove the `BoxedCode*` member
- devirtualize the classes
= with this changes the bytecode can get freely copied around (only need to update the CFGBlock table) which allows us to store them directly next to each other.

- I plan to use one bit of the the opcode to mark the instruction as only requiring 8bit vreg operands (which should handle the majority of cases with 128 temps and 127 constants + 1undef vreg value) 
- another bit will get used to specify if this instruction is inside an `invoke`. if this bit is set there are two 1 or 4 bytes long block indices directly behind the instruction.
 
- serialize the bytecode to disk. (maybe serialize the constant table using pickle)

**thing which need to get improved**
- currently the constant table get's attached to the `BoxedModule` maybe there is a better location, I also needed to pass the `BoxedModule` into some functions e.g. BST printing because otherwise we could not pretty-print the constants
- `BST_Name` is not an opcode it's just used to initialize the arguments when a function get's called and stores where and how the arguments need to get stored.
- more consistent opcode names and rename `TmpValue` to something better
- we currently don't print the `InternedString` name - we only print the vreg number

**additional changed made which are hidden in the large diff** :-1:
- removed unused code initializing the items of `BST_Dict` (we use/used separate assignments to add the items)
- lower `ExtSlice` inside the CFG phase to a tuple of slices
- separated opcode for load subscript when it needs to be a slice and when it's only lower and upper (=`__getslice__`) before this got handled in the interpreter/jit
- generate a constant `None` load inside the CFG when `None` gets loaded by name