### PR TITLE
FrameInfo: store current statement as offset from the bytecode start

### DIFF
--- a/src/asm_writing/assembler.h
+++ b/src/asm_writing/assembler.h
@@ -144,7 +144,9 @@ public:
 
     void clear_reg(Register reg); // = xor reg, reg
 
+    void mov_generic(Immediate src, Indirect dest, MovType type);
     void mov_generic(Indirect src, Register dest, MovType type);
+    void mov_generic(Register src, Indirect dest, MovType type);
 
     void push(Register reg);
     void pop(Register reg);

--- a/src/asm_writing/rewriter.h
+++ b/src/asm_writing/rewriter.h
@@ -166,7 +166,8 @@ public:
         HANDED_OFF,
         REF_USED,
     };
-    void setAttr(int offset, RewriterVar* other, SetattrType type = SetattrType::UNKNOWN);
+    void setAttr(int offset, RewriterVar* other, SetattrType type = SetattrType::UNKNOWN,
+                 assembler::MovType store_wide = assembler::MovType::Q);
 
     // Replaces an owned ref with another one.  Does the equivalent of:
     // Box* prev = this[offset];
@@ -568,7 +569,7 @@ protected:
                   assembler::MovType type = assembler::MovType::Q);
     void _getAttrFloat(RewriterVar* result, RewriterVar* var, int offset, Location loc = Location::any());
     void _getAttrDouble(RewriterVar* result, RewriterVar* var, int offset, Location loc = Location::any());
-    void _setAttr(RewriterVar* var, int offset, RewriterVar* other);
+    void _setAttr(RewriterVar* var, int offset, RewriterVar* other, assembler::MovType store_wide);
     void _cmp(RewriterVar* result, RewriterVar* var1, AST_TYPE::AST_TYPE cmp_type, RewriterVar* var2,
               Location loc = Location::any());
     void _toBool(RewriterVar* result, RewriterVar* var, Location loc = Location::any());

--- a/src/codegen/baseline_jit.cpp
+++ b/src/codegen/baseline_jit.cpp
@@ -715,8 +715,9 @@ void JitFragmentWriter::emitSetBlockLocal(int vreg, STOLEN(RewriterVar*) v) {
         comment("BJIT: emitSetBlockLocal() end");
 }
 
