### PR TITLE
llvm JIT: better handling of `const is const` & less unboxing calls

### DIFF
--- a/src/codegen/compvars.cpp
+++ b/src/codegen/compvars.cpp
@@ -2397,8 +2397,8 @@ public:
         ASSERT(other_type == UNKNOWN || other_type == BOXED_BOOL, "%s", other_type->debugName().c_str());
         llvm::Value* boxed = emitter.getBuilder()->CreateSelect(
             i1FromBool(emitter, var),
-            emitter.setType(embedRelocatablePtr(Py_True, g.llvm_value_type_ptr), RefType::BORROWED),
-            emitter.setType(embedRelocatablePtr(Py_False, g.llvm_value_type_ptr), RefType::BORROWED));
+            emitter.setType(embedRelocatablePtr(Py_True, g.llvm_value_type_ptr, "cTrue"), RefType::BORROWED),
+            emitter.setType(embedRelocatablePtr(Py_False, g.llvm_value_type_ptr, "cFalse"), RefType::BORROWED));
         emitter.setType(boxed, RefType::BORROWED);
         return new ConcreteCompilerVariable(other_type, boxed);
     }

--- a/src/codegen/compvars.h
+++ b/src/codegen/compvars.h
@@ -348,8 +348,6 @@ CompilerVariable* makeUnboxedFloat(IREmitter&, llvm::Value*);
 
 llvm::Value* makeLLVMBool(bool b);
 ConcreteCompilerVariable* makeBool(bool);
-ConcreteCompilerVariable* makeLong(IREmitter&, Box*);
-ConcreteCompilerVariable* makePureImaginary(IREmitter&, Box*);
 CompilerVariable* makeStr(BoxedString*);
 CompilerVariable* makeUnicode(Box*);
 

--- a/src/codegen/irgen/irgenerator.cpp
+++ b/src/codegen/irgen/irgenerator.cpp
@@ -1229,29 +1229,29 @@ private:
         assert(vreg != VREG_UNDEFINED);
         if (vreg < 0) {
             Box* o = irstate->getCode()->code_constants.getConstant(vreg);
-            if (o->cls == int_cls) {
-                return makeInt(((BoxedInt*)o)->n);
-            } else if (o->cls == float_cls) {
-                return makeFloat(((BoxedFloat*)o)->d);
-            } else if (o->cls == complex_cls) {
-                return makePureImaginary(emitter, o);
-            } else if (o->cls == long_cls) {
-                return makeLong(emitter, o);
-            } else if (o->cls == str_cls) {
-                llvm::Value* rtn = embedRelocatablePtr(o, g.llvm_value_type_ptr);
-                emitter.setType(rtn, RefType::BORROWED);
-                return new ConcreteCompilerVariable(STR, rtn);
-            } else if (o->cls == unicode_cls) {
-                llvm::Value* rtn = embedRelocatablePtr(o, g.llvm_value_type_ptr);
-                emitter.setType(rtn, RefType::BORROWED);
-                return new ConcreteCompilerVariable(typeFromClass(unicode_cls), rtn);
-            } else if (o->cls == none_cls) {
+
+            if (o->cls == none_cls)
                 return emitter.getNone();
-            } else if (o->cls == ellipsis_cls) {
+            else if (o->cls == ellipsis_cls)
                 return getEllipsis();
-            } else {
+
+            llvm::Value* rtn = embedRelocatablePtr(o, g.llvm_value_type_ptr);
+            emitter.setType(rtn, RefType::BORROWED);
+
+            if (o->cls == int_cls)
+                return makeUnboxedInt(emitter, rtn);
+            else if (o->cls == float_cls)
+                return makeUnboxedFloat(emitter, rtn);
+            else if (o->cls == complex_cls)
+                return new ConcreteCompilerVariable(BOXED_COMPLEX, rtn);
+            else if (o->cls == long_cls)
+                return new ConcreteCompilerVariable(LONG, rtn);
+            else if (o->cls == str_cls)
+                return new ConcreteCompilerVariable(STR, rtn);
+            else if (o->cls == unicode_cls)
+                return new ConcreteCompilerVariable(typeFromClass(unicode_cls), rtn);
+            else
                 RELEASE_ASSERT(0, "");
-            }
         }
         CompilerVariable* rtn = symbol_table[vreg];
         if (is_kill) {

--- a/src/codegen/irgen/util.h
+++ b/src/codegen/irgen/util.h
@@ -43,7 +43,7 @@ llvm::Constant* getNullPtr(llvm::Type* t);
 
 void clearRelocatableSymsMap();
 void setPointersInCodeStorage(std::vector<const void*>* v);
-const void* getValueOfRelocatableSym(const std::string& str);
+const void* getValueOfRelocatableSym(llvm::StringRef str);
 
 void visitRelocatableSymsMap(gc::GCVisitor* visitor);
 

--- a/test/tests/is.py
+++ b/test/tests/is.py
@@ -14,3 +14,10 @@ print 1 is True
 print 0 is False
 print True is 1
 
+# they don't have to be True but Pyston implements it like this for perf reasons
+print
+print 1 is 1
+print 1.0 is 1.0
+print 1l is 1l
+print "s" is "s"
+print u"u" is u"u"


### PR DESCRIPTION
before the llvm JIT returned in some cases `const is const` `False` where the other tiers returned `True`.