### PR TITLE
Subclassing the bool from long instead int object.

### DIFF
--- a/from_cpython/Include/boolobject.h
+++ b/from_cpython/Include/boolobject.h
@@ -9,8 +9,6 @@ extern "C" {
 #endif
 
 
-typedef PyIntObject PyBoolObject;
-
 // Pyston change: this is no longer a static object
 PyAPI_DATA(PyTypeObject*) bool_cls;
 #define PyBool_Type (*bool_cls)
@@ -22,7 +20,7 @@ Don't forget to apply Py_INCREF() when returning either!!! */
 
 // Pyston change: these are currently stored as pointers, not as static globals
 /* Don't use these directly */
-//PyAPI_DATA(PyIntObject) _Py_ZeroStruct, _Py_TrueStruct;
+// PyAPI_DATA(struct _longobject) _Py_FalseStruct, _Py_TrueStruct;
 PyAPI_DATA(PyObject) *pyston_True, *pyston_False;
 /* Use these macros */
 #define Py_False ((PyObject *) pyston_False)

--- a/from_cpython/Modules/_sre.c
+++ b/from_cpython/Modules/_sre.c
@@ -3310,9 +3310,15 @@ static Py_ssize_t
 match_getindex(MatchObject* self, PyObject* index)
 {
     Py_ssize_t i;
+ 
+    // Python3_updating, bool become long object, temporary fixing.
+    if (index == NULL)
+        /* Default value */
+        return 0;
 
-    if (PyInt_Check(index))
-        return PyInt_AsSsize_t(index);
+    if (PyIndex_Check(index)) {
+        return PyNumber_AsSsize_t(index, NULL);
+    }
 
     i = -1;
 

--- a/src/runtime/bool.cpp
+++ b/src/runtime/bool.cpp
@@ -14,7 +14,7 @@
 
 #include "core/common.h"
 #include "core/types.h"
-#include "runtime/int.h"
+#include "runtime/long.h"
 #include "runtime/objmodel.h"
 #include "runtime/types.h"
 
@@ -62,9 +62,9 @@ extern "C" Box* boolAnd(BoxedBool* lhs, BoxedBool* rhs) {
                        getTypeName(lhs));
 
     if (!PyBool_Check(rhs))
-        return intAnd(lhs, rhs);
+        return longAnd(lhs, rhs);
 
-    return boxBool(lhs->n && rhs->n);
+    return boxBool((lhs == Py_True) & (rhs == Py_True));
 }
 
 extern "C" Box* boolOr(BoxedBool* lhs, BoxedBool* rhs) {
@@ -72,9 +72,9 @@ extern "C" Box* boolOr(BoxedBool* lhs, BoxedBool* rhs) {
         raiseExcHelper(TypeError, "descriptor '__or__' requires a 'bool' object but received a '%s'", getTypeName(lhs));
 
     if (!PyBool_Check(rhs))
-        return intOr(lhs, rhs);
+        return longOr(lhs, rhs);
 
-    return boxBool(lhs->n || rhs->n);
+    return boxBool((lhs == Py_True) | (rhs == Py_True));
 }
 
 extern "C" Box* boolXor(BoxedBool* lhs, BoxedBool* rhs) {
@@ -83,9 +83,9 @@ extern "C" Box* boolXor(BoxedBool* lhs, BoxedBool* rhs) {
                        getTypeName(lhs));
 
     if (!PyBool_Check(rhs))
-        return intXor(lhs, rhs);
+        return longXor(lhs, rhs);
 
-    return boxBool(lhs->n ^ rhs->n);
+    return boxBool((lhs == Py_True) ^ (rhs == Py_True));
 }
 
 
@@ -111,6 +111,6 @@ void setupBool() {
     bool_cls->freeze();
     bool_cls->tp_hash = (hashfunc)bool_hash;
     bool_cls->tp_repr = boolRepr<CAPI>;
-    bool_as_number.nb_int = int_cls->tp_as_number->nb_int;
+    bool_as_number.nb_int = long_cls->tp_as_number->nb_int;
 }
 }

--- a/src/runtime/builtin_modules/pyston.cpp
+++ b/src/runtime/builtin_modules/pyston.cpp
@@ -60,7 +60,7 @@ static Box* dumpStats(Box* includeZeros) {
     if (includeZeros->cls != bool_cls)
         raiseExcHelper(TypeError, "includeZeros must be a 'bool' object but received a '%s'",
                        getTypeName(includeZeros));
-    Stats::dump(((BoxedBool*)includeZeros)->n != 0);
+    Stats::dump(((BoxedBool*)includeZeros) != Py_False);
     Py_RETURN_NONE;
 }
 

--- a/src/runtime/long.h
+++ b/src/runtime/long.h
@@ -16,7 +16,6 @@
 #define PYSTON_RUNTIME_LONG_H
 
 #include <cstddef>
-#include <gmp.h>
 
 #include "core/types.h"
 #include "runtime/types.h"
@@ -27,23 +26,15 @@ void setupLong();
 
 extern BoxedClass* long_cls;
 
-class BoxedLong : public Box {
-public:
-    mpz_t n;
-
-    BoxedLong() __attribute__((visibility("default"))) {}
-
-    static void tp_dealloc(Box* b) noexcept;
-
-    DEFAULT_CLASS_SIMPLE(long_cls, false);
-};
-
 extern "C" Box* createLong(llvm::StringRef s);
 extern "C" BoxedLong* boxLong(int64_t n);
 
 Box* longNeg(BoxedLong* lhs);
 Box* longAbs(BoxedLong* v1);
 
+Box* longAnd(BoxedLong* lhs, Box* rhs);
+Box* longOr(BoxedLong* lhs, Box* rhs);
+Box* longXor(BoxedLong* lhs, Box* rhs);
 Box* longAdd(BoxedLong* lhs, Box* rhs);
 Box* longSub(BoxedLong* lhs, Box* rhs);
 Box* longMul(BoxedLong* lhs, Box* rhs);

--- a/src/runtime/objmodel.cpp
+++ b/src/runtime/objmodel.cpp
@@ -3255,7 +3255,7 @@ static bool nonzeroHelper(STOLEN(Box*) r) {
     // I believe this behavior is handled by the slot wrappers in CPython:
     if (r->cls == bool_cls) {
         BoxedBool* b = static_cast<BoxedBool*>(r);
-        bool rtn = b->n;
+        bool rtn = (b == Py_True);
         return rtn;
     } else if (r->cls == int_cls) {
         BoxedInt* b = static_cast<BoxedInt*>(r);
@@ -3285,14 +3285,8 @@ extern "C" bool nonzero(Box* obj) {
     // able to at least generate rewrites that are as good as the ones we write here.
     // But for now we can't and these should be a bit faster:
     if (obj->cls == bool_cls) {
-        // TODO: is it faster to compare to True? (especially since it will be a constant we can embed in the rewrite)
-        if (rewriter.get()) {
-            RewriterVar* b = r_obj->getAttr(offsetof(BoxedBool, n), rewriter->getReturnDestination());
-            rewriter->commitReturningNonPython(b);
-        }
-
         BoxedBool* bool_obj = static_cast<BoxedBool*>(obj);
-        return bool_obj->n;
+        return bool_obj == Py_True;
     } else if (obj->cls == int_cls) {
         if (rewriter.get()) {
             RewriterVar* n = r_obj->getAttr(offsetof(BoxedInt, n), rewriter->getReturnDestination());

--- a/src/runtime/types.cpp
+++ b/src/runtime/types.cpp
@@ -4262,11 +4262,11 @@ void setupRuntime() {
     int_cls = new (0) BoxedClass(object_cls, 0, 0, sizeof(BoxedInt), false, "int", true, BoxedInt::tp_dealloc,
                                  /*BoxedInt::tp_free*/ NULL, false);
     int_cls->tp_flags |= Py_TPFLAGS_INT_SUBCLASS;
-    bool_cls = new (0) BoxedClass(int_cls, 0, 0, sizeof(BoxedBool), false, "bool", false, NULL, NULL, false);
     complex_cls = new (0) BoxedClass(object_cls, 0, 0, sizeof(BoxedComplex), false, "complex", true, NULL, NULL, false);
     long_cls = new (0)
         BoxedClass(object_cls, 0, 0, sizeof(BoxedLong), false, "long", true, BoxedLong::tp_dealloc, NULL, false);
     long_cls->tp_flags |= Py_TPFLAGS_LONG_SUBCLASS;
+    bool_cls = new (0) BoxedClass(long_cls, 0, 0, sizeof(BoxedLong), false, "bool", false, NULL, NULL, false);
     float_cls = new (0)
         BoxedClass(object_cls, 0, 0, sizeof(BoxedFloat), false, "float", true, BoxedFloat::tp_dealloc, NULL, false);
     function_cls = new (0) BoxedClass(object_cls, offsetof(BoxedFunction, attrs), offsetof(BoxedFunction, weakreflist),
@@ -4304,9 +4304,9 @@ void setupRuntime() {
     attrwrapper_cls->tp_mro = BoxedTuple::create({ attrwrapper_cls, object_cls });
     dict_cls->tp_mro = BoxedTuple::create({ dict_cls, object_cls });
     int_cls->tp_mro = BoxedTuple::create({ int_cls, object_cls });
-    bool_cls->tp_mro = BoxedTuple::create({ bool_cls, int_cls, object_cls });
     complex_cls->tp_mro = BoxedTuple::create({ complex_cls, object_cls });
     long_cls->tp_mro = BoxedTuple::create({ long_cls, object_cls });
+    bool_cls->tp_mro = BoxedTuple::create({ bool_cls, int_cls, object_cls });
     float_cls->tp_mro = BoxedTuple::create({ float_cls, object_cls });
     function_cls->tp_mro = BoxedTuple::create({ function_cls, object_cls });
     builtin_function_or_method_cls->tp_mro = BoxedTuple::create({ builtin_function_or_method_cls, object_cls });
@@ -4318,13 +4318,13 @@ void setupRuntime() {
     STR = typeFromClass(str_cls);
     BOXED_INT = typeFromClass(int_cls);
     BOXED_FLOAT = typeFromClass(float_cls);
-    BOXED_BOOL = typeFromClass(bool_cls);
     NONE = typeFromClass(none_cls);
     LIST = typeFromClass(list_cls);
     MODULE = typeFromClass(module_cls);
     DICT = typeFromClass(dict_cls);
     BOXED_TUPLE = typeFromClass(tuple_cls);
     LONG = typeFromClass(long_cls);
+    BOXED_BOOL = typeFromClass(bool_cls);
     BOXED_COMPLEX = typeFromClass(complex_cls);
 
     pyston_True = new BoxedBool(true);
@@ -4362,9 +4362,9 @@ void setupRuntime() {
     attrwrapper_cls->finishInitialization();
     dict_cls->finishInitialization();
     int_cls->finishInitialization();
-    bool_cls->finishInitialization();
     complex_cls->finishInitialization();
     long_cls->finishInitialization();
+    bool_cls->finishInitialization();
     float_cls->finishInitialization();
     function_cls->finishInitialization();
     builtin_function_or_method_cls->finishInitialization();
@@ -4495,8 +4495,8 @@ void setupRuntime() {
     assert(object_cls->tp_new == object_new);
     assert(object_cls->tp_str == object_str);
 
-    setupBool();
     setupLong();
+    setupBool();
     setupFloat();
     setupComplex();
     setupStr();

--- a/src/runtime/types.h
+++ b/src/runtime/types.h
@@ -18,6 +18,7 @@
 #include <llvm/ADT/StringMap.h>
 #include <llvm/ADT/Twine.h>
 #include <ucontext.h>
+#include <gmp.h>
 
 #include "Python.h"
 #include "structmember.h"
@@ -541,6 +542,18 @@ public:
 static_assert(sizeof(BoxedInt) == sizeof(PyIntObject), "");
 static_assert(offsetof(BoxedInt, n) == offsetof(PyIntObject, ob_ival), "");
 
+class BoxedLong : public Box {
+public:
+    mpz_t n;
+
+    BoxedLong() __attribute__((visibility("default"))){};
+    BoxedLong(int64_t ival) __attribute__((visibility("default"))) { mpz_init_set_si(n, ival); }
+
+    static void tp_dealloc(Box* b) noexcept;
+
+    DEFAULT_CLASS_SIMPLE(long_cls, false);
+};
+
 extern "C" int PyFloat_ClearFreeList() noexcept;
 class BoxedFloat : public Box {
 private:
@@ -593,9 +606,9 @@ static_assert(sizeof(BoxedComplex) == sizeof(PyComplexObject), "");
 static_assert(offsetof(BoxedComplex, real) == offsetof(PyComplexObject, cval.real), "");
 static_assert(offsetof(BoxedComplex, imag) == offsetof(PyComplexObject, cval.imag), "");
 
-class BoxedBool : public BoxedInt {
+class BoxedBool : public BoxedLong {
 public:
-    BoxedBool(bool b) __attribute__((visibility("default"))) : BoxedInt(b ? 1 : 0) {}
+    BoxedBool(bool b) __attribute__((visibility("default"))) { mpz_init_set_si(n, b ? 1 : 0); }
 
     DEFAULT_CLASS_SIMPLE(bool_cls, false);
 };

--- a/src/runtime/types.h
+++ b/src/runtime/types.h
@@ -15,10 +15,10 @@
 #ifndef PYSTON_RUNTIME_TYPES_H
 #define PYSTON_RUNTIME_TYPES_H
 
+#include <gmp.h>
 #include <llvm/ADT/StringMap.h>
 #include <llvm/ADT/Twine.h>
 #include <ucontext.h>
-#include <gmp.h>
 
 #include "Python.h"
 #include "structmember.h"

--- a/tools/tester.py
+++ b/tools/tester.py
@@ -152,6 +152,9 @@ def run_test(fn, check_stats, run_memcheck):
     opts = get_test_options(fn, check_stats, run_memcheck)
     del check_stats, run_memcheck
 
+    if opts.expected != "py3ready":
+        opts.skip = True
+
     if opts.skip:
         return ("(skipped: %s)" % opts.skip) if DISPLAY_SKIPS else ""
 


### PR DESCRIPTION
In Python 2, the bool object is essentially an int object. In Python 3, it is long object. This PR subclass the bool object from long instead of the int. Preparing for removing the int object completely.