### PR TITLE
All execs force "name" lookup behavior

### DIFF
--- a/from_cpython/Include/Python.h
+++ b/from_cpython/Include/Python.h
@@ -152,7 +152,7 @@ PyAPI_FUNC(void) PyGC_Disable(void) PYSTON_NOEXCEPT;
 // automatically filter out any objects that are only indirectly leaked.
 //
 // This will destroy the heap, so it has to be the last thing called.
-PyAPI_FUNC(void) _PyGC_FindLeaks(void) PYSTON_NOEXCEPT;
+PyAPI_FUNC(void) _PyGC_FindLeaks(PyObject**) PYSTON_NOEXCEPT;
 #endif
 
 #ifdef __cplusplus

--- a/from_cpython/Modules/gcmodule.c
+++ b/from_cpython/Modules/gcmodule.c
@@ -519,6 +519,8 @@ has_finalizer(PyObject *op)
 static void
 untrack_dicts(PyGC_Head *head)
 {
+    // Pyston change: skip this (see note in dict.cpp)
+#if 0
     PyGC_Head *next, *gc = head->gc.gc_next;
     while (gc != head) {
         PyObject *op = FROM_GC(gc);
@@ -527,6 +529,7 @@ untrack_dicts(PyGC_Head *head)
             _PyDict_MaybeUntrack(op);
         gc = next;
     }
+#endif
 }
 
 /* Move the objects in unreachable with __del__ methods into `finalizers`.

--- a/src/analysis/scoping_analysis.h
+++ b/src/analysis/scoping_analysis.h
@@ -28,6 +28,15 @@ class AST_Module;
 class AST_Expression;
 class AST_Suite;
 
+enum class NameLookupUsage {
+    // Normal scope
+    NONE,
+    // Loads to unstored names are NAME:
+    SOME,
+    // All stores and loads are NAME lookups:
+    ALL,
+};
+
 class ScopeInfo {
 public:
     ScopeInfo() {}
@@ -78,11 +87,7 @@ public:
     };
     virtual VarScopeType getScopeTypeOfName(InternedString name) = 0;
 
-    // Returns true if the scope may contain NAME variables.
-    // In particular, it returns true for ClassDef scope, for any scope
-    // with an `exec` statement or `import *` statement in it, or for any
-    // `exec` or `eval` scope.
-    virtual bool usesNameLookup() = 0;
+    virtual NameLookupUsage getNameLookupUsage() = 0;
 
     virtual bool areLocalsFromModule() = 0;
 

--- a/src/runtime/dict.cpp
+++ b/src/runtime/dict.cpp
@@ -1112,6 +1112,13 @@ int BoxedDict::clear(PyObject* op) noexcept {
     return 0;
 }
 
+// Pyston change: this is a CPython optimization that we don't support fully.
+// It looks like they try to untrack dicts to remove GC pressure, but then
+// if GC-aware objects get added to the dict then we need to re-track the dict.
+// We're missing that latter part, leading to memory leaks.
+//
+// This isn't as important to us because we don't have as many dict objects.
+#if 0
 extern "C" void _PyDict_MaybeUntrack(PyObject* op) noexcept {
     if (!PyDict_CheckExact(op) || !_PyObject_GC_IS_TRACKED(op))
         return;
@@ -1125,6 +1132,7 @@ extern "C" void _PyDict_MaybeUntrack(PyObject* op) noexcept {
 
     _PyObject_GC_UNTRACK(op);
 }
+#endif
 
 // We use cpythons dictview implementation from dictobject.c
 extern "C" PyObject* dictview_new(PyObject* dict, PyTypeObject* type) noexcept;

--- a/src/runtime/types.cpp
+++ b/src/runtime/types.cpp
@@ -3919,14 +3919,19 @@ static int type_traverse(PyTypeObject* type, visitproc visit, void* arg) {
     Py_VISIT(type->tp_bases);
     Py_VISIT(type->tp_base);
 
-    // TODO: should have something like this to traverse GC references in the type runtime ICs:
-    // if (type->hasnext_ic)
-    // Py_TRAVERSE(*type->hasnext_ic);
+// TODO: should have something like this to traverse GC references in the type runtime ICs:
+// if (type->hasnext_ic)
+// Py_TRAVERSE(*type->hasnext_ic);
 
-    /* There's no need to visit type->tp_subclasses or
-       ((PyHeapTypeObject *)type)->ht_slots, because they can't be involved
-       in cycles; tp_subclasses is a list of weak references,
-       and slots is a tuple of strings. */
+/* There's no need to visit type->tp_subclasses or
+   ((PyHeapTypeObject *)type)->ht_slots, because they can't be involved
+   in cycles; tp_subclasses is a list of weak references,
+   and slots is a tuple of strings. */
+
+#ifdef Py_TRACE_REFS
+    // This is nice for our find_leaks feature:
+    Py_VISIT(type->tp_subclasses);
+#endif
 
     return 0;
 }
