### PR TITLE
OSR: enable type specialization

### DIFF
--- a/src/codegen/ast_interpreter.cpp
+++ b/src/codegen/ast_interpreter.cpp
@@ -674,11 +674,11 @@ Box* ASTInterpreter::doOSR(BST_Jump* node) {
     }
 
     const OSREntryDescriptor* found_entry = nullptr;
-    for (auto& p : getCode()->osr_versions) {
-        if (p.first->backedge != node)
+    for (auto& f : getCode()->osr_versions) {
+        if (f->entry_descriptor->backedge != node)
             continue;
 
-        found_entry = p.first;
+        found_entry = f->entry_descriptor;
     }
 
     int num_vregs = source_info->cfg->getVRegInfo().getTotalNumOfVRegs();

--- a/src/codegen/codegen.cpp
+++ b/src/codegen/codegen.cpp
@@ -54,7 +54,7 @@ void BoxedCode::addVersion(CompiledFunction* compiled) {
         assert(compiled->spec->arg_types.size() == numReceivedArgs());
         versions.push_back(compiled);
     } else {
-        osr_versions.emplace_front(compiled->entry_descriptor, compiled);
+        osr_versions.push_back(compiled);
     }
 }
 

--- a/src/codegen/irgen.cpp
+++ b/src/codegen/irgen.cpp
@@ -493,7 +493,6 @@ static void emitBBs(IRGenState* irstate, TypeAnalysis* types, const OSREntryDesc
                 // good to go
                 v = from_arg;
             } else if (p.second->canConvertTo(phi_type)) {
-                RELEASE_ASSERT(0, "this hasn't been hit in a very long time -- check refcounting");
                 // not sure if/when this happens, but if there's a type mismatch but one we know
                 // can be handled (such as casting from a subclass to a superclass), handle it:
                 ConcreteCompilerVariable* converted = var->makeConverted(*unbox_emitter, phi_type);

--- a/src/runtime/types.h
+++ b/src/runtime/types.h
@@ -1143,7 +1143,7 @@ public:
         versions; // any compiled versions along with their type parameters; in order from most preferred to least
     ExceptionSwitchable<CompiledFunction*>
         always_use_version; // if this version is set, always use it (for unboxed cases)
-    std::forward_list<std::pair<const OSREntryDescriptor*, CompiledFunction*>> osr_versions;
+    llvm::TinyPtrVector<CompiledFunction*> osr_versions;
 
     // Profiling counter:
     int propagated_cxx_exceptions = 0;


### PR DESCRIPTION
```
           django_template3.py             2.5s (4)             2.5s (4)  +1.0%
                 pyxl_bench.py             2.1s (4)             2.1s (4)  -0.3%
     sqlalchemy_imperative2.py             2.6s (4)             2.6s (4)  -0.3%
                pyxl_bench2.py             1.0s (4)             1.0s (4)  -0.9%
             pyxl_bench_10x.py            16.4s (4)            16.0s (4)  -2.3%
       django_template3_10x.py            11.5s (4)            11.5s (4)  +0.0%
 sqlalchemy_imperative2_10x.py            18.1s (4)            17.6s (4)  -2.8%
            pyxl_bench2_10x.py             8.5s (4)             8.2s (4)  -4.0%
                    interp2.py             2.5s (4)             2.5s (4)  -1.7%
                   raytrace.py             5.6s (4)             5.4s (4)  -3.6%
                      nbody.py             8.0s (4)             7.8s (4)  -3.2%
                   fannkuch.py             6.9s (4)             7.0s (4)  +1.2%
                      fasta.py             3.9s (4)             3.7s (4)  -4.4%
                   pidigits.py             2.6s (4)             2.5s (4)  -1.4%
                   richards.py             0.6s (4)             0.6s (4)  -2.0%
                  deltablue.py             0.9s (4)             0.9s (4)  -1.3%
         sre_compile_ubench.py             0.8s (4)             0.8s (4)  +0.2%
                       geomean                 3.4s                 3.4s  -1.5%
```