-void JitFragmentWriter::emitSetCurrentInst(BST_stmt* node) {
-    getInterp()->setAttr(ASTInterpreterJitInterface::getCurrentInstOffset(), imm(node));
+void JitFragmentWriter::emitSetCurrentInst(int offset) {
+    getInterp()->setAttr(ASTInterpreterJitInterface::getCurrentInstOffset(), imm(offset),
+                         RewriterVar::SetattrType::UNKNOWN, assembler::MovType::L);
 }
 
 void JitFragmentWriter::emitSetExcInfo(RewriterVar* type, RewriterVar* value, RewriterVar* traceback) {

--- a/src/codegen/baseline_jit.h
+++ b/src/codegen/baseline_jit.h
@@ -322,7 +322,7 @@ public:
     void emitReturn(RewriterVar* v);
     void emitSetAttr(BST_stmt* node, RewriterVar* obj, BoxedString* s, STOLEN(RewriterVar*) attr);
     void emitSetBlockLocal(int vreg, STOLEN(RewriterVar*) v);
-    void emitSetCurrentInst(BST_stmt* node);
+    void emitSetCurrentInst(int offset);
     void emitSetExcInfo(RewriterVar* type, RewriterVar* value, RewriterVar* traceback);
     void emitSetGlobal(BoxedString* s, STOLEN(RewriterVar*) v, bool are_globals_from_module);
     void emitSetItemName(BoxedString* s, RewriterVar* v);

--- a/src/codegen/codegen.h
+++ b/src/codegen/codegen.h
@@ -73,7 +73,7 @@ struct GlobalState {
     llvm::Type* llvm_value_type, *llvm_value_type_ptr, *llvm_value_type_ptr_ptr;
     llvm::Type* llvm_class_type, *llvm_class_type_ptr;
     llvm::Type* llvm_opaque_type;
-    llvm::Type* llvm_boxedstring_type_ptr, *llvm_dict_type_ptr, *llvm_bststmt_type_ptr;
+    llvm::Type* llvm_boxedstring_type_ptr, *llvm_dict_type_ptr;
     llvm::Type* llvm_frame_info_type;
     llvm::Type* llvm_code_type_ptr, *llvm_closure_type_ptr, *llvm_generator_type_ptr;
     llvm::Type* llvm_module_type_ptr, *llvm_bool_type_ptr;

--- a/src/codegen/runtime_hooks.cpp
+++ b/src/codegen/runtime_hooks.cpp
@@ -147,10 +147,6 @@ void initGlobalFuncs(GlobalState& g) {
     assert(g.llvm_dict_type_ptr);
     g.llvm_dict_type_ptr = g.llvm_dict_type_ptr->getPointerTo();
 
-    g.llvm_bststmt_type_ptr = g.stdlib_module->getTypeByName("class.pyston::BST_stmt");
-    assert(g.llvm_bststmt_type_ptr);
-    g.llvm_bststmt_type_ptr = g.llvm_bststmt_type_ptr->getPointerTo();
-
     // The LLVM vector type for the arguments that we pass to runtimeCall and related functions.
     // It will be a pointer to a type named something like class.std::vector or
     // class.std::vector.##. We can figure out exactly what it is by looking at the last

--- a/src/core/cfg.h
+++ b/src/core/cfg.h
@@ -281,6 +281,12 @@ public:
 #endif
     }
 
+    BST_stmt* getStmtFromOffset(int offset) {
+        if (offset == -1)
+            return NULL;
+        return (BST_stmt*)&bytecode.getData()[offset];
+    }
+
     void print(const CodeConstants& code_constants, llvm::raw_ostream& stream = llvm::outs());
 };
 

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -1046,7 +1046,7 @@ struct FrameInfo {
     Box** vregs;
     int num_vregs;
 
-    BST_stmt* stmt; // current statement
+    int stmt_offset; // offset of current statement from the bytecode start
     // This is either a module or a dict
     BORROWED(Box*) globals;
 
@@ -1070,7 +1070,7 @@ struct FrameInfo {
           passed_closure(0),
           vregs(0),
           num_vregs(INT_MAX),
-          stmt(0),
+          stmt_offset(-1),
           globals(0),
           back(0),
           code(0) {}

--- a/src/runtime/frame.cpp
+++ b/src/runtime/frame.cpp
@@ -140,7 +140,7 @@ public:
             return boxInt(f->_linenumber);
         }
 
-        BST_stmt* stmt = f->frame_info->stmt;
+        BST_stmt* stmt = f->frame_info->code->source->cfg->getStmtFromOffset(f->frame_info->stmt_offset);
         ASSERT(stmt->lineno > 0 && stmt->lineno < 1000000, "%d", stmt->lineno);
         return boxInt(stmt->lineno);
     }
@@ -155,8 +155,10 @@ public:
         globals(this, NULL);
         assert(!_locals);
         _locals = incref(locals(this, NULL));
-        ASSERT(frame_info->stmt->lineno > 0 && frame_info->stmt->lineno < 1000000, "%d", frame_info->stmt->lineno);
-        _linenumber = frame_info->stmt->lineno;
+
+        BST_stmt* stmt = frame_info->code->source->cfg->getStmtFromOffset(frame_info->stmt_offset);
+        ASSERT(stmt->lineno > 0 && stmt->lineno < 1000000, "%d", stmt->lineno);
+        _linenumber = stmt->lineno;
 
         frame_info = NULL; // this means exited == true
         assert(hasExited());


### PR DESCRIPTION
- this transforms all stores from 64bit to 32bit
- but more importantly removes a lot of embedded pointers and replaces them with constant integers which lets llvm use smaller opcodes.
- had to teach our assembler how to generate 32bit stores
```
           django_template3.py             2.4s (6)             2.4s (4)  +0.3%
                 pyxl_bench.py             2.1s (6)             2.1s (4)  -1.9%
     sqlalchemy_imperative2.py             2.6s (6)             2.5s (4)  -1.2%
                pyxl_bench2.py             1.1s (6)             1.1s (4)  -1.9%
             pyxl_bench_10x.py            16.7s (6)            16.5s (4)  -1.4%
       django_template3_10x.py            11.8s (6)            11.5s (4)  -3.0%
 sqlalchemy_imperative2_10x.py            18.0s (6)            17.9s (4)  -0.4%
            pyxl_bench2_10x.py             9.3s (6)             8.8s (4)  -5.1%
                       geomean                 5.1s                 5.0s  -1.8%
```