### PR TITLE
[WIP] BST: allocate instructions and operands adjacent to each other

### DIFF
--- a/src/analysis/function_analysis.cpp
+++ b/src/analysis/function_analysis.cpp
@@ -102,7 +102,7 @@ LivenessAnalysis::LivenessAnalysis(CFG* cfg, const CodeConstants& code_constants
 
     for (CFGBlock* b : cfg->blocks) {
         auto visitor = new LivenessBBVisitor(this); // livenessCache unique_ptr will delete it.
-        for (BST_stmt* stmt : b->body) {
+        for (BST_stmt* stmt : *b) {
             stmt->accept(visitor);
         }
         liveness_cache.insert(std::make_pair(b, std::unique_ptr<LivenessBBVisitor>(visitor)));
@@ -257,8 +257,8 @@ public:
 void DefinednessBBAnalyzer::processBB(Map& starting, CFGBlock* block) const {
     DefinednessVisitor visitor(code_constants, starting);
 
-    for (int i = 0; i < block->body.size(); i++) {
-        block->body[i]->accept(&visitor);
+    for (BST_stmt* stmt : *block) {
+        stmt->accept(&visitor);
     }
 
     if (VERBOSITY("analysis") >= 3) {

--- a/src/analysis/type_analysis.cpp
+++ b/src/analysis/type_analysis.cpp
@@ -101,8 +101,8 @@ private:
           speculation(speculation) {}
 
     void run() {
-        for (int i = 0; i < block->body.size(); i++) {
-            block->body[i]->accept_stmt(this);
+        for (BST_stmt* stmt : *block) {
+            stmt->accept_stmt(this);
         }
     }
 

--- a/src/codegen/codegen.cpp
+++ b/src/codegen/codegen.cpp
@@ -69,7 +69,7 @@ SourceInfo::SourceInfo(BoxedModule* m, ScopingResults scoping, FutureFlags futur
 }
 
 SourceInfo::~SourceInfo() {
-    // TODO: release memory..
+    delete cfg;
 }
 
 void FunctionAddressRegistry::registerFunction(const std::string& name, void* addr, int length,

--- a/src/codegen/irgen.cpp
+++ b/src/codegen/irgen.cpp
@@ -640,7 +640,7 @@ static void emitBBs(IRGenState* irstate, TypeAnalysis* types, const OSREntryDesc
 
             // Function-entry safepoint:
             // TODO might be more efficient to do post-call safepoints?
-            generator->doSafePoint(block->body[0]);
+            generator->doSafePoint(block->body);
         } else if (entry_descriptor && block == entry_descriptor->backedge->target) {
             assert(block->predecessors.size() > 1);
             assert(osr_entry_block);
@@ -733,7 +733,7 @@ static void emitBBs(IRGenState* irstate, TypeAnalysis* types, const OSREntryDesc
                 //   are disallowed
 
                 auto pred = block->predecessors[0];
-                auto last_inst = pred->body.back();
+                auto last_inst = pred->getLastStmt();
 
                 SymbolTable* sym_table = ending_symbol_tables[pred];
                 bool created_new_sym_table = false;
@@ -800,7 +800,7 @@ static void emitBBs(IRGenState* irstate, TypeAnalysis* types, const OSREntryDesc
             if (predecessor->idx > block->idx) {
                 // Loop safepoint:
                 // TODO does it matter which side of the backedge these are on?
-                generator->doSafePoint(block->body[0]);
+                generator->doSafePoint(block->body);
                 break;
             }
         }
@@ -815,7 +815,7 @@ static void emitBBs(IRGenState* irstate, TypeAnalysis* types, const OSREntryDesc
         llvm_exit_blocks[block] = ending_st.ending_block;
 
         if (ending_st.exception_state.size()) {
-            BST_stmt* last_stmt = block->body.back();
+            BST_stmt* last_stmt = block->getLastStmt();
             assert(last_stmt->type == BST_TYPE::Invoke);
             CFGBlock* exc_block = bst_cast<BST_Invoke>(last_stmt)->exc_dest;
             assert(!incoming_exception_state.count(exc_block));

--- a/src/codegen/irgen/irgenerator.cpp
+++ b/src/codegen/irgen/irgenerator.cpp
@@ -2951,18 +2951,17 @@ public:
             }
             printf("\n");
         }
-        for (int i = 0; i < block->body.size(); i++) {
+        for (BST_stmt* stmt : *block) {
             if (state == DEAD)
                 break;
             assert(state != FINISHED);
 
 #if ENABLE_SAMPLING_PROFILER
-            auto stmt = block->body[i];
             if (stmt->type != BST_TYPE::Landigpad && stmt->lineno > 0)
-                doSafePoint(block->body[i]);
+                doSafePoint(stmt);
 #endif
 
-            doStmt(block->body[i], UnwindInfo(irstate->getCode(), block->body[i], NULL));
+            doStmt(stmt, UnwindInfo(irstate->getCode(), stmt, NULL));
         }
         if (VERBOSITY("irgenerator") >= 2) { // print ending symbol table
             printf("  %d fini:", block->idx);

--- a/src/core/bst.cpp
+++ b/src/core/bst.cpp
@@ -43,6 +43,25 @@ template <class T> static void visitVector(const std::vector<T*>& vec, BSTVisito
     }
 }
 
+void BST_stmt::accept(BSTVisitor* v) {
+    switch (type) {
+#define DISPATCH_ACCEPT(x, y)                                                                                          \
+    case BST_TYPE::x:                                                                                                  \
+        return bst_cast<BST_##x>(this)->accept(v);
+        FOREACH_TYPE(DISPATCH_ACCEPT)
+    };
+}
+
+void BST_stmt::accept_stmt(StmtVisitor* v) {
+    switch (type) {
+#define DISPATCH_ACCEPT_STMT(x, y)                                                                                     \
+    case BST_TYPE::x:                                                                                                  \
+        return bst_cast<BST_##x>(this)->accept_stmt(v);
+        FOREACH_TYPE(DISPATCH_ACCEPT_STMT)
+    };
+}
+
+
 void BST_Assert::accept(BSTVisitor* v) {
     bool skip = v->visit_assert(this);
     if (skip)

--- a/src/core/bst.h
+++ b/src/core/bst.h
@@ -99,7 +99,6 @@ static const char* stringify(int n) {
     return m[n];
 }
 
-#undef FOREACH_TYPE
 #undef GENERATE_ENUM
 #undef GENERATE_STRING
 };
@@ -128,17 +127,23 @@ static constexpr int VREG_UNDEFINED = std::numeric_limits<int>::min();
 //  in order to make it easier for a human to understand we print the actual value of the constant between | characters.
 
 
+#define PACKED __attribute__((packed)) __attribute__((__aligned__(1)))
+
 class BST_stmt {
 public:
-    virtual ~BST_stmt() {}
-
     const BST_TYPE::BST_TYPE type;
     uint32_t lineno;
 
-    virtual void accept(BSTVisitor* v) = 0;
-    virtual void accept_stmt(StmtVisitor* v) = 0;
+    void accept(BSTVisitor* v);
+    void accept_stmt(StmtVisitor* v);
 
-    virtual bool has_dest_vreg() const { return false; }
+    inline int size_in_bytes() const __attribute__((always_inline));
+    inline bool has_dest_vreg() const __attribute__((always_inline));
+    bool is_terminator() const __attribute__((always_inline)) {
+        return type == BST_TYPE::Branch || type == BST_TYPE::Jump || type == BST_TYPE::Invoke
+               || type == BST_TYPE::Return || type == BST_TYPE::Raise || type == BST_TYPE::Assert;
+    }
+
 
 // #define DEBUG_LINE_NUMBERS 1
 #ifdef DEBUG_LINE_NUMBERS
@@ -153,7 +158,7 @@ public:
     BST_stmt(BST_TYPE::BST_TYPE type) : type(type), lineno(0) {}
 #endif
     BST_stmt(BST_TYPE::BST_TYPE type, uint32_t lineno) : type(type), lineno(lineno) {}
-};
+} PACKED;
 
 // base class of all nodes which have a single destination vreg
 class BST_stmt_with_dest : public BST_stmt {
@@ -161,24 +166,24 @@ public:
     int vreg_dst = VREG_UNDEFINED;
     BST_stmt_with_dest(BST_TYPE::BST_TYPE type) : BST_stmt(type) {}
     BST_stmt_with_dest(BST_TYPE::BST_TYPE type, int lineno) : BST_stmt(type, lineno) {}
-
-    bool has_dest_vreg() const override { return true; }
-};
+} PACKED;
 
 #define BSTNODE(opcode)                                                                                                \
-    virtual void accept(BSTVisitor* v);                                                                                \
-    virtual void accept_stmt(StmtVisitor* v);                                                                          \
+    void accept(BSTVisitor* v);                                                                                        \
+    void accept_stmt(StmtVisitor* v);                                                                                  \
     static const BST_TYPE::BST_TYPE TYPE = BST_TYPE::opcode;
 
 #define BSTFIXEDVREGS(opcode, base_class)                                                                              \
     BSTNODE(opcode)                                                                                                    \
-    BST_##opcode() : base_class(BST_TYPE::opcode) {}
+    BST_##opcode() : base_class(BST_TYPE::opcode) {}                                                                   \
+    int size_in_bytes() const { return sizeof(*this); }
 
 #define BSTVARVREGS(opcode, base_class, num_elts, vreg_dst)                                                            \
 public:                                                                                                                \
     BSTNODE(opcode)                                                                                                    \
     static BST_##opcode* create(int num_elts) { return new (num_elts) BST_##opcode(num_elts); }                        \
     static void operator delete(void* ptr) { ::operator delete[](ptr); }                                               \
+    int size_in_bytes() const { return offsetof(BST_##opcode, vreg_dst) + num_elts * sizeof(int); }                    \
                                                                                                                        \
 private:                                                                                                               \
     static void* operator new(size_t, int num_elts) {                                                                  \
@@ -197,6 +202,7 @@ public:                                                                         
         return new (num_elts + num_elts2) BST_##opcode(num_elts, num_elts2);                                           \
     }                                                                                                                  \
     static void operator delete(void* ptr) { ::operator delete[](ptr); }                                               \
+    int size_in_bytes() const { return offsetof(BST_##opcode, vreg_dst) + (num_elts + num_elts2) * sizeof(int); }      \
                                                                                                                        \
 private:                                                                                                               \
     static void* operator new(size_t, int num_elts_total) {                                                            \
@@ -216,6 +222,7 @@ public:                                                                         
         return new (num_elts + num_elts2) BST_##opcode(num_elts, num_elts2);                                           \
     }                                                                                                                  \
     static void operator delete(void* ptr) { ::operator delete[](ptr); }                                               \
+    int size_in_bytes() const { return offsetof(BST_##opcode, vreg_dst) + (num_elts + num_elts2) * sizeof(int); }      \
                                                                                                                        \
 private:                                                                                                               \
     static void* operator new(size_t, int num_elts_total) {                                                            \
@@ -232,7 +239,7 @@ public:
     int vreg_msg = VREG_UNDEFINED;
 
     BSTFIXEDVREGS(Assert, BST_stmt)
-};
+} PACKED;
 
 class BST_UnpackIntoArray : public BST_stmt {
 public:
@@ -241,7 +248,7 @@ public:
     int vreg_dst[1];
 
     BSTVARVREGS(UnpackIntoArray, BST_stmt, num_elts, vreg_dst)
-};
+} PACKED;
 
 // This is a special instruction which copies a vreg without destroying the source.
 // All other instructions always kill the operands (except if they are a constant) so if one needs the operand to stay
@@ -251,7 +258,7 @@ public:
     int vreg_src = VREG_UNDEFINED; // this vreg will not get killed!
 
     BSTFIXEDVREGS(CopyVReg, BST_stmt_with_dest)
-};
+} PACKED;
 
 
 class BST_StoreName : public BST_stmt {
@@ -268,7 +275,7 @@ public:
     int closure_offset = -1;
 
     BSTFIXEDVREGS(StoreName, BST_stmt)
-};
+} PACKED;
 
 class BST_StoreAttr : public BST_stmt {
 public:
@@ -277,7 +284,7 @@ public:
     int vreg_value = VREG_UNDEFINED;
 
     BSTFIXEDVREGS(StoreAttr, BST_stmt)
-};
+} PACKED;
 
 class BST_StoreSub : public BST_stmt {
 public:
@@ -286,7 +293,7 @@ public:
     int vreg_value = VREG_UNDEFINED;
 
     BSTFIXEDVREGS(StoreSub, BST_stmt)
-};
+} PACKED;
 
 class BST_StoreSubSlice : public BST_stmt {
 public:
@@ -295,7 +302,7 @@ public:
     int vreg_value = VREG_UNDEFINED;
 
     BSTFIXEDVREGS(StoreSubSlice, BST_stmt)
-};
+} PACKED;
 
 class BST_LoadName : public BST_stmt_with_dest {
 public:
@@ -310,7 +317,7 @@ public:
     int closure_offset = -1;
 
     BSTFIXEDVREGS(LoadName, BST_stmt_with_dest)
-};
+} PACKED;
 
 class BST_LoadAttr : public BST_stmt_with_dest {
 public:
@@ -319,7 +326,7 @@ public:
     bool clsonly = false;
 
     BSTFIXEDVREGS(LoadAttr, BST_stmt_with_dest)
-};
+} PACKED;
 
 class BST_LoadSub : public BST_stmt_with_dest {
 public:
@@ -327,7 +334,7 @@ public:
     int vreg_slice = VREG_UNDEFINED;
 
     BSTFIXEDVREGS(LoadSub, BST_stmt_with_dest)
-};
+} PACKED;
 
 class BST_LoadSubSlice : public BST_stmt_with_dest {
 public:
@@ -335,7 +342,7 @@ public:
     int vreg_lower = VREG_UNDEFINED, vreg_upper = VREG_UNDEFINED;
 
     BSTFIXEDVREGS(LoadSubSlice, BST_stmt_with_dest)
-};
+} PACKED;
 
 class BST_AugBinOp : public BST_stmt_with_dest {
 public:
@@ -343,7 +350,7 @@ public:
     int vreg_left = VREG_UNDEFINED, vreg_right = VREG_UNDEFINED;
 
     BSTFIXEDVREGS(AugBinOp, BST_stmt_with_dest)
-};
+} PACKED;
 
 class BST_BinOp : public BST_stmt_with_dest {
 public:
@@ -351,7 +358,7 @@ public:
     int vreg_left = VREG_UNDEFINED, vreg_right = VREG_UNDEFINED;
 
     BSTFIXEDVREGS(BinOp, BST_stmt_with_dest)
-};
+} PACKED;
 
 class BST_Call : public BST_stmt_with_dest {
 public:
@@ -363,7 +370,7 @@ public:
 
     BST_Call(BST_TYPE::BST_TYPE type, int num_args, int num_keywords)
         : BST_stmt_with_dest(type), num_args(num_args), num_keywords(num_keywords) {}
-};
+} PACKED;
 
 class BST_CallFunc : public BST_Call {
 public:
@@ -371,7 +378,7 @@ public:
     int elts[1];
 
     BSTVARVREGS2CALL(CallFunc, num_args, num_keywords, elts)
-};
+} PACKED;
 
 class BST_CallAttr : public BST_Call {
 public:
@@ -380,7 +387,7 @@ public:
     int elts[1];
 
     BSTVARVREGS2CALL(CallAttr, num_args, num_keywords, elts)
-};
+} PACKED;
 
 class BST_CallClsAttr : public BST_Call {
 public:
@@ -389,7 +396,7 @@ public:
     int elts[1];
 
     BSTVARVREGS2CALL(CallClsAttr, num_args, num_keywords, elts)
-};
+} PACKED;
 
 
 class BST_Compare : public BST_stmt_with_dest {
@@ -399,7 +406,7 @@ public:
     int vreg_left = VREG_UNDEFINED;
 
     BSTFIXEDVREGS(Compare, BST_stmt_with_dest)
-};
+} PACKED;
 
 class BST_ClassDef : public BST_stmt {
 public:
@@ -409,12 +416,12 @@ public:
     int decorator[1];
 
     BSTVARVREGS(ClassDef, BST_stmt, num_decorator, decorator)
-};
+} PACKED;
 
 class BST_Dict : public BST_stmt_with_dest {
 public:
     BSTFIXEDVREGS(Dict, BST_stmt_with_dest)
-};
+} PACKED;
 
 class BST_DeleteAttr : public BST_stmt {
 public:
@@ -422,7 +429,7 @@ public:
     int index_attr = VREG_UNDEFINED;
 
     BSTFIXEDVREGS(DeleteAttr, BST_stmt)
-};
+} PACKED;
 
 class BST_DeleteName : public BST_stmt {
 public:
@@ -436,7 +443,7 @@ public:
     int closure_offset = -1;
 
     BSTFIXEDVREGS(DeleteName, BST_stmt)
-};
+} PACKED;
 
 class BST_DeleteSub : public BST_stmt {
 public:
@@ -444,7 +451,7 @@ public:
     int vreg_slice = VREG_UNDEFINED;
 
     BSTFIXEDVREGS(DeleteSub, BST_stmt)
-};
+} PACKED;
 
 class BST_DeleteSubSlice : public BST_stmt {
 public:
@@ -453,7 +460,7 @@ public:
     int vreg_upper = VREG_UNDEFINED;
 
     BSTFIXEDVREGS(DeleteSubSlice, BST_stmt)
-};
+} PACKED;
 
 class BST_Exec : public BST_stmt {
 public:
@@ -462,7 +469,7 @@ public:
     int vreg_locals = VREG_UNDEFINED;
 
     BSTFIXEDVREGS(Exec, BST_stmt)
-};
+} PACKED;
 
 class BST_FunctionDef : public BST_stmt {
 public:
@@ -474,7 +481,7 @@ public:
     int elts[1]; // decorators followed by defaults
 
     BSTVARVREGS2(FunctionDef, BST_stmt, num_decorator, num_defaults, elts)
-};
+} PACKED;
 
 class BST_List : public BST_stmt_with_dest {
 public:
@@ -482,14 +489,14 @@ public:
     int elts[1];
 
     BSTVARVREGS(List, BST_stmt_with_dest, num_elts, elts)
-};
+} PACKED;
 
 class BST_Repr : public BST_stmt_with_dest {
 public:
     int vreg_value = VREG_UNDEFINED;
 
     BSTFIXEDVREGS(Repr, BST_stmt_with_dest)
-};
+} PACKED;
 
 class BST_Print : public BST_stmt {
 public:
@@ -498,7 +505,7 @@ public:
     int vreg_value = VREG_UNDEFINED;
 
     BSTFIXEDVREGS(Print, BST_stmt)
-};
+} PACKED;
 
 class BST_Raise : public BST_stmt {
 public:
@@ -509,14 +516,14 @@ public:
     int vreg_arg0 = VREG_UNDEFINED, vreg_arg1 = VREG_UNDEFINED, vreg_arg2 = VREG_UNDEFINED;
 
     BSTFIXEDVREGS(Raise, BST_stmt)
-};
+} PACKED;
 
 class BST_Return : public BST_stmt {
 public:
     int vreg_value = VREG_UNDEFINED;
 
     BSTFIXEDVREGS(Return, BST_stmt)
-};
+} PACKED;
 
 class BST_Set : public BST_stmt_with_dest {
 public:
@@ -524,14 +531,14 @@ public:
     int elts[1];
 
     BSTVARVREGS(Set, BST_stmt_with_dest, num_elts, elts)
-};
+} PACKED;
 
 class BST_MakeSlice : public BST_stmt_with_dest {
 public:
     int vreg_lower = VREG_UNDEFINED, vreg_upper = VREG_UNDEFINED, vreg_step = VREG_UNDEFINED;
 
     BSTFIXEDVREGS(MakeSlice, BST_stmt_with_dest)
-};
+} PACKED;
 
 class BST_Tuple : public BST_stmt_with_dest {
 public:
@@ -539,7 +546,7 @@ public:
     int elts[1];
 
     BSTVARVREGS(Tuple, BST_stmt_with_dest, num_elts, elts)
-};
+} PACKED;
 
 class BST_UnaryOp : public BST_stmt_with_dest {
 public:
@@ -547,14 +554,14 @@ public:
     AST_TYPE::AST_TYPE op_type;
 
     BSTFIXEDVREGS(UnaryOp, BST_stmt_with_dest)
-};
+} PACKED;
 
 class BST_Yield : public BST_stmt_with_dest {
 public:
     int vreg_value = VREG_UNDEFINED;
 
     BSTFIXEDVREGS(Yield, BST_stmt_with_dest)
-};
+} PACKED;
 
 class BST_MakeFunction : public BST_stmt_with_dest {
 public:
@@ -562,9 +569,10 @@ public:
 
     BST_MakeFunction(BST_FunctionDef* fd, int index_func_def)
         : BST_stmt_with_dest(BST_TYPE::MakeFunction, fd->lineno), index_func_def(index_func_def) {}
+    int size_in_bytes() const { return sizeof(*this); }
 
     BSTNODE(MakeFunction)
-};
+} PACKED;
 
 class BST_MakeClass : public BST_stmt_with_dest {
 public:
@@ -572,9 +580,10 @@ public:
 
     BST_MakeClass(BST_ClassDef* cd, int index_class_def)
         : BST_stmt_with_dest(BST_TYPE::MakeClass, cd->lineno), index_class_def(index_class_def) {}
+    int size_in_bytes() const { return sizeof(*this); }
 
     BSTNODE(MakeClass)
-};
+} PACKED;
 
 class CFGBlock;
 
