### PR TITLE
Typo fixes from PR #1389

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -20,7 +20,7 @@ limitations under the License.
 
 Some directories are distributed under different licenses, and contain
 separate LICENSE files, which applies to all files in that directory
-and its decendents, unless overridden by another LICENSE file.
+and its descendants, unless overridden by another LICENSE file.
 
 
 Regardless of any separate LICENSE files, all code in this repository

--- a/cmake/CheckTypeSizeof.c.in
+++ b/cmake/CheckTypeSizeof.c.in
@@ -1,4 +1,4 @@
-/* Pyston: This file is included from cmake 3 for compatability
+/* Pyston: This file is included from cmake 3 for compatibility
  * downloaded 2015-04-03
  * https://github.com/Kitware/CMake/blob/master/Modules/CheckTypeSize.c.in
  */

--- a/cmake/CheckTypeSizeof.cmake
+++ b/cmake/CheckTypeSizeof.cmake
@@ -2,7 +2,7 @@
 # CheckTypeSizeof
 # -------------
 #
-# Pyston: This file is included from cmake 3 for compatability
+# Pyston: This file is included from cmake 3 for compatibility
 # downloaded 2015-04-03
 # https://github.com/Kitware/CMake/blob/master/Modules/CheckTypeSize.cmake
 #

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -1998,7 +1998,7 @@ PREDEFINED             =
 EXPAND_AS_DEFINED      = 
 
 # If the SKIP_FUNCTION_MACROS tag is set to YES then doxygen's preprocessor will
-# remove all refrences to function-like macros that are alone on a line, have an
+# remove all references to function-like macros that are alone on a line, have an
 # all uppercase name, and do not end with a semicolon. Such function macros are
 # typically used for boiler-plate code, and will confuse the parser if not
 # removed.