@@ -4925,8 +4930,17 @@ extern "C" void Py_Finalize() noexcept {
 
     if (assert_refs) {
 #ifdef Py_TRACE_REFS
+        // TODO This really should be done by hooking the type_dealloc function,
+        // since we don't know that the memory wasn't reused:
+        std::vector<Box*> leaked_classes;
+        for (Box* b : classes) {
+            if (!PyObject_IS_GC(b) && b->ob_refcnt > 0)
+                leaked_classes.push_back(b);
+        }
+        leaked_classes.push_back(0);
+
         if (_Py_RefTotal != 0)
-            _PyGC_FindLeaks();
+            _PyGC_FindLeaks(&leaked_classes[0]);
 #endif
 
         RELEASE_ASSERT(_Py_RefTotal == 0, "%ld refs remaining!", _Py_RefTotal);

--- a/test/tests/exec_set_local.py
+++ b/test/tests/exec_set_local.py
@@ -1,4 +1,72 @@
-def f():
-    exec "a = 5"
+a = 0
+b = 0
+
+def bare_exec_func():
+    a = 1
+    exec "a = 5; b = 5"
+    # NAME lookup:
     print a
-f()
+    print locals()['a']
+    # NAME lookup:
+    print b
+bare_exec_func()
+print
+
+def nonbare_exec_func():
+    a = 1
+    exec "a = 5; b = 5" in {}, locals()
+    # FAST lookup:
+    print a
+    print locals()['a']
+    # NAME lookup:
+    print b
+nonbare_exec_func()
+print
+
+try:
+    exec """
+def bare_exec_nested():
+    a = 1
+    exec "a = 5; b = 5"
+    def g():
+        print a
+        print b
+    """
+    assert 0
+except SyntaxError:
+    pass
+print
+
+def nonbare_exec_nested():
+    a = 1
+    exec "a = 5; b = 5" in {}, locals()
+    def g():
+        # DEREF
+        print a
+        # GLOBAL
+        print b
+    g()
+    # CLOSURE
+    print a
+    # NAME
+    print b
+    print locals()['a']
+nonbare_exec_nested()
+print
+
+class C(object):
+    a = 1
+    exec "a = 5; b = 5" in {}, locals()
+
+    def g():
+        # GLOBAL:
+        print a
+        # GLOBAL:
+        print b
+    g()
+
+    # NAME:
+    print a
+    # NAME:
+    print b
+print

--- a/test/tests/name_scopes.py
+++ b/test/tests/name_scopes.py
@@ -31,3 +31,9 @@ class C(object):
 print __module__ # prints "2"
 print __name__ # prints "2"
 print __doc__ # prints "hello world"
+
+def f3():
+    # All execs are name-forcing:
+    exec "g='hi world'" in {}, locals()
+    print g
+f3()


### PR DESCRIPTION
Previously we only thought this was true for bare execs,
but this is important for `exec s in {}, locals()` since
it is allowed to change the locals in a way that should
get picked up.