@@ -584,15 +593,19 @@ public:
     CFGBlock* iftrue, *iffalse;
 
     BSTFIXEDVREGS(Branch, BST_stmt)
-};
+} PACKED;
 
 class BST_Jump : public BST_stmt {
 public:
     CFGBlock* target;
 
     BSTFIXEDVREGS(Jump, BST_stmt)
-};
+} PACKED;
 
+// This instruction is special because it contains a pointer to another stmt
+// After the final bytecode is constructed the stmt will always be exactly after the invoke
+// TODO: we should never emit this instruction in the final bytecode but instead use a bit in the opcode to specify
+// invokes and append the blocks directly after the stmt
 class BST_Invoke : public BST_stmt {
 public:
     BST_stmt* stmt;
@@ -600,28 +613,29 @@ public:
     CFGBlock* normal_dest, *exc_dest;
 
     BST_Invoke(BST_stmt* stmt) : BST_stmt(BST_TYPE::Invoke), stmt(stmt) {}
+    int size_in_bytes() const { return sizeof(*this); }
 
     BSTNODE(Invoke)
-};
+} PACKED;
 
 
 // grabs the info about the last raised exception
 class BST_Landingpad : public BST_stmt_with_dest {
 public:
     BSTFIXEDVREGS(Landingpad, BST_stmt_with_dest)
-};
+} PACKED;
 
 class BST_Locals : public BST_stmt_with_dest {
 public:
     BSTFIXEDVREGS(Locals, BST_stmt_with_dest)
-};
+} PACKED;
 
 class BST_GetIter : public BST_stmt_with_dest {
 public:
     int vreg_value = VREG_UNDEFINED;
 
     BSTFIXEDVREGS(GetIter, BST_stmt_with_dest)
-};
+} PACKED;
 
 class BST_ImportFrom : public BST_stmt_with_dest {
 public:
@@ -629,7 +643,7 @@ public:
     int vreg_name = VREG_UNDEFINED;
 
     BSTFIXEDVREGS(ImportFrom, BST_stmt_with_dest)
-};
+} PACKED;
 
 class BST_ImportName : public BST_stmt_with_dest {
 public:
@@ -638,14 +652,14 @@ public:
     int vreg_name = VREG_UNDEFINED;
 
     BSTFIXEDVREGS(ImportName, BST_stmt_with_dest)
-};
+} PACKED;
 
 class BST_ImportStar : public BST_stmt_with_dest {
 public:
     int vreg_name = VREG_UNDEFINED;
 
     BSTFIXEDVREGS(ImportStar, BST_stmt_with_dest)
-};
+} PACKED;
 
 // determines whether something is "true" for purposes of `if' and so forth
 class BST_Nonzero : public BST_stmt_with_dest {
@@ -653,7 +667,7 @@ public:
     int vreg_value = VREG_UNDEFINED;
 
     BSTFIXEDVREGS(Nonzero, BST_stmt_with_dest)
-};
+} PACKED;
 
 class BST_CheckExcMatch : public BST_stmt_with_dest {
 public:
@@ -661,7 +675,7 @@ public:
     int vreg_cls = VREG_UNDEFINED;
 
     BSTFIXEDVREGS(CheckExcMatch, BST_stmt_with_dest)
-};
+} PACKED;
 
 class BST_SetExcInfo : public BST_stmt {
 public:
@@ -670,27 +684,56 @@ public:
     int vreg_traceback = VREG_UNDEFINED;
 
     BSTFIXEDVREGS(SetExcInfo, BST_stmt)
-};
+} PACKED;
 
 class BST_UncacheExcInfo : public BST_stmt {
 public:
     BSTFIXEDVREGS(UncacheExcInfo, BST_stmt)
-};
+} PACKED;
 
 class BST_HasNext : public BST_stmt_with_dest {
 public:
     int vreg_value = VREG_UNDEFINED;
 
     BSTFIXEDVREGS(HasNext, BST_stmt_with_dest)
-};
+} PACKED;
 
 class BST_PrintExpr : public BST_stmt {
 public:
     int vreg_value = VREG_UNDEFINED;
 
     BSTFIXEDVREGS(PrintExpr, BST_stmt)
-};
+} PACKED;
 