--- a/docs/TIPS.md
+++ b/docs/TIPS.md
@@ -286,7 +286,7 @@ In that case, the backtrace might not be very helpful. For example:
 
 ```
 
-The backtrace is misleading since it suggests that an error occured on line 852, which is entirely wrong (that line is never actually reached!).
+The backtrace is misleading since it suggests that an error occurred on line 852, which is entirely wrong (that line is never actually reached!).
 
 If that happens, you should either add a try/catch pair, or use C-style exceptions instead.
 

--- a/from_cpython/Modules/_struct.c
+++ b/from_cpython/Modules/_struct.c
@@ -1846,7 +1846,7 @@ static PyObject *
 clearcache(PyObject *self)
 {
     // `cache` is already registered as a static root; we would need to unregister it.
-    Py_FatalError("_struct.clearcache dosen't currently work well with Pyston");
+    Py_FatalError("_struct.clearcache doesn't currently work well with Pyston");
     abort();
     Py_CLEAR(cache);
     Py_RETURN_NONE;

--- a/from_cpython/Python/import.c
+++ b/from_cpython/Python/import.c
@@ -408,7 +408,7 @@ imp_modules_reloading_clear(void)
 }
 
 /* Helper for sys */
-// Pyston change: use diferent implementation from import.cpp
+// Pyston change: use different implementation from import.cpp
 #if 0
 PyObject *
 PyImport_GetModuleDict(void)

--- a/from_cpython/setup.py
+++ b/from_cpython/setup.py
@@ -510,7 +510,7 @@ class PyBuildExt(build_ext):
                 add_dir_to_list(inc_dirs, d)
             for d in (
                 '/lib64', '/usr/lib64',
-                # Pyston change: add addtional search path for lib
+                # Pyston change: add additional search path for lib
                 '/lib', '/usr/lib', '/usr/lib/x86_64-linux-gnu'
                 ):
                 add_dir_to_list(lib_dirs, d)

--- a/src/asm_writing/icinfo.cpp
+++ b/src/asm_writing/icinfo.cpp
@@ -214,7 +214,7 @@ void ICSlotRewrite::commit(CommitHook* hook, std::vector<void*> gc_references,
         ic->slots.emplace_back(ic, ic_entry->start_addr + actual_size, empty_space);
     }
 
-    // if (VERBOSITY()) printf("Commiting to %p-%p\n", start, start + ic->slot_size);
+    // if (VERBOSITY()) printf("Committing to %p-%p\n", start, start + ic->slot_size);
     memcpy(slot_start, buf, original_size);
 
     ic_entry->clear(false /* don't invalidate */);

--- a/src/asm_writing/mc_writer.cpp
+++ b/src/asm_writing/mc_writer.cpp
@@ -418,7 +418,7 @@ private:
         _emitByte(0x39);
         if (displacement == 0) {
             // Since we're emitting into a fixed-size section I guess there might not be
-            // too much benifit to the more compact encoding, but it makes me feel better:
+            // too much benefit to the more compact encoding, but it makes me feel better:
             _emitModRM(0b00, reg1, reg2);
         } else {
             _emitModRM(0b01, reg1, reg2);

--- a/src/asm_writing/rewriter.h
+++ b/src/asm_writing/rewriter.h
@@ -250,7 +250,7 @@ private:
     // Call this on the result at the end of the action in which it's created
     // TODO we should have a better way of dealing with variables that have 0 uses
     void releaseIfNoUses();
-    // Helper funciton to release all the resources that this var is using.
+    // Helper function to release all the resources that this var is using.
     // Don't call it directly: call bumpUse and releaseIfNoUses instead.
     void _release();
     bool isDoneUsing() { return next_use == uses.size(); }

--- a/src/codegen/ast_interpreter.cpp
+++ b/src/codegen/ast_interpreter.cpp
@@ -2146,7 +2146,7 @@ extern "C" Box* astInterpretDeoptFromASM(BoxedCode* code, BST_stmt* enclosing_st
     }
 
     // clear the frame_state now that we have initalized the interpreter with it.
-    // this make sure that we don't have unneccessary references around (e.g. could be a problem for PASSED_GENERATOR)
+    // this make sure that we don't have unnecessary references around (e.g. could be a problem for PASSED_GENERATOR)
     Py_CLEAR(frame_state.locals);
 
     Box* v = ASTInterpreter::execute(interpreter, start_block, starting_statement);

--- a/src/codegen/ast_interpreter_exec.S
+++ b/src/codegen/ast_interpreter_exec.S
@@ -14,7 +14,7 @@
 
 // This functions sets up a fixed stack frame which we use to detect ASTInterpreter frames
 // and which makes it easy retrieve the passed ASTInterpreter pointer (stored at frame_ptr-8). 
-// It's written in ASM to make sure the stack layout keeps beeing the same and that nothing gets inlined.
+// It's written in ASM to make sure the stack layout keeps being the same and that nothing gets inlined.
 // Our unwinder treats this function specialy.
 
 // Box* executeInnerAndSetupFrame(ASTInterpreter& interpreter, CFGBlock* start_block, AST_stmt* start_at)
@@ -40,7 +40,7 @@ executeInnerAndSetupFrame:
 .size executeInnerAndSetupFrame,.-executeInnerAndSetupFrame
 
 // This function is just a small wrapper around astInterpretDeoptFromASM.
-// Our unwinder must be able to detect deopt frames and by writting this wrapper in assembler we can be sure to correctly
+// Our unwinder must be able to detect deopt frames and by writing this wrapper in assembler we can be sure to correctly
 // detect the frame independent of compiler optimizations because this function will always appear in the call stack.
 //
 // Box* astInterpretDeopt(FunctionMetadata* cf, AST_stmt* enclosing_stmt, Box* expr_val,

--- a/src/codegen/entry.cpp
+++ b/src/codegen/entry.cpp
@@ -203,7 +203,7 @@ public:
 };
 
 
-// Stream which calculates the SHA256 hash of the data writen to.
+// Stream which calculates the SHA256 hash of the data written to.
 class HashOStream : public llvm::raw_ostream {
     EVP_MD_CTX* md_ctx;
 

--- a/src/codegen/irgen/irgenerator.cpp
+++ b/src/codegen/irgen/irgenerator.cpp
@@ -2214,7 +2214,7 @@ private:
             = new ConcreteCompilerVariable(FRAME_INFO, irstate->getFrameInfoVar());
 
         // For OSR calls, we use the same calling convention as in some other places; namely,
-        // arg1, arg2, arg3, argarray [nargs is ommitted]
+        // arg1, arg2, arg3, argarray [nargs is omitted]
         // It would be nice to directly pass all variables as arguments, instead of packing them into
         // an array, for a couple reasons (eliminate copies, and allow for a tail call).
         // But this doesn't work if the IR is being interpreted, because the interpreter can't
@@ -2345,8 +2345,8 @@ private:
     }
 
     void doRaise(BST_Raise* node, const UnwindInfo& unw_info) {
-        // It looks like ommitting the second and third arguments are equivalent to passing None,
-        // but ommitting the first argument is *not* the same as passing None.
+        // It looks like omitting the second and third arguments are equivalent to passing None,
+        // but omitting the first argument is *not* the same as passing None.
 
         ExceptionStyle target_exception_style;
 

--- a/src/codegen/opt/mallocs_nonnull.cpp
+++ b/src/codegen/opt/mallocs_nonnull.cpp
@@ -184,5 +184,5 @@ FunctionPass* createMallocsNonNullPass() {
 }
 }
 
-static RegisterPass<pyston::MallocsNonNullPass> X("mallocs_nonnull", "Use the fact that malloc() doesnt return NULL",
+static RegisterPass<pyston::MallocsNonNullPass> X("mallocs_nonnull", "Use the fact that malloc() doesn't return NULL",
                                                   true, false);

--- a/src/codegen/unwinding.cpp
+++ b/src/codegen/unwinding.cpp
@@ -580,7 +580,7 @@ public:
     }
 
     void handleCFrame(unw_cursor_t* cursor) {
-        // deinit the previous frame and do decrefs if neccessary
+        // deinit the previous frame and do decrefs if necessary
         // but we need to pause unwinding because decrefing objects can cause finalizers to get run (and they can use
         // exceptions).
         unw_word_t ip = get_cursor_ip(cursor);

--- a/src/runtime/complex.cpp
+++ b/src/runtime/complex.cpp
@@ -645,7 +645,7 @@ Box* complexRFloordiv(BoxedComplex* lhs, Box* _rhs) {
 
 extern "C" Box* complexEq(BoxedComplex* lhs, Box* rhs) {
     if (lhs->cls != complex_cls) {
-        raiseExcHelper(TypeError, "descriptor '__eq__' requires a 'complex' object but recieved a '%s'",
+        raiseExcHelper(TypeError, "descriptor '__eq__' requires a 'complex' object but received a '%s'",
                        getTypeName(lhs));
     }
     Box* res = complex_richcompare(lhs, rhs, Py_EQ);
@@ -658,7 +658,7 @@ extern "C" Box* complexEq(BoxedComplex* lhs, Box* rhs) {
 
 extern "C" Box* complexNe(BoxedComplex* lhs, Box* rhs) {
     if (lhs->cls != complex_cls) {
-        raiseExcHelper(TypeError, "descriptor '__ne__' requires a 'complex' object but recieved a '%s'",
+        raiseExcHelper(TypeError, "descriptor '__ne__' requires a 'complex' object but received a '%s'",
                        getTypeName(lhs));
     }
     Box* res = complex_richcompare(lhs, rhs, Py_NE);
@@ -671,7 +671,7 @@ extern "C" Box* complexNe(BoxedComplex* lhs, Box* rhs) {
 
 extern "C" Box* complexLe(BoxedComplex* lhs, Box* rhs) {
     if (lhs->cls != complex_cls) {
-        raiseExcHelper(TypeError, "descriptor '__le__' requires a 'complex' object but recieved a '%s'",
+        raiseExcHelper(TypeError, "descriptor '__le__' requires a 'complex' object but received a '%s'",
                        getTypeName(lhs));
     }
     Box* res = complex_richcompare(lhs, rhs, Py_LE);
@@ -684,7 +684,7 @@ extern "C" Box* complexLe(BoxedComplex* lhs, Box* rhs) {
 
 extern "C" Box* complexLt(BoxedComplex* lhs, Box* rhs) {
     if (lhs->cls != complex_cls) {
-        raiseExcHelper(TypeError, "descriptor '__lt__' requires a 'complex' object but recieved a '%s'",
+        raiseExcHelper(TypeError, "descriptor '__lt__' requires a 'complex' object but received a '%s'",
                        getTypeName(lhs));
     }
     Box* res = complex_richcompare(lhs, rhs, Py_LT);
@@ -696,7 +696,7 @@ extern "C" Box* complexLt(BoxedComplex* lhs, Box* rhs) {
 
 extern "C" Box* complexGe(BoxedComplex* lhs, Box* rhs) {
     if (lhs->cls != complex_cls) {
-        raiseExcHelper(TypeError, "descriptor '__ge__' requires a 'complex' object but recieved a '%s'",
+        raiseExcHelper(TypeError, "descriptor '__ge__' requires a 'complex' object but received a '%s'",
                        getTypeName(lhs));
     }
     Box* res = complex_richcompare(lhs, rhs, Py_GE);
@@ -709,7 +709,7 @@ extern "C" Box* complexGe(BoxedComplex* lhs, Box* rhs) {
 
 extern "C" Box* complexGt(BoxedComplex* lhs, Box* rhs) {
     if (lhs->cls != complex_cls) {
-        raiseExcHelper(TypeError, "descriptor '__gt__' requires a 'complex' object but recieved a '%s'",
+        raiseExcHelper(TypeError, "descriptor '__gt__' requires a 'complex' object but received a '%s'",
                        getTypeName(lhs));
     }
     Box* res = complex_richcompare(lhs, rhs, Py_GT);

--- a/src/runtime/cxx_unwind.cpp
+++ b/src/runtime/cxx_unwind.cpp
@@ -563,7 +563,7 @@ static inline void unwind_loop(ExcInfo* exc_data) {
 
         int64_t switch_value = determine_action(&info, &entry);
         if (switch_value != CLEANUP_ACTION) {
-            // we're transfering control to a non-cleanup landing pad.
+            // we're transferring control to a non-cleanup landing pad.
             // i.e. a catch block.  thus ends our unwind session.
             endPythonUnwindSession(unwind_session);
 #if STAT_TIMERS
@@ -583,7 +583,7 @@ static inline void unwind_loop(ExcInfo* exc_data) {
         //
         // the only way this could bite us is if we somehow clobber
         // the PythonUnwindSession's storage, or cause a GC to occur, before
-        // transfering control to the landing pad in resume().
+        // transferring control to the landing pad in resume().
         //
         resume(&cursor, entry.landing_pad, switch_value, exc_data);
     }

--- a/src/runtime/objmodel.cpp
+++ b/src/runtime/objmodel.cpp
@@ -7562,7 +7562,7 @@ extern "C" Box* boxedLocalsGet(Box* boxedLocals, BoxedString* attr, Box* globals
         } catch (ExcInfo e) {
             // TODO should check the exact semantic here but it's something like:
             // If it throws a KeyError, then the variable doesn't exist so move on
-            // and check the globals (below); otherwise, just propogate the exception.
+            // and check the globals (below); otherwise, just propagate the exception.
             if (!isSubclass(e.value->cls, KeyError)) {
                 throw e;
             }

--- a/src/runtime/types.cpp
+++ b/src/runtime/types.cpp
@@ -1703,11 +1703,11 @@ static int function_set_defaults(Box* b, Box* v, void*) noexcept {
     // The better way to handle this would be to not add the __defaults__ descriptor to the
     // builtin_function_or_method_cls so that it would be an AttributeError to try to access it,
     // and leave this assert.
-    RELEASE_ASSERT(func->can_change_defaults, "trying to change the defaults on a non-defaults-changable function.");
+    RELEASE_ASSERT(func->can_change_defaults, "trying to change the defaults on a non-defaults-changeable function.");
 
     // Changing defaults of builtins would be very scary.  Python functions are safe since they
     // store their arguments into their symbol table, but builtin functions are free to let them
-    // stay borrowed.  If a builtin function has changable defaults, and it can call into arbitrary
+    // stay borrowed.  If a builtin function has changeable defaults, and it can call into arbitrary
     // user code, then it could call something that changes its own defaults, and all of a sudden
     // one of its arguments gets deallocated from under it.
 

--- a/test/CPYTHON_TEST_NOTES.md
+++ b/test/CPYTHON_TEST_NOTES.md
@@ -89,7 +89,7 @@ test_hotshot            No module named _hotshot
 test_idle               No module named Tkinter
 test_imageop            No module named imageop
 test_imgfile            no module named imgfile
-test_importhooks        "import compiler" doesnt work
+test_importhooks        "import compiler" doesn't work
 test_import             Marshaling code objects not supported
 test_inspect            missing sys.exc_traceback
 test_io                 memory/gc issue?

--- a/test/integration/scipy_test.py
+++ b/test/integration/scipy_test.py
@@ -12,7 +12,7 @@ from test_helper import run_test
 """
 Using this test file.
 
-Note that sometimes it can be a pain to run this script everytime you make a
+Note that sometimes it can be a pain to run this script every time you make a
 change, as it does take a while. You can cd to the scipy_test_env_* directory
 and run the binaries inside of that folder, which will be able to "see" the
 SciPy module. For example:

--- a/test/test_extension/slots_test.c
+++ b/test/test_extension/slots_test.c
@@ -682,25 +682,25 @@ call_funcs(PyObject* _module, PyObject* args) {
     if (cls->tp_new) {
         printf("tp_new exists\n");
     } else {
-        printf("tp_new doesnt exist\n");
+        printf("tp_new doesn't exist\n");
     }
 
     if (cls->tp_init) {
         printf("tp_init exists\n");
     } else {
-        printf("tp_init doesnt exist\n");
+        printf("tp_init doesn't exist\n");
     }
 
     if (cls->tp_call) {
         printf("tp_call exists\n");
     } else {
-        printf("tp_call doesnt exist\n");
+        printf("tp_call doesn't exist\n");
     }
 
     if (cls->tp_getattr) {
         printf("tp_getattr exists\n");
     } else {
-        printf("tp_getattr doesnt exist\n");
+        printf("tp_getattr doesn't exist\n");
     }
 
     // we aren't checking for tp_getattro.  it's set in cpython and not in pyston
@@ -708,7 +708,7 @@ call_funcs(PyObject* _module, PyObject* args) {
     if (cls->tp_setattr) {
         printf("tp_setattr exists\n");
     } else {
-        printf("tp_setattr doesnt exist\n");
+        printf("tp_setattr doesn't exist\n");
     }
 
     // we aren't checking for tp_setattro.  it's set in cpython and not in pyston
@@ -716,7 +716,7 @@ call_funcs(PyObject* _module, PyObject* args) {
     if (cls->tp_descr_get) {
         printf("tp_descr_get exists\n");
     } else {
-        printf("tp_descr_get doesnt exist\n");
+        printf("tp_descr_get doesn't exist\n");
     }
 
     if (cls->tp_as_mapping) {
@@ -738,7 +738,7 @@ call_funcs(PyObject* _module, PyObject* args) {
             printf("mp_length exists and returned %ld\n", rtn);
         }
     } else {
-        printf("tp_as_mapping doesnt exist\n");
+        printf("tp_as_mapping doesn't exist\n");
     }
 
     if (cls->tp_as_sequence) {
@@ -756,7 +756,7 @@ call_funcs(PyObject* _module, PyObject* args) {
             Py_DECREF(rtn);
         }
     } else {
-        printf("tp_as_sequence doesnt exist\n");
+        printf("tp_as_sequence doesn't exist\n");
     }
 
     if (cls->tp_as_number) {
@@ -819,7 +819,7 @@ call_funcs(PyObject* _module, PyObject* args) {
 #undef CHECK_BIN
 
     } else {
-        printf("tp_as_number doesnt exist\n");
+        printf("tp_as_number doesn't exist\n");
     }
 
     Py_RETURN_NONE;

--- a/test/tests/delattr.py
+++ b/test/tests/delattr.py
@@ -121,7 +121,7 @@ class CustSetClass(object):
 a=CustSetClass()
 a.attr
 a.val
-#del won't invoke __getattr__ or __getattribute__ to check wether attr is an attribute of a
+#del won't invoke __getattr__ or __getattribute__ to check whether attr is an attribute of a
 try:
     del a.attr
 except AttributeError, e:

--- a/test/tests/exceptions_test.py
+++ b/test/tests/exceptions_test.py
@@ -356,7 +356,7 @@ def f12():
         try:
             raise e
         except Exception as l[0]:
-            print "shouldnt get here"
+            print "shouldn't get here"
     except Exception as e2:
         # print it to stderr, so that our tester's error message substituter can
         # deal with differences between error messages between different Python
@@ -369,7 +369,7 @@ def f12():
         try:
             raise e
         except Exception as l[1/0]:
-            print "shouldnt get here"
+            print "shouldn't get here"
     except Exception as e2:
         print e2
 f12()

--- a/test/tests/import_failure_test.py
+++ b/test/tests/import_failure_test.py
@@ -16,7 +16,7 @@ try:
 except ImportError, e:
     print e
 
-# Run it all again inside a funtion scope:
+# Run it all again inside a function scope:
 def f():
     try:
         import non_existent_module


### PR DESCRIPTION
Minus the ones to code that we inherited from CPython or LLVM,
in order to keep those diffs clean.

Closes #1389