+
+template <typename T> T* bst_cast(const BST_stmt* node) {
+    ASSERT(!node || node->type == T::TYPE, "%d", node ? node->type : 0);
+    return static_cast<T*>(node);
+}
+
+int BST_stmt::size_in_bytes() const {
+    switch (type) {
+#define DISPATCH_SIZE(x, y)                                                                                            \
+    case BST_TYPE::x:                                                                                                  \
+        return bst_cast<const BST_##x>(this)->size_in_bytes();
+        FOREACH_TYPE(DISPATCH_SIZE)
+    };
+    assert(0);
+    __builtin_unreachable();
+#undef DISPATCH_SIZE
+}
+
+bool BST_stmt::has_dest_vreg() const {
+    switch (type) {
+#define DISPATCH_HAS_DEST(x, y)                                                                                        \
+    case BST_TYPE::x:                                                                                                  \
+        return std::is_base_of<BST_stmt_with_dest, BST_##x>();
+        FOREACH_TYPE(DISPATCH_HAS_DEST)
+    };
+    assert(0);
+    __builtin_unreachable();
+#undef DISPATCH_HAS_DEST
+}
 
 // this is not a real bytecode it's only used to initalize arguments
 class BST_Name {

--- a/test/unittests/analysis.cpp
+++ b/test/unittests/analysis.cpp
@@ -27,7 +27,7 @@ protected:
 
 static BoxedCode* getCodeObjectOfFirstMakeFunction(BoxedCode* module_code) {
     BoxedCode* code = NULL;
-    for (BST_stmt* stmt : module_code->source->cfg->blocks[0]->body) {
+    for (BST_stmt* stmt : *module_code->source->cfg->getStartingBlock()) {
         if (stmt->type !=  BST_TYPE::MakeFunction)
             continue;
         code = module_code->code_constants.getFuncOrClass(bst_cast<BST_MakeFunction>(stmt)->index_func_def).second;
@@ -74,7 +74,7 @@ TEST_F(AnalysisTest, augassign) {
 
     for (CFGBlock* block : cfg->blocks) {
         //printf("%d\n", block->idx);
-        if (block->body.back()->type != BST_TYPE::Return)
+        if (block->getLastStmt()->type != BST_TYPE::Return)
             ASSERT_TRUE(liveness->isLiveAtEnd(vregs.getVReg(module->interned_strings->get("a")), block));
     }
 
@@ -116,10 +116,10 @@ void doOsrTest(bool is_osr, bool i_maybe_undefined) {
 
     CFGBlock* loop_backedge = cfg->blocks[5];
     ASSERT_EQ(6, loop_backedge->idx);
-    ASSERT_EQ(1, loop_backedge->body.size());
+    ASSERT_TRUE(loop_backedge->body->is_terminator());
 
-    ASSERT_EQ(BST_TYPE::Jump, loop_backedge->body[0]->type);
-    BST_Jump* backedge = bst_cast<BST_Jump>(loop_backedge->body[0]);
+    ASSERT_EQ(BST_TYPE::Jump, loop_backedge->body->type);
+    BST_Jump* backedge = bst_cast<BST_Jump>(loop_backedge->body);
     ASSERT_LE(backedge->target->idx, loop_backedge->idx);
 
     std::unique_ptr<PhiAnalysis> phis;


### PR DESCRIPTION
transform BST to gapless bytecode
    - all instructions of the CFG are copied into a single memory region.
    - all instructions are packed and follow each other directly
    - the CFGBlock just point into the bytecode block where the first instruction of the block is located
